### PR TITLE
Move functions to Utils package

### DIFF
--- a/src/manifest/naming.go
+++ b/src/manifest/naming.go
@@ -1,23 +1,15 @@
 package manifest
 
 import (
-	"github.com/iancoleman/strcase"
-	"github.com/spf13/cast"
 	"keboola-as-code/src/model"
-	"regexp"
-	"strings"
-)
-
-const (
-	TransformationBlock = `blocks/{block_order}-{block_name}`
-	TransformationCode  = `{code_order}-{code_name}`
+	"keboola-as-code/src/utils"
 )
 
 // LocalNaming of the files
 type LocalNaming struct {
-	Branch    PathTemplate `json:"branch" validate:"required"`
-	Config    PathTemplate `json:"config" validate:"required"`
-	ConfigRow PathTemplate `json:"configRow" validate:"required"`
+	Branch    utils.PathTemplate `json:"branch" validate:"required"`
+	Config    utils.PathTemplate `json:"config" validate:"required"`
+	ConfigRow utils.PathTemplate `json:"configRow" validate:"required"`
 }
 
 func DefaultNaming() *LocalNaming {
@@ -29,38 +21,24 @@ func DefaultNaming() *LocalNaming {
 }
 
 func (n *LocalNaming) BranchPath(branch *model.Branch) string {
-	return n.replace(string(n.Branch), map[string]interface{}{
+	return utils.ReplacePlaceholders(string(n.Branch), map[string]interface{}{
 		"branch_id":   branch.Id,
-		"branch_name": n.normalizeName(branch.Name),
+		"branch_name": utils.NormalizeName(branch.Name),
 	})
 }
 
 func (n *LocalNaming) ConfigPath(component *model.Component, config *model.Config) string {
-	return n.replace(string(n.Config), map[string]interface{}{
+	return utils.ReplacePlaceholders(string(n.Config), map[string]interface{}{
 		"component_type": component.Type,
 		"component_id":   component.Id,
 		"config_id":      config.Id,
-		"config_name":    n.normalizeName(config.Name),
+		"config_name":    utils.NormalizeName(config.Name),
 	})
 }
 
 func (n *LocalNaming) ConfigRowPath(row *model.ConfigRow) string {
-	return n.replace(string(n.ConfigRow), map[string]interface{}{
+	return utils.ReplacePlaceholders(string(n.ConfigRow), map[string]interface{}{
 		"config_row_id":   row.Id,
-		"config_row_name": n.normalizeName(row.Name),
+		"config_row_name": utils.NormalizeName(row.Name),
 	})
-}
-
-func (n *LocalNaming) normalizeName(name string) string {
-	str := regexp.
-		MustCompile(`[^a-zA-Z0-9]+`).
-		ReplaceAllString(strcase.ToDelimited(name, '-'), "-")
-	return strings.Trim(str, "-")
-}
-
-func (n *LocalNaming) replace(path string, placeholders map[string]interface{}) string {
-	for key, value := range placeholders {
-		path = strings.ReplaceAll(path, "{"+key+"}", cast.ToString(value))
-	}
-	return path
 }

--- a/src/manifest/naming_test.go
+++ b/src/manifest/naming_test.go
@@ -59,14 +59,3 @@ func TestDefaultNaming(t *testing.T) {
 			},
 		))
 }
-
-func TestNamingNormalizeName(t *testing.T) {
-	n := LocalNaming{}
-	assert.Equal(t, "", n.normalizeName(""))
-	assert.Equal(t, "abc", n.normalizeName("abc"))
-	assert.Equal(t, "camel-case", n.normalizeName("CamelCase"))
-	assert.Equal(t, "space-separated", n.normalizeName("   space   separated  "))
-	assert.Equal(t, "abc-def-xyz", n.normalizeName("__abc_def_xyz___"))
-	assert.Equal(t, "abc-dev-xyz", n.normalizeName("--abc-dev-xyz---"))
-	assert.Equal(t, "a-b-cd-e-f-x-y-z", n.normalizeName("a B cd-eF   x_y___z__"))
-}

--- a/src/utils/path.go
+++ b/src/utils/path.go
@@ -1,4 +1,4 @@
-package manifest
+package utils
 
 import (
 	"fmt"

--- a/src/utils/path_test.go
+++ b/src/utils/path_test.go
@@ -1,4 +1,4 @@
-package manifest
+package utils
 
 import (
 	"github.com/stretchr/testify/assert"

--- a/src/utils/string.go
+++ b/src/utils/string.go
@@ -1,0 +1,22 @@
+package utils
+
+import (
+	"github.com/iancoleman/strcase"
+	"github.com/spf13/cast"
+	"regexp"
+	"strings"
+)
+
+func NormalizeName(name string) string {
+	str := regexp.
+		MustCompile(`[^a-zA-Z0-9]+`).
+		ReplaceAllString(strcase.ToDelimited(name, '-'), "-")
+	return strings.Trim(str, "-")
+}
+
+func ReplacePlaceholders(path string, placeholders map[string]interface{}) string {
+	for key, value := range placeholders {
+		path = strings.ReplaceAll(path, "{"+key+"}", cast.ToString(value))
+	}
+	return path
+}

--- a/src/utils/string_test.go
+++ b/src/utils/string_test.go
@@ -1,0 +1,16 @@
+package utils
+
+import (
+	"github.com/stretchr/testify/assert"
+	"testing"
+)
+
+func TestNamingNormalizeName(t *testing.T) {
+	assert.Equal(t, "", NormalizeName(""))
+	assert.Equal(t, "abc", NormalizeName("abc"))
+	assert.Equal(t, "camel-case", NormalizeName("CamelCase"))
+	assert.Equal(t, "space-separated", NormalizeName("   space   separated  "))
+	assert.Equal(t, "abc-def-xyz", NormalizeName("__abc_def_xyz___"))
+	assert.Equal(t, "abc-dev-xyz", NormalizeName("--abc-dev-xyz---"))
+	assert.Equal(t, "a-b-cd-e-f-x-y-z", NormalizeName("a B cd-eF   x_y___z__"))
+}


### PR DESCRIPTION
Changes:
- Moved some functions to the `utils` package, so they can be reused.