### PR TITLE
Install goreleaser as stati binnary

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,8 +1,7 @@
 FROM golang:1.17-buster
 
-RUN echo 'deb [trusted=yes] https://repo.goreleaser.com/apt/ /' | tee /etc/apt/sources.list.d/goreleaser.list
 RUN apt-get update -y && \
-    apt-get install -y jq time zip git binutils-common goreleaser
+    apt-get install -y jq time zip git binutils-common
 
 ENV HOME=/tmp/home
 ENV GOPATH=/tmp/go
@@ -18,6 +17,13 @@ RUN curl --silent "https://api.github.com/repos/kyoh86/richgo/releases/latest" |
 
 # Install linter
 RUN curl -sSfL https://raw.githubusercontent.com/golangci/golangci-lint/master/install.sh | sh -s -- -b /usr/local/bin v1.42.0
+
+# Install goreleaser
+RUN curl --silent "https://api.github.com/repos/goreleaser/goreleaser/releases/latest" | \
+    jq -r '.assets[] | select(.name | endswith("Linux_x86_64.tar.gz")).browser_download_url' | \
+    wget -i - -O - | \
+    tar -xz -C /usr/local/bin goreleaser && \
+    chmod +x /usr/local/bin/goreleaser
 
 RUN rm -rf /tmp/* && \
     mkdir -p /tmp/home && \


### PR DESCRIPTION
Vsimol som si, ze `goreleaser` balicke zo sebou zbytocne stiahne `go1.11`:
![image](https://user-images.githubusercontent.com/19371734/131975282-8b6ccb54-1098-46f3-bcd9-bcee0c0550de.png)
- je to zbytocne, spomaluje to build
- a moze byt z toho aj nejaky problem, ked su v kontajnery 2 verzie GO.
- preto to stahujem ako staticku binarku