### PR TITLE
homebrew linux release

### DIFF
--- a/.github/workflows/push.yml
+++ b/.github/workflows/push.yml
@@ -194,15 +194,6 @@ jobs:
           tag: ${{ github.ref }}
           overwrite: true
           file_glob: true
-      - name: create homebrew formulae
-        env:
-          TARGET_VERSION: ${{ needs.set_version.outputs.version }}
-        run: |
-          mkdir homebrew
-          export DARWIN_ARM_TARGET_SHA256=$(ls release/signed/*darwin_arm64.zip | sha256sum | cut -f 1 -d ' ' )
-          export DARWIN_AMD_TARGET_SHA256=$(ls release/signed/*darwin_amd64.zip | sha256sum | cut -f 1 -d ' ')
-          envsubst < homebrew.template.rb > homebrew/keboola-as-code.rb
-          cat homebrew/keboola-as-code.rb
       - name: Upload zipped files to artifacts
         uses: actions/upload-artifact@v2
         with:

--- a/.github/workflows/push.yml
+++ b/.github/workflows/push.yml
@@ -137,6 +137,11 @@ jobs:
         env:
           TARGET_VERSION: ${{ needs.set_version.outputs.version }}
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+      - name: Upload zipped files to artifacts
+        uses: actions/upload-artifact@v2
+        with:
+          name: linux
+          path: target/*linux*.zip
   release-mac-os:
     needs:
       - set_version
@@ -170,7 +175,6 @@ jobs:
         run: |
           brew tap mitchellh/gon
           brew install mitchellh/gon/gon
-          brew install coreutils
       - name: Sign the mac binaries with Gon
         env:
           AC_USERNAME: ${{ secrets.AC_USERNAME }}
@@ -195,29 +199,48 @@ jobs:
           TARGET_VERSION: ${{ needs.set_version.outputs.version }}
         run: |
           mkdir homebrew
-          export ARM_TARGET_SHA256=$(ls release/signed/*darwin_arm64.zip | sha256sum | cut -f 1 -d ' ' )
-          export AMD_TARGET_SHA256=$(ls release/signed/*darwin_amd64.zip | sha256sum | cut -f 1 -d ' ')
+          export DARWIN_ARM_TARGET_SHA256=$(ls release/signed/*darwin_arm64.zip | sha256sum | cut -f 1 -d ' ' )
+          export DARWIN_AMD_TARGET_SHA256=$(ls release/signed/*darwin_amd64.zip | sha256sum | cut -f 1 -d ' ')
           envsubst < homebrew.template.rb > homebrew/keboola-as-code.rb
           cat homebrew/keboola-as-code.rb
-      - name: Upload homebrew formulae to artifacts
+      - name: Upload zipped files to artifacts
         uses: actions/upload-artifact@v2
         with:
-          name: homebrew
-          path: homebrew
+          name: darwin
+          path: release/signed
 
   release-homebrew:
     needs:
+      - set_version
       - release-mac-os
+      - release
     runs-on: ubuntu-latest
     if: startsWith(github.ref, 'refs/tags/') && needs.set_version.outputs.is_semantic_tag == 'true'
     steps:
       - name: Checkout
         uses: actions/checkout@v2
-      - name: Download Homebrew
+      - name: Download Darwin zipped artifacts
         uses: actions/download-artifact@v2
         with:
-          name: homebrew
-          path: homebrew
+          name: darwin
+          path: darwin
+      - name: Download Linux zipped artifacts
+        uses: actions/download-artifact@v2
+        with:
+          name: linux
+          path: linux
+      - name: Create Homebrew formulae
+        env:
+          TARGET_VERSION: ${{ needs.set_version.outputs.version }}
+        run: |
+          mkdir homebrew
+          export DARWIN_ARM_TARGET_SHA256=$(ls darwin/*darwin_arm64.zip | sha256sum | cut -f 1 -d ' ' )
+          export DARWIN_AMD_TARGET_SHA256=$(ls darwin/*darwin_amd64.zip | sha256sum | cut -f 1 -d ' ')
+          export LINUX_ARM_TARGET_SHA256=$(ls linux/*linux_arm.zip | sha256sum | cut -f 1 -d ' ' )
+          export LINUX_ARM64_TARGET_SHA256=$(ls linux/*linux_arm64.zip | sha256sum | cut -f 1 -d ' ' )
+          export LINUX_AMD_TARGET_SHA256=$(ls linux/*linux_amd64.zip | sha256sum | cut -f 1 -d ' ' )
+          envsubst < homebrew.template.rb > homebrew/keboola-as-code.rb
+          cat homebrew/keboola-as-code.rb
       - name: Push formulae to keboola/homebrew-tap repository
         uses: cpina/github-action-push-to-another-repository@main
         env:

--- a/.github/workflows/push.yml
+++ b/.github/workflows/push.yml
@@ -123,7 +123,7 @@ jobs:
       - tests
       - cross-compile
     runs-on: ubuntu-latest
-    #if: startsWith(github.ref, 'refs/tags/') && needs.set_version.outputs.is_semantic_tag == 'true'
+    if: startsWith(github.ref, 'refs/tags/') && needs.set_version.outputs.is_semantic_tag == 'true'
     steps:
       - name: Check out the repo
         uses: actions/checkout@v2
@@ -133,7 +133,7 @@ jobs:
         continue-on-error: true
         uses: ./.github/actions/load-build-cache
       - name: Release
-        run: docker-compose run --rm -u "$UID:$GID" -e GITHUB_TOKEN -e TARGET_VERSION -v /tmp/go-cache:/tmp/go-cache dev make release-local
+        run: docker-compose run --rm -u "$UID:$GID" -e GITHUB_TOKEN -e TARGET_VERSION -v /tmp/go-cache:/tmp/go-cache dev make release
         env:
           TARGET_VERSION: ${{ needs.set_version.outputs.version }}
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
@@ -148,7 +148,7 @@ jobs:
       - cross-compile
       - tests
     runs-on: macos-latest
-    #if: startsWith(github.ref, 'refs/tags/') && needs.set_version.outputs.is_semantic_tag == 'true'
+    if: startsWith(github.ref, 'refs/tags/') && needs.set_version.outputs.is_semantic_tag == 'true'
     steps:
       - name: Checkout
         uses: actions/checkout@v2
@@ -206,7 +206,7 @@ jobs:
       - release-mac-os
       - release
     runs-on: ubuntu-latest
-    #if: startsWith(github.ref, 'refs/tags/') && needs.set_version.outputs.is_semantic_tag == 'true'
+    if: startsWith(github.ref, 'refs/tags/') && needs.set_version.outputs.is_semantic_tag == 'true'
     steps:
       - name: Checkout
         uses: actions/checkout@v2

--- a/.github/workflows/push.yml
+++ b/.github/workflows/push.yml
@@ -123,7 +123,7 @@ jobs:
       - tests
       - cross-compile
     runs-on: ubuntu-latest
-    if: startsWith(github.ref, 'refs/tags/') && needs.set_version.outputs.is_semantic_tag == 'true'
+    #if: startsWith(github.ref, 'refs/tags/') && needs.set_version.outputs.is_semantic_tag == 'true'
     steps:
       - name: Check out the repo
         uses: actions/checkout@v2
@@ -133,7 +133,7 @@ jobs:
         continue-on-error: true
         uses: ./.github/actions/load-build-cache
       - name: Release
-        run: docker-compose run --rm -u "$UID:$GID" -e GITHUB_TOKEN -e TARGET_VERSION -v /tmp/go-cache:/tmp/go-cache dev make release
+        run: docker-compose run --rm -u "$UID:$GID" -e GITHUB_TOKEN -e TARGET_VERSION -v /tmp/go-cache:/tmp/go-cache dev make release-local
         env:
           TARGET_VERSION: ${{ needs.set_version.outputs.version }}
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
@@ -148,7 +148,7 @@ jobs:
       - cross-compile
       - tests
     runs-on: macos-latest
-    if: startsWith(github.ref, 'refs/tags/') && needs.set_version.outputs.is_semantic_tag == 'true'
+    #if: startsWith(github.ref, 'refs/tags/') && needs.set_version.outputs.is_semantic_tag == 'true'
     steps:
       - name: Checkout
         uses: actions/checkout@v2
@@ -215,7 +215,7 @@ jobs:
       - release-mac-os
       - release
     runs-on: ubuntu-latest
-    if: startsWith(github.ref, 'refs/tags/') && needs.set_version.outputs.is_semantic_tag == 'true'
+    #if: startsWith(github.ref, 'refs/tags/') && needs.set_version.outputs.is_semantic_tag == 'true'
     steps:
       - name: Checkout
         uses: actions/checkout@v2

--- a/README.md
+++ b/README.md
@@ -15,7 +15,7 @@
   - To fix the issue add the binary to the allowed applications by running the command: `spctl --add ./kbc`
 - Optionally move the binary to your [PATH](https://en.wikipedia.org/wiki/PATH_(variable)).
 - Run.
-### MacOS Homebrew
+### MacOS/Linux Homebrew Installation
 Install cli via [homebrew](https://brew.sh/) as follows
 ```
 brew tap keboola/homebrew-tap

--- a/homebrew.template.rb
+++ b/homebrew.template.rb
@@ -6,11 +6,23 @@ class KeboolaAsCode < Formula
 
   if OS.mac? && Hardware::CPU.arm?
     url "https://github.com/keboola/keboola-as-code/releases/download/v${TARGET_VERSION}/kbc_${TARGET_VERSION}_darwin_arm64.zip"
-    sha256 "${ARM_TARGET_SHA256}"
+    sha256 "${DARWIN_ARM_TARGET_SHA256}"
   end
   if OS.mac? && Hardware::CPU.intel?
-        url "https://github.com/keboola/keboola-as-code/releases/download/v${TARGET_VERSION}/kbc_${TARGET_VERSION}_darwin_amd64.zip"
-    sha256 "${AMD_TARGET_SHA256}"
+    url "https://github.com/keboola/keboola-as-code/releases/download/v${TARGET_VERSION}/kbc_${TARGET_VERSION}_darwin_amd64.zip"
+    sha256 "${DARWIN_AMD_TARGET_SHA256}"
+  end
+  if OS.linux? && Hardware::CPU.intel?
+    url "https://github.com/keboola/keboola-as-code/releases/download/v${TARGET_VERSION}/kbc_${TARGET_VERSION}_linux_amd64.zip"
+    sha256 "${LINUX_AMD_TARGET_SHA256}"
+  end
+  if OS.linux? && Hardware::CPU.arm? && !Hardware::CPU.is_64_bit?
+    url "https://github.com/keboola/keboola-as-code/releases/download/v${TARGET_VERSION}/kbc_${TARGET_VERSION}_linux_arm.zip"
+    sha256 "${LINUX_ARM_TARGET_SHA256}"
+  end
+  if OS.linux? && Hardware::CPU.arm? && Hardware::CPU.is_64_bit?
+    url "https://github.com/keboola/keboola-as-code/releases/download/v${TARGET_VERSION}/kbc_${TARGET_VERSION}_linux_arm64.zip"
+    sha256 "${LINUX_ARM64_TARGET_SHA256}"
   end
 
   def install


### PR DESCRIPTION
Uprava vytvori homebrew release pre Linux buildy.


### Testing deploy build
pustil som bez taggovaneho releasu a preslo:
https://github.com/keboola/keboola-as-code/actions/runs/1209553320

![image](https://user-images.githubusercontent.com/1412120/132354705-55e797b6-69ca-4c2e-9d44-775ec48ebbe9.png)
Ak mas linux OS tak mozes skusit `brew tap keboola/homebrew-tap` 