### PR TITLE
Fix bug in rename after pull

### DIFF
--- a/src/manifest/manifest.go
+++ b/src/manifest/manifest.go
@@ -52,6 +52,7 @@ type RecordState struct {
 	Invalid   bool // if true, object files are not valid, eg. missing file, invalid JSON, ...
 	NotFound  bool // if true, object directory is not present in the filesystem
 	Persisted bool // if true, record will be part of the manifest when saved
+	Deleted   bool // if true, record has been deleted in this command run
 }
 
 type Paths struct {
@@ -312,6 +313,7 @@ func (m *Manifest) DeleteRecordByKey(key model.Key) {
 	if found {
 		m.lock.Lock()
 		defer m.lock.Unlock()
+		record.State().SetDeleted()
 		m.changed = m.changed || record.State().IsPersisted()
 		m.records.Delete(key.String())
 	}
@@ -379,6 +381,14 @@ func (s *RecordState) IsPersisted() bool {
 func (s *RecordState) SetPersisted() {
 	s.Invalid = false
 	s.Persisted = true
+}
+
+func (s *RecordState) IsDeleted() bool {
+	return s.Deleted
+}
+
+func (s *RecordState) SetDeleted() {
+	s.Deleted = true
 }
 
 func (b *BranchManifest) ResolveParentPath() {

--- a/src/state/state.go
+++ b/src/state/state.go
@@ -203,9 +203,13 @@ func (s *State) All() []ObjectState {
 		return all[i].key < all[j].key
 	})
 
-	// Convert to slice
+	// Convert to slice, ignore deleted
 	var slice []ObjectState
 	for _, pair := range all {
+		if pair.state.Manifest().State().IsDeleted() {
+			continue
+		}
+
 		slice = append(slice, pair.state)
 	}
 	return slice
@@ -214,6 +218,9 @@ func (s *State) All() []ObjectState {
 func (s *State) Branches() []*BranchState {
 	var branches []*BranchState
 	for _, b := range s.branches {
+		if b.Manifest().State().IsDeleted() {
+			continue
+		}
 		branches = append(branches, b)
 	}
 	sort.SliceStable(branches, func(i, j int) bool {
@@ -225,6 +232,9 @@ func (s *State) Branches() []*BranchState {
 func (s *State) Configs() []*ConfigState {
 	var configs []*ConfigState
 	for _, c := range s.configs {
+		if c.Manifest().State().IsDeleted() {
+			continue
+		}
 		configs = append(configs, c)
 	}
 	sort.SliceStable(configs, func(i, j int) bool {
@@ -236,6 +246,9 @@ func (s *State) Configs() []*ConfigState {
 func (s *State) ConfigRows() []*ConfigRowState {
 	var configRows []*ConfigRowState
 	for _, r := range s.configRows {
+		if r.Manifest().State().IsDeleted() {
+			continue
+		}
 		configRows = append(configRows, r)
 	}
 	sort.SliceStable(configRows, func(i, j int) bool {

--- a/src/tests/pull-delete-all/expected-stdout
+++ b/src/tests/pull-delete-all/expected-stdout
@@ -1,4 +1,8 @@
 Plan for "pull" operation:
 	×  C main/extractor/ex-generic-v2/empty
 	×  C main/extractor/ex-generic-v2/without-rows
+	×  C main/extractor/keboola.ex-db-mysql/with-rows
+	×  R main/extractor/keboola.ex-db-mysql/with-rows/rows/disabled
+	×  R main/extractor/keboola.ex-db-mysql/with-rows/rows/test-view
+	×  R main/extractor/keboola.ex-db-mysql/with-rows/rows/users
 Pull done.

--- a/src/tests/pull-delete-all/in/.keboola/manifest.json
+++ b/src/tests/pull-delete-all/in/.keboola/manifest.json
@@ -30,6 +30,26 @@
       "id": "456",
       "path": "extractor/ex-generic-v2/without-rows",
       "rows": []
+    },
+    {
+      "branchId": %%TEST_BRANCH_MAIN_ID%%,
+      "componentId": "keboola.ex-db-mysql",
+      "id": "789",
+      "path": "extractor/keboola.ex-db-mysql/with-rows",
+      "rows": [
+        {
+          "id": "10",
+          "path": "rows/disabled"
+        },
+        {
+          "id": "11",
+          "path": "rows/test-view"
+        },
+        {
+          "id": "12",
+          "path": "rows/users"
+        }
+      ]
     }
   ]
 }

--- a/src/tests/pull-delete-all/in/main/extractor/keboola.ex-db-mysql/with-rows/config.json
+++ b/src/tests/pull-delete-all/in/main/extractor/keboola.ex-db-mysql/with-rows/config.json
@@ -1,0 +1,7 @@
+{
+  "parameters": {
+    "db": {
+      "host": "mysql.example.com"
+    }
+  }
+}

--- a/src/tests/pull-delete-all/in/main/extractor/keboola.ex-db-mysql/with-rows/meta.json
+++ b/src/tests/pull-delete-all/in/main/extractor/keboola.ex-db-mysql/with-rows/meta.json
@@ -1,0 +1,4 @@
+{
+  "name": "with-rows",
+  "description": "test fixture"
+}

--- a/src/tests/pull-delete-all/in/main/extractor/keboola.ex-db-mysql/with-rows/rows/disabled/config.json
+++ b/src/tests/pull-delete-all/in/main/extractor/keboola.ex-db-mysql/with-rows/rows/disabled/config.json
@@ -1,0 +1,5 @@
+{
+  "parameters": {
+    "incremental": false
+  }
+}

--- a/src/tests/pull-delete-all/in/main/extractor/keboola.ex-db-mysql/with-rows/rows/disabled/meta.json
+++ b/src/tests/pull-delete-all/in/main/extractor/keboola.ex-db-mysql/with-rows/rows/disabled/meta.json
@@ -1,0 +1,5 @@
+{
+  "name": "disabled",
+  "description": "test fixture",
+  "isDisabled": true
+}

--- a/src/tests/pull-delete-all/in/main/extractor/keboola.ex-db-mysql/with-rows/rows/test-view/config.json
+++ b/src/tests/pull-delete-all/in/main/extractor/keboola.ex-db-mysql/with-rows/rows/test-view/config.json
@@ -1,0 +1,5 @@
+{
+  "parameters": {
+    "incremental": false
+  }
+}

--- a/src/tests/pull-delete-all/in/main/extractor/keboola.ex-db-mysql/with-rows/rows/test-view/meta.json
+++ b/src/tests/pull-delete-all/in/main/extractor/keboola.ex-db-mysql/with-rows/rows/test-view/meta.json
@@ -1,0 +1,5 @@
+{
+  "name": "test_view",
+  "description": "test fixture",
+  "isDisabled": false
+}

--- a/src/tests/pull-delete-all/in/main/extractor/keboola.ex-db-mysql/with-rows/rows/users/config.json
+++ b/src/tests/pull-delete-all/in/main/extractor/keboola.ex-db-mysql/with-rows/rows/users/config.json
@@ -1,0 +1,5 @@
+{
+  "parameters": {
+    "incremental": false
+  }
+}

--- a/src/tests/pull-delete-all/in/main/extractor/keboola.ex-db-mysql/with-rows/rows/users/meta.json
+++ b/src/tests/pull-delete-all/in/main/extractor/keboola.ex-db-mysql/with-rows/rows/users/meta.json
@@ -1,0 +1,5 @@
+{
+  "name": "users",
+  "description": "test fixture",
+  "isDisabled": false
+}


### PR DESCRIPTION
Changes:
- Fixed bug, if config row is removed inside pull -> rename fails.

Narazil som na bug:
- ak sa v prikaze `pull` maze config + row (lebo v remote neexistuje)
- tak `pull` prebehne v poriadku, ... no za pull sme pridali `rename`
- a tam to spadne
- kedze `rename` prechadza vsetky objekty zo `state.State`
- pride ku zmazanemu row a hlada jeho rodica - config -> aby sa dala vygenerovat `path`
- no ale parent config bol tiez zmazany a neexistuje o nom zaznam -> spadne to.

Fix:
- po zmazani zaznamu sa dany `manifest.Record` oznaci ako `isDeleted = true`
- a ked sa zavola `state.State.All()` tak sa zmazane zaznamy preskocia