### PR TITLE
HTTP pool: fix data race

### DIFF
--- a/src/client/client.go
+++ b/src/client/client.go
@@ -62,16 +62,11 @@ func (c *Client) GetRestyClient() *resty.Client {
 
 func (c *Client) Send(request *Request) {
 	// Sent
-	request.lock.Lock()
-	request.sent = true
-	request.lock.Unlock()
+	request.MarkSent()
 	restyResponse, err := request.Request.Send()
 
 	// Done
-	request.lock.Lock()
-	request.Response = NewResponse(request, restyResponse, err)
-	request.done = true
-	request.lock.Unlock()
+	request.MarkDone(NewResponse(request, restyResponse, err))
 
 	// Listeners
 	request.invokeListeners()

--- a/src/client/request.go
+++ b/src/client/request.go
@@ -87,11 +87,28 @@ func (r *Request) Send() *Request {
 	return r
 }
 
+func (r *Request) MarkSent() {
+	r.lock.Lock()
+	r.sent = true
+	r.lock.Unlock()
+}
+
 func (r *Request) IsSent() bool {
+	r.lock.Lock()
+	defer r.lock.Unlock()
 	return r.sent
 }
 
+func (r *Request) MarkDone(response *Response) {
+	r.lock.Lock()
+	r.Response = response
+	r.done = true
+	r.lock.Unlock()
+}
+
 func (r *Request) IsDone() bool {
+	r.lock.Lock()
+	defer r.lock.Unlock()
 	return r.done
 }
 
@@ -136,7 +153,7 @@ func (r *Request) isWaiting() bool {
 	r.lock.Lock()
 	defer r.lock.Unlock()
 	for _, subRequest := range r.waitingFor {
-		if !subRequest.done {
+		if !subRequest.IsDone() {
 			return true
 		}
 	}


### PR DESCRIPTION
Vsimol som si, ze padol tento test na data race:
- https://github.com/keboola/keboola-as-code/runs/3260813649
- ![image](https://user-images.githubusercontent.com/19371734/131850519-7c880914-c6cc-4e62-8d8e-81dff3c72c35.png)

Bohuzial, neda sa to dopredu v Go zvalidovat, ze taka chyba v kode nie je.