### PR TITLE
Fix typo in docs

### DIFF
--- a/docs/DEVELOPMENT.md
+++ b/docs/DEVELOPMENT.md
@@ -25,7 +25,7 @@ TEST_KBC_PROJECTS="connection.keboola.com|1234|project-1234-token;host2|id2|toke
 Run the test suite and download the dependencies using:
 
 ```
-`docker-compose run --rm -u "$UID:$GID" dev` make ci
+docker-compose run --rm -u "$UID:$GID" dev make ci
 ```
 
 To start the interactive console in the container, you can use:
@@ -110,4 +110,6 @@ If a ENV placeholder in the form `^TEST_NEW_TICKET_\d+$` is found, it is replace
 
 ### IDE setup
 
-In IntelliJ IDEA is needed to set project GOPATH to `/go` directory, for code autocompletion to work.
+The scripts `make mod`, `make fix`, `make ci` calls `go mod vendor`.
+It syncs all dependencies (Go modules) to the `vendor` directory.
+So integration with the IDE should work automatically.

--- a/scripts/tools.sh
+++ b/scripts/tools.sh
@@ -11,4 +11,4 @@ cd "$SCRIPT_DIR"
 
 ./install-gotestsum.sh -b $(go env GOPATH)/bin
 curl -sSfL https://raw.githubusercontent.com/golangci/golangci-lint/master/install.sh | sh -s -- -b $(go env GOPATH)/bin v1.42.1
-curl -sfL https://install.goreleaser.com/github.com/goreleaser/goreleaser.sh | sh -s -- -b $(go env GOPATH)/bin
+curl -sfL https://install.goreleaser.com/github.com/goreleaser/goreleaser.sh | sh -s -- -b $(go env GOPATH)/bin v0.181.1


### PR DESCRIPTION
Changes:
- Fixed typo in `DEVELOPMENT.md `.
- Fixed installation of the Goreleaser on Mac Os.