### PR TITLE
Reuse mocked storage/scheduler API in testdeps.TestContainer

### DIFF
--- a/internal/pkg/testdeps/dependencies.go
+++ b/internal/pkg/testdeps/dependencies.go
@@ -27,6 +27,10 @@ type commonDeps = dependencies.TestContainer
 type TestContainer struct {
 	*testDependencies
 	*commonDeps
+	mockedStorageApi            *remote.StorageApi
+	mockedStorageApiTransport   *httpmock.MockTransport
+	mockedSchedulerApi          *scheduler.Api
+	mockedSchedulerApiTransport *httpmock.MockTransport
 }
 
 func New() *TestContainer {
@@ -70,15 +74,21 @@ func (v *TestContainer) InitFromTestProject(project *testproject.Project) {
 }
 
 func (v *TestContainer) UseMockedStorageApi() (*remote.StorageApi, *httpmock.MockTransport) {
-	storageApi, httpTransport := testapi.NewMockedStorageApi(v.DebugLogger())
-	v.SetStorageApi(storageApi)
-	return storageApi, httpTransport
+	if v.mockedStorageApi == nil {
+		v.mockedStorageApi, v.mockedStorageApiTransport = testapi.NewMockedStorageApi(v.DebugLogger())
+	}
+
+	v.SetStorageApi(v.mockedStorageApi)
+	return v.mockedStorageApi, v.mockedStorageApiTransport
 }
 
 func (v *TestContainer) UseMockedSchedulerApi() (*scheduler.Api, *httpmock.MockTransport) {
-	schedulerApi, httpTransport := testapi.NewMockedSchedulerApi(v.DebugLogger())
-	v.SetSchedulerApi(schedulerApi)
-	return schedulerApi, httpTransport
+	if v.mockedSchedulerApi == nil {
+		v.mockedSchedulerApi, v.mockedSchedulerApiTransport = testapi.NewMockedSchedulerApi(v.DebugLogger())
+	}
+
+	v.SetSchedulerApi(v.mockedSchedulerApi)
+	return v.mockedSchedulerApi, v.mockedSchedulerApiTransport
 }
 
 // EmptyState without mappers. Useful for mappers unit tests.


### PR DESCRIPTION
Aby fungoval tento priklad:
```
func createStateWithMapper(t *testing.T) (*state.State, *testdeps.TestContainer) {
	t.Helper()
	d := testdeps.New()
        _, httpTransport := d.UseMockedStorageApi()
        //
        // register mocked responses to httpTransport
        //
	mockedState := d.EmptyState()
	mockedState.Mapper().AddMapper(PKG.NewMapper(mockedState, d))
	return mockedState, d
}
```

Je potrebna este drobna zmena.
`d.EmptyState()` totiz interne vola `d.UseMockedStorageApi()`.
https://github.com/keboola/keboola-as-code/blob/cbe2fbdb4891deba40a644935cdf04d54732759f/internal/pkg/testdeps/dependencies.go#L84-L90

Tak aby sa ti tie mocked response neprepisali, 
tak `UseMockedStorageApi` musi vytvarat mocked API, iba ked este nie je vytvorene.
To fixuje tento PR.
