### PR TITLE
Trim SQL statements

### DIFF
--- a/src/sql/sql.go
+++ b/src/sql/sql.go
@@ -10,10 +10,18 @@ import (
 const splitSqlRegexp = `\s*((?:'[^'\\]*(?:\\.[^'\\]*)*'|"[^"\\]*(?:\\.[^"\\]*)*"|\/\*[^*]*\*+(?:[^*/][^*]*\*+)*\/|#.*|--.*|[^"';#])+(?:;|$))`
 
 func Split(sql string) []string {
-	results := regexpcache.MustCompile(splitSqlRegexp).FindAllString(sql, -1)
-	if results == nil {
-		return make([]string, 0)
+	sql = strings.TrimSuffix(sql, "\n")
+	rawResults := regexpcache.MustCompile(splitSqlRegexp).FindAllString(sql, -1)
+
+	// Trim spaces
+	results := make([]string, 0)
+	for _, result := range rawResults {
+		result := strings.TrimSpace(result)
+		if len(result) > 0 {
+			results = append(results, result)
+		}
 	}
+
 	return results
 }
 

--- a/src/sql/sql_test.go
+++ b/src/sql/sql_test.go
@@ -27,17 +27,17 @@ func TestSqlSplitAndJoin(t *testing.T) {
 		{
 			comment:    "one statement + whitespaces",
 			input:      "   \n\n\nSELECT * FROM [bar]\t\n  ",
-			output:     "   \n\n\nSELECT * FROM [bar]\t\n  ",
-			statements: []string{"   \n\n\nSELECT * FROM [bar]\t\n  "},
+			output:     "SELECT * FROM [bar]",
+			statements: []string{"SELECT * FROM [bar]"},
 		},
 		{
 			comment: "multiple",
 			input:   "   \n\n\nSELECT * FROM [bar];\t\n  INSERT INTO bar VALUES('x', 'y'); TRUNCATE records;;;",
-			output:  "   \n\n\nSELECT * FROM [bar];\n\n\t\n  INSERT INTO bar VALUES('x', 'y');\n\n TRUNCATE records;",
+			output:  "SELECT * FROM [bar];\n\nINSERT INTO bar VALUES('x', 'y');\n\nTRUNCATE records;",
 			statements: []string{
-				"   \n\n\nSELECT * FROM [bar];",
-				"\t\n  INSERT INTO bar VALUES('x', 'y');",
-				" TRUNCATE records;",
+				"SELECT * FROM [bar];",
+				"INSERT INTO bar VALUES('x', 'y');",
+				"TRUNCATE records;",
 			},
 		},
 	}


### PR DESCRIPTION
V tomto PR:
- sa  robi `trim` bielych znakov z SQL

Zistil som, ze UI po ulozeni transformacie odstrani biele znaky zo zaciatku a konca vsetkych SQL statements, ... takze to musi fungovat rovnako aj v tomto CLI toole.

Pred ulozenim:
![image](https://user-images.githubusercontent.com/19371734/126050595-e64ce187-c676-4254-91f4-3a7d5ad6df66.png)

Po ulozeni v UI:
![image](https://user-images.githubusercontent.com/19371734/126050601-b052da5a-7605-4464-9cdf-5993df44db47.png)

