### PR TITLE
Preserve temporary logs on cmd init

### DIFF
--- a/internal/pkg/log/cli.go
+++ b/internal/pkg/log/cli.go
@@ -4,7 +4,6 @@ package log
 import (
 	"io"
 
-	"go.uber.org/zap"
 	"go.uber.org/zap/zapcore"
 )
 
@@ -24,5 +23,5 @@ func NewCliLogger(stdout io.Writer, stderr io.Writer, logFile *File, verbose boo
 	cores = append(cores, stderrCore(stderr, verbose))
 
 	// Create zapLogger
-	return loggerFromZap(zap.New(zapcore.NewTee(cores...)))
+	return loggerFromZapCore(zapcore.NewTee(cores...))
 }

--- a/internal/pkg/log/debug.go
+++ b/internal/pkg/log/debug.go
@@ -4,7 +4,6 @@ package log
 import (
 	"io"
 
-	"go.uber.org/zap"
 	"go.uber.org/zap/zapcore"
 
 	"github.com/keboola/keboola-as-code/internal/pkg/utils/ioutil"
@@ -42,14 +41,14 @@ func NewDebugLogger() DebugLogger {
 		warnOrError: ioutil.NewBufferedWriter(),
 		error:       ioutil.NewBufferedWriter(),
 	}
-	l.zapLogger = loggerFromZap(zap.New(zapcore.NewTee(
+	l.zapLogger = loggerFromZapCore(zapcore.NewTee(
 		debugCore(l.all, DebugLevel),                            // all = debug level and higher
 		debugCore(l.debug, &oneLevelEnabler{level: DebugLevel}), // only debug msgs
 		debugCore(l.info, &oneLevelEnabler{level: InfoLevel}),   // only info msgs
 		debugCore(l.warn, &oneLevelEnabler{level: WarnLevel}),   // only warn msgs
 		debugCore(l.warnOrError, WarnLevel),                     // warn or error = warn level and higher
 		debugCore(l.error, ErrorLevel),                          // error = error level and higher
-	)))
+	))
 	return l
 }
 

--- a/internal/pkg/log/log.go
+++ b/internal/pkg/log/log.go
@@ -19,6 +19,11 @@ type Logger interface {
 	toWriter
 }
 
+type loggerWithZapCore interface {
+	Logger
+	zapCore() zapcore.Core
+}
+
 // DebugLogger returns logs as string in tests.
 type DebugLogger interface {
 	Logger
@@ -41,6 +46,7 @@ type baseLogger interface {
 }
 
 type sugaredLogger interface {
+	With(args ...interface{}) Logger // creates a child logger and adds structured context to it.
 	Debugf(template string, args ...interface{})
 	Infof(template string, args ...interface{})
 	Warnf(template string, args ...interface{})

--- a/internal/pkg/log/logger.go
+++ b/internal/pkg/log/logger.go
@@ -3,16 +3,23 @@ package log
 
 import (
 	"go.uber.org/zap"
+	"go.uber.org/zap/zapcore"
 )
 
 // zapLogger is default implementation of the Logger interface.
 // It is wrapped zap.SugaredLogger.
 type zapLogger struct {
 	*zap.SugaredLogger
+	core zapcore.Core
 }
 
-func loggerFromZap(l *zap.Logger) *zapLogger {
-	return &zapLogger{SugaredLogger: l.Sugar()}
+func loggerFromZapCore(core zapcore.Core, with ...interface{}) *zapLogger {
+	return &zapLogger{SugaredLogger: zap.New(core).Sugar().With(with...), core: core}
+}
+
+// With creates a child logger and adds structured context to it.
+func (l *zapLogger) With(args ...interface{}) Logger {
+	return loggerFromZapCore(l.core, args...)
 }
 
 func (l *zapLogger) DebugWriter() *LevelWriter {
@@ -29,4 +36,8 @@ func (l *zapLogger) WarnWriter() *LevelWriter {
 
 func (l *zapLogger) ErrorWriter() *LevelWriter {
 	return &LevelWriter{logger: l, level: ErrorLevel}
+}
+
+func (l *zapLogger) zapCore() zapcore.Core {
+	return l.core
 }

--- a/internal/pkg/log/memory.go
+++ b/internal/pkg/log/memory.go
@@ -1,0 +1,80 @@
+// nolint:forbidigo // allow usage of the "zap" package
+package log
+
+import (
+	"fmt"
+
+	"go.uber.org/zap/zapcore"
+
+	"github.com/keboola/keboola-as-code/internal/pkg/utils/deepcopy"
+)
+
+func NewMemoryLogger() *MemoryLogger {
+	var entries []memoryEntry
+	core := &memoryCore{entries: &entries}
+	return &MemoryLogger{
+		zapLogger: loggerFromZapCore(core),
+		core:      core,
+	}
+}
+
+type MemoryLogger struct {
+	*zapLogger
+	core *memoryCore
+}
+
+func (l *MemoryLogger) CopyLogsTo(target Logger) {
+	if zap, ok := target.(loggerWithZapCore); ok {
+		targetCore := zap.zapCore()
+		for _, entry := range *l.core.entries {
+			if ce := targetCore.Check(entry.entry, nil); ce != nil {
+				ce.Write(entry.fields...)
+			}
+		}
+	} else {
+		panic(fmt.Errorf(`not implemented: cannot copy logs to "%T"`, target))
+	}
+}
+
+type memoryCore struct {
+	fields  []zapcore.Field
+	entries *[]memoryEntry
+}
+
+type memoryEntry struct {
+	entry  zapcore.Entry
+	fields []zapcore.Field
+}
+
+// With creates a child core and adds structured context to it.
+func (c *memoryCore) With(fields []zapcore.Field) zapcore.Core {
+	// Return clone, but with the same entries slice.
+	return &memoryCore{
+		fields:  append(deepcopy.Copy(c.fields).([]zapcore.Field), fields...),
+		entries: c.entries,
+	}
+}
+
+// Enabled for each level.
+func (*memoryCore) Enabled(zapcore.Level) bool {
+	return true
+}
+
+// Write log entry to memory.
+func (c *memoryCore) Write(entry zapcore.Entry, fields []zapcore.Field) error {
+	*c.entries = append(*c.entries, memoryEntry{
+		entry:  entry,
+		fields: append(c.fields, fields...), // merge logger level and entry level fields
+	})
+	return nil
+}
+
+// Check - can this core log entry?
+func (c *memoryCore) Check(entry zapcore.Entry, ce *zapcore.CheckedEntry) *zapcore.CheckedEntry {
+	return ce.AddCore(entry, c)
+}
+
+// Sync - nop.
+func (*memoryCore) Sync() error {
+	return nil
+}

--- a/internal/pkg/log/memory_test.go
+++ b/internal/pkg/log/memory_test.go
@@ -1,0 +1,31 @@
+// nolint:forbidigo // allow usage of the "zap" package
+package log
+
+import (
+	"strings"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+)
+
+func TestMemoryLogger(t *testing.T) {
+	t.Parallel()
+
+	mem := NewMemoryLogger()
+	mem.Debug(`Debug message.`)
+	mem.Info(`Info message.`)
+	memWithCtx := mem.With("key1", "value1", "key2", "value2")
+	memWithCtx.Debug(`Debug message.`)
+	memWithCtx.Info(`Info message.`)
+
+	target := NewDebugLogger()
+	mem.CopyLogsTo(target)
+
+	expected := `
+DEBUG  Debug message.
+INFO  Info message.
+DEBUG  Debug message.  {"key1": "value1", "key2": "value2"}
+INFO  Info message.  {"key1": "value1", "key2": "value2"}
+`
+	assert.Equal(t, strings.TrimLeft(expected, "\n"), target.AllMessages())
+}

--- a/internal/pkg/log/nop.go
+++ b/internal/pkg/log/nop.go
@@ -2,10 +2,10 @@
 package log
 
 import (
-	"go.uber.org/zap"
+	"go.uber.org/zap/zapcore"
 )
 
 // NewNopLogger returns no operation log. The logs are discarded.
 func NewNopLogger() Logger {
-	return loggerFromZap(zap.NewNop())
+	return loggerFromZapCore(zapcore.NewNopCore())
 }


### PR DESCRIPTION
Fixed missing messages from temporary logger, on command init.