### PR TITLE
mac-os release to homebrew

### DIFF
--- a/.github/workflows/push.yml
+++ b/.github/workflows/push.yml
@@ -201,13 +201,33 @@ jobs:
           export AMD_TARGET_SHA256=$(ls release/signed/*darwin_amd64.zip | sha256sum | cut -f 1 -d ' ')
           envsubst < homebrew.template.rb > homebrew/keboola-as-code.rb
           cat homebrew/keboola-as-code.rb
+      - name: Upload homebrew formulae to artifacts
+        uses: actions/upload-artifact@v2
+        with:
+          name: homebrew
+          path: |
+            homebrew
+
+  release-homebrew:
+    needs:
+      - release-mac-os
+      #- tests
+    runs-on: ubuntu-latest
+    #if: startsWith(github.ref, 'refs/tags/') && needs.set_version.outputs.is_semantic_tag == 'true'
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v2
+      - name: Download Homebrew
+        uses: actions/download-artifact@v2
+        with:
+          name: homebrew
       - name: Push formulae to keboola/homebrew-tap repository
         uses: cpina/github-action-push-to-another-repository@main
         env:
           API_TOKEN_GITHUB: ${{ secrets.API_TOKEN_GITHUB }}
         with:
-          source-directory: 'homebrew'
-          destination-github-username: 'keboola'
-          destination-repository-name: 'homebrew-tap'
+          source-directory: "homebrew"
+          destination-github-username: "keboola"
+          destination-repository-name: "homebrew-tap"
           user-email: tomas.kacur@keboola.com
           target-branch: main

--- a/.github/workflows/push.yml
+++ b/.github/workflows/push.yml
@@ -171,6 +171,7 @@ jobs:
           brew tap mitchellh/gon
           brew install mitchellh/gon/gon
           brew install tree
+          brew install coreutils
           tree release
       - name: Sign the mac binaries with Gon
         env:

--- a/.github/workflows/push.yml
+++ b/.github/workflows/push.yml
@@ -173,17 +173,17 @@ jobs:
           brew install tree
           brew install coreutils
           tree release
-      # - name: Sign the mac binaries with Gon
-      #   env:
-      #     AC_USERNAME: ${{ secrets.AC_USERNAME }}
-      #     AC_PASSWORD: ${{ secrets.AC_PASSWORD }}
-      #   run: |
-      #     gon -log-level=info ./gon-amd64.json
-      #     gon -log-level=info ./gon-arm64.json
+      - name: Sign the mac binaries with Gon
+        env:
+          AC_USERNAME: ${{ secrets.AC_USERNAME }}
+          AC_PASSWORD: ${{ secrets.AC_PASSWORD }}
+        run: |
+          gon -log-level=info ./gon-amd64.json
+          gon -log-level=info ./gon-arm64.json
       - name: rename signed binaries
         run: |
-          echo "foobar" > release/signed/kbc_${{ needs.set_version.outputs.version }}_darwin_amd64.zip
-          echo "foobar" > release/signed/kbc_${{ needs.set_version.outputs.version }}_darwin_arm64.zip
+          mv release/signed/kbc-amd64.zip release/signed/kbc_${{ needs.set_version.outputs.version }}_darwin_amd64.zip
+          mv release/signed/kbc-arm64.zip release/signed/kbc_${{ needs.set_version.outputs.version }}_darwin_arm64.zip
       # - name: Upload binaries to release
       #   uses: svenstaro/upload-release-action@v2
       #   with:

--- a/.github/workflows/push.yml
+++ b/.github/workflows/push.yml
@@ -173,17 +173,17 @@ jobs:
           brew install tree
           brew install coreutils
           tree release
-      - name: Sign the mac binaries with Gon
-        env:
-          AC_USERNAME: ${{ secrets.AC_USERNAME }}
-          AC_PASSWORD: ${{ secrets.AC_PASSWORD }}
-        run: |
-          gon -log-level=info ./gon-amd64.json
-          gon -log-level=info ./gon-arm64.json
+      # - name: Sign the mac binaries with Gon
+      #   env:
+      #     AC_USERNAME: ${{ secrets.AC_USERNAME }}
+      #     AC_PASSWORD: ${{ secrets.AC_PASSWORD }}
+      #   run: |
+      #     gon -log-level=info ./gon-amd64.json
+      #     gon -log-level=info ./gon-arm64.json
       - name: rename signed binaries
         run: |
-          mv release/signed/kbc-amd64.zip release/signed/kbc_${{ needs.set_version.outputs.version }}_darwin_amd64.zip
-          mv release/signed/kbc-arm64.zip release/signed/kbc_${{ needs.set_version.outputs.version }}_darwin_arm64.zip
+          echo "foobar" > release/signed/kbc_${{ needs.set_version.outputs.version }}_darwin_amd64.zip
+          echo "foobar" > release/signed/kbc_${{ needs.set_version.outputs.version }}_darwin_arm64.zip
       # - name: Upload binaries to release
       #   uses: svenstaro/upload-release-action@v2
       #   with:

--- a/.github/workflows/push.yml
+++ b/.github/workflows/push.yml
@@ -224,7 +224,7 @@ jobs:
       - name: Push formulae to keboola/homebrew-tap repository
         uses: cpina/github-action-push-to-another-repository@main
         env:
-          API_TOKEN_GITHUB: ${{ secrets.API_TOKEN_GITHUB }}
+          API_TOKEN_GITHUB: ${{ secrets.GITHUB_TOKEN }}
         with:
           source-directory: "homebrew"
           destination-github-username: "keboola"

--- a/.github/workflows/push.yml
+++ b/.github/workflows/push.yml
@@ -190,7 +190,7 @@ jobs:
       #     repo_token: ${{ secrets.GITHUB_TOKEN }}
       #     file: release/signed/*
       #     tag: ${{ github.ref }}
-      #     overwrite: true
+      #     overwrite: false
       #     file_glob: true
       - name: create homebrew formulae
         env:
@@ -205,8 +205,7 @@ jobs:
         uses: actions/upload-artifact@v2
         with:
           name: homebrew
-          path: |
-            homebrew
+          path: homebrew
 
   release-homebrew:
     needs:
@@ -221,6 +220,7 @@ jobs:
         uses: actions/download-artifact@v2
         with:
           name: homebrew
+          path: homebrew
       - name: Push formulae to keboola/homebrew-tap repository
         uses: cpina/github-action-push-to-another-repository@main
         env:

--- a/.github/workflows/push.yml
+++ b/.github/workflows/push.yml
@@ -63,24 +63,24 @@ jobs:
           cache-from: type=registry,ref=${{ env.IMAGE }}:buildcache
           cache-to: type=registry,ref=${{ env.IMAGE }}:buildcache,mode=max
 
-  # tests:
-  #   needs:
-  #     - set_version
-  #     - build_image
-  #   # only one parallel job allowed - used shared testing project
-  #   concurrency:
-  #     group: ci
-  #     cancel-in-progress: false
-  #   runs-on: ubuntu-latest
-  #   steps:
-  #     - name: Check out the repo
-  #       uses: actions/checkout@v2
-  #     - name: Load Docker image
-  #       uses: ./.github/actions/load-image
-  #     - name: Tests
-  #       run: docker-compose run --rm -u "$UID:$GID" -e TARGET_VERSION dev make ci
-  #       env:
-  #         TARGET_VERSION: ${{ needs.set_version.outputs.version }}
+  tests:
+    needs:
+      - set_version
+      - build_image
+    # only one parallel job allowed - used shared testing project
+    concurrency:
+      group: ci
+      cancel-in-progress: false
+    runs-on: ubuntu-latest
+    steps:
+      - name: Check out the repo
+        uses: actions/checkout@v2
+      - name: Load Docker image
+        uses: ./.github/actions/load-image
+      - name: Tests
+        run: docker-compose run --rm -u "$UID:$GID" -e TARGET_VERSION dev make ci
+        env:
+          TARGET_VERSION: ${{ needs.set_version.outputs.version }}
 
   cross-compile:
     needs:
@@ -120,7 +120,7 @@ jobs:
     needs:
       - set_version
       - build_image
-      #- tests
+      - tests
       - cross-compile
     runs-on: ubuntu-latest
     if: startsWith(github.ref, 'refs/tags/') && needs.set_version.outputs.is_semantic_tag == 'true'
@@ -141,9 +141,9 @@ jobs:
     needs:
       - set_version
       - cross-compile
-      #- tests
+      - tests
     runs-on: macos-latest
-    #if: startsWith(github.ref, 'refs/tags/') && needs.set_version.outputs.is_semantic_tag == 'true'
+    if: startsWith(github.ref, 'refs/tags/') && needs.set_version.outputs.is_semantic_tag == 'true'
     steps:
       - name: Checkout
         uses: actions/checkout@v2
@@ -170,9 +170,7 @@ jobs:
         run: |
           brew tap mitchellh/gon
           brew install mitchellh/gon/gon
-          brew install tree
           brew install coreutils
-          tree release
       - name: Sign the mac binaries with Gon
         env:
           AC_USERNAME: ${{ secrets.AC_USERNAME }}
@@ -184,14 +182,14 @@ jobs:
         run: |
           mv release/signed/kbc-amd64.zip release/signed/kbc_${{ needs.set_version.outputs.version }}_darwin_amd64.zip
           mv release/signed/kbc-arm64.zip release/signed/kbc_${{ needs.set_version.outputs.version }}_darwin_arm64.zip
-      # - name: Upload binaries to release
-      #   uses: svenstaro/upload-release-action@v2
-      #   with:
-      #     repo_token: ${{ secrets.GITHUB_TOKEN }}
-      #     file: release/signed/*
-      #     tag: ${{ github.ref }}
-      #     overwrite: false
-      #     file_glob: true
+      - name: Upload binaries to release
+        uses: svenstaro/upload-release-action@v2
+        with:
+          repo_token: ${{ secrets.GITHUB_TOKEN }}
+          file: release/signed/*
+          tag: ${{ github.ref }}
+          overwrite: false
+          file_glob: true
       - name: create homebrew formulae
         env:
           TARGET_VERSION: ${{ needs.set_version.outputs.version }}
@@ -210,9 +208,8 @@ jobs:
   release-homebrew:
     needs:
       - release-mac-os
-      #- tests
     runs-on: ubuntu-latest
-    #if: startsWith(github.ref, 'refs/tags/') && needs.set_version.outputs.is_semantic_tag == 'true'
+    if: startsWith(github.ref, 'refs/tags/') && needs.set_version.outputs.is_semantic_tag == 'true'
     steps:
       - name: Checkout
         uses: actions/checkout@v2

--- a/.github/workflows/push.yml
+++ b/.github/workflows/push.yml
@@ -229,5 +229,4 @@ jobs:
           source-directory: "homebrew"
           destination-github-username: "keboola"
           destination-repository-name: "homebrew-tap"
-          user-email: tomas.kacur@keboola.com
           target-branch: main

--- a/.github/workflows/push.yml
+++ b/.github/workflows/push.yml
@@ -224,7 +224,7 @@ jobs:
       - name: Push formulae to keboola/homebrew-tap repository
         uses: cpina/github-action-push-to-another-repository@main
         env:
-          API_TOKEN_GITHUB: ${{ secrets.GITHUB_TOKEN }}
+          API_TOKEN_GITHUB: ${{ secrets.HOMEBREW_RELEASE_GITHUB_PERSONAL_ACCESS_TOKEN }}
         with:
           source-directory: "homebrew"
           destination-github-username: "keboola"

--- a/.github/workflows/push.yml
+++ b/.github/workflows/push.yml
@@ -143,7 +143,7 @@ jobs:
       - cross-compile
       - tests
     runs-on: macos-latest
-    if: startsWith(github.ref, 'refs/tags/') && needs.set_version.outputs.is_semantic_tag == 'true'
+    #if: startsWith(github.ref, 'refs/tags/') && needs.set_version.outputs.is_semantic_tag == 'true'
     steps:
       - name: Checkout
         uses: actions/checkout@v2
@@ -183,11 +183,20 @@ jobs:
         run: |
           mv release/signed/kbc-amd64.zip release/signed/kbc_${{ needs.set_version.outputs.version }}_darwin_amd64.zip
           mv release/signed/kbc-arm64.zip release/signed/kbc_${{ needs.set_version.outputs.version }}_darwin_arm64.zip
-      - name: Upload binaries to release
-        uses: svenstaro/upload-release-action@v2
-        with:
-          repo_token: ${{ secrets.GITHUB_TOKEN }}
-          file: release/signed/*
-          tag: ${{ github.ref }}
-          overwrite: true
-          file_glob: true
+      # - name: Upload binaries to release
+      #   uses: svenstaro/upload-release-action@v2
+      #   with:
+      #     repo_token: ${{ secrets.GITHUB_TOKEN }}
+      #     file: release/signed/*
+      #     tag: ${{ github.ref }}
+      #     overwrite: true
+      #     file_glob: true
+      - name: create homebrew formulae
+        env:
+          TARGET_VERSION: ${{ needs.set_version.outputs.version }}
+        run: |
+          mkdir homebrew
+          export ARM_TARGET_SHA256=$(ls release/signed/*darwin_arm64.zip | sha256sum | cut -f 1 -d ' ' )
+          export AMD_TARGET_SHA256=$(ls release/signed/*darwin_amd64.zip | sha256sum | cut -f 1 -d ' ')
+          envsubst < homebrew.template.rb > homebrew/keboola-as-code.rb
+          cat homebrew/keboola-as-code.rb

--- a/.github/workflows/push.yml
+++ b/.github/workflows/push.yml
@@ -63,24 +63,24 @@ jobs:
           cache-from: type=registry,ref=${{ env.IMAGE }}:buildcache
           cache-to: type=registry,ref=${{ env.IMAGE }}:buildcache,mode=max
 
-  tests:
-    needs:
-      - set_version
-      - build_image
-    # only one parallel job allowed - used shared testing project
-    concurrency:
-      group: ci
-      cancel-in-progress: false
-    runs-on: ubuntu-latest
-    steps:
-      - name: Check out the repo
-        uses: actions/checkout@v2
-      - name: Load Docker image
-        uses: ./.github/actions/load-image
-      - name: Tests
-        run: docker-compose run --rm -u "$UID:$GID" -e TARGET_VERSION dev make ci
-        env:
-          TARGET_VERSION: ${{ needs.set_version.outputs.version }}
+  # tests:
+  #   needs:
+  #     - set_version
+  #     - build_image
+  #   # only one parallel job allowed - used shared testing project
+  #   concurrency:
+  #     group: ci
+  #     cancel-in-progress: false
+  #   runs-on: ubuntu-latest
+  #   steps:
+  #     - name: Check out the repo
+  #       uses: actions/checkout@v2
+  #     - name: Load Docker image
+  #       uses: ./.github/actions/load-image
+  #     - name: Tests
+  #       run: docker-compose run --rm -u "$UID:$GID" -e TARGET_VERSION dev make ci
+  #       env:
+  #         TARGET_VERSION: ${{ needs.set_version.outputs.version }}
 
   cross-compile:
     needs:
@@ -120,7 +120,7 @@ jobs:
     needs:
       - set_version
       - build_image
-      - tests
+      #- tests
       - cross-compile
     runs-on: ubuntu-latest
     if: startsWith(github.ref, 'refs/tags/') && needs.set_version.outputs.is_semantic_tag == 'true'
@@ -141,7 +141,7 @@ jobs:
     needs:
       - set_version
       - cross-compile
-      - tests
+      #- tests
     runs-on: macos-latest
     #if: startsWith(github.ref, 'refs/tags/') && needs.set_version.outputs.is_semantic_tag == 'true'
     steps:

--- a/.github/workflows/push.yml
+++ b/.github/workflows/push.yml
@@ -178,8 +178,8 @@ jobs:
           AC_USERNAME: ${{ secrets.AC_USERNAME }}
           AC_PASSWORD: ${{ secrets.AC_PASSWORD }}
         run: |
-          gon -log-level=info -log-json ./gon-amd64.json
-          gon -log-level=info -log-json ./gon-arm64.json
+          gon -log-level=info ./gon-amd64.json
+          gon -log-level=info ./gon-arm64.json
       - name: rename signed binaries
         run: |
           mv release/signed/kbc-amd64.zip release/signed/kbc_${{ needs.set_version.outputs.version }}_darwin_amd64.zip

--- a/.github/workflows/push.yml
+++ b/.github/workflows/push.yml
@@ -188,7 +188,7 @@ jobs:
           repo_token: ${{ secrets.GITHUB_TOKEN }}
           file: release/signed/*
           tag: ${{ github.ref }}
-          overwrite: false
+          overwrite: true
           file_glob: true
       - name: create homebrew formulae
         env:

--- a/.github/workflows/push.yml
+++ b/.github/workflows/push.yml
@@ -201,3 +201,13 @@ jobs:
           export AMD_TARGET_SHA256=$(ls release/signed/*darwin_amd64.zip | sha256sum | cut -f 1 -d ' ')
           envsubst < homebrew.template.rb > homebrew/keboola-as-code.rb
           cat homebrew/keboola-as-code.rb
+      - name: Push formulae to keboola/homebrew-tap repository
+        uses: cpina/github-action-push-to-another-repository@main
+        env:
+          API_TOKEN_GITHUB: ${{ secrets.API_TOKEN_GITHUB }}
+        with:
+          source-directory: 'homebrew'
+          destination-github-username: 'keboola'
+          destination-repository-name: 'homebrew-tap'
+          user-email: tomas.kacur@keboola.com
+          target-branch: main

--- a/.goreleaser.yml
+++ b/.goreleaser.yml
@@ -3,7 +3,7 @@ dist: "target"
 builds:
   - main: "./src/main.go"
     binary: "kbc"
-    goos: ["linux", "windows"]
+    goos: ["linux", "windows", "darwin"]
     goarch: ["amd64", "arm", "arm64"]
     goarm: ["6"]
     env:
@@ -43,4 +43,3 @@ nfpms:
       - apk
       - deb
       - rpm
-

--- a/README.md
+++ b/README.md
@@ -11,10 +11,17 @@
 - Extract archive, eg. `unzip kbc-vx.x.x-linux_arm64.zip`.
 - Make binary executable, eg. `chmod +x ./kbc`.
 - Fix permissions on MacOS > v10.15:
-  - Binary as an macOS application is not yet signed and you may encounter error saying `“kbc” cannot be opened because it is from an unidentified developer.` 
+  - Binary as an macOS application is not yet signed and you may encounter error saying `“kbc” cannot be opened because it is from an unidentified developer.`
   - To fix the issue add the binary to the allowed applications by running the command: `spctl --add ./kbc`
 - Optionally move the binary to your [PATH](https://en.wikipedia.org/wiki/PATH_(variable)).
 - Run.
+### MacOS Homebrew
+Install cli via [homebrew](https://brew.sh/) as follows
+```
+brew tap keboola/homebrew-tap
+brew install keboola-as-code
+```
+After succesfull installation run cli via `kbc` command.
 
 ## Directory Structure
 

--- a/homebrew.template.rb
+++ b/homebrew.template.rb
@@ -1,0 +1,21 @@
+class KeboolaAsCode < Formula
+  desc "Keboola as Code cli tool"
+  homepage "https://github.com/keboola/keboola-as-code"
+  license "MIT"
+  bottle :unneeded
+
+  if OS.Mac? && Hardware::CPU.arm?
+    url "https://github.com/keboola/keboola-as-code/releases/download/v${TARGET_VERSION}/kbc_${TARGET_VERSION}_darwin_arm64.zip"
+    sha256 "${ARM_TARGET_SHA256}"
+  end
+  if OS.Mac? && Hardware::CPU.intel?
+        url "https://github.com/keboola/keboola-as-code/releases/download/v${TARGET_VERSION}/kbc_${TARGET_VERSION}_darwin_amd64.zip"
+    sha256 "${AMD_TARGET_SHA256}"
+  end
+
+  def install
+    bin.install "kbc"
+    bin.install_symlink Dir["#{libexec}/bin/*"]
+  end
+
+end

--- a/homebrew.template.rb
+++ b/homebrew.template.rb
@@ -4,11 +4,11 @@ class KeboolaAsCode < Formula
   license "MIT"
   bottle :unneeded
 
-  if OS.Mac? && Hardware::CPU.arm?
+  if OS.mac? && Hardware::CPU.arm?
     url "https://github.com/keboola/keboola-as-code/releases/download/v${TARGET_VERSION}/kbc_${TARGET_VERSION}_darwin_arm64.zip"
     sha256 "${ARM_TARGET_SHA256}"
   end
-  if OS.Mac? && Hardware::CPU.intel?
+  if OS.mac? && Hardware::CPU.intel?
         url "https://github.com/keboola/keboola-as-code/releases/download/v${TARGET_VERSION}/kbc_${TARGET_VERSION}_darwin_amd64.zip"
     sha256 "${AMD_TARGET_SHA256}"
   end


### PR DESCRIPTION
fixes https://keboola.atlassian.net/browse/SRE-2532
Tato uprava vytvara release mac os signed binarok do homebrew. 
Takze po release sa commitne nova verze homebrew formulae do https://github.com/keboola/homebrew-tap
potom staci nainstalovat:
```
brew tap keboola/homebrew-tap 
brew install keboola-as-code
```
a mal by fungovat command `kbc`.

### Testing builds
Build s celou pipelinou az po commit do https://github.com/keboola/homebrew-tap
https://github.com/keboola/keboola-as-code/actions/runs/1209114165
Netagovany build(preskoci release):
https://github.com/keboola/keboola-as-code/actions/runs/1209144335