### PR TITLE
encrypt api call

### DIFF
--- a/src/encryption/api.go
+++ b/src/encryption/api.go
@@ -1,0 +1,58 @@
+package encryption
+
+import (
+	"context"
+	"keboola-as-code/src/client"
+	"keboola-as-code/src/remote"
+	"strings"
+
+	"github.com/go-resty/resty/v2"
+	"go.uber.org/zap"
+)
+
+type EncryptionApi struct {
+	apiHost string
+	client  *client.Client
+	logger  *zap.SugaredLogger
+}
+
+func getEncryptionApiHost(connectionApiHost string) string {
+	return strings.ReplaceAll(connectionApiHost, "connection.", "encryption.")
+}
+
+func NewEncryptionApi(connectionApiHost string, ctx context.Context, logger *zap.SugaredLogger, verbose bool) *EncryptionApi {
+	apiHost := getEncryptionApiHost(connectionApiHost)
+	apiHostUrl := "https://" + apiHost
+	c := client.NewClient(ctx, logger, verbose).WithHostUrl(apiHostUrl)
+	c.SetError(&remote.Error{})
+	api := &EncryptionApi{client: c, logger: logger, apiHost: apiHost}
+	return api
+}
+
+func (a *EncryptionApi) NewRequest(method string, url string) *client.Request {
+	return a.client.NewRequest(method, url)
+}
+
+func (a *EncryptionApi) createRequest(componentId string, projectId string, requestBody map[string]string) (*client.Request, error) {
+	// Create request
+	request := a.
+		client.NewRequest(resty.MethodPost, "encrypt").
+		SetPathParam("componentId", componentId).
+		SetPathParam("projectId", projectId).
+		SetBody(requestBody)
+
+	return request, nil
+}
+
+func (a *EncryptionApi) EncryptMapValues(componentId string, projectId string, mapValues map[string]string) (map[string]string, error) {
+	request, err := a.createRequest(componentId, projectId, mapValues)
+	if err != nil {
+		return nil, err
+	}
+	response := request.Send().Response
+	if response.HasResult() {
+		return response.Result().(map[string]string), nil
+	}
+	return nil, response.Err()
+
+}

--- a/src/encryption/api.go
+++ b/src/encryption/api.go
@@ -2,8 +2,8 @@ package encryption
 
 import (
 	"context"
+	"fmt"
 	"keboola-as-code/src/client"
-	"keboola-as-code/src/remote"
 	"strings"
 
 	"github.com/go-resty/resty/v2"
@@ -16,6 +16,21 @@ type EncryptionApi struct {
 	logger  *zap.SugaredLogger
 }
 
+// Error represents Encryption API error structure
+type Error struct {
+	Message     string `json:"error"`
+	ErrCode     int    `json:"code"`
+	ExceptionId string `json:"exceptionId"`
+}
+
+func (e *Error) Error() string {
+	msg := fmt.Sprintf(`"%v", errCode: "%v"`, e.Message, e.ErrCode)
+	if len(e.ExceptionId) > 0 {
+		msg += fmt.Sprintf(`, exceptionId: "%s"`, e.ExceptionId)
+	}
+	return msg
+}
+
 func getEncryptionApiHost(connectionApiHost string) string {
 	return strings.ReplaceAll(connectionApiHost, "connection.", "encryption.")
 }
@@ -24,7 +39,7 @@ func NewEncryptionApi(connectionApiHost string, ctx context.Context, logger *zap
 	apiHost := getEncryptionApiHost(connectionApiHost)
 	apiHostUrl := "https://" + apiHost
 	c := client.NewClient(ctx, logger, verbose).WithHostUrl(apiHostUrl)
-	c.SetError(&remote.Error{})
+	c.SetError(&Error{})
 	api := &EncryptionApi{client: c, logger: logger, apiHost: apiHost}
 	return api
 }

--- a/src/encryption/api.go
+++ b/src/encryption/api.go
@@ -35,11 +35,14 @@ func (a *EncryptionApi) NewRequest(method string, url string) *client.Request {
 
 func (a *EncryptionApi) createRequest(componentId string, projectId string, requestBody map[string]string) (*client.Request, error) {
 	// Create request
+	result := make(map[string]string)
 	request := a.
 		client.NewRequest(resty.MethodPost, "encrypt").
-		SetPathParam("componentId", componentId).
-		SetPathParam("projectId", projectId).
-		SetBody(requestBody)
+		SetQueryParam("componentId", componentId).
+		SetQueryParam("projectId", projectId).
+		SetResult(&result)
+	request.Request.SetBody(requestBody)
+	request.Request.SetHeader("Content-Type", "application/json")
 
 	return request, nil
 }
@@ -51,8 +54,7 @@ func (a *EncryptionApi) EncryptMapValues(componentId string, projectId string, m
 	}
 	response := request.Send().Response
 	if response.HasResult() {
-		return response.Result().(map[string]string), nil
+		return *response.Result().(*map[string]string), nil
 	}
 	return nil, response.Err()
-
 }

--- a/src/encryption/api.go
+++ b/src/encryption/api.go
@@ -4,16 +4,16 @@ import (
 	"context"
 	"fmt"
 	"keboola-as-code/src/client"
-	"strings"
+	"keboola-as-code/src/remote"
 
 	"github.com/go-resty/resty/v2"
 	"go.uber.org/zap"
 )
 
-type EncryptionApi struct {
-	apiHost string
-	client  *client.Client
-	logger  *zap.SugaredLogger
+type Api struct {
+	apiHostUrl string
+	client     *client.Client
+	logger     *zap.SugaredLogger
 }
 
 // Error represents Encryption API error structure
@@ -31,24 +31,37 @@ func (e *Error) Error() string {
 	return msg
 }
 
-func getEncryptionApiHost(connectionApiHost string) string {
-	return strings.ReplaceAll(connectionApiHost, "connection.", "encryption.")
+func getEncryptionApiHost(connectionApiHost string, ctx context.Context, logger *zap.SugaredLogger) string {
+	storageApi := remote.NewStorageApi(connectionApiHost, ctx, logger, false)
+	services, err := storageApi.GetServices()
+	if err != nil {
+		panic(fmt.Errorf("failed to retrieve services from Storage API: \"%s\"", err))
+	}
+
+	for _, object := range services {
+		service := object.(map[string]interface{})
+		if service["id"] == "encryption" {
+			apiHost := service["url"]
+			return apiHost.(string)
+		}
+	}
+	panic(fmt.Errorf("encryption API not found in services from Storage API: \"%s\"", services))
 }
 
-func NewEncryptionApi(connectionApiHost string, ctx context.Context, logger *zap.SugaredLogger, verbose bool) *EncryptionApi {
-	apiHost := getEncryptionApiHost(connectionApiHost)
-	apiHostUrl := "https://" + apiHost
+func NewEncryptionApi(connectionApiHost string, ctx context.Context, logger *zap.SugaredLogger, verbose bool) *Api {
+
+	apiHostUrl := getEncryptionApiHost(connectionApiHost, ctx, logger)
 	c := client.NewClient(ctx, logger, verbose).WithHostUrl(apiHostUrl)
 	c.SetError(&Error{})
-	api := &EncryptionApi{client: c, logger: logger, apiHost: apiHost}
+	api := &Api{client: c, logger: logger, apiHostUrl: apiHostUrl}
 	return api
 }
 
-func (a *EncryptionApi) NewRequest(method string, url string) *client.Request {
+func (a *Api) NewRequest(method string, url string) *client.Request {
 	return a.client.NewRequest(method, url)
 }
 
-func (a *EncryptionApi) createRequest(componentId string, projectId string, requestBody map[string]string) (*client.Request, error) {
+func (a *Api) createRequest(componentId string, projectId string, requestBody map[string]string) (*client.Request, error) {
 	// Create request
 	result := make(map[string]string)
 	request := a.
@@ -62,7 +75,7 @@ func (a *EncryptionApi) createRequest(componentId string, projectId string, requ
 	return request, nil
 }
 
-func (a *EncryptionApi) EncryptMapValues(componentId string, projectId string, mapValues map[string]string) (map[string]string, error) {
+func (a *Api) EncryptMapValues(componentId string, projectId string, mapValues map[string]string) (map[string]string, error) {
 	request, err := a.createRequest(componentId, projectId, mapValues)
 	if err != nil {
 		return nil, err

--- a/src/encryption/api_test.go
+++ b/src/encryption/api_test.go
@@ -19,3 +19,12 @@ func TestNewEncryptionApi(t *testing.T) {
 	assert.NotNil(t, encryptedMap)
 	assert.True(t, isEncrypted(encryptedMap["#keyToEncrypt"]))
 }
+
+func TestErrorEncryptionApi(t *testing.T) {
+	logger, _ := utils.NewDebugLogger()
+	mapToEncrypt := map[string]string{"#keyToEncrypt": "value"}
+	a := NewEncryptionApi("connection.keboola.com", context.Background(), logger, false)
+	_, err := a.EncryptMapValues("", "", mapToEncrypt)
+	assert.NotNil(t, err)
+	assert.Contains(t, err.Error(), "The componentId parameter is required")
+}

--- a/src/encryption/api_test.go
+++ b/src/encryption/api_test.go
@@ -28,3 +28,9 @@ func TestErrorEncryptionApi(t *testing.T) {
 	assert.NotNil(t, err)
 	assert.Contains(t, err.Error(), "The componentId parameter is required")
 }
+
+func TestGetEncryptionApiHost(t *testing.T) {
+	assert.Equal(t, getEncryptionApiHost("connection.keboola.com"), "encryption.keboola.com")
+	assert.Equal(t, getEncryptionApiHost("connection.east-us-1.azure.keboola-testing.com"), "encryption.east-us-1.azure.keboola-testing.com")
+
+}

--- a/src/encryption/api_test.go
+++ b/src/encryption/api_test.go
@@ -12,7 +12,7 @@ func TestNewEncryptionApi(t *testing.T) {
 	logger, _ := utils.NewDebugLogger()
 	a := NewEncryptionApi("connection.keboola.com", context.Background(), logger, true)
 	assert.NotNil(t, a)
-	assert.Equal(t, "encryption.keboola.com", a.apiHost)
+	assert.Equal(t, "https://encryption.keboola.com", a.apiHostUrl)
 	mapToEncrypt := map[string]string{"#keyToEncrypt": "value"}
 	encryptedMap, err := a.EncryptMapValues("keboola.ex-generic-v2", "1234", mapToEncrypt)
 	assert.Nil(t, err)
@@ -27,10 +27,4 @@ func TestErrorEncryptionApi(t *testing.T) {
 	_, err := a.EncryptMapValues("", "", mapToEncrypt)
 	assert.NotNil(t, err)
 	assert.Contains(t, err.Error(), "The componentId parameter is required")
-}
-
-func TestGetEncryptionApiHost(t *testing.T) {
-	assert.Equal(t, getEncryptionApiHost("connection.keboola.com"), "encryption.keboola.com")
-	assert.Equal(t, getEncryptionApiHost("connection.east-us-1.azure.keboola-testing.com"), "encryption.east-us-1.azure.keboola-testing.com")
-
 }

--- a/src/encryption/api_test.go
+++ b/src/encryption/api_test.go
@@ -2,7 +2,6 @@ package encryption
 
 import (
 	"context"
-	"fmt"
 	"keboola-as-code/src/utils"
 	"testing"
 
@@ -15,10 +14,8 @@ func TestNewEncryptionApi(t *testing.T) {
 	assert.NotNil(t, a)
 	assert.Equal(t, "encryption.keboola.com", a.apiHost)
 	mapToEncrypt := map[string]string{"#keyToEncrypt": "value"}
-
 	encryptedMap, err := a.EncryptMapValues("keboola.ex-generic-v2", "1234", mapToEncrypt)
-	fmt.Println(err.Error())
 	assert.Nil(t, err)
 	assert.NotNil(t, encryptedMap)
-	assert.True(t, isValueEncrypted(encryptedMap["#keyToEncrypt"]))
+	assert.True(t, isEncrypted(encryptedMap["#keyToEncrypt"]))
 }

--- a/src/encryption/api_test.go
+++ b/src/encryption/api_test.go
@@ -1,0 +1,24 @@
+package encryption
+
+import (
+	"context"
+	"fmt"
+	"keboola-as-code/src/utils"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+)
+
+func TestNewEncryptionApi(t *testing.T) {
+	logger, _ := utils.NewDebugLogger()
+	a := NewEncryptionApi("connection.keboola.com", context.Background(), logger, true)
+	assert.NotNil(t, a)
+	assert.Equal(t, "encryption.keboola.com", a.apiHost)
+	mapToEncrypt := map[string]string{"#keyToEncrypt": "value"}
+
+	encryptedMap, err := a.EncryptMapValues("keboola.ex-generic-v2", "1234", mapToEncrypt)
+	fmt.Println(err.Error())
+	assert.Nil(t, err)
+	assert.NotNil(t, encryptedMap)
+	assert.True(t, isValueEncrypted(encryptedMap["#keyToEncrypt"]))
+}

--- a/src/encryption/api_test.go
+++ b/src/encryption/api_test.go
@@ -10,9 +10,9 @@ import (
 
 func TestNewEncryptionApi(t *testing.T) {
 	logger, _ := utils.NewDebugLogger()
-	a := NewEncryptionApi("connection.keboola.com", context.Background(), logger, true)
+	a := NewEncryptionApi("https://encryption.keboola.com", context.Background(), logger, true)
 	assert.NotNil(t, a)
-	assert.Equal(t, "https://encryption.keboola.com", a.apiHostUrl)
+	assert.Equal(t, "https://encryption.keboola.com", a.hostUrl)
 	mapToEncrypt := map[string]string{"#keyToEncrypt": "value"}
 	encryptedMap, err := a.EncryptMapValues("keboola.ex-generic-v2", "1234", mapToEncrypt)
 	assert.Nil(t, err)
@@ -23,7 +23,7 @@ func TestNewEncryptionApi(t *testing.T) {
 func TestErrorEncryptionApi(t *testing.T) {
 	logger, _ := utils.NewDebugLogger()
 	mapToEncrypt := map[string]string{"#keyToEncrypt": "value"}
-	a := NewEncryptionApi("connection.keboola.com", context.Background(), logger, false)
+	a := NewEncryptionApi("https://encryption.keboola.com", context.Background(), logger, false)
 	_, err := a.EncryptMapValues("", "", mapToEncrypt)
 	assert.NotNil(t, err)
 	assert.Contains(t, err.Error(), "The componentId parameter is required")

--- a/src/remote/services.go
+++ b/src/remote/services.go
@@ -1,0 +1,29 @@
+package remote
+
+import (
+	"fmt"
+	"keboola-as-code/src/client"
+
+	"github.com/go-resty/resty/v2"
+)
+
+func (a *StorageApi) GetServices() ([]interface{}, error) {
+	request := a.GetServicesRequest()
+	response := request.Send().Response
+	if response.HasResult() {
+		storageIndex := *response.Result().(*map[string]interface{})
+		if services, ok := storageIndex["services"]; ok {
+			return services.([]interface{}), nil
+		} else {
+			return nil, fmt.Errorf("services array not found in Storage API index info: %v", storageIndex)
+		}
+	}
+	return nil, response.Err()
+}
+
+func (a *StorageApi) GetServicesRequest() *client.Request {
+	result := make(map[string]interface{})
+	return a.NewRequest(resty.MethodGet, "/").
+		SetQueryParam("exclude", "components").
+		SetResult(&result)
+}

--- a/src/remote/services.go
+++ b/src/remote/services.go
@@ -21,6 +21,24 @@ func (a *StorageApi) GetServices() ([]interface{}, error) {
 	return nil, response.Err()
 }
 
+func (a *StorageApi) GetEncryptionApiUrl() (string, error) {
+
+	services, err := a.GetServices()
+	if err != nil {
+		return "", err
+	}
+
+	for _, object := range services {
+		service := object.(map[string]interface{})
+		if service["id"] == "encryption" {
+			apiHost := service["url"]
+			return apiHost.(string), nil
+		}
+	}
+	return "", fmt.Errorf("encryption API not found in services from Storage API: \"%s\"", services)
+
+}
+
 func (a *StorageApi) GetServicesRequest() *client.Request {
 	result := make(map[string]interface{})
 	return a.NewRequest(resty.MethodGet, "/").

--- a/src/remote/services.go
+++ b/src/remote/services.go
@@ -31,8 +31,8 @@ func (a *StorageApi) GetEncryptionApiUrl() (string, error) {
 	for _, object := range services {
 		service := object.(map[string]interface{})
 		if service["id"] == "encryption" {
-			apiHost := service["url"]
-			return apiHost.(string), nil
+			url := service["url"]
+			return url.(string), nil
 		}
 	}
 	return "", fmt.Errorf("encryption API not found in services from Storage API: \"%s\"", services)

--- a/src/remote/services_test.go
+++ b/src/remote/services_test.go
@@ -1,0 +1,28 @@
+package remote
+
+import (
+	"context"
+	"fmt"
+	"keboola-as-code/src/utils"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+)
+
+func TestGetEncryptionApiUrl(t *testing.T) {
+	logger, _ := utils.NewDebugLogger()
+	api := NewStorageApi("connection.keboola.com", context.Background(), logger, false)
+	encryptionApiUrl, _ := api.GetEncryptionApiUrl()
+
+	assert.NotEmpty(t, encryptionApiUrl)
+	assert.Equal(t, encryptionApiUrl, "https://encryption.keboola.com")
+}
+
+func TestErrorGetEncryptionApiUrl(t *testing.T) {
+	logger, _ := utils.NewDebugLogger()
+	api := NewStorageApi("connection.foobar.keboola.com", context.Background(), logger, false)
+	_, err := api.GetEncryptionApiUrl()
+	fmt.Printf("%v", err)
+	assert.NotNil(t, err)
+	assert.Contains(t, err.Error(), "no such host")
+}


### PR DESCRIPTION
fixes https://keboola.atlassian.net/browse/SRE-2478
Cele som to tak nejak obkukal a zkopcil z ineho kodu(client.go, remote package..).
Vysledok je taky ze existuje funkcia `EncryptMapValues` ktora ma na vstupe mapu stringov a vrati mapu zasifrovanych stringov.