### PR TITLE
Run compile parallel

### DIFF
--- a/.github/actions/load-build-cache/action.yml
+++ b/.github/actions/load-build-cache/action.yml
@@ -1,0 +1,15 @@
+name: 'Load build cache'
+description: 'Load build cache'
+runs:
+  using: "composite"
+  steps:
+    - name: Create directory
+      run: mkdir -p /tmp/go-cache
+      shell: bash
+    - uses: actions/download-artifact@v2
+      with:
+        name: build-cache
+        path: /tmp
+    - name: Unzip build cache
+      run: unzip -q /tmp/go-cache.zip -d /
+      shell: bash

--- a/.github/actions/load-image/action.yml
+++ b/.github/actions/load-image/action.yml
@@ -1,0 +1,13 @@
+name: 'Load Docker image'
+description: 'Load Docker image'
+runs:
+  using: "composite"
+  steps:
+    - name: Docker login
+      run: docker login --username "$DOCKERHUB_USER" --password "$DOCKERHUB_TOKEN"
+      shell: bash
+    - name: Pull image
+      run: |
+        docker pull ${{ env.IMAGE }}:$IMAGE_TAG
+        docker tag ${{ env.IMAGE }}:$IMAGE_TAG ${{ env.IMAGE }}:latest
+      shell: bash

--- a/.github/workflows/push.yml
+++ b/.github/workflows/push.yml
@@ -1,6 +1,15 @@
 name: GitHub Actions
 on: [ push ]
 env:
+  # Dev docker image, must be same as in docker-compose.yml
+  IMAGE: keboolabot/keboola-as-code-dev
+  IMAGE_TAG: ${{ github.sha }}
+
+  # DockerHub login
+  DOCKERHUB_USER: "keboolabot"
+  DOCKERHUB_TOKEN: ${{ secrets.DOCKERHUB_TOKEN }}
+
+  # Test project in KBC
   TEST_PROJECT_ID: 8614
   TEST_PROJECT_NAME: keboola-as-code-tests
   TEST_KBC_STORAGE_API_HOST: connection.keboola.com
@@ -8,7 +17,60 @@ env:
   TEST_KBC_STORAGE_API_TOKEN_MASTER: ${{ secrets.TEST_KBC_STORAGE_API_TOKEN_MASTER }}
   TEST_KBC_STORAGE_API_TOKEN_EXPIRED: ${{ secrets.TEST_KBC_STORAGE_API_TOKEN_EXPIRED }}
 jobs:
-  Build:
+  set_version:
+    runs-on: ubuntu-latest
+    outputs:
+      tag: ${{ steps.set_version.outputs.tag }}
+      is_semantic_tag: ${{ steps.set_version.outputs.is_semantic_tag }}
+      version: ${{ steps.set_version.outputs.version }}
+    steps:
+      - name: Set version
+        id: set_version
+        run: |
+          TAG="${GITHUB_REF##*/}"
+          IS_SEMANTIC_TAG=$(echo "$TAG" | grep -q '^v\?[0-9]\+\.[0-9]\+\.[0-9]\+$' && echo true || echo false)
+          if [[ "${GITHUB_REF}" == refs/tags/* ]];
+          then
+            export TARGET_VERSION=${GITHUB_REF/refs\/tags\//}
+          else
+            export TARGET_VERSION="dev"
+          fi
+          echo "Tag = '$TAG', is semantic tag = '$IS_SEMANTIC_TAG', target version = '$TARGET_VERSION'"
+          echo "::set-output name=tag::$TAG"
+          echo "::set-output name=is_semantic_tag::$IS_SEMANTIC_TAG"
+          echo "::set-output name=version::$TARGET_VERSION"
+
+  build_image:
+    needs:
+      - set_version
+    runs-on: ubuntu-latest
+    steps:
+      -
+        name: Check out the repo
+        uses: actions/checkout@v2
+      -
+        name: Set up Docker Buildx
+        uses: docker/setup-buildx-action@v1
+      -
+        name: Login to DockerHub
+        uses: docker/login-action@v1
+        with:
+          username: ${{ env.DOCKERHUB_USER }}
+          password: ${{ env.DOCKERHUB_TOKEN }}
+      -
+        name: Build and push
+        id: docker_build
+        uses: docker/build-push-action@v2
+        with:
+          push: true
+          tags: ${{ env.IMAGE }}:${{ env.IMAGE_TAG }}
+          cache-from: type=registry,ref=${{ env.IMAGE }}:buildcache
+          cache-to: type=registry,ref=${{ env.IMAGE }}:buildcache,mode=max
+
+  tests:
+    needs:
+      - set_version
+      - build_image
     # only one parallel job allowed - used shared testing project
     concurrency:
       group: ci
@@ -17,31 +79,58 @@ jobs:
     steps:
       - name: Check out the repo
         uses: actions/checkout@v2
-      - name: Print Docker version
-        run: |
-          docker -v
-      - name: Set version
-        run: |
-          if [[ "${GITHUB_REF}" == refs/tags/* ]];
-          then
-            export TARGET_VERSION=${GITHUB_REF/refs\/tags\//}
-          else
-            export TARGET_VERSION="dev"
-          fi
-          echo ${TARGET_VERSION}
-          echo "TARGET_VERSION=${TARGET_VERSION}" >> $GITHUB_ENV
-      - name: Build dev Docker image
-        run: |
-          docker-compose build
+      - name: Load Docker image
+        uses: ./.github/actions/load-image
       - name: Tests
-        run: |
-          docker-compose run --rm -u "$UID:$GID" dev make ci
-      - name: Compile
-        run: |
-          docker-compose run --rm -u "$UID:$GID" dev make build
-      - name: Compile and Release
-        if: startsWith(github.ref, 'refs/tags/')
-        run: |
-          docker-compose run --rm -u "$UID:$GID" -e GITHUB_TOKEN -e TARGET_VERSION dev make release
+        run: docker-compose run --rm -u "$UID:$GID" -e TARGET_VERSION dev make ci
         env:
+          TARGET_VERSION: ${{ needs.set_version.outputs.version }}
+
+  cross-compile:
+    needs:
+      - set_version
+      - build_image
+    runs-on: ubuntu-latest
+    steps:
+      - name: Check out the repo
+        uses: actions/checkout@v2
+      - name: Load Docker image
+        uses: ./.github/actions/load-image
+      - name: Cross compile
+        run: |
+          mkdir -p /tmp/go-cache
+          docker-compose run --rm -u "$UID:$GID" -e TARGET_VERSION -v /tmp/go-cache:/tmp/go-cache dev make build
+        env:
+          TARGET_VERSION: ${{ needs.set_version.outputs.version }}
+      - name: Zip build cache
+        #if: startsWith(github.ref, 'refs/tags/') && needs.set_version.outputs.is_semantic_tag == 'true'
+        run: zip -q -4 -r /tmp/go-cache.zip /tmp/go-cache
+      - name: Upload build cache
+        #if: startsWith(github.ref, 'refs/tags/') && needs.set_version.outputs.is_semantic_tag == 'true'
+        uses: actions/upload-artifact@v2
+        with:
+          name: build-cache
+          path: /tmp/go-cache.zip
+          retention-days: 1
+
+  release:
+    needs:
+      - set_version
+      - build_image
+      - tests
+      - cross-compile
+    runs-on: ubuntu-latest
+    #if: startsWith(github.ref, 'refs/tags/') && needs.set_version.outputs.is_semantic_tag == 'true'
+    steps:
+      - name: Check out the repo
+        uses: actions/checkout@v2
+      - name: Load Docker image
+        uses: ./.github/actions/load-image
+      - name: Load build cache
+        continue-on-error: true
+        uses: ./.github/actions/load-build-cache
+      - name: Release
+        run: docker-compose run --rm -u "$UID:$GID" -e GITHUB_TOKEN -e TARGET_VERSION -v /tmp/go-cache:/tmp/go-cache dev make release-local
+        env:
+          TARGET_VERSION: ${{ needs.set_version.outputs.version }}
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}

--- a/.github/workflows/push.yml
+++ b/.github/workflows/push.yml
@@ -103,10 +103,10 @@ jobs:
         env:
           TARGET_VERSION: ${{ needs.set_version.outputs.version }}
       - name: Zip build cache
-        #if: startsWith(github.ref, 'refs/tags/') && needs.set_version.outputs.is_semantic_tag == 'true'
+        if: startsWith(github.ref, 'refs/tags/') && needs.set_version.outputs.is_semantic_tag == 'true'
         run: zip -q -4 -r /tmp/go-cache.zip /tmp/go-cache
       - name: Upload build cache
-        #if: startsWith(github.ref, 'refs/tags/') && needs.set_version.outputs.is_semantic_tag == 'true'
+        if: startsWith(github.ref, 'refs/tags/') && needs.set_version.outputs.is_semantic_tag == 'true'
         uses: actions/upload-artifact@v2
         with:
           name: build-cache
@@ -120,7 +120,7 @@ jobs:
       - tests
       - cross-compile
     runs-on: ubuntu-latest
-    #if: startsWith(github.ref, 'refs/tags/') && needs.set_version.outputs.is_semantic_tag == 'true'
+    if: startsWith(github.ref, 'refs/tags/') && needs.set_version.outputs.is_semantic_tag == 'true'
     steps:
       - name: Check out the repo
         uses: actions/checkout@v2
@@ -130,7 +130,7 @@ jobs:
         continue-on-error: true
         uses: ./.github/actions/load-build-cache
       - name: Release
-        run: docker-compose run --rm -u "$UID:$GID" -e GITHUB_TOKEN -e TARGET_VERSION -v /tmp/go-cache:/tmp/go-cache dev make release-local
+        run: docker-compose run --rm -u "$UID:$GID" -e GITHUB_TOKEN -e TARGET_VERSION -v /tmp/go-cache:/tmp/go-cache dev make release
         env:
           TARGET_VERSION: ${{ needs.set_version.outputs.version }}
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}

--- a/Dockerfile
+++ b/Dockerfile
@@ -4,7 +4,7 @@ RUN apt-get update -y && \
     apt-get install -y jq time zip git binutils-common
 
 ENV HOME=/tmp/home
-ENV GOPATH=/tmp/go
+ENV GOPATH=/code/go
 ENV GOCACHE=/tmp/go-cache
 ENV GOBIN=/usr/local/bin
 

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,11 +1,10 @@
 version: '3'
 services:
   dev:
-    image: keboola/keboola-as-code-dev
+    image: keboolabot/keboola-as-code-dev
     build: .
     volumes:
       - ./:/code:z
-      - ./go:/go:z
     environment:
       - TEST_PROJECT_ID
       - TEST_PROJECT_NAME

--- a/src/remote/api_test.go
+++ b/src/remote/api_test.go
@@ -23,8 +23,8 @@ func TestHostnameNotFound(t *testing.T) {
 	token, err := api.GetToken("mytoken")
 	assert.Nil(t, token)
 	assert.Error(t, err)
-	assert.Contains(t, err.Error(), `Get "https://foo.bar.com/v2/storage/tokens/verify": dial tcp: lookup foo.bar.com: No address associated with hostname`)
-	assert.Regexp(t, `DEBUG  HTTP-ERROR\tGet "https://foo.bar.com/v2/storage/tokens/verify": dial tcp: lookup foo.bar.com: No address associated with hostname`, logs.String())
+	assert.Contains(t, err.Error(), `Get "https://foo.bar.com/v2/storage/tokens/verify": dial tcp`)
+	assert.Regexp(t, `DEBUG  HTTP-ERROR\tGet "https://foo.bar.com/v2/storage/tokens/verify": dial tcp`, logs.String())
 }
 
 func TestInvalidHost(t *testing.T) {


### PR DESCRIPTION
Spustenie kompilacie parallelne s testami, zrychli celkovy cas buildu:
![image](https://user-images.githubusercontent.com/19371734/131980874-0764cd39-3dea-4e39-b17b-2bc3786cf134.png)

----------------------------

Pridal som este:
- cachovanie Docker image (usetrenych ~45 sekund).
- build cache z `cross-compile` sa posiela do `release` jobu, ... a teda nemusi sa vsetko kompilovat znova (usetrene 3 minuty).
![image](https://user-images.githubusercontent.com/19371734/132009447-1c2d725a-6a3c-47bb-bdb0-e1ab2c643820.png)
