### PR TITLE
HTTP pool: fix too many requests problem

### DIFF
--- a/src/client/client.go
+++ b/src/client/client.go
@@ -23,7 +23,7 @@ const (
 	ResponseHeaderTimeout = 20 * time.Second
 	ExpectContinueTimeout = 2 * time.Second
 	KeepAlive             = 20 * time.Second
-	MaxIdleConns          = 64
+	MaxIdleConns          = 32
 	RetryCount            = 5
 	RetryWaitTime         = 100 * time.Millisecond
 	RetryWaitTimeMax      = 3 * time.Second

--- a/src/client/pool.go
+++ b/src/client/pool.go
@@ -27,7 +27,7 @@ type Pool struct {
 	activeRequests      sync.WaitGroup     // detect when all requests are processed (count of the requests = count of the processed responses)
 	sendersCount        int                // number of parallel http connections -> value of MaxIdleConns
 	processorsCount     int                // number of processors workers -> number of CPUs
-	requestsQueuedCount *utils.SafeCounter // number of send requests
+	requestsQueuedCount *utils.SafeCounter // number of total queued requests
 	requestsSendCount   *utils.SafeCounter // number of send requests
 	requests            []*Request         // to check that the Send () method has been called on all requests
 	requestsLock        *sync.Mutex        // lock for access to requests slice
@@ -87,7 +87,6 @@ func (p *Pool) Send(request *Request) {
 }
 
 func (p *Pool) StartAndWait() error {
-	p.startTime = time.Now()
 	p.start()
 	err := p.wait()
 	if err == nil {
@@ -109,6 +108,7 @@ func (p *Pool) start() {
 		panic(fmt.Errorf(`Pool has been already started.`))
 	}
 	p.started = true
+	p.startTime = time.Now()
 
 	// Work is done -> all responses are processed
 	go func() {


### PR DESCRIPTION
Jira: https://keboola.atlassian.net/browse/COM-1101

Changes:
- Limit of the queued requests in HTTP pool `100` -> `10 000`.
- Limit is checked on `Send`. No deadlock.