### PR TITLE
Fix shared codes diff

### DIFF
--- a/internal/pkg/diff/reporter_test.go
+++ b/internal/pkg/diff/reporter_test.go
@@ -2,11 +2,48 @@ package diff
 
 import (
 	"fmt"
+	"reflect"
 	"strings"
 	"testing"
 
 	"github.com/stretchr/testify/assert"
 )
+
+func TestReporterValuesDiffSameType1(t *testing.T) {
+	t.Parallel()
+	out := valuesDiff(reflect.ValueOf(`123`), reflect.ValueOf(`456`))
+	assert.Equal(t, []string{
+		`- 123`,
+		`+ 456`,
+	}, out)
+}
+
+func TestReporterValuesDiffSameType2(t *testing.T) {
+	t.Parallel()
+	out := valuesDiff(reflect.ValueOf([]int{1, 2}), reflect.ValueOf([]int{3, 4}))
+	assert.Equal(t, []string{
+		`- [1 2]`,
+		`+ [3 4]`,
+	}, out)
+}
+
+func TestReporterValuesDiffDifferentType1(t *testing.T) {
+	t.Parallel()
+	out := valuesDiff(reflect.ValueOf(123), reflect.ValueOf(`456`))
+	assert.Equal(t, []string{
+		`- 123`,
+		`+ "456"`,
+	}, out)
+}
+
+func TestReporterValuesDiffDifferentType2(t *testing.T) {
+	t.Parallel()
+	out := valuesDiff(reflect.ValueOf([]float64{1, 2}), reflect.ValueOf([]int{1, 2}))
+	assert.Equal(t, []string{
+		`- []float64{1, 2}`,
+		`+ []int{1, 2}`,
+	}, out)
+}
 
 func TestReporterStringsDiff(t *testing.T) {
 	t.Parallel()

--- a/internal/pkg/mapper/sharedcode/codes/load.go
+++ b/internal/pkg/mapper/sharedcode/codes/load.go
@@ -51,10 +51,14 @@ func (l *loader) load() error {
 	}
 	l.Record.AddRelatedPath(codeFilePath)
 
+	// Convert []string -> []interface{} (so there is no type difference against API type)
+	scripts := strhelper.ParseTransformationScript(codeFile.Content, targetComponentId)
+	scriptsRaw := make([]interface{}, 0)
+	for _, script := range scripts {
+		scriptsRaw = append(scriptsRaw, script)
+	}
+
 	// Set to config row JSON
-	l.configRow.Content.Set(
-		model.ShareCodeContentKey,
-		strhelper.ParseTransformationScript(codeFile.Content, targetComponentId),
-	)
+	l.configRow.Content.Set(model.ShareCodeContentKey, scriptsRaw)
 	return nil
 }

--- a/internal/pkg/mapper/sharedcode/codes/load_test.go
+++ b/internal/pkg/mapper/sharedcode/codes/load_test.go
@@ -36,7 +36,7 @@ func TestSharedCodeLoadOk(t *testing.T) {
 	assert.NoError(t, err)
 	codeContent, found := row.Content.Get(model.ShareCodeContentKey)
 	assert.True(t, found)
-	assert.Equal(t, []string{"foo bar"}, codeContent)
+	assert.Equal(t, []interface{}{"foo bar"}, codeContent)
 
 	// Path is present in related paths
 	assert.Equal(t, []string{

--- a/internal/pkg/mapper/sharedcode/links/load.go
+++ b/internal/pkg/mapper/sharedcode/links/load.go
@@ -83,11 +83,13 @@ func (m *mapper) replaceSharedCodePathById(object model.Object) error {
 	}
 
 	// Convert row IDs map -> slice
-	rowIds := make([]string, 0)
+	rowIds := make([]interface{}, 0)
 	for id := range rowIdsMap {
 		rowIds = append(rowIds, id)
 	}
-	sort.Strings(rowIds)
+	sort.SliceStable(rowIds, func(i, j int) bool {
+		return rowIds[i].(string) < rowIds[j].(string)
+	})
 
 	// Set rows IDs
 	transformation.Content.Set(model.SharedCodeRowsIdContentKey, rowIds)

--- a/internal/pkg/mapper/sharedcode/links/load_test.go
+++ b/internal/pkg/mapper/sharedcode/links/load_test.go
@@ -82,7 +82,7 @@ func TestSharedCodeLinksAfterLocalLoad(t *testing.T) {
 	assert.Equal(t, sharedCodeId, `456`)
 	sharedCodeRowIds, found := configState.Local.Content.Get(model.SharedCodeRowsIdContentKey)
 	assert.True(t, found)
-	assert.Equal(t, sharedCodeRowIds, []string{`1234`, `5678`})
+	assert.Equal(t, sharedCodeRowIds, []interface{}{`1234`, `5678`})
 
 	// Paths in transformation blocks are replaced by IDs
 	assert.Equal(t, model.Blocks{

--- a/internal/pkg/plan/persist_test.go
+++ b/internal/pkg/plan/persist_test.go
@@ -415,7 +415,7 @@ func TestPersistSharedCode(t *testing.T) {
 					Content: utils.PairsToOrderedMap([]utils.Pair{
 						{
 							Key: "code_content",
-							Value: []string{
+							Value: []interface{}{
 								"print('Hello, world!')",
 							},
 						},
@@ -574,7 +574,7 @@ func TestPersistSharedCodeWithVariables(t *testing.T) {
 					Content: utils.PairsToOrderedMap([]utils.Pair{
 						{
 							Key: "code_content",
-							Value: []string{
+							Value: []interface{}{
 								"num1 = {{num1}}\nnum2 = {{num2}}\nsum = num1 + num2",
 							},
 						},


### PR DESCRIPTION
Part of: https://keboola.atlassian.net/browse/COM-1138

Este som to testoval manualne, a zistil som, ze pada `diff`:
- pri `local` load sa vytvaral typ `[]string`
- a `remote` load pouziva JSON decode, a je tam genericky `[]interface{}`
- -> fixnute, `[]string -> []interface`

![image](https://user-images.githubusercontent.com/19371734/141330094-5dfc5ad3-ed6e-448d-bc03-feab0ed0dc8d.png)
