### PR TITLE
Call mapper in reverse order on Save

### DIFF
--- a/internal/pkg/mapper/mapper_test.go
+++ b/internal/pkg/mapper/mapper_test.go
@@ -1,0 +1,60 @@
+package mapper
+
+import (
+	"fmt"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+)
+
+func TestMappers_ForEach_StopOnFailure(t *testing.T) {
+	t.Parallel()
+	callOrder := make([]string, 0)
+	mappers := Mappers{`1`, `2`, `3`, `4`, `5`}
+	err := mappers.ForEach(true, func(mapper interface{}) error {
+		callOrder = append(callOrder, mapper.(string))
+		return fmt.Errorf(`error %s`, mapper.(string))
+	})
+	assert.Error(t, err)
+	assert.Equal(t, `error 1`, err.Error())
+	assert.Equal(t, []string{`1`}, callOrder)
+}
+
+func TestMappers_ForEach_DontStopOnFailure(t *testing.T) {
+	t.Parallel()
+	callOrder := make([]string, 0)
+	mappers := Mappers{`1`, `2`, `3`, `4`, `5`}
+	err := mappers.ForEach(false, func(mapper interface{}) error {
+		callOrder = append(callOrder, mapper.(string))
+		return fmt.Errorf(`error %s`, mapper.(string))
+	})
+	assert.Error(t, err)
+	assert.Equal(t, "- error 1\n- error 2\n- error 3\n- error 4\n- error 5", err.Error())
+	assert.Equal(t, []string{`1`, `2`, `3`, `4`, `5`}, callOrder)
+}
+
+func TestMappers_ForEachReverse_StopOnFailure(t *testing.T) {
+	t.Parallel()
+	callOrder := make([]string, 0)
+	mappers := Mappers{`1`, `2`, `3`, `4`, `5`}
+	err := mappers.ForEachReverse(true, func(mapper interface{}) error {
+		callOrder = append(callOrder, mapper.(string))
+		return fmt.Errorf(`error %s`, mapper.(string))
+	})
+	assert.Error(t, err)
+	assert.Equal(t, `error 5`, err.Error())
+	assert.Equal(t, []string{`5`}, callOrder)
+}
+
+func TestMappers_ForEachReverse_DontStopOnFailure(t *testing.T) {
+	t.Parallel()
+	callOrder := make([]string, 0)
+	mappers := Mappers{`1`, `2`, `3`, `4`, `5`}
+	err := mappers.ForEachReverse(false, func(mapper interface{}) error {
+		callOrder = append(callOrder, mapper.(string))
+		return fmt.Errorf(`error %s`, mapper.(string))
+	})
+	assert.Error(t, err)
+	assert.Equal(t, "- error 5\n- error 4\n- error 3\n- error 2\n- error 1", err.Error())
+	assert.Equal(t, []string{`5`, `4`, `3`, `2`, `1`}, callOrder)
+}

--- a/internal/pkg/state/state.go
+++ b/internal/pkg/state/state.go
@@ -117,16 +117,23 @@ func newState(options *Options) *State {
 	s.remoteManager = remote.NewManager(s.localManager, options.api, s.State, s.mapper)
 
 	mappers := []interface{}{
-		variables.NewMapper(mapperContext),
-		schedulerMapper.NewMapper(mapperContext, options.schedulerApi),
-		sharedcode.NewVariablesMapper(mapperContext),
-		orchestrator.NewMapper(s.localManager, mapperContext),
-		relations.NewMapper(mapperContext),
-		sharedcode.NewCodesMapper(mapperContext),
-		sharedcode.NewLinksMapper(s.localManager, mapperContext),
-		transformation.NewMapper(mapperContext),
+		// Core files
 		description.NewMapper(),
+		// Storage
 		defaultbucket.NewMapper(mapperContext),
+		// Variables
+		variables.NewMapper(mapperContext),
+		sharedcode.NewVariablesMapper(mapperContext),
+		// Special components
+		schedulerMapper.NewMapper(mapperContext, options.schedulerApi),
+		orchestrator.NewMapper(s.localManager, mapperContext),
+		// Native codes
+		transformation.NewMapper(mapperContext),
+		sharedcode.NewCodesMapper(mapperContext),
+		// Shared code links
+		sharedcode.NewLinksMapper(s.localManager, mapperContext),
+		// Relations between objects
+		relations.NewMapper(mapperContext),
 	}
 	s.mapper.AddMapper(mappers...)
 


### PR DESCRIPTION
Part of: https://keboola.atlassian.net/browse/COM-1211

Narazil som na to, ze potrebujem volat `mappers` v opacnom poradi pri `Save` ako pri `Load`.
Podoba sa to na middleware code patern.

Priklad:
- mapper `template`, uklada sablonu `json -> jsonet`.
- pri `load` je to prvy krok, `jsonet -> json`
- pri `save` je to posledny krok `json -> jsonnet`
- a takto to plati aj na ine usecases

`mappers`, ktore uz mame to neovplyvnuje, kedze im to je jedno.
Preto tu nie su ani ziadne ine zmeny a testy presli.

![image](https://user-images.githubusercontent.com/19371734/145771750-9098c701-d1ec-4b7e-bfdb-826151bfc10c.png)
