### PR TITLE
Fix generated GitHub workflow, fail on an error

### DIFF
--- a/internal/pkg/workflows/template/pull.yml.tmpl
+++ b/internal/pkg/workflows/template/pull.yml.tmpl
@@ -20,6 +20,7 @@ jobs:
       - name: Pull from Keboola Connection
         id: kbc_pull_step
         run: |
+          set -eo pipefail
           kbc pull --force 2>&1 | tee "$RUNNER_TEMP/log.txt"
       # Automatic pull can be canceled by push, wait a while
       - name: Wait

--- a/test/init/out/.github/workflows/pull.yml
+++ b/test/init/out/.github/workflows/pull.yml
@@ -20,6 +20,7 @@ jobs:
       - name: Pull from Keboola Connection
         id: kbc_pull_step
         run: |
+          set -eo pipefail
           kbc pull --force 2>&1 | tee "$RUNNER_TEMP/log.txt"
       # Automatic pull can be canceled by push, wait a while
       - name: Wait

--- a/test/workflows/out/.github/workflows/pull.yml
+++ b/test/workflows/out/.github/workflows/pull.yml
@@ -20,6 +20,7 @@ jobs:
       - name: Pull from Keboola Connection
         id: kbc_pull_step
         run: |
+          set -eo pipefail
           kbc pull --force 2>&1 | tee "$RUNNER_TEMP/log.txt"
       # Automatic pull can be canceled by push, wait a while
       - name: Wait


### PR DESCRIPTION
Part of: https://keboola.atlassian.net/browse/COM-1215

Z KDS nahlasili, ze `GitHub Action Workflow`, ktory generuje CLI, je `false positive` v pripade chyby:
![image](https://user-images.githubusercontent.com/19371734/141486162-b3c405e5-f08a-401f-b6f7-8ddfd44c5da4.png)

Teraz to uz spravne spadne:
![image](https://user-images.githubusercontent.com/19371734/141488592-fcccbe31-099e-4e45-a701-198e18644373.png)
https://github.com/keboola/temp-keboola-cli-gha-test/runs/4191218165?check_suite_focus=true