### PR TITLE
Components provider

### DIFF
--- a/src/components/provider.go
+++ b/src/components/provider.go
@@ -1,0 +1,71 @@
+package components
+
+import (
+	"fmt"
+	"keboola-as-code/src/model"
+	"sort"
+	"sync"
+)
+
+type remoteProvider interface {
+	GetComponent(componentId string) (*model.Component, error)
+}
+
+type Provider struct {
+	mutex          *sync.Mutex
+	remoteProvider remoteProvider
+	components     map[string]*model.Component
+}
+
+func NewProvider(remoteProvider remoteProvider) *Provider {
+	return &Provider{
+		mutex:          &sync.Mutex{},
+		remoteProvider: remoteProvider,
+		components:     make(map[string]*model.Component),
+	}
+}
+
+func (c *Provider) AllLoaded() []*model.Component {
+	var components []*model.Component
+	for _, c := range c.components {
+		components = append(components, c)
+	}
+	sort.SliceStable(components, func(i, j int) bool {
+		return components[i].Id < components[j].Id
+	})
+	return components
+}
+
+func (c *Provider) Get(key model.ComponentKey) (*model.Component, error) {
+	// Load component from cache if present
+	if component, found := c.doGet(key); found {
+		return component, nil
+	}
+
+	// Or by API
+	if component, err := c.remoteProvider.GetComponent(key.Id); err == nil {
+		return component, nil
+	} else {
+		return nil, err
+	}
+}
+
+func (c *Provider) Set(component *model.Component) {
+	if component == nil {
+		panic(fmt.Errorf("component is not set"))
+	}
+	c.doSet(component)
+}
+
+func (c *Provider) doGet(key model.ComponentKey) (*model.Component, bool) {
+	c.mutex.Lock()
+	defer c.mutex.Unlock()
+	component, found := c.components[key.String()]
+	return component, found
+}
+
+func (c *Provider) doSet(component *model.Component) {
+	c.mutex.Lock()
+	defer c.mutex.Unlock()
+	c.components[component.String()] = component
+}

--- a/src/local/delete_test.go
+++ b/src/local/delete_test.go
@@ -2,8 +2,8 @@ package local
 
 import (
 	"github.com/stretchr/testify/assert"
+	"keboola-as-code/src/components"
 	"keboola-as-code/src/manifest"
-	"keboola-as-code/src/remote"
 	"keboola-as-code/src/utils"
 	"os"
 	"path/filepath"
@@ -18,8 +18,7 @@ func TestLocalDeleteModel(t *testing.T) {
 	logger, _ := utils.NewDebugLogger()
 	m, err := manifest.NewManifest(1, "connection.keboola.com", projectDir, metadataDir)
 	assert.NoError(t, err)
-	api, _ := remote.TestMockedStorageApi(t)
-	manager := NewManager(logger, m, api)
+	manager := NewManager(logger, m, components.NewProvider(nil))
 
 	metaFile := `{
   "myKey": "3",
@@ -60,8 +59,7 @@ func TestDeleteEmptyDirectories(t *testing.T) {
 	logger, _ := utils.NewDebugLogger()
 	m, err := manifest.NewManifest(1, "connection.keboola.com", projectDir, metadataDir)
 	assert.NoError(t, err)
-	api, _ := remote.TestMockedStorageApi(t)
-	manager := NewManager(logger, m, api)
+	manager := NewManager(logger, m, components.NewProvider(nil))
 
 	// Create empty hidden dir
 	assert.NoError(t, os.MkdirAll(filepath.Join(projectDir, `.hidden`), 0755))

--- a/src/local/load_test.go
+++ b/src/local/load_test.go
@@ -2,8 +2,8 @@ package local
 
 import (
 	"github.com/stretchr/testify/assert"
+	"keboola-as-code/src/components"
 	"keboola-as-code/src/manifest"
-	"keboola-as-code/src/remote"
 	"keboola-as-code/src/utils"
 	"os"
 	"path/filepath"
@@ -17,8 +17,7 @@ func TestLocalLoadModel(t *testing.T) {
 	logger, _ := utils.NewDebugLogger()
 	m, err := manifest.NewManifest(12345, "connection.keboola.com", projectDir, metadataDir)
 	assert.NoError(t, err)
-	api, _ := remote.TestMockedStorageApi(t)
-	manager := NewManager(logger, m, api)
+	manager := NewManager(logger, m, components.NewProvider(nil))
 
 	metaFile := `{
   "myKey": "3",
@@ -60,8 +59,7 @@ func TestLocalLoadModelNotFound(t *testing.T) {
 	logger, _ := utils.NewDebugLogger()
 	m, err := manifest.NewManifest(12345, "connection.keboola.com", projectDir, metadataDir)
 	assert.NoError(t, err)
-	api, _ := remote.TestMockedStorageApi(t)
-	manager := NewManager(logger, m, api)
+	manager := NewManager(logger, m, components.NewProvider(nil))
 
 	// Save files
 	target := &ModelStruct{}

--- a/src/local/manager.go
+++ b/src/local/manager.go
@@ -2,22 +2,22 @@ package local
 
 import (
 	"go.uber.org/zap"
+	"keboola-as-code/src/components"
 	"keboola-as-code/src/manifest"
 	"keboola-as-code/src/model"
-	"keboola-as-code/src/remote"
 )
 
 type Manager struct {
-	logger   *zap.SugaredLogger
-	manifest *manifest.Manifest
-	api      *remote.StorageApi
+	logger     *zap.SugaredLogger
+	manifest   *manifest.Manifest
+	components *components.Provider
 }
 
-func NewManager(logger *zap.SugaredLogger, m *manifest.Manifest, api *remote.StorageApi) *Manager {
+func NewManager(logger *zap.SugaredLogger, m *manifest.Manifest, components *components.Provider) *Manager {
 	return &Manager{
-		logger:   logger,
-		manifest: m,
-		api:      api,
+		logger:     logger,
+		manifest:   m,
+		components: components,
 	}
 }
 
@@ -31,7 +31,7 @@ func (m *Manager) Naming() *model.Naming {
 
 func (m *Manager) isTransformationConfig(object interface{}) (bool, error) {
 	if v, ok := object.(*model.Config); ok {
-		if component, err := m.api.Components().Get(*v.ComponentKey()); err == nil {
+		if component, err := m.components.Get(*v.ComponentKey()); err == nil {
 			return component.IsTransformation(), nil
 		} else {
 			return false, err

--- a/src/local/save_test.go
+++ b/src/local/save_test.go
@@ -2,8 +2,8 @@ package local
 
 import (
 	"github.com/stretchr/testify/assert"
+	"keboola-as-code/src/components"
 	"keboola-as-code/src/manifest"
-	"keboola-as-code/src/remote"
 	"keboola-as-code/src/utils"
 	"os"
 	"path/filepath"
@@ -18,8 +18,7 @@ func TestLocalSaveModel(t *testing.T) {
 	logger, _ := utils.NewDebugLogger()
 	m, err := manifest.NewManifest(1, "connection.keboola.com", projectDir, metadataDir)
 	assert.NoError(t, err)
-	api, _ := remote.TestMockedStorageApi(t)
-	manager := NewManager(logger, m, api)
+	manager := NewManager(logger, m, components.NewProvider(nil))
 
 	config := utils.NewOrderedMap()
 	config.Set("foo", "bar")

--- a/src/remote/api.go
+++ b/src/remote/api.go
@@ -5,6 +5,7 @@ import (
 	"fmt"
 	"go.uber.org/zap"
 	"keboola-as-code/src/client"
+	"keboola-as-code/src/components"
 	"keboola-as-code/src/model"
 	"keboola-as-code/src/options"
 	"keboola-as-code/src/utils"
@@ -17,7 +18,7 @@ type StorageApi struct {
 	client     *client.Client
 	logger     *zap.SugaredLogger
 	token      *model.Token
-	components *ComponentsCache
+	components *components.Provider
 }
 
 func NewStorageApiFromOptions(options *options.Options, ctx context.Context, logger *zap.SugaredLogger) (*StorageApi, error) {
@@ -51,11 +52,11 @@ func NewStorageApi(apiHost string, ctx context.Context, logger *zap.SugaredLogge
 	c := client.NewClient(ctx, logger, verbose).WithHostUrl(apiHostUrl)
 	c.SetError(&Error{})
 	api := &StorageApi{client: c, logger: logger, apiHost: apiHost, apiHostUrl: apiHostUrl}
-	api.components = NewComponentCache(api)
+	api.components = components.NewProvider(api)
 	return api
 }
 
-func (a *StorageApi) Components() *ComponentsCache {
+func (a *StorageApi) Components() *components.Provider {
 	return a.components
 }
 

--- a/src/remote/component.go
+++ b/src/remote/component.go
@@ -1,12 +1,9 @@
 package remote
 
 import (
-	"fmt"
 	"github.com/go-resty/resty/v2"
 	"keboola-as-code/src/client"
 	"keboola-as-code/src/model"
-	"sort"
-	"sync"
 )
 
 func (a *StorageApi) GetComponent(componentId string) (*model.Component, error) {
@@ -28,63 +25,4 @@ func (a *StorageApi) GetComponentRequest(componentId string) *client.Request {
 		OnSuccess(func(response *client.Response) {
 			a.Components().Set(component)
 		})
-}
-
-type ComponentsCache struct {
-	mutex      *sync.Mutex
-	api        *StorageApi
-	components map[string]*model.Component
-}
-
-func NewComponentCache(api *StorageApi) *ComponentsCache {
-	return &ComponentsCache{
-		mutex:      &sync.Mutex{},
-		api:        api,
-		components: make(map[string]*model.Component),
-	}
-}
-
-func (c *ComponentsCache) AllLoaded() []*model.Component {
-	var components []*model.Component
-	for _, c := range c.components {
-		components = append(components, c)
-	}
-	sort.SliceStable(components, func(i, j int) bool {
-		return components[i].Id < components[j].Id
-	})
-	return components
-}
-
-func (c *ComponentsCache) Get(key model.ComponentKey) (*model.Component, error) {
-	// Load component from cache if present
-	if component, found := c.doGet(key); found {
-		return component, nil
-	}
-
-	// Or by API
-	if component, err := c.api.GetComponent(key.Id); err == nil {
-		return component, nil
-	} else {
-		return nil, err
-	}
-}
-
-func (c *ComponentsCache) Set(component *model.Component) {
-	if component == nil {
-		panic(fmt.Errorf("component is not set"))
-	}
-	c.doSet(component)
-}
-
-func (c *ComponentsCache) doGet(key model.ComponentKey) (*model.Component, bool) {
-	c.mutex.Lock()
-	defer c.mutex.Unlock()
-	component, found := c.components[key.String()]
-	return component, found
-}
-
-func (c *ComponentsCache) doSet(component *model.Component) {
-	c.mutex.Lock()
-	defer c.mutex.Unlock()
-	c.components[component.String()] = component
 }

--- a/src/state/state.go
+++ b/src/state/state.go
@@ -81,7 +81,7 @@ func newState(options *Options) *State {
 		localErrors:  utils.NewMultiError(),
 		objects:      utils.NewOrderedMap(),
 	}
-	s.localManager = local.NewManager(options.logger, options.manifest, s.api)
+	s.localManager = local.NewManager(options.logger, options.manifest, s.api.Components())
 	s.paths = NewPathsState(s.manifest.ProjectDir, s.localErrors)
 	return s
 }

--- a/src/state/state.go
+++ b/src/state/state.go
@@ -5,6 +5,7 @@ import (
 	"fmt"
 	"github.com/iancoleman/orderedmap"
 	"go.uber.org/zap"
+	"keboola-as-code/src/components"
 	"keboola-as-code/src/local"
 	"keboola-as-code/src/manifest"
 	"keboola-as-code/src/model"
@@ -97,7 +98,7 @@ func (s *State) Naming() *model.Naming {
 	return s.manifest.Naming
 }
 
-func (s *State) Components() *remote.ComponentsCache {
+func (s *State) Components() *components.Provider {
 	return s.api.Components()
 }
 

--- a/src/state/state.go
+++ b/src/state/state.go
@@ -249,6 +249,9 @@ func (s *State) SetLocalState(local model.Object, record model.Record) model.Obj
 }
 
 func (s *State) getOrCreate(key model.Key) (model.ObjectState, error) {
+	s.mutex.Lock()
+	defer s.mutex.Unlock()
+
 	if v, ok := s.objects.Get(key.String()); ok {
 		// Get
 		return v.(model.ObjectState), nil


### PR DESCRIPTION
Changes:
- created `components.Provider`
- removed hard dependency of the `local` package on the `remote.StorageApi` ... instead of the API, `local` package now depends on the `components.Provider`.