### PR TITLE
Separated mappers for project /template

### DIFF
--- a/internal/pkg/cli/cmd/cmd.go
+++ b/internal/pkg/cli/cmd/cmd.go
@@ -307,7 +307,7 @@ func (root *RootCommand) printError(errRaw error) {
 			root.Logger.Infof(`Please change working directory to a project directory.`)
 			root.Logger.Infof(`Or use the "sync init" command in an empty directory.`)
 			modifiedErrs.Append(fmt.Errorf(`none of this and parent directories is project dir`))
-		case errors.Is(err, dependencies.ErrRepoManifestNotFound):
+		case errors.Is(err, dependencies.ErrRepositoryManifestNotFound):
 			root.Logger.Infof(`Repository directory must contain the "%s" file.`, repositoryManifest.Path())
 			root.Logger.Infof(`Please change working directory to a repository directory.`)
 			root.Logger.Infof(`Or use the "template repository init" command in an empty directory.`)

--- a/internal/pkg/fixtures/sharedcode.go
+++ b/internal/pkg/fixtures/sharedcode.go
@@ -6,11 +6,10 @@ import (
 	"github.com/stretchr/testify/assert"
 
 	"github.com/keboola/keboola-as-code/internal/pkg/model"
-	"github.com/keboola/keboola-as-code/internal/pkg/naming"
 	"github.com/keboola/keboola-as-code/internal/pkg/utils/orderedmap"
 )
 
-func CreateSharedCode(t *testing.T, state model.ObjectStates, naming *naming.Registry) (model.ConfigKey, []model.ConfigRowKey) {
+func CreateSharedCode(t *testing.T, state model.ObjectStates) (model.ConfigKey, []model.ConfigRowKey) {
 	t.Helper()
 
 	// Branch

--- a/internal/pkg/local/load_test.go
+++ b/internal/pkg/local/load_test.go
@@ -1,18 +1,12 @@
 package local
 
 import (
-	"strings"
 	"testing"
 
 	"github.com/stretchr/testify/assert"
 
 	"github.com/keboola/keboola-as-code/internal/pkg/filesystem"
 	"github.com/keboola/keboola-as-code/internal/pkg/fixtures"
-	"github.com/keboola/keboola-as-code/internal/pkg/log"
-	"github.com/keboola/keboola-as-code/internal/pkg/mapper"
-	"github.com/keboola/keboola-as-code/internal/pkg/mapper/transformation"
-	"github.com/keboola/keboola-as-code/internal/pkg/model"
-	"github.com/keboola/keboola-as-code/internal/pkg/naming"
 	"github.com/keboola/keboola-as-code/internal/pkg/utils/orderedmap"
 )
 
@@ -67,83 +61,4 @@ func TestLocalLoadModelNotFound(t *testing.T) {
 	assert.False(t, found)
 	assert.Error(t, err)
 	assert.Equal(t, "kind \"test\" not found", err.Error())
-}
-
-func TestLocalLoadModelInvalidTransformation(t *testing.T) {
-	t.Parallel()
-
-	namingTemplate := naming.TemplateWithIds()
-	namingRegistry := naming.NewRegistry()
-	namingGenerator := naming.NewGenerator(namingTemplate, namingRegistry)
-
-	manager, mapperIst := newTestLocalManager(t)
-	fs := manager.fs
-	mapperIst.AddMapper(transformation.NewMapper(mapper.Context{
-		Logger:          log.NewDebugLogger(),
-		State:           manager.state,
-		NamingGenerator: namingGenerator,
-		Fs:              fs,
-	}))
-
-	componentProvider := manager.state.Components()
-	component := &model.Component{
-		ComponentKey: model.ComponentKey{Id: "keboola.foo-bar"},
-		Type:         model.TransformationType,
-	}
-	componentProvider.Set(component)
-
-	// Files content
-	metaFile := `{foo`
-	descFile := `abc`
-	configFile := ``
-	blockMeta := `{"name": "foo1"}`
-	codeMeta := `{"name": "foo2"}`
-	codeContent := `SELECT 1`
-
-	// Save files
-	configKey := model.ConfigKey{
-		BranchId:    123,
-		ComponentId: component.Id,
-		Id:          "456",
-	}
-	target := &model.Config{
-		ConfigKey: configKey,
-	}
-	record := &model.ConfigManifest{
-		ConfigKey: configKey,
-		Paths:     model.Paths{PathInProject: model.PathInProject{ObjectPath: "config"}},
-	}
-	assert.NoError(t, fs.Mkdir(record.Path()))
-	assert.NoError(t, fs.WriteFile(filesystem.NewFile(namingGenerator.MetaFilePath(record.Path()), metaFile)))
-	assert.NoError(t, fs.WriteFile(filesystem.NewFile(namingGenerator.DescriptionFilePath(record.Path()), descFile)))
-	assert.NoError(t, fs.WriteFile(filesystem.NewFile(namingGenerator.ConfigFilePath(record.Path()), configFile)))
-	blocksDir := namingGenerator.BlocksDir(record.Path())
-	assert.NoError(t, fs.Mkdir(blocksDir))
-	block := &model.Block{BlockKey: model.BlockKey{Index: 123}, Name: `block`}
-	block.PathInProject = namingGenerator.BlockPath(blocksDir, block)
-	assert.NoError(t, fs.Mkdir(block.Path()))
-	assert.NoError(t, fs.WriteFile(filesystem.NewFile(namingGenerator.MetaFilePath(block.Path()), blockMeta)))
-	code := &model.Code{CodeKey: model.CodeKey{Index: 123}, Name: `code`}
-	code.PathInProject = namingGenerator.CodePath(block.Path(), code)
-	code.CodeFileName = namingGenerator.CodeFileName(component.Id)
-	assert.NoError(t, fs.Mkdir(code.Path()))
-	assert.NoError(t, fs.WriteFile(filesystem.NewFile(namingGenerator.MetaFilePath(code.Path()), codeMeta)))
-	assert.NoError(t, fs.WriteFile(filesystem.NewFile(namingGenerator.CodeFilePath(code), codeContent)))
-
-	// Load
-	found, err := manager.loadObject(record, target)
-	assert.True(t, found)
-
-	// Files are not valid
-	assert.Error(t, err)
-	expectedErr := `
-- config metadata file "config/meta.json" is invalid:
-  - invalid character 'f' looking for beginning of object key string, offset: 2
-- config file "config/config.json" is invalid:
-  - empty, please use "{}" for an empty JSON
-`
-	assert.Equal(t, strings.TrimSpace(expectedErr), err.Error())
-
-	// But the blocks are parsed, no crash
-	assert.Len(t, target.Transformation.Blocks, 1)
 }

--- a/internal/pkg/mapper/defaultbucket/defaultbucket.go
+++ b/internal/pkg/mapper/defaultbucket/defaultbucket.go
@@ -3,15 +3,15 @@ package defaultbucket
 import (
 	"fmt"
 
-	"github.com/keboola/keboola-as-code/internal/pkg/local"
-	"github.com/keboola/keboola-as-code/internal/pkg/mapper"
+	"github.com/keboola/keboola-as-code/internal/pkg/log"
 	"github.com/keboola/keboola-as-code/internal/pkg/model"
+	"github.com/keboola/keboola-as-code/internal/pkg/state"
 	"github.com/keboola/keboola-as-code/internal/pkg/utils/orderedmap"
 )
 
 type defaultBucketMapper struct {
-	mapper.Context
-	localManager *local.Manager
+	state  *state.State
+	logger log.Logger
 }
 
 type configOrRow interface {
@@ -19,11 +19,8 @@ type configOrRow interface {
 	BranchKey() model.BranchKey
 }
 
-func NewMapper(localManager *local.Manager, context mapper.Context) *defaultBucketMapper {
-	return &defaultBucketMapper{
-		Context:      context,
-		localManager: localManager,
-	}
+func NewMapper(s *state.State) *defaultBucketMapper {
+	return &defaultBucketMapper{state: s, logger: s.Logger()}
 }
 
 func (m *defaultBucketMapper) visitStorageInputTables(config configOrRow, content *orderedmap.OrderedMap, callback func(

--- a/internal/pkg/mapper/defaultbucket/local_rename.go
+++ b/internal/pkg/mapper/defaultbucket/local_rename.go
@@ -34,13 +34,13 @@ func (m *defaultBucketMapper) onObjectsRename(renamed []model.RenameAction, allO
 	}
 
 	// Log and save
-	uow := m.localManager.NewUnitOfWork(context.Background())
+	uow := m.state.LocalManager().NewUnitOfWork(context.Background())
 	errors := utils.NewMultiError()
 	if len(objectsToUpdate) > 0 {
-		m.Logger.Debug(`Need to update configurations:`)
+		m.logger.Debug(`Need to update configurations:`)
 		for _, key := range objectsToUpdate {
-			m.Logger.Debugf(`  - %s`, key.Desc())
-			objectState := m.State.MustGet(key)
+			m.logger.Debugf(`  - %s`, key.Desc())
+			objectState := m.state.MustGet(key)
 			uow.SaveObject(objectState, objectState.LocalState(), model.NewChangedFields(`configuration`))
 		}
 	}

--- a/internal/pkg/mapper/defaultbucket/local_save.go
+++ b/internal/pkg/mapper/defaultbucket/local_save.go
@@ -22,7 +22,7 @@ func (m *defaultBucketMapper) MapBeforeLocalSave(recipe *model.LocalSaveRecipe) 
 	}
 
 	if err := m.visitStorageInputTables(config, configFile.Content, m.replaceDefaultBucketWithPlaceholder); err != nil {
-		m.Logger.Warnf(`Warning: %s`, err)
+		m.logger.Warnf(`Warning: %s`, err)
 	}
 	return nil
 }
@@ -47,7 +47,7 @@ func (m *defaultBucketMapper) replaceDefaultBucketWithPlaceholder(
 }
 
 func (m *defaultBucketMapper) getDefaultBucketSourceConfig(config configOrRow, tableId string) (model.ObjectState, bool, error) {
-	componentId, configId, match := m.State.Components().GetDefaultBucketByTableId(tableId)
+	componentId, configId, match := m.state.Components().GetDefaultBucketByTableId(tableId)
 	if !match {
 		return nil, false, nil
 	}
@@ -57,7 +57,7 @@ func (m *defaultBucketMapper) getDefaultBucketSourceConfig(config configOrRow, t
 		ComponentId: componentId,
 		Id:          configId,
 	}
-	sourceConfigState, found := m.State.Get(sourceConfigKey)
+	sourceConfigState, found := m.state.Get(sourceConfigKey)
 	if !found {
 		errors := utils.NewMultiError()
 		errors.Append(fmt.Errorf(`%s not found`, sourceConfigKey.Desc()))

--- a/internal/pkg/mapper/description/description_test.go
+++ b/internal/pkg/mapper/description/description_test.go
@@ -1,9 +1,9 @@
-package variables_test
+package description_test
 
 import (
 	"testing"
 
-	"github.com/keboola/keboola-as-code/internal/pkg/mapper/sharedcode/variables"
+	"github.com/keboola/keboola-as-code/internal/pkg/mapper/description"
 	"github.com/keboola/keboola-as-code/internal/pkg/state"
 	"github.com/keboola/keboola-as-code/internal/pkg/testdeps"
 )
@@ -12,6 +12,6 @@ func createStateWithMapper(t *testing.T) (*state.State, *testdeps.TestContainer)
 	t.Helper()
 	d := testdeps.New()
 	mockedState := d.EmptyState()
-	mockedState.Mapper().AddMapper(variables.NewMapper(mockedState))
+	mockedState.Mapper().AddMapper(description.NewMapper())
 	return mockedState, d
 }

--- a/internal/pkg/mapper/description/remote_load_test.go
+++ b/internal/pkg/mapper/description/remote_load_test.go
@@ -1,4 +1,4 @@
-package description
+package description_test
 
 import (
 	"testing"
@@ -11,10 +11,11 @@ import (
 
 func TestDescriptionMapAfterRemoteLoad(t *testing.T) {
 	t.Parallel()
+	state, _ := createStateWithMapper(t)
 
 	object := &model.Config{Description: "foo\nbar\n\r\t ", Content: orderedmap.New()}
 	recipe := &model.RemoteLoadRecipe{Object: object}
 
-	assert.NoError(t, NewMapper().MapAfterRemoteLoad(recipe))
+	assert.NoError(t, state.Mapper().MapAfterRemoteLoad(recipe))
 	assert.Equal(t, "foo\nbar", object.Description)
 }

--- a/internal/pkg/mapper/mapper.go
+++ b/internal/pkg/mapper/mapper.go
@@ -1,20 +1,9 @@
 package mapper
 
 import (
-	"github.com/keboola/keboola-as-code/internal/pkg/filesystem"
-	"github.com/keboola/keboola-as-code/internal/pkg/log"
 	"github.com/keboola/keboola-as-code/internal/pkg/model"
-	"github.com/keboola/keboola-as-code/internal/pkg/naming"
 	"github.com/keboola/keboola-as-code/internal/pkg/utils"
 )
-
-type Context struct {
-	Logger          log.Logger
-	Fs              filesystem.Fs
-	NamingGenerator *naming.Generator
-	NamingRegistry  *naming.Registry
-	State           model.ObjectStates
-}
 
 // LocalSaveMapper to modify how the object will be saved in the filesystem.
 type LocalSaveMapper interface {

--- a/internal/pkg/mapper/orchestrator/local.go
+++ b/internal/pkg/mapper/orchestrator/local.go
@@ -7,7 +7,7 @@ import (
 
 func (m *orchestratorMapper) OnLocalChange(changes *model.LocalChanges) error {
 	errors := utils.NewMultiError()
-	allObjects := m.State.LocalObjects()
+	allObjects := m.state.LocalObjects()
 
 	// Map loaded objects
 	for _, objectState := range changes.Loaded() {

--- a/internal/pkg/mapper/orchestrator/local_rename.go
+++ b/internal/pkg/mapper/orchestrator/local_rename.go
@@ -45,12 +45,12 @@ func (m *orchestratorMapper) onObjectsRename(renamed []model.RenameAction, allOb
 	}
 
 	// Log and save
-	uow := m.localManager.NewUnitOfWork(context.Background())
+	uow := m.state.LocalManager().NewUnitOfWork(context.Background())
 	if len(orchestratorsToUpdate) > 0 {
-		m.Logger.Debug(`Need to update orchestrators:`)
+		m.logger.Debug(`Need to update orchestrators:`)
 		for _, key := range orchestratorsToUpdate {
-			m.Logger.Debugf(`  - %s`, key.Desc())
-			orchestrator := m.State.MustGet(key)
+			m.logger.Debugf(`  - %s`, key.Desc())
+			orchestrator := m.state.MustGet(key)
 			uow.SaveObject(orchestrator, orchestrator.LocalState(), model.NewChangedFields(`orchestrator`))
 		}
 	}

--- a/internal/pkg/mapper/orchestrator/orchestrator.go
+++ b/internal/pkg/mapper/orchestrator/orchestrator.go
@@ -1,18 +1,18 @@
 package orchestrator
 
 import (
-	"github.com/keboola/keboola-as-code/internal/pkg/local"
-	"github.com/keboola/keboola-as-code/internal/pkg/mapper"
+	"github.com/keboola/keboola-as-code/internal/pkg/log"
 	"github.com/keboola/keboola-as-code/internal/pkg/model"
+	"github.com/keboola/keboola-as-code/internal/pkg/state"
 )
 
 type orchestratorMapper struct {
-	mapper.Context
-	localManager *local.Manager
+	state  *state.State
+	logger log.Logger
 }
 
-func NewMapper(localManager *local.Manager, context mapper.Context) *orchestratorMapper {
-	return &orchestratorMapper{Context: context, localManager: localManager}
+func NewMapper(s *state.State) *orchestratorMapper {
+	return &orchestratorMapper{state: s, logger: s.Logger()}
 }
 
 func (m *orchestratorMapper) isOrchestratorConfigKey(key model.Key) (bool, error) {
@@ -21,7 +21,7 @@ func (m *orchestratorMapper) isOrchestratorConfigKey(key model.Key) (bool, error
 		return false, nil
 	}
 
-	component, err := m.State.Components().Get(config.ComponentKey())
+	component, err := m.state.Components().Get(config.ComponentKey())
 	if err != nil {
 		return false, err
 	}

--- a/internal/pkg/mapper/orchestrator/path.go
+++ b/internal/pkg/mapper/orchestrator/path.go
@@ -26,13 +26,13 @@ func (m *orchestratorMapper) OnObjectPathUpdate(event model.OnObjectPathUpdateEv
 func (m *orchestratorMapper) updatePhasePath(g model.PathsGenerator, parent *model.ConfigState, phase *model.Phase) {
 	// Update parent path
 	oldPath := phase.Path()
-	phasesDir := m.NamingGenerator.PhasesDir(parent.Path())
+	phasesDir := m.state.NamingGenerator().PhasesDir(parent.Path())
 	phase.SetParentPath(phasesDir)
 
 	// Re-generate object path IF rename is enabled OR path is not set
 	if phase.ObjectPath == "" || g.RenameEnabled() {
 		renameFrom := phase.Path()
-		phase.PathInProject = m.NamingGenerator.PhasePath(phase.GetParentPath(), phase)
+		phase.PathInProject = m.state.NamingGenerator().PhasePath(phase.GetParentPath(), phase)
 
 		// Has been phase renamed?
 		newPath := phase.Path()
@@ -55,7 +55,7 @@ func (m *orchestratorMapper) updateTaskPath(g model.PathsGenerator, parent *mode
 	// Re-generate object path IF rename is enabled OR path is not set
 	if task.ObjectPath == "" || g.RenameEnabled() {
 		renameFrom := task.Path()
-		task.PathInProject = m.NamingGenerator.TaskPath(task.GetParentPath(), task)
+		task.PathInProject = m.state.NamingGenerator().TaskPath(task.GetParentPath(), task)
 		// Has been task renamed?
 		newPath := task.Path()
 		if renameFrom != newPath {

--- a/internal/pkg/mapper/orchestrator/remote_save_test.go
+++ b/internal/pkg/mapper/orchestrator/remote_save_test.go
@@ -13,7 +13,9 @@ import (
 
 func TestMapBeforeRemoteSave(t *testing.T) {
 	t.Parallel()
-	mapper, _, logs := createMapper(t)
+	state, d := createStateWithMapper(t)
+	logger := d.DebugLogger()
+
 	orchestration := &model.Orchestration{
 		Phases: []*model.Phase{
 			{
@@ -135,8 +137,8 @@ func TestMapBeforeRemoteSave(t *testing.T) {
 	}
 
 	// Save
-	assert.NoError(t, mapper.MapBeforeRemoteSave(recipe))
-	assert.Empty(t, logs.AllMessages())
+	assert.NoError(t, state.Mapper().MapBeforeRemoteSave(recipe))
+	assert.Empty(t, logger.WarnAndErrorMessages())
 
 	// Orchestration is stored in API object content
 	expectedContent := `

--- a/internal/pkg/mapper/relations/link.go
+++ b/internal/pkg/mapper/relations/link.go
@@ -11,7 +11,7 @@ import (
 // OnLocalChange links relation sides on local load.
 func (m *relationsMapper) OnLocalChange(changes *model.LocalChanges) error {
 	errors := utils.NewMultiError()
-	allObjects := m.State.LocalObjects()
+	allObjects := m.state.LocalObjects()
 	for _, objectState := range changes.Loaded() {
 		if err := m.linkAndValidateRelations(objectState.LocalState(), allObjects); err != nil {
 			errors.Append(err)
@@ -20,7 +20,7 @@ func (m *relationsMapper) OnLocalChange(changes *model.LocalChanges) error {
 
 	// Log errors as warning
 	if errors.Len() > 0 {
-		m.Logger.Warn(utils.PrefixError(`Warning`, errors))
+		m.logger.Warn(utils.PrefixError(`Warning`, errors))
 	}
 
 	return nil
@@ -29,7 +29,7 @@ func (m *relationsMapper) OnLocalChange(changes *model.LocalChanges) error {
 // OnRemoteChange links relation sides on remote load.
 func (m *relationsMapper) OnRemoteChange(changes *model.RemoteChanges) error {
 	errors := utils.NewMultiError()
-	allObjects := m.State.RemoteObjects()
+	allObjects := m.state.RemoteObjects()
 	for _, objectState := range changes.Loaded() {
 		if err := m.linkAndValidateRelations(objectState.RemoteState(), allObjects); err != nil {
 			errors.Append(err)
@@ -38,7 +38,7 @@ func (m *relationsMapper) OnRemoteChange(changes *model.RemoteChanges) error {
 
 	// Log errors as warning
 	if errors.Len() > 0 {
-		m.Logger.Warn(utils.PrefixError(`Warning`, errors))
+		m.logger.Warn(utils.PrefixError(`Warning`, errors))
 	}
 
 	return nil

--- a/internal/pkg/mapper/relations/local_load_test.go
+++ b/internal/pkg/mapper/relations/local_load_test.go
@@ -6,13 +6,14 @@ import (
 	"github.com/stretchr/testify/assert"
 
 	"github.com/keboola/keboola-as-code/internal/pkg/fixtures"
-	. "github.com/keboola/keboola-as-code/internal/pkg/mapper/relations"
 	"github.com/keboola/keboola-as-code/internal/pkg/model"
 )
 
 func TestRelationsMapperLocalLoad(t *testing.T) {
 	t.Parallel()
-	context, _ := createMapperContext(t)
+	state, d := createStateWithMapper(t)
+	logger := d.DebugLogger()
+
 	record := &fixtures.MockedManifest{}
 	object := &fixtures.MockedObject{}
 	recipe := &model.LocalLoadRecipe{ObjectManifest: record, Object: object}
@@ -22,7 +23,8 @@ func TestRelationsMapperLocalLoad(t *testing.T) {
 
 	assert.NotEmpty(t, record.Relations)
 	assert.Empty(t, object.Relations)
-	assert.NoError(t, NewMapper(context).MapAfterLocalLoad(recipe))
+	assert.NoError(t, state.Mapper().MapAfterLocalLoad(recipe))
+	assert.Empty(t, logger.WarnAndErrorMessages())
 
 	// Copied, record.Relations -> object.Relations
 	assert.NotEmpty(t, record.Relations)

--- a/internal/pkg/mapper/relations/local_save_test.go
+++ b/internal/pkg/mapper/relations/local_save_test.go
@@ -6,13 +6,14 @@ import (
 	"github.com/stretchr/testify/assert"
 
 	"github.com/keboola/keboola-as-code/internal/pkg/fixtures"
-	. "github.com/keboola/keboola-as-code/internal/pkg/mapper/relations"
 	"github.com/keboola/keboola-as-code/internal/pkg/model"
 )
 
 func TestRelationsMapperSaveLocal(t *testing.T) {
 	t.Parallel()
-	context, _ := createMapperContext(t)
+	state, d := createStateWithMapper(t)
+	logger := d.DebugLogger()
+
 	objectManifest := &model.ConfigManifest{}
 	object := &fixtures.MockedObject{}
 	recipe := &model.LocalSaveRecipe{ChangedFields: model.ChangedFields{}, ObjectManifest: objectManifest, Object: object}
@@ -24,7 +25,8 @@ func TestRelationsMapperSaveLocal(t *testing.T) {
 
 	assert.Empty(t, objectManifest.Relations)
 	assert.NotEmpty(t, object.Relations)
-	assert.NoError(t, NewMapper(context).MapBeforeLocalSave(recipe))
+	assert.NoError(t, state.Mapper().MapBeforeLocalSave(recipe))
+	assert.Empty(t, logger.WarnAndErrorMessages())
 
 	// ManifestSide relations copied from object.Relations -> manifest.Relations
 	assert.NotEmpty(t, objectManifest.Relations)

--- a/internal/pkg/mapper/relations/relations.go
+++ b/internal/pkg/mapper/relations/relations.go
@@ -1,13 +1,15 @@
 package relations
 
 import (
-	"github.com/keboola/keboola-as-code/internal/pkg/mapper"
+	"github.com/keboola/keboola-as-code/internal/pkg/log"
+	"github.com/keboola/keboola-as-code/internal/pkg/state"
 )
 
 type relationsMapper struct {
-	mapper.Context
+	state  *state.State
+	logger log.Logger
 }
 
-func NewMapper(context mapper.Context) *relationsMapper {
-	return &relationsMapper{Context: context}
+func NewMapper(s *state.State) *relationsMapper {
+	return &relationsMapper{state: s, logger: s.Logger()}
 }

--- a/internal/pkg/mapper/relations/relations_test.go
+++ b/internal/pkg/mapper/relations/relations_test.go
@@ -3,26 +3,15 @@ package relations_test
 import (
 	"testing"
 
-	"github.com/stretchr/testify/assert"
-
-	"github.com/keboola/keboola-as-code/internal/pkg/filesystem/aferofs"
-	"github.com/keboola/keboola-as-code/internal/pkg/filesystem/knownpaths"
-	"github.com/keboola/keboola-as-code/internal/pkg/log"
-	"github.com/keboola/keboola-as-code/internal/pkg/mapper"
-	"github.com/keboola/keboola-as-code/internal/pkg/model"
-	"github.com/keboola/keboola-as-code/internal/pkg/naming"
+	"github.com/keboola/keboola-as-code/internal/pkg/mapper/relations"
 	"github.com/keboola/keboola-as-code/internal/pkg/state"
-	"github.com/keboola/keboola-as-code/internal/pkg/testapi"
+	"github.com/keboola/keboola-as-code/internal/pkg/testdeps"
 )
 
-func createMapperContext(t *testing.T) (mapper.Context, log.DebugLogger) {
+func createStateWithMapper(t *testing.T) (*state.State, *testdeps.TestContainer) {
 	t.Helper()
-	logger := log.NewDebugLogger()
-	fs, err := aferofs.NewMemoryFs(logger, ".")
-	assert.NoError(t, err)
-	namingRegistry := naming.NewRegistry()
-	projectState := state.NewRegistry(knownpaths.NewNop(), namingRegistry, model.NewComponentsMap(testapi.NewMockedComponentsProvider()), model.SortByPath)
-	namingTemplate := naming.TemplateWithIds()
-	namingGenerator := naming.NewGenerator(namingTemplate, namingRegistry)
-	return mapper.Context{Logger: logger, Fs: fs, NamingGenerator: namingGenerator, NamingRegistry: namingRegistry, State: projectState}, logger
+	d := testdeps.New()
+	mockedState := d.EmptyState()
+	mockedState.Mapper().AddMapper(relations.NewMapper(mockedState))
+	return mockedState, d
 }

--- a/internal/pkg/mapper/scheduler/persist.go
+++ b/internal/pkg/mapper/scheduler/persist.go
@@ -20,7 +20,7 @@ func (m *schedulerMapper) MapBeforePersist(recipe *model.PersistRecipe) error {
 	}
 
 	// Get component
-	component, err := m.State.Components().Get(configManifest.ComponentKey())
+	component, err := m.state.Components().Get(configManifest.ComponentKey())
 	if err != nil {
 		return err
 	}

--- a/internal/pkg/mapper/scheduler/persist_test.go
+++ b/internal/pkg/mapper/scheduler/persist_test.go
@@ -5,17 +5,13 @@ import (
 
 	"github.com/stretchr/testify/assert"
 
-	"github.com/keboola/keboola-as-code/internal/pkg/log"
-	. "github.com/keboola/keboola-as-code/internal/pkg/mapper/scheduler"
 	"github.com/keboola/keboola-as-code/internal/pkg/model"
-	"github.com/keboola/keboola-as-code/internal/pkg/testapi"
 )
 
 func TestVariablesMapBeforePersist(t *testing.T) {
 	t.Parallel()
-	context := createMapperContext(t)
-	schedulerApi, _ := testapi.NewMockedSchedulerApi(context.Logger.(log.DebugLogger))
-	mapper := NewMapper(context, schedulerApi)
+	state, d := createStateWithMapper(t)
+	logger := d.DebugLogger()
 
 	parentKey := model.ConfigKey{
 		BranchId:    123,
@@ -36,7 +32,8 @@ func TestVariablesMapBeforePersist(t *testing.T) {
 
 	// Invoke
 	assert.Empty(t, configManifest.Relations)
-	assert.NoError(t, mapper.MapBeforePersist(recipe))
+	assert.NoError(t, state.Mapper().MapBeforePersist(recipe))
+	assert.Empty(t, logger.WarnAndErrorMessages())
 
 	// Relation has been created
 	assert.Equal(t, model.Relations{

--- a/internal/pkg/mapper/scheduler/remote_activate.go
+++ b/internal/pkg/mapper/scheduler/remote_activate.go
@@ -3,9 +3,10 @@ package scheduler
 import (
 	"github.com/keboola/keboola-as-code/internal/pkg/client"
 	"github.com/keboola/keboola-as-code/internal/pkg/model"
+	"github.com/keboola/keboola-as-code/internal/pkg/scheduler"
 )
 
 // onRemoteSave activates scheduler by Scheduler API when scheduler configuration is created/updated.
-func (m *schedulerMapper) onRemoteSave(pool *client.Pool, configState *model.ConfigState) {
-	pool.Request(m.api.ActivateScheduleRequest(configState.Id, "")).Send()
+func (m *schedulerMapper) onRemoteSave(api *scheduler.Api, pool *client.Pool, configState *model.ConfigState) {
+	pool.Request(api.ActivateScheduleRequest(configState.Id, "")).Send()
 }

--- a/internal/pkg/mapper/scheduler/remote_deactivate.go
+++ b/internal/pkg/mapper/scheduler/remote_deactivate.go
@@ -3,9 +3,10 @@ package scheduler
 import (
 	"github.com/keboola/keboola-as-code/internal/pkg/client"
 	"github.com/keboola/keboola-as-code/internal/pkg/model"
+	"github.com/keboola/keboola-as-code/internal/pkg/scheduler"
 )
 
 // onRemoteDelete deactivates scheduler by Scheduler API when scheduler configuration is deleted.
-func (m *schedulerMapper) onRemoteDelete(pool *client.Pool, configState *model.ConfigState) {
-	pool.Request(m.api.DeleteSchedulesForConfigurationRequest(configState.Id)).Send()
+func (m *schedulerMapper) onRemoteDelete(api *scheduler.Api, pool *client.Pool, configState *model.ConfigState) {
+	pool.Request(api.DeleteSchedulesForConfigurationRequest(configState.Id)).Send()
 }

--- a/internal/pkg/mapper/scheduler/remote_load.go
+++ b/internal/pkg/mapper/scheduler/remote_load.go
@@ -13,7 +13,7 @@ func (m *schedulerMapper) MapAfterRemoteLoad(recipe *model.RemoteLoadRecipe) err
 	}
 
 	// Check component type
-	component, err := m.State.Components().Get(object.ComponentKey())
+	component, err := m.state.Components().Get(object.ComponentKey())
 	if err != nil {
 		return err
 	}

--- a/internal/pkg/mapper/scheduler/remote_load_test.go
+++ b/internal/pkg/mapper/scheduler/remote_load_test.go
@@ -6,18 +6,14 @@ import (
 	"github.com/stretchr/testify/assert"
 
 	"github.com/keboola/keboola-as-code/internal/pkg/json"
-	"github.com/keboola/keboola-as-code/internal/pkg/log"
-	. "github.com/keboola/keboola-as-code/internal/pkg/mapper/scheduler"
 	"github.com/keboola/keboola-as-code/internal/pkg/model"
-	"github.com/keboola/keboola-as-code/internal/pkg/testapi"
 	"github.com/keboola/keboola-as-code/internal/pkg/utils/orderedmap"
 )
 
 func TestSchedulerMapAfterRemoteLoad(t *testing.T) {
 	t.Parallel()
-	context := createMapperContext(t)
-	schedulerApi, _ := testapi.NewMockedSchedulerApi(log.NewDebugLogger())
-	mapper := NewMapper(context, schedulerApi)
+	state, d := createStateWithMapper(t)
+	logger := d.DebugLogger()
 
 	// Create api and internal object
 	key := model.ConfigKey{BranchId: 1, ComponentId: model.SchedulerComponentId, Id: `123`}
@@ -35,7 +31,8 @@ func TestSchedulerMapAfterRemoteLoad(t *testing.T) {
 
 	// Invoke
 	assert.Empty(t, object.Relations)
-	assert.NoError(t, mapper.MapAfterRemoteLoad(recipe))
+	assert.NoError(t, state.Mapper().MapAfterRemoteLoad(recipe))
+	assert.Empty(t, logger.WarnAndErrorMessages())
 
 	// Internal object has new relation
 	assert.Equal(t, model.Relations{

--- a/internal/pkg/mapper/scheduler/remote_save_test.go
+++ b/internal/pkg/mapper/scheduler/remote_save_test.go
@@ -6,18 +6,14 @@ import (
 	"github.com/stretchr/testify/assert"
 
 	"github.com/keboola/keboola-as-code/internal/pkg/json"
-	"github.com/keboola/keboola-as-code/internal/pkg/log"
-	. "github.com/keboola/keboola-as-code/internal/pkg/mapper/scheduler"
 	"github.com/keboola/keboola-as-code/internal/pkg/model"
-	"github.com/keboola/keboola-as-code/internal/pkg/testapi"
 	"github.com/keboola/keboola-as-code/internal/pkg/utils/orderedmap"
 )
 
 func TestSchedulerMapBeforeRemoteSave(t *testing.T) {
 	t.Parallel()
-	context := createMapperContext(t)
-	schedulerApi, _ := testapi.NewMockedSchedulerApi(log.NewDebugLogger())
-	mapper := NewMapper(context, schedulerApi)
+	state, d := createStateWithMapper(t)
+	logger := d.DebugLogger()
 
 	// Scheduler config
 	content := orderedmap.New()
@@ -34,7 +30,8 @@ func TestSchedulerMapBeforeRemoteSave(t *testing.T) {
 
 	// Invoke
 	assert.NotEmpty(t, object.Relations)
-	assert.NoError(t, mapper.MapBeforeRemoteSave(recipe))
+	assert.NoError(t, state.Mapper().MapBeforeRemoteSave(recipe))
+	assert.Empty(t, logger.WarnAndErrorMessages())
 
 	// All relations have been mapped
 	assert.Empty(t, object.Relations)

--- a/internal/pkg/mapper/scheduler/scheduler.go
+++ b/internal/pkg/mapper/scheduler/scheduler.go
@@ -1,15 +1,19 @@
 package scheduler
 
 import (
-	"github.com/keboola/keboola-as-code/internal/pkg/mapper"
 	"github.com/keboola/keboola-as-code/internal/pkg/scheduler"
+	"github.com/keboola/keboola-as-code/internal/pkg/state"
 )
 
-type schedulerMapper struct {
-	mapper.Context
-	api *scheduler.Api
+type dependencies interface {
+	SchedulerApi() (*scheduler.Api, error)
 }
 
-func NewMapper(context mapper.Context, api *scheduler.Api) *schedulerMapper {
-	return &schedulerMapper{Context: context, api: api}
+type schedulerMapper struct {
+	dependencies
+	state *state.State
+}
+
+func NewMapper(s *state.State, d dependencies) *schedulerMapper {
+	return &schedulerMapper{state: s, dependencies: d}
 }

--- a/internal/pkg/mapper/scheduler/scheduler_test.go
+++ b/internal/pkg/mapper/scheduler/scheduler_test.go
@@ -3,26 +3,15 @@ package scheduler_test
 import (
 	"testing"
 
-	"github.com/stretchr/testify/assert"
-
-	"github.com/keboola/keboola-as-code/internal/pkg/filesystem/aferofs"
-	"github.com/keboola/keboola-as-code/internal/pkg/filesystem/knownpaths"
-	"github.com/keboola/keboola-as-code/internal/pkg/log"
-	"github.com/keboola/keboola-as-code/internal/pkg/mapper"
-	"github.com/keboola/keboola-as-code/internal/pkg/model"
-	"github.com/keboola/keboola-as-code/internal/pkg/naming"
+	"github.com/keboola/keboola-as-code/internal/pkg/mapper/scheduler"
 	"github.com/keboola/keboola-as-code/internal/pkg/state"
-	"github.com/keboola/keboola-as-code/internal/pkg/testapi"
+	"github.com/keboola/keboola-as-code/internal/pkg/testdeps"
 )
 
-func createMapperContext(t *testing.T) mapper.Context {
+func createStateWithMapper(t *testing.T) (*state.State, *testdeps.TestContainer) {
 	t.Helper()
-	logger := log.NewDebugLogger()
-	fs, err := aferofs.NewMemoryFs(logger, ".")
-	assert.NoError(t, err)
-	namingRegistry := naming.NewRegistry()
-	projectState := state.NewRegistry(knownpaths.NewNop(), namingRegistry, model.NewComponentsMap(testapi.NewMockedComponentsProvider()), model.SortByPath)
-	namingTemplate := naming.TemplateWithIds()
-	namingGenerator := naming.NewGenerator(namingTemplate, namingRegistry)
-	return mapper.Context{Logger: logger, Fs: fs, NamingGenerator: namingGenerator, NamingRegistry: namingRegistry, State: projectState}
+	d := testdeps.New()
+	mockedState := d.EmptyState()
+	mockedState.Mapper().AddMapper(scheduler.NewMapper(mockedState, d))
+	return mockedState, d
 }

--- a/internal/pkg/mapper/sharedcode/codes/codes.go
+++ b/internal/pkg/mapper/sharedcode/codes/codes.go
@@ -1,16 +1,18 @@
 package codes
 
 import (
-	mapperPkg "github.com/keboola/keboola-as-code/internal/pkg/mapper"
+	"github.com/keboola/keboola-as-code/internal/pkg/log"
 	"github.com/keboola/keboola-as-code/internal/pkg/mapper/sharedcode/helper"
+	"github.com/keboola/keboola-as-code/internal/pkg/state"
 )
 
 // mapper saves shared codes (config rows) to "codes" local dir.
 type mapper struct {
-	mapperPkg.Context
 	*helper.SharedCodeHelper
+	state  *state.State
+	logger log.Logger
 }
 
-func NewMapper(context mapperPkg.Context) *mapper {
-	return &mapper{Context: context, SharedCodeHelper: helper.New(context.State, context.NamingRegistry)}
+func NewMapper(s *state.State) *mapper {
+	return &mapper{state: s, logger: s.Logger(), SharedCodeHelper: helper.New(s)}
 }

--- a/internal/pkg/mapper/sharedcode/codes/local_load.go
+++ b/internal/pkg/mapper/sharedcode/codes/local_load.go
@@ -26,7 +26,7 @@ func (m *mapper) MapAfterLocalLoad(recipe *model.LocalLoadRecipe) error {
 		return err
 	} else if ok {
 		row := recipe.Object.(*model.ConfigRow)
-		config := m.State.MustGet(row.ConfigKey()).LocalState().(*model.Config)
+		config := m.state.MustGet(row.ConfigKey()).LocalState().(*model.Config)
 		if err := m.onRowLocalLoad(config, row, recipe); err != nil {
 			errors.Append(err)
 		}
@@ -67,8 +67,8 @@ func (m *mapper) onRowLocalLoad(config *model.Config, row *model.ConfigRow, reci
 	}
 
 	// Load file
-	codeFilePath := m.NamingGenerator.SharedCodeFilePath(recipe.Path(), config.SharedCode.Target)
-	codeFile, err := m.Fs.ReadFile(codeFilePath, `shared code`)
+	codeFilePath := m.state.NamingGenerator().SharedCodeFilePath(recipe.Path(), config.SharedCode.Target)
+	codeFile, err := m.state.Fs().ReadFile(codeFilePath, `shared code`)
 	if err != nil {
 		return err
 	}

--- a/internal/pkg/mapper/sharedcode/codes/local_save.go
+++ b/internal/pkg/mapper/sharedcode/codes/local_save.go
@@ -44,7 +44,7 @@ func (m *mapper) onRowLocalSave(row *model.ConfigRow, recipe *model.LocalSaveRec
 
 	// Create code file
 	codeContent := row.SharedCode.String()
-	codeFilePath := m.NamingGenerator.SharedCodeFilePath(recipe.Path(), row.SharedCode.Target)
+	codeFilePath := m.state.NamingGenerator().SharedCodeFilePath(recipe.Path(), row.SharedCode.Target)
 	recipe.Files.
 		Add(filesystem.NewFile(codeFilePath, codeContent).SetDescription(`shared code`)).
 		AddTag(model.FileTypeOther).

--- a/internal/pkg/mapper/sharedcode/codes/remote_load.go
+++ b/internal/pkg/mapper/sharedcode/codes/remote_load.go
@@ -23,7 +23,7 @@ func (m *mapper) OnRemoteChange(changes *model.RemoteChanges) error {
 
 	if errors.Len() > 0 {
 		// Convert errors to warning
-		m.Logger.Warn(utils.PrefixError(`Warning`, errors))
+		m.logger.Warn(utils.PrefixError(`Warning`, errors))
 	}
 
 	return nil
@@ -54,7 +54,7 @@ func (m *mapper) onConfigRemoteLoad(config *model.Config) error {
 	config.SharedCode = &model.SharedCodeConfig{Target: model.ComponentId(target)}
 
 	errors := utils.NewMultiError()
-	for _, row := range m.State.RemoteObjects().ConfigRowsFrom(config.ConfigKey) {
+	for _, row := range m.state.RemoteObjects().ConfigRowsFrom(config.ConfigKey) {
 		if err := m.onRowRemoteLoad(config, row); err != nil {
 			errors.Append(err)
 		}

--- a/internal/pkg/mapper/sharedcode/codes/remote_load_test.go
+++ b/internal/pkg/mapper/sharedcode/codes/remote_load_test.go
@@ -6,13 +6,16 @@ import (
 
 	"github.com/stretchr/testify/assert"
 
-	. "github.com/keboola/keboola-as-code/internal/pkg/mapper/sharedcode/codes"
 	"github.com/keboola/keboola-as-code/internal/pkg/model"
 )
 
 func TestSharedCodeRemoteLoad(t *testing.T) {
 	t.Parallel()
-	context, logs, configState, rowState := createRemoteSharedCode(t)
+
+	state, d := createStateWithMapper(t)
+	logger := d.DebugLogger()
+	configState, rowState := createRemoteSharedCode(t, state)
+
 	rowState.Remote.Content.Set(model.SharedCodeContentKey, []interface{}{
 		"SELECT 1;",
 		"SELECT 2;",
@@ -22,8 +25,8 @@ func TestSharedCodeRemoteLoad(t *testing.T) {
 	changes := model.NewRemoteChanges()
 	changes.AddLoaded(configState)
 	changes.AddLoaded(rowState)
-	assert.NoError(t, NewMapper(context).OnRemoteChange(changes))
-	assert.Empty(t, logs.AllMessages())
+	assert.NoError(t, state.Mapper().OnRemoteChange(changes))
+	assert.Empty(t, logger.WarnAndErrorMessages())
 
 	// Check config
 	assert.Equal(t, &model.SharedCodeConfig{
@@ -46,15 +49,19 @@ func TestSharedCodeRemoteLoad(t *testing.T) {
 
 func TestSharedCodeRemoteLoad_Legacy(t *testing.T) {
 	t.Parallel()
-	context, logs, configState, rowState := createRemoteSharedCode(t)
+
+	state, d := createStateWithMapper(t)
+	logger := d.DebugLogger()
+	configState, rowState := createRemoteSharedCode(t, state)
+
 	rowState.Remote.Content.Set(model.SharedCodeContentKey, "SELECT 1; \n  SELECT 2; \n ")
 
 	// Invoke
 	changes := model.NewRemoteChanges()
 	changes.AddLoaded(configState)
 	changes.AddLoaded(rowState)
-	assert.NoError(t, NewMapper(context).OnRemoteChange(changes))
-	assert.Empty(t, logs.AllMessages())
+	assert.NoError(t, state.Mapper().OnRemoteChange(changes))
+	assert.Empty(t, logger.WarnAndErrorMessages())
 
 	// Check config
 	assert.Equal(t, &model.SharedCodeConfig{
@@ -77,14 +84,18 @@ func TestSharedCodeRemoteLoad_Legacy(t *testing.T) {
 
 func TestSharedCodeRemoteLoad_UnexpectedTypeInConfig(t *testing.T) {
 	t.Parallel()
-	context, logs, configState, rowState := createRemoteSharedCode(t)
+
+	state, d := createStateWithMapper(t)
+	logger := d.DebugLogger()
+	configState, rowState := createRemoteSharedCode(t, state)
+
 	configState.Remote.Content.Set(model.ShareCodeTargetComponentKey, 123)
 
 	// Invoke
 	changes := model.NewRemoteChanges()
 	changes.AddLoaded(configState)
 	changes.AddLoaded(rowState)
-	assert.NoError(t, NewMapper(context).OnRemoteChange(changes))
+	assert.NoError(t, state.Mapper().OnRemoteChange(changes))
 
 	// Check logs
 	expectedLogs := `
@@ -92,7 +103,7 @@ WARN  Warning:
   - invalid config "branch:789/component:keboola.shared-code/config:123":
     - key "componentId" should be string, found "int"
 `
-	assert.Equal(t, strings.TrimLeft(expectedLogs, "\n"), logs.AllMessages())
+	assert.Equal(t, strings.TrimLeft(expectedLogs, "\n"), logger.AllMessages())
 
 	// Check config and row
 	assert.Empty(t, configState.Remote.SharedCode)
@@ -101,14 +112,18 @@ WARN  Warning:
 
 func TestSharedCodeRemoteLoad_UnexpectedTypeInRow(t *testing.T) {
 	t.Parallel()
-	context, logs, configState, rowState := createRemoteSharedCode(t)
+
+	state, d := createStateWithMapper(t)
+	logger := d.DebugLogger()
+	configState, rowState := createRemoteSharedCode(t, state)
+
 	rowState.Remote.Content.Set(model.SharedCodeContentKey, 123)
 
 	// Invoke
 	changes := model.NewRemoteChanges()
 	changes.AddLoaded(configState)
 	changes.AddLoaded(rowState)
-	assert.NoError(t, NewMapper(context).OnRemoteChange(changes))
+	assert.NoError(t, state.Mapper().OnRemoteChange(changes))
 
 	// Check logs
 	expectedLogs := `
@@ -116,7 +131,7 @@ WARN  Warning:
   - invalid config row "branch:789/component:keboola.shared-code/config:123/row:456":
     - key "code_content" should be string or array, found "int"
 `
-	assert.Equal(t, strings.TrimLeft(expectedLogs, "\n"), logs.AllMessages())
+	assert.Equal(t, strings.TrimLeft(expectedLogs, "\n"), logger.AllMessages())
 
 	// Check config and row
 	assert.Equal(t, &model.SharedCodeConfig{

--- a/internal/pkg/mapper/sharedcode/codes/remote_save_test.go
+++ b/internal/pkg/mapper/sharedcode/codes/remote_save_test.go
@@ -5,14 +5,16 @@ import (
 
 	"github.com/stretchr/testify/assert"
 
-	. "github.com/keboola/keboola-as-code/internal/pkg/mapper/sharedcode/codes"
 	"github.com/keboola/keboola-as-code/internal/pkg/model"
 )
 
 func TestSharedCodeRemoteSave(t *testing.T) {
 	t.Parallel()
 	targetComponentId := model.ComponentId(`keboola.python-transformation-v2`)
-	context, logs, configState, rowState := createInternalSharedCode(t, targetComponentId)
+
+	state, d := createStateWithMapper(t)
+	logger := d.DebugLogger()
+	configState, rowState := createInternalSharedCode(t, targetComponentId, state)
 
 	// Map config
 	configRecipe := &model.RemoteSaveRecipe{
@@ -20,9 +22,9 @@ func TestSharedCodeRemoteSave(t *testing.T) {
 		Object:         configState.Remote,
 		ChangedFields:  model.NewChangedFields(`configuration`),
 	}
-	err := NewMapper(context).MapBeforeRemoteSave(configRecipe)
+	err := state.Mapper().MapBeforeRemoteSave(configRecipe)
 	assert.NoError(t, err)
-	assert.Empty(t, logs.AllMessages())
+	assert.Empty(t, logger.WarnAndErrorMessages())
 
 	// Map row
 	rowRecipe := &model.RemoteSaveRecipe{
@@ -30,9 +32,9 @@ func TestSharedCodeRemoteSave(t *testing.T) {
 		Object:         rowState.Remote,
 		ChangedFields:  model.NewChangedFields(`configuration`),
 	}
-	err = NewMapper(context).MapBeforeRemoteSave(rowRecipe)
+	err = state.Mapper().MapBeforeRemoteSave(rowRecipe)
 	assert.NoError(t, err)
-	assert.Empty(t, logs.AllMessages())
+	assert.Empty(t, logger.WarnAndErrorMessages())
 
 	// Assert
 	assert.Equal(t,

--- a/internal/pkg/mapper/sharedcode/helper/helper.go
+++ b/internal/pkg/mapper/sharedcode/helper/helper.go
@@ -86,52 +86,52 @@ func (h *SharedCodeHelper) GetSharedCodeByPath(branchKey model.BranchKey, path s
 
 	// Get key by path
 	path = filesystem.Join(branch.Path(), path)
-	keyRaw, found := h.namingRegistry.KeyByPath(path)
+	configStateRaw, found := h.state.GetByPath(path)
 	if !found {
 		return nil, fmt.Errorf(`missing shared code "%s"`, path)
 	}
 
 	// Is config?
-	key, ok := keyRaw.(model.ConfigKey)
+	configState, ok := configStateRaw.(*model.ConfigState)
 	if !ok {
 		return nil, fmt.Errorf(`path "%s" is not shared code config`, path)
 	}
 
 	// Is from right parent?
-	if branchKey != key.BranchKey() {
+	if branchKey != configState.BranchKey() {
 		return nil, fmt.Errorf(`config "%s" is not from branch "%s"`, path, branch.Path())
 	}
 
 	// Shared code?
-	if key.ComponentId != model.SharedCodeComponentId {
+	if configState.ComponentId != model.SharedCodeComponentId {
 		return nil, fmt.Errorf(`config "%s" is not shared code`, path)
 	}
 
 	// Ok
-	return h.state.MustGet(key).(*model.ConfigState), nil
+	return configState, nil
 }
 
 func (h *SharedCodeHelper) GetSharedCodeRowByPath(sharedCode *model.ConfigState, path string) (*model.ConfigRowState, error) {
 	// Get key by path
 	path = filesystem.Join(sharedCode.Path(), path)
-	keyRaw, found := h.namingRegistry.KeyByPath(path)
+	configRowStateRaw, found := h.state.GetByPath(path)
 	if !found {
 		return nil, fmt.Errorf(`missing shared code "%s"`, path)
 	}
 
 	// Is config row?
-	key, ok := keyRaw.(model.ConfigRowKey)
+	configRowState, ok := configRowStateRaw.(*model.ConfigRowState)
 	if !ok {
 		return nil, fmt.Errorf(`path "%s" is not config row`, path)
 	}
 
 	// Is from parent?
-	if sharedCode.Key() != key.ConfigKey() {
+	if sharedCode.Key() != configRowState.ConfigKey() {
 		return nil, fmt.Errorf(`row "%s" is not from shared code "%s"`, path, sharedCode.Path())
 	}
 
 	// Ok
-	return h.state.MustGet(key).(*model.ConfigRowState), nil
+	return configRowState, nil
 }
 
 func (h *SharedCodeHelper) GetSharedCodeVariablesId(configRow *model.ConfigRow) (string, bool) {

--- a/internal/pkg/mapper/sharedcode/helper/helper.go
+++ b/internal/pkg/mapper/sharedcode/helper/helper.go
@@ -5,18 +5,17 @@ import (
 
 	"github.com/keboola/keboola-as-code/internal/pkg/filesystem"
 	"github.com/keboola/keboola-as-code/internal/pkg/model"
-	"github.com/keboola/keboola-as-code/internal/pkg/naming"
+	"github.com/keboola/keboola-as-code/internal/pkg/state"
 	"github.com/keboola/keboola-as-code/internal/pkg/utils"
 )
 
 // SharedCodeHelper gets some values from shared codes.
 type SharedCodeHelper struct {
-	state          model.ObjectStates
-	namingRegistry *naming.Registry
+	state *state.State
 }
 
-func New(state model.ObjectStates, naming *naming.Registry) *SharedCodeHelper {
-	return &SharedCodeHelper{state: state, namingRegistry: naming}
+func New(s *state.State) *SharedCodeHelper {
+	return &SharedCodeHelper{state: s}
 }
 
 func (h *SharedCodeHelper) IsSharedCodeKey(key model.Key) (bool, error) {

--- a/internal/pkg/mapper/sharedcode/links/links.go
+++ b/internal/pkg/mapper/sharedcode/links/links.go
@@ -32,7 +32,7 @@ func NewMapper(s *state.State) *mapper {
 
 func (m *mapper) linkToIdPlaceholder(code *model.Code, link model.Script) (model.Script, error) {
 	if link, ok := link.(model.LinkScript); ok {
-		row, ok := m.State.GetOrNil(link.Target).(*model.ConfigRowState)
+		row, ok := m.state.GetOrNil(link.Target).(*model.ConfigRowState)
 		script := model.StaticScript{Value: m.id.format(row.Id)}
 		if !ok {
 			return script, utils.PrefixError(
@@ -47,7 +47,7 @@ func (m *mapper) linkToIdPlaceholder(code *model.Code, link model.Script) (model
 
 func (m *mapper) linkToPathPlaceholder(code *model.Code, link model.Script, sharedCode *model.ConfigState) (model.Script, error) {
 	if link, ok := link.(model.LinkScript); ok {
-		row, ok := m.State.GetOrNil(link.Target).(*model.ConfigRowState)
+		row, ok := m.state.GetOrNil(link.Target).(*model.ConfigRowState)
 		if !ok || sharedCode == nil {
 			// Return ID placeholder, if row is not found
 			return model.StaticScript{Value: m.id.format(link.Target.Id)}, utils.PrefixError(
@@ -80,7 +80,7 @@ func (m *mapper) parseIdPlaceholder(code *model.Code, script model.Script, share
 		ConfigId:    sharedCode.Id,
 		Id:          id,
 	}
-	row, found := m.State.GetOrNil(rowKey).(*model.ConfigRowState)
+	row, found := m.state.GetOrNil(rowKey).(*model.ConfigRowState)
 	if !found {
 		return nil, nil, utils.PrefixError(
 			fmt.Sprintf(`missing shared code %s`, rowKey.Desc()),
@@ -101,7 +101,7 @@ func (m *mapper) parsePathPlaceholder(code *model.Code, script model.Script, sha
 	}
 
 	// Get shared code row
-	row, err := m.GetSharedCodeRowByPath(sharedCode, path)
+	row, err := m.helper.GetSharedCodeRowByPath(sharedCode, path)
 	if err != nil {
 		return nil, nil, utils.PrefixError(
 			err.Error(),

--- a/internal/pkg/mapper/sharedcode/links/links.go
+++ b/internal/pkg/mapper/sharedcode/links/links.go
@@ -4,29 +4,29 @@ import (
 	"fmt"
 
 	"github.com/keboola/keboola-as-code/internal/pkg/filesystem"
-	"github.com/keboola/keboola-as-code/internal/pkg/local"
-	mapperPkg "github.com/keboola/keboola-as-code/internal/pkg/mapper"
+	"github.com/keboola/keboola-as-code/internal/pkg/log"
 	"github.com/keboola/keboola-as-code/internal/pkg/mapper/sharedcode/helper"
 	"github.com/keboola/keboola-as-code/internal/pkg/model"
+	"github.com/keboola/keboola-as-code/internal/pkg/state"
 	"github.com/keboola/keboola-as-code/internal/pkg/utils"
 )
 
 // mapper replaces "shared_code_id" with "shared_code_path" in local fs.
 type mapper struct {
-	mapperPkg.Context
-	*helper.SharedCodeHelper
-	localManager *local.Manager
-	id           *idUtils
-	path         *pathUtils
+	state  *state.State
+	logger log.Logger
+	helper *helper.SharedCodeHelper
+	id     *idUtils
+	path   *pathUtils
 }
 
-func NewMapper(localManager *local.Manager, context mapperPkg.Context) *mapper {
+func NewMapper(s *state.State) *mapper {
 	return &mapper{
-		Context:          context,
-		SharedCodeHelper: helper.New(context.State, context.NamingRegistry),
-		localManager:     localManager,
-		id:               newIdUtils(),
-		path:             newPathUtils(),
+		state:  s,
+		logger: s.Logger(),
+		helper: helper.New(s),
+		id:     newIdUtils(),
+		path:   newPathUtils(),
 	}
 }
 

--- a/internal/pkg/mapper/sharedcode/links/links_test.go
+++ b/internal/pkg/mapper/sharedcode/links/links_test.go
@@ -5,39 +5,22 @@ import (
 
 	"github.com/stretchr/testify/assert"
 
-	"github.com/keboola/keboola-as-code/internal/pkg/filesystem/aferofs"
-	"github.com/keboola/keboola-as-code/internal/pkg/filesystem/knownpaths"
-	"github.com/keboola/keboola-as-code/internal/pkg/local"
-	"github.com/keboola/keboola-as-code/internal/pkg/log"
-	"github.com/keboola/keboola-as-code/internal/pkg/mapper"
 	"github.com/keboola/keboola-as-code/internal/pkg/mapper/sharedcode/links"
 	"github.com/keboola/keboola-as-code/internal/pkg/model"
-	"github.com/keboola/keboola-as-code/internal/pkg/naming"
-	projectManifest "github.com/keboola/keboola-as-code/internal/pkg/project/manifest"
 	"github.com/keboola/keboola-as-code/internal/pkg/state"
-	"github.com/keboola/keboola-as-code/internal/pkg/testapi"
+	"github.com/keboola/keboola-as-code/internal/pkg/testdeps"
 	"github.com/keboola/keboola-as-code/internal/pkg/utils/orderedmap"
 )
 
-func createMapper(t *testing.T) (*mapper.Mapper, mapper.Context, log.DebugLogger) {
+func createStateWithMapper(t *testing.T) (*state.State, *testdeps.TestContainer) {
 	t.Helper()
-	logger := log.NewDebugLogger()
-	fs, err := aferofs.NewMemoryFs(logger, ".")
-	assert.NoError(t, err)
-	namingRegistry := naming.NewRegistry()
-	projectState := state.NewRegistry(knownpaths.NewNop(), namingRegistry, model.NewComponentsMap(testapi.NewMockedComponentsProvider()), model.SortByPath)
-	namingTemplate := naming.TemplateWithIds()
-	namingGenerator := naming.NewGenerator(namingTemplate, namingRegistry)
-	context := mapper.Context{Logger: logger, Fs: fs, NamingGenerator: namingGenerator, NamingRegistry: namingRegistry, State: projectState}
-	manifest := projectManifest.New(1, `foo.bar`)
-	assert.NoError(t, err)
-	mapperInst := mapper.New()
-	localManager := local.NewManager(logger, fs, manifest, namingGenerator, projectState, mapperInst)
-	mapperInst.AddMapper(links.NewMapper(localManager, context))
-	return mapperInst, context, logger
+	d := testdeps.New()
+	mockedState := d.EmptyState()
+	mockedState.Mapper().AddMapper(links.NewMapper(mockedState))
+	return mockedState, d
 }
 
-func createLocalTranWithSharedCode(t *testing.T, context mapper.Context) *model.ConfigState {
+func createLocalTranWithSharedCode(t *testing.T, state *state.State) *model.ConfigState {
 	t.Helper()
 
 	key := model.ConfigKey{
@@ -95,12 +78,11 @@ func createLocalTranWithSharedCode(t *testing.T, context mapper.Context) *model.
 			},
 		},
 	}
-	assert.NoError(t, context.State.Set(transformation))
-	assert.NoError(t, context.NamingRegistry.Attach(transformation.Key(), transformation.PathInProject))
+	assert.NoError(t, state.Set(transformation))
 	return transformation
 }
 
-func createInternalTranWithSharedCode(t *testing.T, sharedCodeKey model.ConfigKey, sharedCodeRowsKeys []model.ConfigRowKey, context mapper.Context) *model.ConfigState {
+func createInternalTranWithSharedCode(t *testing.T, sharedCodeKey model.ConfigKey, sharedCodeRowsKeys []model.ConfigRowKey, state *state.State) *model.ConfigState {
 	t.Helper()
 
 	key := model.ConfigKey{
@@ -158,11 +140,11 @@ func createInternalTranWithSharedCode(t *testing.T, sharedCodeKey model.ConfigKe
 		},
 	}
 
-	assert.NoError(t, context.State.Set(transformation))
+	assert.NoError(t, state.Set(transformation))
 	return transformation
 }
 
-func createRemoteTranWithSharedCode(t *testing.T, sharedCodeKey model.ConfigKey, sharedCodeRowsKeys []model.ConfigRowKey, context mapper.Context) *model.ConfigState {
+func createRemoteTranWithSharedCode(t *testing.T, sharedCodeKey model.ConfigKey, sharedCodeRowsKeys []model.ConfigRowKey, state *state.State) *model.ConfigState {
 	t.Helper()
 
 	// Rows -> rows IDs
@@ -191,6 +173,6 @@ func createRemoteTranWithSharedCode(t *testing.T, sharedCodeKey model.ConfigKey,
 		},
 	}
 
-	assert.NoError(t, context.State.Set(transformation))
+	assert.NoError(t, state.Set(transformation))
 	return transformation
 }

--- a/internal/pkg/mapper/sharedcode/links/local_load.go
+++ b/internal/pkg/mapper/sharedcode/links/local_load.go
@@ -34,7 +34,7 @@ func (m *mapper) onLocalLoad(objectState model.ObjectState) error {
 	}
 
 	// Get shared code
-	sharedCodeState, err := m.GetSharedCodeByPath(transformation.BranchKey(), sharedCodePath)
+	sharedCodeState, err := m.helper.GetSharedCodeByPath(transformation.BranchKey(), sharedCodePath)
 	if err != nil {
 		return utils.PrefixError(
 			err.Error(),
@@ -53,7 +53,7 @@ func (m *mapper) onLocalLoad(objectState model.ObjectState) error {
 	}
 
 	// Check: target component of the shared code = transformation component
-	if err := m.CheckTargetComponent(sharedCodeConfig, transformation.ConfigKey); err != nil {
+	if err := m.helper.CheckTargetComponent(sharedCodeConfig, transformation.ConfigKey); err != nil {
 		return err
 	}
 

--- a/internal/pkg/mapper/sharedcode/links/local_save.go
+++ b/internal/pkg/mapper/sharedcode/links/local_save.go
@@ -22,7 +22,7 @@ func (m *mapper) MapBeforeLocalSave(recipe *model.LocalSaveRecipe) error {
 
 	if err := m.replaceSharedCodeIdByPath(transformation, recipe); err != nil {
 		// Log errors as warning
-		m.Logger.Warn(utils.PrefixError(`Warning`, err))
+		m.logger.Warn(utils.PrefixError(`Warning`, err))
 	}
 
 	return nil
@@ -38,7 +38,7 @@ func (m *mapper) replaceSharedCodeIdByPath(transformation *model.Config, recipe 
 
 	// Get shared code
 	sharedCodeKey := transformation.Transformation.LinkToSharedCode.Config
-	sharedCodeState, found := m.State.GetOrNil(sharedCodeKey).(*model.ConfigState)
+	sharedCodeState, found := m.state.GetOrNil(sharedCodeKey).(*model.ConfigState)
 
 	// Convert LinkScript to path placeholder
 	errors := utils.NewMultiError()
@@ -62,7 +62,7 @@ func (m *mapper) replaceSharedCodeIdByPath(transformation *model.Config, recipe 
 	}
 
 	// Check: target component of the shared code = transformation component
-	if err := m.CheckTargetComponent(sharedCodeState.LocalOrRemoteState().(*model.Config), transformation.ConfigKey); err != nil {
+	if err := m.helper.CheckTargetComponent(sharedCodeState.LocalOrRemoteState().(*model.Config), transformation.ConfigKey); err != nil {
 		return err
 	}
 

--- a/internal/pkg/mapper/sharedcode/links/remote.go
+++ b/internal/pkg/mapper/sharedcode/links/remote.go
@@ -16,7 +16,7 @@ func (m *mapper) OnRemoteChange(changes *model.RemoteChanges) error {
 
 	if errors.Len() > 0 {
 		// Convert errors to warning
-		m.Logger.Warn(utils.PrefixError(`Warning`, errors))
+		m.logger.Warn(utils.PrefixError(`Warning`, errors))
 	}
 	return nil
 }

--- a/internal/pkg/mapper/sharedcode/links/remote_load.go
+++ b/internal/pkg/mapper/sharedcode/links/remote_load.go
@@ -43,7 +43,7 @@ func (m *mapper) onRemoteLoad(objectState model.ObjectState) error {
 			Id:          model.ConfigId(sharedCodeId),
 		},
 	}
-	sharedCodeState, found := m.State.GetOrNil(linkToSharedCode.Config).(*model.ConfigState)
+	sharedCodeState, found := m.state.GetOrNil(linkToSharedCode.Config).(*model.ConfigState)
 	if !found || !sharedCodeState.HasRemoteState() {
 		return utils.PrefixError(
 			fmt.Sprintf(`missing shared code %s`, linkToSharedCode.Config.Desc()),
@@ -52,7 +52,7 @@ func (m *mapper) onRemoteLoad(objectState model.ObjectState) error {
 	}
 
 	// Check: target component of the shared code = transformation component
-	if err := m.CheckTargetComponent(sharedCodeState.LocalOrRemoteState().(*model.Config), transformation.ConfigKey); err != nil {
+	if err := m.helper.CheckTargetComponent(sharedCodeState.LocalOrRemoteState().(*model.Config), transformation.ConfigKey); err != nil {
 		return err
 	}
 
@@ -90,7 +90,7 @@ func (m *mapper) onRemoteLoad(objectState model.ObjectState) error {
 			ConfigId:    linkToSharedCode.Config.Id,
 			Id:          model.RowId(cast.ToString(rowId)),
 		}
-		if _, found := m.State.Get(rowKey); found {
+		if _, found := m.state.Get(rowKey); found {
 			linkToSharedCode.Rows = append(linkToSharedCode.Rows, rowKey)
 		} else {
 			errors.Append(utils.PrefixError(

--- a/internal/pkg/mapper/sharedcode/links/remote_save_test.go
+++ b/internal/pkg/mapper/sharedcode/links/remote_save_test.go
@@ -11,13 +11,14 @@ import (
 
 func TestRemoteSaveTranWithSharedCode(t *testing.T) {
 	t.Parallel()
-	mapperInst, context, logs := createMapper(t)
+	state, d := createStateWithMapper(t)
+	logger := d.DebugLogger()
 
 	// Shared code config with rows
-	sharedCodeKey, sharedCodeRowsKeys := fixtures.CreateSharedCode(t, context.State, context.NamingRegistry)
+	sharedCodeKey, sharedCodeRowsKeys := fixtures.CreateSharedCode(t, state)
 
 	// Create transformation with shared code
-	transformation := createInternalTranWithSharedCode(t, sharedCodeKey, sharedCodeRowsKeys, context)
+	transformation := createInternalTranWithSharedCode(t, sharedCodeKey, sharedCodeRowsKeys, state)
 
 	// Invoke
 	object := transformation.Local
@@ -25,8 +26,8 @@ func TestRemoteSaveTranWithSharedCode(t *testing.T) {
 		Object:         object,
 		ObjectManifest: transformation.Manifest(),
 	}
-	assert.NoError(t, mapperInst.MapBeforeRemoteSave(recipe))
-	assert.Empty(t, logs.AllMessages())
+	assert.NoError(t, state.Mapper().MapBeforeRemoteSave(recipe))
+	assert.Empty(t, logger.WarnAndErrorMessages())
 
 	// Config ID and rows ID are set in Content
 	id, found := object.Content.Get(model.SharedCodeIdContentKey)

--- a/internal/pkg/mapper/sharedcode/sharedcode.go
+++ b/internal/pkg/mapper/sharedcode/sharedcode.go
@@ -1,24 +1,23 @@
 package sharedcode
 
 import (
-	"github.com/keboola/keboola-as-code/internal/pkg/local"
-	"github.com/keboola/keboola-as-code/internal/pkg/mapper"
 	"github.com/keboola/keboola-as-code/internal/pkg/mapper/sharedcode/codes"
 	"github.com/keboola/keboola-as-code/internal/pkg/mapper/sharedcode/links"
 	"github.com/keboola/keboola-as-code/internal/pkg/mapper/sharedcode/variables"
+	"github.com/keboola/keboola-as-code/internal/pkg/state"
 )
 
 // NewCodesMapper saves shared codes (config rows) to "codes" local dir.
-func NewCodesMapper(context mapper.Context) interface{} {
-	return codes.NewMapper(context)
+func NewCodesMapper(s *state.State) interface{} {
+	return codes.NewMapper(s)
 }
 
 // NewVariablesMapper embeds variables config according "variables_id".
-func NewVariablesMapper(context mapper.Context) interface{} {
-	return variables.NewMapper(context)
+func NewVariablesMapper(s *state.State) interface{} {
+	return variables.NewMapper(s)
 }
 
 // NewLinksMapper replaces "shared_code_id" with "shared_code_path" in local fs.
-func NewLinksMapper(localManager *local.Manager, context mapper.Context) interface{} {
-	return links.NewMapper(localManager, context)
+func NewLinksMapper(s *state.State) interface{} {
+	return links.NewMapper(s)
 }

--- a/internal/pkg/mapper/sharedcode/variables/persist.go
+++ b/internal/pkg/mapper/sharedcode/variables/persist.go
@@ -14,7 +14,7 @@ func (m *mapper) MapBeforePersist(recipe *model.PersistRecipe) error {
 	}
 
 	// Component must be "variables"
-	variablesComponent, err := m.State.Components().Get(configManifest.ComponentKey())
+	variablesComponent, err := m.state.Components().Get(configManifest.ComponentKey())
 	if err != nil {
 		return err
 	}
@@ -29,7 +29,7 @@ func (m *mapper) MapBeforePersist(recipe *model.PersistRecipe) error {
 	}
 
 	// Parent component must be "variables"
-	parentComponent, err := m.State.Components().Get(sharedCodeRowKey.ComponentKey())
+	parentComponent, err := m.state.Components().Get(sharedCodeRowKey.ComponentKey())
 	if err != nil {
 		return err
 	}

--- a/internal/pkg/mapper/sharedcode/variables/persist_test.go
+++ b/internal/pkg/mapper/sharedcode/variables/persist_test.go
@@ -5,13 +5,13 @@ import (
 
 	"github.com/stretchr/testify/assert"
 
-	. "github.com/keboola/keboola-as-code/internal/pkg/mapper/sharedcode/variables"
 	"github.com/keboola/keboola-as-code/internal/pkg/model"
 )
 
 func TestSharedCodeMapBeforePersist(t *testing.T) {
 	t.Parallel()
-	context := createMapperContext(t)
+	state, d := createStateWithMapper(t)
+	logger := d.DebugLogger()
 
 	parentKey := model.ConfigRowKey{
 		BranchId:    123,
@@ -33,7 +33,8 @@ func TestSharedCodeMapBeforePersist(t *testing.T) {
 
 	// Invoke
 	assert.Empty(t, configManifest.Relations)
-	assert.NoError(t, NewMapper(context).MapBeforePersist(recipe))
+	assert.NoError(t, state.Mapper().MapBeforePersist(recipe))
+	assert.Empty(t, logger.WarnAndErrorMessages())
 
 	// Relation has been created
 	assert.Equal(t, model.Relations{

--- a/internal/pkg/mapper/sharedcode/variables/remote_load_test.go
+++ b/internal/pkg/mapper/sharedcode/variables/remote_load_test.go
@@ -5,14 +5,14 @@ import (
 
 	"github.com/stretchr/testify/assert"
 
-	. "github.com/keboola/keboola-as-code/internal/pkg/mapper/sharedcode/variables"
 	"github.com/keboola/keboola-as-code/internal/pkg/model"
 	"github.com/keboola/keboola-as-code/internal/pkg/utils/orderedmap"
 )
 
 func TestSharedCodeMapAfterRemoteLoad(t *testing.T) {
 	t.Parallel()
-	context := createMapperContext(t)
+	state, d := createStateWithMapper(t)
+	logger := d.DebugLogger()
 
 	variablesConfigId := `123456`
 	content := orderedmap.New()
@@ -25,7 +25,8 @@ func TestSharedCodeMapAfterRemoteLoad(t *testing.T) {
 
 	// Invoke
 	assert.Empty(t, object.Relations)
-	assert.NoError(t, NewMapper(context).MapAfterRemoteLoad(recipe))
+	assert.NoError(t, state.Mapper().MapAfterRemoteLoad(recipe))
+	assert.Empty(t, logger.WarnAndErrorMessages())
 
 	// Object has new relation + content without variables ID
 	assert.Equal(t, model.Relations{

--- a/internal/pkg/mapper/sharedcode/variables/remote_save_test.go
+++ b/internal/pkg/mapper/sharedcode/variables/remote_save_test.go
@@ -5,14 +5,14 @@ import (
 
 	"github.com/stretchr/testify/assert"
 
-	. "github.com/keboola/keboola-as-code/internal/pkg/mapper/sharedcode/variables"
 	"github.com/keboola/keboola-as-code/internal/pkg/model"
 	"github.com/keboola/keboola-as-code/internal/pkg/utils/orderedmap"
 )
 
 func TestSharedCodeMapBeforeRemoteSave(t *testing.T) {
 	t.Parallel()
-	context := createMapperContext(t)
+	state, d := createStateWithMapper(t)
+	logger := d.DebugLogger()
 
 	variablesConfigId := `123456`
 	object := &model.ConfigRow{
@@ -30,7 +30,8 @@ func TestSharedCodeMapBeforeRemoteSave(t *testing.T) {
 	// Invoke
 	assert.NotEmpty(t, object.Relations)
 	assert.NotEmpty(t, object.Relations)
-	assert.NoError(t, NewMapper(context).MapBeforeRemoteSave(recipe))
+	assert.NoError(t, state.Mapper().MapBeforeRemoteSave(recipe))
+	assert.Empty(t, logger.WarnAndErrorMessages())
 
 	// All relations have been mapped
 	assert.Empty(t, object.Relations)

--- a/internal/pkg/mapper/sharedcode/variables/variables.go
+++ b/internal/pkg/mapper/sharedcode/variables/variables.go
@@ -1,16 +1,16 @@
 package variables
 
 import (
-	mapperPkg "github.com/keboola/keboola-as-code/internal/pkg/mapper"
 	"github.com/keboola/keboola-as-code/internal/pkg/mapper/sharedcode/helper"
+	"github.com/keboola/keboola-as-code/internal/pkg/state"
 )
 
 // mapper embeds variables config according "variables_id".
 type mapper struct {
-	mapperPkg.Context
+	state *state.State
 	*helper.SharedCodeHelper
 }
 
-func NewMapper(context mapperPkg.Context) *mapper {
-	return &mapper{Context: context, SharedCodeHelper: helper.New(context.State, context.NamingRegistry)}
+func NewMapper(s *state.State) *mapper {
+	return &mapper{state: s, SharedCodeHelper: helper.New(s)}
 }

--- a/internal/pkg/mapper/transformation/local_load_test.go
+++ b/internal/pkg/mapper/transformation/local_load_test.go
@@ -8,36 +8,42 @@ import (
 
 	"github.com/keboola/keboola-as-code/internal/pkg/filesystem"
 	"github.com/keboola/keboola-as-code/internal/pkg/fixtures"
-	. "github.com/keboola/keboola-as-code/internal/pkg/mapper/transformation"
 	"github.com/keboola/keboola-as-code/internal/pkg/model"
 )
 
 func TestLoadTransformationMissingBlockMetaSql(t *testing.T) {
 	t.Parallel()
-	context, configState := createTestFixtures(t, "keboola.snowflake-transformation")
+	state, d := createStateWithMapper(t)
+	fs := d.Fs()
+	logger := d.DebugLogger()
+
+	configState := createTestFixtures(t, "keboola.snowflake-transformation")
 	recipe := fixtures.NewLocalLoadRecipe(configState.Manifest(), configState.Local)
-	fs := context.Fs
-	blocksDir := filesystem.Join(`branch`, `config`, `blocks`)
 
 	// Create files/dirs
+	blocksDir := filesystem.Join(`branch`, `config`, `blocks`)
 	assert.NoError(t, fs.Mkdir(blocksDir))
 	block1 := filesystem.Join(blocksDir, `001-block-1`)
 	assert.NoError(t, fs.Mkdir(block1))
 
 	// Load, assert
-	err := NewMapper(context).MapAfterLocalLoad(recipe)
+	err := state.Mapper().MapAfterLocalLoad(recipe)
 	assert.Error(t, err)
 	assert.Equal(t, `missing block metadata file "branch/config/blocks/001-block-1/meta.json"`, err.Error())
+	assert.Empty(t, logger.WarnAndErrorMessages())
 }
 
 func TestLoadTransformationMissingCodeMeta(t *testing.T) {
 	t.Parallel()
-	context, configState := createTestFixtures(t, "keboola.snowflake-transformation")
+	state, d := createStateWithMapper(t)
+	fs := d.Fs()
+	logger := d.DebugLogger()
+
+	configState := createTestFixtures(t, "keboola.snowflake-transformation")
 	recipe := fixtures.NewLocalLoadRecipe(configState.Manifest(), configState.Local)
-	fs := context.Fs
-	blocksDir := filesystem.Join(`branch`, `config`, `blocks`)
 
 	// Create files/dirs
+	blocksDir := filesystem.Join(`branch`, `config`, `blocks`)
 	assert.NoError(t, fs.Mkdir(blocksDir))
 	block1 := filesystem.Join(blocksDir, `001-block-1`)
 	assert.NoError(t, fs.Mkdir(block1))
@@ -46,22 +52,26 @@ func TestLoadTransformationMissingCodeMeta(t *testing.T) {
 	assert.NoError(t, fs.Mkdir(block1Code1))
 
 	// Load, assert
-	err := NewMapper(context).MapAfterLocalLoad(recipe)
+	err := state.Mapper().MapAfterLocalLoad(recipe)
 	assert.Error(t, err)
 	assert.Equal(t, strings.Join([]string{
 		`- missing code metadata file "branch/config/blocks/001-block-1/001-code-1/meta.json"`,
 		`- missing code file in "branch/config/blocks/001-block-1/001-code-1"`,
 	}, "\n"), err.Error())
+	assert.Empty(t, logger.WarnAndErrorMessages())
 }
 
 func TestLoadLocalTransformationSql(t *testing.T) {
 	t.Parallel()
-	context, configState := createTestFixtures(t, `keboola.snowflake-transformation`)
+	state, d := createStateWithMapper(t)
+	fs := d.Fs()
+	logger := d.DebugLogger()
+
+	configState := createTestFixtures(t, "keboola.snowflake-transformation")
 	recipe := fixtures.NewLocalLoadRecipe(configState.Manifest(), configState.Local)
-	fs := context.Fs
-	blocksDir := filesystem.Join(`branch`, `config`, `blocks`)
 
 	// Create files/dirs
+	blocksDir := filesystem.Join(`branch`, `config`, `blocks`)
 	assert.NoError(t, fs.Mkdir(blocksDir))
 	block1 := filesystem.Join(blocksDir, `001-block-1`)
 	assert.NoError(t, fs.Mkdir(block1))
@@ -86,7 +96,8 @@ func TestLoadLocalTransformationSql(t *testing.T) {
 	assert.NoError(t, fs.WriteFile(filesystem.NewFile(filesystem.Join(block3, `meta.json`), `{"name": "003"}`)))
 
 	// Load
-	assert.NoError(t, NewMapper(context).MapAfterLocalLoad(recipe))
+	assert.NoError(t, state.Mapper().MapAfterLocalLoad(recipe))
+	assert.Empty(t, logger.WarnAndErrorMessages())
 
 	// Assert
 	expected := []*model.Block{
@@ -195,12 +206,15 @@ func TestLoadLocalTransformationSql(t *testing.T) {
 
 func TestLoadLocalTransformationPy(t *testing.T) {
 	t.Parallel()
-	context, configState := createTestFixtures(t, `keboola.python-transformation-v2`)
+	state, d := createStateWithMapper(t)
+	fs := d.Fs()
+	logger := d.DebugLogger()
+
+	configState := createTestFixtures(t, `keboola.python-transformation-v2`)
 	recipe := fixtures.NewLocalLoadRecipe(configState.Manifest(), configState.Local)
-	fs := context.Fs
-	blocksDir := filesystem.Join(`branch`, `config`, `blocks`)
 
 	// Create files/dirs
+	blocksDir := filesystem.Join(`branch`, `config`, `blocks`)
 	assert.NoError(t, fs.Mkdir(blocksDir))
 	block1 := filesystem.Join(blocksDir, `001-block-1`)
 	assert.NoError(t, fs.Mkdir(block1))
@@ -225,7 +239,8 @@ func TestLoadLocalTransformationPy(t *testing.T) {
 	assert.NoError(t, fs.WriteFile(filesystem.NewFile(filesystem.Join(block3, `meta.json`), `{"name": "003"}`)))
 
 	// Load
-	assert.NoError(t, NewMapper(context).MapAfterLocalLoad(recipe))
+	assert.NoError(t, state.Mapper().MapAfterLocalLoad(recipe))
+	assert.Empty(t, logger.WarnAndErrorMessages())
 
 	// Assert
 	expected := []*model.Block{

--- a/internal/pkg/mapper/transformation/local_save.go
+++ b/internal/pkg/mapper/transformation/local_save.go
@@ -4,8 +4,8 @@ import (
 	"fmt"
 
 	"github.com/keboola/keboola-as-code/internal/pkg/filesystem"
-	"github.com/keboola/keboola-as-code/internal/pkg/mapper"
 	"github.com/keboola/keboola-as-code/internal/pkg/model"
+	"github.com/keboola/keboola-as-code/internal/pkg/state"
 	"github.com/keboola/keboola-as-code/internal/pkg/utils"
 	"github.com/keboola/keboola-as-code/internal/pkg/utils/orderedmap"
 	"github.com/keboola/keboola-as-code/internal/pkg/validator"
@@ -22,7 +22,7 @@ func (m *transformationMapper) MapBeforeLocalSave(recipe *model.LocalSaveRecipe)
 
 	// Create local writer
 	w := &localWriter{
-		Context:         m.Context,
+		State:           m.state,
 		LocalSaveRecipe: recipe,
 		config:          recipe.Object.(*model.Config),
 		errors:          utils.NewMultiError(),
@@ -33,14 +33,14 @@ func (m *transformationMapper) MapBeforeLocalSave(recipe *model.LocalSaveRecipe)
 }
 
 type localWriter struct {
-	mapper.Context
+	*state.State
 	*model.LocalSaveRecipe
 	config *model.Config
 	errors *utils.MultiError
 }
 
 func (w *localWriter) save() error {
-	blocksDir := w.NamingGenerator.BlocksDir(w.ObjectManifest.Path())
+	blocksDir := w.NamingGenerator().BlocksDir(w.ObjectManifest.Path())
 
 	// Generate ".gitkeep" to preserve the "blocks" directory, even if there are no blocks.
 	w.Files.
@@ -56,8 +56,8 @@ func (w *localWriter) save() error {
 
 	// Delete all old files from blocks dir
 	// We always do full generation of blocks dir.
-	for _, path := range w.State.TrackedPaths() {
-		if filesystem.IsFrom(path, blocksDir) && w.State.IsFile(path) {
+	for _, path := range w.TrackedPaths() {
+		if filesystem.IsFrom(path, blocksDir) && w.IsFile(path) {
 			w.ToDelete = append(w.ToDelete, path)
 		}
 	}
@@ -74,7 +74,7 @@ func (w *localWriter) generateBlockFiles(block *model.Block) {
 
 	// Create metadata file
 	if metadata := utils.MapFromTaggedFields(model.MetaFileFieldsTag, block); metadata != nil {
-		metadataPath := w.NamingGenerator.MetaFilePath(block.Path())
+		metadataPath := w.NamingGenerator().MetaFilePath(block.Path())
 		w.createMetadataFile(metadataPath, `block metadata`, model.FileKindBlockMeta, metadata)
 	}
 
@@ -87,13 +87,13 @@ func (w *localWriter) generateBlockFiles(block *model.Block) {
 func (w *localWriter) generateCodeFiles(code *model.Code) {
 	// Create metadata file
 	if metadata := utils.MapFromTaggedFields(model.MetaFileFieldsTag, code); metadata != nil {
-		metadataPath := w.NamingGenerator.MetaFilePath(code.Path())
+		metadataPath := w.NamingGenerator().MetaFilePath(code.Path())
 		w.createMetadataFile(metadataPath, `code metadata`, model.FileKindCodeMeta, metadata)
 	}
 
 	// Create code file
 	w.Files.
-		Add(filesystem.NewFile(w.NamingGenerator.CodeFilePath(code), code.Scripts.String(code.ComponentId)).SetDescription(`code`)).
+		Add(filesystem.NewFile(w.NamingGenerator().CodeFilePath(code), code.Scripts.String(code.ComponentId)).SetDescription(`code`)).
 		AddTag(model.FileTypeOther).
 		AddTag(model.FileKindNativeCode)
 }

--- a/internal/pkg/mapper/transformation/local_save_test.go
+++ b/internal/pkg/mapper/transformation/local_save_test.go
@@ -8,21 +8,25 @@ import (
 	"github.com/keboola/keboola-as-code/internal/pkg/filesystem"
 	"github.com/keboola/keboola-as-code/internal/pkg/fixtures"
 	"github.com/keboola/keboola-as-code/internal/pkg/json"
-	. "github.com/keboola/keboola-as-code/internal/pkg/mapper/transformation"
 	"github.com/keboola/keboola-as-code/internal/pkg/model"
 )
 
 func TestLocalSaveTransformationEmpty(t *testing.T) {
 	t.Parallel()
-	context, configState := createTestFixtures(t, "keboola.snowflake-transformation")
+	state, d := createStateWithMapper(t)
+	fs := d.Fs()
+	logger := d.DebugLogger()
+
+	configState := createTestFixtures(t, "keboola.snowflake-transformation")
 	recipe := fixtures.NewLocalSaveRecipe(configState.Manifest(), configState.Local)
-	fs := context.Fs
+
 	blocksDir := filesystem.Join(`branch`, `config`, `blocks`)
 	assert.NoError(t, fs.Mkdir(blocksDir))
 
 	// Save
-	err := NewMapper(context).MapBeforeLocalSave(recipe)
+	err := state.Mapper().MapBeforeLocalSave(recipe)
 	assert.NoError(t, err)
+	assert.Empty(t, logger.WarnAndErrorMessages())
 	configFile, err := recipe.Files.ObjectConfigFile()
 	assert.NoError(t, err)
 	assert.Equal(t, "{}\n", json.MustEncodeString(configFile.Content, true))
@@ -30,9 +34,13 @@ func TestLocalSaveTransformationEmpty(t *testing.T) {
 
 func TestLocalSaveTransformation(t *testing.T) {
 	t.Parallel()
-	context, configState := createTestFixtures(t, "keboola.snowflake-transformation")
+	state, d := createStateWithMapper(t)
+	fs := d.Fs()
+	logger := d.DebugLogger()
+
+	configState := createTestFixtures(t, "keboola.snowflake-transformation")
 	recipe := fixtures.NewLocalSaveRecipe(configState.Manifest(), configState.Local)
-	fs := context.Fs
+
 	blocksDir := filesystem.Join(`branch`, `config`, `blocks`)
 	assert.NoError(t, fs.Mkdir(blocksDir))
 
@@ -128,7 +136,8 @@ func TestLocalSaveTransformation(t *testing.T) {
 	}
 
 	// Save
-	assert.NoError(t, NewMapper(context).MapBeforeLocalSave(recipe))
+	assert.NoError(t, state.Mapper().MapBeforeLocalSave(recipe))
+	assert.Empty(t, logger.WarnAndErrorMessages())
 
 	// Minify JSON + remove file description
 	var files []*filesystem.File

--- a/internal/pkg/mapper/transformation/path.go
+++ b/internal/pkg/mapper/transformation/path.go
@@ -26,13 +26,13 @@ func (m *transformationMapper) OnObjectPathUpdate(event model.OnObjectPathUpdate
 func (m *transformationMapper) updateBlockPath(g model.PathsGenerator, parent *model.ConfigState, block *model.Block) {
 	// Update parent path
 	oldPath := block.Path()
-	blocksDir := m.NamingGenerator.BlocksDir(parent.Path())
+	blocksDir := m.state.NamingGenerator().BlocksDir(parent.Path())
 	block.SetParentPath(blocksDir)
 
 	// Re-generate object path IF rename is enabled OR path is not set
 	if block.ObjectPath == "" || g.RenameEnabled() {
 		renameFrom := block.Path()
-		block.PathInProject = m.NamingGenerator.BlockPath(block.GetParentPath(), block)
+		block.PathInProject = m.state.NamingGenerator().BlockPath(block.GetParentPath(), block)
 
 		// Has been block renamed?
 		newPath := block.Path()
@@ -50,13 +50,13 @@ func (m *transformationMapper) updateBlockPath(g model.PathsGenerator, parent *m
 func (m *transformationMapper) updateCodePath(g model.PathsGenerator, parent *model.ConfigState, block *model.Block, code *model.Code) {
 	// Update parent path
 	oldPath := code.Path()
-	oldPathCodeFile := m.NamingGenerator.CodeFilePath(code)
+	oldPathCodeFile := m.state.NamingGenerator().CodeFilePath(code)
 	code.SetParentPath(block.Path())
 
 	// Re-generate object path IF rename is enabled OR path is not set
 	if code.ObjectPath == "" || g.RenameEnabled() {
 		renameFrom := code.Path()
-		code.PathInProject = m.NamingGenerator.CodePath(code.GetParentPath(), code)
+		code.PathInProject = m.state.NamingGenerator().CodePath(code.GetParentPath(), code)
 		// Has been code renamed?
 		newPath := code.Path()
 		if renameFrom != newPath {
@@ -69,9 +69,9 @@ func (m *transformationMapper) updateCodePath(g model.PathsGenerator, parent *mo
 }
 
 func (m *transformationMapper) updateCodeFilePath(g model.PathsGenerator, parent *model.ConfigState, code *model.Code, oldPath string) {
-	renameFrom := m.NamingGenerator.CodeFilePath(code)
-	code.CodeFileName = m.NamingGenerator.CodeFileName(code.ComponentId)
-	newPath := m.NamingGenerator.CodeFilePath(code)
+	renameFrom := m.state.NamingGenerator().CodeFilePath(code)
+	code.CodeFileName = m.state.NamingGenerator().CodeFileName(code.ComponentId)
+	newPath := m.state.NamingGenerator().CodeFilePath(code)
 	if renameFrom != newPath {
 		g.AddRenamed(model.RenamedPath{ObjectState: parent, OldPath: oldPath, RenameFrom: renameFrom, NewPath: newPath})
 	}

--- a/internal/pkg/mapper/transformation/remote_load.go
+++ b/internal/pkg/mapper/transformation/remote_load.go
@@ -63,20 +63,20 @@ func (m *transformationMapper) MapAfterRemoteLoad(recipe *model.RemoteLoadRecipe
 
 	// Set paths if parent path is set
 	if recipe.Path() != "" {
-		blocksDir := m.NamingGenerator.BlocksDir(recipe.Path())
+		blocksDir := m.state.NamingGenerator().BlocksDir(recipe.Path())
 		for _, block := range config.Transformation.Blocks {
-			if path, found := m.NamingRegistry.PathByKey(block.Key()); found {
+			if path, found := m.state.GetPath(block.Key()); found {
 				block.PathInProject = path
 			} else {
-				block.PathInProject = m.NamingGenerator.BlockPath(blocksDir, block)
+				block.PathInProject = m.state.NamingGenerator().BlockPath(blocksDir, block)
 			}
 			for _, code := range block.Codes {
-				if path, found := m.NamingRegistry.PathByKey(code.Key()); found {
+				if path, found := m.state.GetPath(code.Key()); found {
 					code.PathInProject = path
 				} else {
-					code.PathInProject = m.NamingGenerator.CodePath(block.Path(), code)
+					code.PathInProject = m.state.NamingGenerator().CodePath(block.Path(), code)
 				}
-				code.CodeFileName = m.NamingGenerator.CodeFileName(config.ComponentId)
+				code.CodeFileName = m.state.NamingGenerator().CodeFileName(config.ComponentId)
 			}
 		}
 	}

--- a/internal/pkg/mapper/transformation/remote_load_test.go
+++ b/internal/pkg/mapper/transformation/remote_load_test.go
@@ -6,14 +6,16 @@ import (
 	"github.com/stretchr/testify/assert"
 
 	"github.com/keboola/keboola-as-code/internal/pkg/json"
-	. "github.com/keboola/keboola-as-code/internal/pkg/mapper/transformation"
 	"github.com/keboola/keboola-as-code/internal/pkg/model"
 	"github.com/keboola/keboola-as-code/internal/pkg/utils/orderedmap"
 )
 
 func TestLoadRemoteTransformation(t *testing.T) {
 	t.Parallel()
-	context, configState := createTestFixtures(t, `keboola.snowflake-transformation`)
+	state, d := createStateWithMapper(t)
+	logger := d.DebugLogger()
+
+	configState := createTestFixtures(t, "keboola.snowflake-transformation")
 
 	// Api representation
 	configInApi := `
@@ -61,7 +63,8 @@ func TestLoadRemoteTransformation(t *testing.T) {
 	}
 	json.MustDecodeString(configInApi, object.Content)
 	recipe := &model.RemoteLoadRecipe{ObjectManifest: configState.ConfigManifest, Object: object}
-	assert.NoError(t, NewMapper(context).MapAfterRemoteLoad(recipe))
+	assert.NoError(t, state.Mapper().MapAfterRemoteLoad(recipe))
+	assert.Empty(t, logger.WarnAndErrorMessages())
 
 	// Internal representation
 	expected := []*model.Block{

--- a/internal/pkg/mapper/transformation/remote_save_test.go
+++ b/internal/pkg/mapper/transformation/remote_save_test.go
@@ -7,14 +7,17 @@ import (
 	"github.com/stretchr/testify/assert"
 
 	"github.com/keboola/keboola-as-code/internal/pkg/json"
-	. "github.com/keboola/keboola-as-code/internal/pkg/mapper/transformation"
 	"github.com/keboola/keboola-as-code/internal/pkg/model"
 	"github.com/keboola/keboola-as-code/internal/pkg/utils/orderedmap"
 )
 
 func TestRemoteSaveTransformation(t *testing.T) {
 	t.Parallel()
-	context, configState := createTestFixtures(t, "keboola.snowflake-transformation")
+	state, d := createStateWithMapper(t)
+	logger := d.DebugLogger()
+
+	configState := createTestFixtures(t, "keboola.snowflake-transformation")
+
 	blocks := []*model.Block{
 		{
 			Name: "001",
@@ -63,7 +66,8 @@ func TestRemoteSaveTransformation(t *testing.T) {
 	}
 
 	// Save
-	assert.NoError(t, NewMapper(context).MapBeforeRemoteSave(recipe))
+	assert.NoError(t, state.Mapper().MapBeforeRemoteSave(recipe))
+	assert.Empty(t, logger.WarnAndErrorMessages())
 
 	// Blocks are stored in API object content
 	expectedBlocks := `

--- a/internal/pkg/mapper/transformation/transformation.go
+++ b/internal/pkg/mapper/transformation/transformation.go
@@ -1,16 +1,18 @@
 package transformation
 
 import (
-	"github.com/keboola/keboola-as-code/internal/pkg/mapper"
+	"github.com/keboola/keboola-as-code/internal/pkg/log"
 	"github.com/keboola/keboola-as-code/internal/pkg/model"
+	"github.com/keboola/keboola-as-code/internal/pkg/state"
 )
 
 type transformationMapper struct {
-	mapper.Context
+	state  *state.State
+	logger log.Logger
 }
 
-func NewMapper(context mapper.Context) *transformationMapper {
-	return &transformationMapper{Context: context}
+func NewMapper(s *state.State) *transformationMapper {
+	return &transformationMapper{state: s, logger: s.Logger()}
 }
 
 func (m *transformationMapper) isTransformationConfig(object interface{}) (bool, error) {

--- a/internal/pkg/mapper/transformation/transformation.go
+++ b/internal/pkg/mapper/transformation/transformation.go
@@ -21,7 +21,7 @@ func (m *transformationMapper) isTransformationConfig(object interface{}) (bool,
 		return false, nil
 	}
 
-	component, err := m.State.Components().Get(v.ComponentKey())
+	component, err := m.state.Components().Get(v.ComponentKey())
 	if err != nil {
 		return false, err
 	}
@@ -35,7 +35,7 @@ func (m *transformationMapper) isTransformationConfigState(objectState model.Obj
 		return false, nil
 	}
 
-	component, err := m.State.Components().Get(v.ComponentKey())
+	component, err := m.state.Components().Get(v.ComponentKey())
 	if err != nil {
 		return false, err
 	}

--- a/internal/pkg/mapper/transformation/transformation_test.go
+++ b/internal/pkg/mapper/transformation/transformation_test.go
@@ -3,20 +3,22 @@ package transformation_test
 import (
 	"testing"
 
-	"github.com/stretchr/testify/assert"
-
-	"github.com/keboola/keboola-as-code/internal/pkg/filesystem/aferofs"
-	"github.com/keboola/keboola-as-code/internal/pkg/filesystem/knownpaths"
-	"github.com/keboola/keboola-as-code/internal/pkg/log"
-	"github.com/keboola/keboola-as-code/internal/pkg/mapper"
+	"github.com/keboola/keboola-as-code/internal/pkg/mapper/transformation"
 	"github.com/keboola/keboola-as-code/internal/pkg/model"
-	"github.com/keboola/keboola-as-code/internal/pkg/naming"
 	"github.com/keboola/keboola-as-code/internal/pkg/state"
-	"github.com/keboola/keboola-as-code/internal/pkg/testapi"
+	"github.com/keboola/keboola-as-code/internal/pkg/testdeps"
 	"github.com/keboola/keboola-as-code/internal/pkg/utils/orderedmap"
 )
 
-func createTestFixtures(t *testing.T, componentId string) (mapper.Context, *model.ConfigState) {
+func createStateWithMapper(t *testing.T) (*state.State, *testdeps.TestContainer) {
+	t.Helper()
+	d := testdeps.New()
+	mockedState := d.EmptyState()
+	mockedState.Mapper().AddMapper(transformation.NewMapper(mockedState))
+	return mockedState, d
+}
+
+func createTestFixtures(t *testing.T, componentId string) *model.ConfigState {
 	t.Helper()
 
 	configKey := model.ConfigKey{
@@ -41,14 +43,5 @@ func createTestFixtures(t *testing.T, componentId string) (mapper.Context, *mode
 		},
 	}
 
-	logger := log.NewDebugLogger()
-	fs, err := aferofs.NewMemoryFs(logger, ".")
-	assert.NoError(t, err)
-
-	namingRegistry := naming.NewRegistry()
-	projectState := state.NewRegistry(knownpaths.NewNop(), namingRegistry, model.NewComponentsMap(testapi.NewMockedComponentsProvider()), model.SortByPath)
-	namingTemplate := naming.TemplateWithIds()
-	namingGenerator := naming.NewGenerator(namingTemplate, namingRegistry)
-	context := mapper.Context{Logger: logger, Fs: fs, NamingGenerator: namingGenerator, NamingRegistry: namingRegistry, State: projectState}
-	return context, configState
+	return configState
 }

--- a/internal/pkg/mapper/variables/local_persist.go
+++ b/internal/pkg/mapper/variables/local_persist.go
@@ -22,7 +22,7 @@ func (m *variablesMapper) MapBeforePersist(recipe *model.PersistRecipe) error {
 	}
 
 	// Get component
-	component, err := m.State.Components().Get(configManifest.ComponentKey())
+	component, err := m.state.Components().Get(configManifest.ComponentKey())
 	if err != nil {
 		return err
 	}
@@ -55,7 +55,7 @@ func (m *variablesMapper) OnLocalChange(changes *model.LocalChanges) error {
 		object := objectState.LocalState()
 		if config, ok := object.(*model.Config); ok {
 			// Variables config?
-			component, err := m.State.Components().Get(config.ComponentKey())
+			component, err := m.state.Components().Get(config.ComponentKey())
 			if err != nil {
 				errors.Append(err)
 				continue
@@ -65,7 +65,7 @@ func (m *variablesMapper) OnLocalChange(changes *model.LocalChanges) error {
 			}
 		} else if row, ok := object.(*model.ConfigRow); ok {
 			// Variables values row?
-			component, err := m.State.Components().Get(row.ComponentKey())
+			component, err := m.state.Components().Get(row.ComponentKey())
 			if err != nil {
 				errors.Append(err)
 				continue
@@ -78,7 +78,7 @@ func (m *variablesMapper) OnLocalChange(changes *model.LocalChanges) error {
 
 	// Ensure that each variables config has one row with default values
 	for configKey := range configs {
-		config := m.State.MustGet(configKey).LocalState().(*model.Config)
+		config := m.state.MustGet(configKey).LocalState().(*model.Config)
 		if err := m.ensureOneRowHasRelation(config); err != nil {
 			errors.Append(err)
 		}
@@ -95,7 +95,7 @@ func (m *variablesMapper) ensureOneRowHasRelation(config *model.Config) error {
 	}
 
 	// Process rows
-	rows := m.State.ConfigRowsFrom(config.ConfigKey)
+	rows := m.state.ConfigRowsFrom(config.ConfigKey)
 	var rowsWithRelation []*model.ConfigRowState
 	var rowsWithDefaultInName []*model.ConfigRowState
 	for _, row := range rows {

--- a/internal/pkg/mapper/variables/remote_load_test.go
+++ b/internal/pkg/mapper/variables/remote_load_test.go
@@ -5,14 +5,14 @@ import (
 
 	"github.com/stretchr/testify/assert"
 
-	. "github.com/keboola/keboola-as-code/internal/pkg/mapper/variables"
 	"github.com/keboola/keboola-as-code/internal/pkg/model"
 	"github.com/keboola/keboola-as-code/internal/pkg/utils/orderedmap"
 )
 
 func TestVariablesMapAfterRemoteLoad(t *testing.T) {
 	t.Parallel()
-	context := createMapperContext(t)
+	state, d := createStateWithMapper(t)
+	logger := d.DebugLogger()
 
 	variablesConfigId := `123456`
 	valuesConfigRowId := `456789`
@@ -24,7 +24,8 @@ func TestVariablesMapAfterRemoteLoad(t *testing.T) {
 
 	// Invoke
 	assert.Empty(t, object.Relations)
-	assert.NoError(t, NewMapper(context).MapAfterRemoteLoad(recipe))
+	assert.NoError(t, state.Mapper().MapAfterRemoteLoad(recipe))
+	assert.Empty(t, logger.WarnAndErrorMessages())
 
 	// Internal object has new relation + content without variables ID
 	assert.Equal(t, model.Relations{

--- a/internal/pkg/mapper/variables/remote_save_test.go
+++ b/internal/pkg/mapper/variables/remote_save_test.go
@@ -5,14 +5,14 @@ import (
 
 	"github.com/stretchr/testify/assert"
 
-	. "github.com/keboola/keboola-as-code/internal/pkg/mapper/variables"
 	"github.com/keboola/keboola-as-code/internal/pkg/model"
 	"github.com/keboola/keboola-as-code/internal/pkg/utils/orderedmap"
 )
 
 func TestVariablesMapBeforeRemoteSave(t *testing.T) {
 	t.Parallel()
-	context := createMapperContext(t)
+	state, d := createStateWithMapper(t)
+	logger := d.DebugLogger()
 
 	variablesConfigId := `123456`
 	valuesConfigRowId := `456789`
@@ -31,7 +31,8 @@ func TestVariablesMapBeforeRemoteSave(t *testing.T) {
 	// Invoke
 	assert.NotEmpty(t, object.Relations)
 	assert.NotEmpty(t, object.Relations)
-	assert.NoError(t, NewMapper(context).MapBeforeRemoteSave(recipe))
+	assert.NoError(t, state.Mapper().MapBeforeRemoteSave(recipe))
+	assert.Empty(t, logger.WarnAndErrorMessages())
 
 	// All relations have been mapped
 	assert.Empty(t, object.Relations)

--- a/internal/pkg/mapper/variables/variables.go
+++ b/internal/pkg/mapper/variables/variables.go
@@ -1,13 +1,13 @@
 package variables
 
 import (
-	"github.com/keboola/keboola-as-code/internal/pkg/mapper"
+	"github.com/keboola/keboola-as-code/internal/pkg/state"
 )
 
 type variablesMapper struct {
-	mapper.Context
+	state *state.State
 }
 
-func NewMapper(context mapper.Context) *variablesMapper {
-	return &variablesMapper{Context: context}
+func NewMapper(s *state.State) *variablesMapper {
+	return &variablesMapper{state: s}
 }

--- a/internal/pkg/mapper/variables/variables_test.go
+++ b/internal/pkg/mapper/variables/variables_test.go
@@ -5,26 +5,18 @@ import (
 
 	"github.com/stretchr/testify/assert"
 
-	"github.com/keboola/keboola-as-code/internal/pkg/filesystem/aferofs"
-	"github.com/keboola/keboola-as-code/internal/pkg/filesystem/knownpaths"
-	"github.com/keboola/keboola-as-code/internal/pkg/log"
-	"github.com/keboola/keboola-as-code/internal/pkg/mapper"
+	"github.com/keboola/keboola-as-code/internal/pkg/mapper/variables"
 	"github.com/keboola/keboola-as-code/internal/pkg/model"
-	"github.com/keboola/keboola-as-code/internal/pkg/naming"
 	"github.com/keboola/keboola-as-code/internal/pkg/state"
-	"github.com/keboola/keboola-as-code/internal/pkg/testapi"
+	"github.com/keboola/keboola-as-code/internal/pkg/testdeps"
 )
 
-func createMapperContext(t *testing.T) mapper.Context {
+func createStateWithMapper(t *testing.T) (*state.State, *testdeps.TestContainer) {
 	t.Helper()
-	logger := log.NewDebugLogger()
-	fs, err := aferofs.NewMemoryFs(logger, ".")
-	assert.NoError(t, err)
-	namingRegistry := naming.NewRegistry()
-	projectState := state.NewRegistry(knownpaths.NewNop(), namingRegistry, model.NewComponentsMap(testapi.NewMockedComponentsProvider()), model.SortByPath)
-	namingTemplate := naming.TemplateWithIds()
-	namingGenerator := naming.NewGenerator(namingTemplate, namingRegistry)
-	return mapper.Context{Logger: logger, Fs: fs, NamingGenerator: namingGenerator, NamingRegistry: namingRegistry, State: projectState}
+	d := testdeps.New()
+	mockedState := d.EmptyState()
+	mockedState.Mapper().AddMapper(variables.NewMapper(mockedState))
+	return mockedState, d
 }
 
 func createTestObjectForPersist(t *testing.T, state model.ObjectStates) {

--- a/internal/pkg/naming/generator.go
+++ b/internal/pkg/naming/generator.go
@@ -77,7 +77,7 @@ func (g Generator) ConfigPath(parentPath string, component *Component, config *C
 	switch {
 	case parent.IsBranch() && component.IsSharedCode():
 		if config.SharedCode == nil {
-			panic(fmt.Errorf(`invalid shared code config "%s", value is not set`, config.Desc()))
+			panic(fmt.Errorf(`invalid shared code %s, value is not set`, config.Desc()))
 		}
 		// Shared code
 		template = string(g.template.SharedCodeConfig)

--- a/internal/pkg/project/mappers.go
+++ b/internal/pkg/project/mappers.go
@@ -1,0 +1,36 @@
+package project
+
+import (
+	"github.com/keboola/keboola-as-code/internal/pkg/mapper"
+	"github.com/keboola/keboola-as-code/internal/pkg/mapper/defaultbucket"
+	"github.com/keboola/keboola-as-code/internal/pkg/mapper/description"
+	"github.com/keboola/keboola-as-code/internal/pkg/mapper/orchestrator"
+	"github.com/keboola/keboola-as-code/internal/pkg/mapper/relations"
+	"github.com/keboola/keboola-as-code/internal/pkg/mapper/scheduler"
+	"github.com/keboola/keboola-as-code/internal/pkg/mapper/sharedcode"
+	"github.com/keboola/keboola-as-code/internal/pkg/mapper/transformation"
+	"github.com/keboola/keboola-as-code/internal/pkg/mapper/variables"
+	"github.com/keboola/keboola-as-code/internal/pkg/state"
+)
+
+func MappersFor(s *state.State, d dependencies) mapper.Mappers {
+	return mapper.Mappers{
+		// Core files
+		description.NewMapper(),
+		// Storage
+		defaultbucket.NewMapper(s),
+		// Variables
+		variables.NewMapper(s),
+		sharedcode.NewVariablesMapper(s),
+		// Special components
+		scheduler.NewMapper(s, d),
+		orchestrator.NewMapper(s),
+		// Native codes
+		transformation.NewMapper(s),
+		sharedcode.NewCodesMapper(s),
+		// Shared code links
+		sharedcode.NewLinksMapper(s),
+		// Relations between objects
+		relations.NewMapper(s),
+	}
+}

--- a/internal/pkg/project/project.go
+++ b/internal/pkg/project/project.go
@@ -2,8 +2,13 @@ package project
 
 import (
 	"github.com/keboola/keboola-as-code/internal/pkg/filesystem"
+	"github.com/keboola/keboola-as-code/internal/pkg/log"
 	"github.com/keboola/keboola-as-code/internal/pkg/manifest"
+	"github.com/keboola/keboola-as-code/internal/pkg/mapper"
 	projectManifest "github.com/keboola/keboola-as-code/internal/pkg/project/manifest"
+	"github.com/keboola/keboola-as-code/internal/pkg/remote"
+	"github.com/keboola/keboola-as-code/internal/pkg/scheduler"
+	"github.com/keboola/keboola-as-code/internal/pkg/state"
 )
 
 type Manifest = projectManifest.Manifest
@@ -12,15 +17,23 @@ func LoadManifest(fs filesystem.Fs) (*Manifest, error) {
 	return projectManifest.Load(fs)
 }
 
+type dependencies interface {
+	Logger() log.Logger
+	StorageApi() (*remote.StorageApi, error)
+	SchedulerApi() (*scheduler.Api, error)
+}
+
 type Project struct {
+	dependencies
 	fs       filesystem.Fs
 	manifest *Manifest
 }
 
-func New(fs filesystem.Fs, manifest *Manifest) *Project {
+func New(fs filesystem.Fs, manifest *Manifest, d dependencies) *Project {
 	return &Project{
-		fs:       fs,
-		manifest: manifest,
+		dependencies: d,
+		fs:           fs,
+		manifest:     manifest,
 	}
 }
 
@@ -30,4 +43,8 @@ func (p *Project) Fs() filesystem.Fs {
 
 func (p *Project) Manifest() manifest.Manifest {
 	return p.manifest
+}
+
+func (p *Project) MappersFor(state *state.State) mapper.Mappers {
+	return MappersFor(state, p.dependencies)
 }

--- a/internal/pkg/state/load_local_test.go
+++ b/internal/pkg/state/load_local_test.go
@@ -267,7 +267,7 @@ func loadLocalTestState(t *testing.T, m *manifest.Manifest, fs filesystem.Fs) (*
 	assert.NoError(t, err)
 	state, err := New(project, d)
 	assert.NoError(t, err)
-	_, localErr, remoteErr := state.Load(Options{LoadLocalState: true})
+	_, localErr, remoteErr := state.Load(LoadOptions{LoadLocalState: true})
 	assert.NoError(t, remoteErr)
 	return state, localErr
 }

--- a/internal/pkg/state/load_remote_test.go
+++ b/internal/pkg/state/load_remote_test.go
@@ -448,7 +448,7 @@ func loadRemoteState(t *testing.T, m *manifest.Manifest, projectStateFile string
 
 	state, err := New(project, d)
 	assert.NoError(t, err)
-	_, localErr, remoteErr := state.Load(Options{LoadRemoteState: true})
+	_, localErr, remoteErr := state.Load(LoadOptions{LoadRemoteState: true})
 	assert.NoError(t, localErr)
 	return state, envs, remoteErr
 }

--- a/internal/pkg/state/load_test.go
+++ b/internal/pkg/state/load_test.go
@@ -44,7 +44,7 @@ func TestLoadState(t *testing.T) {
 	assert.NoError(t, err)
 
 	// Load
-	options := Options{
+	options := LoadOptions{
 		LoadLocalState:  true,
 		LoadRemoteState: true,
 	}

--- a/internal/pkg/template/mappers.go
+++ b/internal/pkg/template/mappers.go
@@ -1,0 +1,36 @@
+package template
+
+import (
+	"github.com/keboola/keboola-as-code/internal/pkg/mapper"
+	"github.com/keboola/keboola-as-code/internal/pkg/mapper/defaultbucket"
+	"github.com/keboola/keboola-as-code/internal/pkg/mapper/description"
+	"github.com/keboola/keboola-as-code/internal/pkg/mapper/orchestrator"
+	"github.com/keboola/keboola-as-code/internal/pkg/mapper/relations"
+	"github.com/keboola/keboola-as-code/internal/pkg/mapper/scheduler"
+	"github.com/keboola/keboola-as-code/internal/pkg/mapper/sharedcode"
+	"github.com/keboola/keboola-as-code/internal/pkg/mapper/transformation"
+	"github.com/keboola/keboola-as-code/internal/pkg/mapper/variables"
+	"github.com/keboola/keboola-as-code/internal/pkg/state"
+)
+
+func MappersFor(s *state.State, d dependencies) mapper.Mappers {
+	return mapper.Mappers{
+		// Core files
+		description.NewMapper(),
+		// Storage
+		defaultbucket.NewMapper(s),
+		// Variables
+		variables.NewMapper(s),
+		sharedcode.NewVariablesMapper(s),
+		// Special components
+		scheduler.NewMapper(s, d),
+		orchestrator.NewMapper(s),
+		// Native codes
+		transformation.NewMapper(s),
+		sharedcode.NewCodesMapper(s),
+		// Shared code links
+		sharedcode.NewLinksMapper(s),
+		// Relations between objects
+		relations.NewMapper(s),
+	}
+}

--- a/internal/pkg/template/template.go
+++ b/internal/pkg/template/template.go
@@ -2,8 +2,13 @@ package template
 
 import (
 	"github.com/keboola/keboola-as-code/internal/pkg/filesystem"
+	"github.com/keboola/keboola-as-code/internal/pkg/log"
 	"github.com/keboola/keboola-as-code/internal/pkg/manifest"
+	"github.com/keboola/keboola-as-code/internal/pkg/mapper"
 	"github.com/keboola/keboola-as-code/internal/pkg/model"
+	"github.com/keboola/keboola-as-code/internal/pkg/remote"
+	"github.com/keboola/keboola-as-code/internal/pkg/scheduler"
+	"github.com/keboola/keboola-as-code/internal/pkg/state"
 	templateManifest "github.com/keboola/keboola-as-code/internal/pkg/template/manifest"
 )
 
@@ -13,15 +18,23 @@ func LoadManifest(fs filesystem.Fs) (*Manifest, error) {
 	return templateManifest.Load(fs)
 }
 
+type dependencies interface {
+	Logger() log.Logger
+	StorageApi() (*remote.StorageApi, error)
+	SchedulerApi() (*scheduler.Api, error)
+}
+
 type Template struct {
+	dependencies
 	fs       filesystem.Fs
 	manifest *Manifest
 }
 
-func New(fs filesystem.Fs, manifest *Manifest) *Template {
+func New(fs filesystem.Fs, manifest *Manifest, d dependencies) *Template {
 	return &Template{
-		fs:       fs,
-		manifest: manifest,
+		dependencies: d,
+		fs:           fs,
+		manifest:     manifest,
 	}
 }
 
@@ -31,6 +44,10 @@ func (p *Template) Fs() filesystem.Fs {
 
 func (p *Template) Manifest() manifest.Manifest {
 	return p.manifest
+}
+
+func (p *Template) MappersFor(state *state.State) mapper.Mappers {
+	return MappersFor(state, p.dependencies)
 }
 
 // --- move next code - ReplacesKeys to mapper

--- a/internal/pkg/testdeps/manifest.go
+++ b/internal/pkg/testdeps/manifest.go
@@ -1,0 +1,28 @@
+package testdeps
+
+import (
+	"github.com/keboola/keboola-as-code/internal/pkg/manifest"
+	"github.com/keboola/keboola-as-code/internal/pkg/model"
+	"github.com/keboola/keboola-as-code/internal/pkg/naming"
+)
+
+func NewManifest() *Manifest {
+	return &Manifest{
+		Records:             manifest.NewRecords(model.SortByPath),
+		NamingTemplateValue: naming.TemplateWithoutIds(),
+	}
+}
+
+// Manifest implementation for tests.
+type Manifest struct {
+	*manifest.Records
+	NamingTemplateValue naming.Template
+}
+
+func (m *Manifest) IsObjectIgnored(object model.Object) bool {
+	return false
+}
+
+func (m *Manifest) NamingTemplate() naming.Template {
+	return m.NamingTemplateValue
+}

--- a/internal/pkg/testdeps/objects.go
+++ b/internal/pkg/testdeps/objects.go
@@ -1,0 +1,33 @@
+package testdeps
+
+import (
+	"github.com/keboola/keboola-as-code/internal/pkg/filesystem"
+	"github.com/keboola/keboola-as-code/internal/pkg/manifest"
+	"github.com/keboola/keboola-as-code/internal/pkg/mapper"
+	"github.com/keboola/keboola-as-code/internal/pkg/state"
+)
+
+func NewObjectsContainer(fs filesystem.Fs, m manifest.Manifest) *ObjectsContainer {
+	return &ObjectsContainer{
+		FsValue:       fs,
+		ManifestValue: m,
+	}
+}
+
+// ObjectsContainer implementation for tests.
+type ObjectsContainer struct {
+	FsValue       filesystem.Fs
+	ManifestValue manifest.Manifest
+}
+
+func (p *ObjectsContainer) Fs() filesystem.Fs {
+	return p.FsValue
+}
+
+func (p *ObjectsContainer) Manifest() manifest.Manifest {
+	return p.ManifestValue
+}
+
+func (p *ObjectsContainer) MappersFor(_ *state.State) mapper.Mappers {
+	return mapper.Mappers{}
+}

--- a/internal/pkg/testdeps/state.go
+++ b/internal/pkg/testdeps/state.go
@@ -1,0 +1,14 @@
+package testdeps
+
+import (
+	"github.com/keboola/keboola-as-code/internal/pkg/manifest"
+	"github.com/keboola/keboola-as-code/internal/pkg/state"
+)
+
+func NewEmptyState(d *TestContainer, manifest manifest.Manifest) *state.State {
+	s, err := state.New(NewObjectsContainer(d.Fs(), manifest), d)
+	if err != nil {
+		panic(err)
+	}
+	return s
+}

--- a/internal/pkg/testfs/fs.go
+++ b/internal/pkg/testfs/fs.go
@@ -17,7 +17,11 @@ func NewBasePathLocalFs(basePath string) filesystem.Fs {
 }
 
 func NewMemoryFs() filesystem.Fs {
-	fs, err := aferofs.NewMemoryFs(log.NewNopLogger(), `/`)
+	return NewMemoryFsWithLogger(log.NewNopLogger())
+}
+
+func NewMemoryFsWithLogger(logger log.Logger) filesystem.Fs {
+	fs, err := aferofs.NewMemoryFs(logger, `/`)
 	if err != nil {
 		panic(err)
 	}

--- a/pkg/lib/operation/local/manifest/save/operation.go
+++ b/pkg/lib/operation/local/manifest/save/operation.go
@@ -31,6 +31,6 @@ func Run(d Dependencies) (changed bool, err error) {
 		return true, nil
 	}
 
-	d.Logger().Debugf(`ProjectManifest has not changed.`)
+	d.Logger().Debugf(`Project manifest has not changed.`)
 	return false, nil
 }

--- a/pkg/lib/operation/state/load/operation.go
+++ b/pkg/lib/operation/state/load/operation.go
@@ -42,7 +42,7 @@ type dependencies interface {
 
 func Run(container state.ObjectsContainer, o Options, d dependencies) (*state.State, error) {
 	logger := d.Logger()
-	loadOptions := state.Options{
+	loadOptions := state.LoadOptions{
 		LoadLocalState:    o.LoadLocalState,
 		LoadRemoteState:   o.LoadRemoteState,
 		IgnoreNotFoundErr: o.IgnoreNotFoundErr,


### PR DESCRIPTION
Vysledkom tohto PR je, ze vieme definovat `mappers` samostatne pre projekt a template.
A tak sa da dalej pokracovat v implementacii template.

Mapper pre projekt:
https://github.com/keboola/keboola-as-code/blob/6371463633e56f017b9e5e113eaa4ce1fd2321c6/internal/pkg/project/mappers.go#L16-L36

Mappers pre template:
https://github.com/keboola/keboola-as-code/blob/6371463633e56f017b9e5e113eaa4ce1fd2321c6/internal/pkg/template/mappers.go#L16-L36

Zatial su pre project/template rovnake `mappers`, bude to upravene v dalsich PRs.

Vid komentare k jednotlivym commitom.