### PR TITLE
Create filesystem.FileLoader

### DIFF
--- a/internal/pkg/filesystem/fileloader/fileloader.go
+++ b/internal/pkg/filesystem/fileloader/fileloader.go
@@ -1,0 +1,96 @@
+package fileloader
+
+import (
+	"fmt"
+	"strings"
+
+	"github.com/keboola/keboola-as-code/internal/pkg/filesystem"
+	"github.com/keboola/keboola-as-code/internal/pkg/json"
+	"github.com/keboola/keboola-as-code/internal/pkg/utils"
+	"github.com/keboola/keboola-as-code/internal/pkg/utils/orderedmap"
+)
+
+type loader struct {
+	fs filesystem.Fs
+}
+
+func New(fs filesystem.Fs) filesystem.FileLoader {
+	return &loader{fs: fs}
+}
+
+func (l *loader) ReadFile(path, desc string) (*filesystem.File, error) {
+	return l.fs.ReadFile(path, desc)
+}
+
+// ReadJsonFile to ordered map.
+func (l *loader) ReadJsonFile(path, desc string) (*filesystem.JsonFile, error) {
+	file, err := l.fs.ReadFile(path, desc)
+	if err != nil {
+		return nil, err
+	}
+
+	jsonFile, err := file.ToJsonFile()
+	if err != nil {
+		return nil, err
+	}
+
+	return jsonFile, nil
+}
+
+// ReadJsonFileTo to target struct.
+func (l *loader) ReadJsonFileTo(path, desc string, target interface{}) (*filesystem.File, error) {
+	file, err := l.fs.ReadFile(path, desc)
+	if err != nil {
+		return nil, err
+	}
+
+	if err := json.DecodeString(file.Content, target); err != nil {
+		fileDesc := strings.TrimSpace(file.Desc + " file")
+		return nil, utils.PrefixError(fmt.Sprintf("%s \"%s\" is invalid", fileDesc, file.Path), err)
+	}
+
+	return file, nil
+}
+
+// ReadJsonFieldsTo target struct by tag.
+func (l *loader) ReadJsonFieldsTo(path, desc string, target interface{}, tag string) (*filesystem.JsonFile, bool, error) {
+	if fields := utils.GetFieldsWithTag(tag, target); len(fields) > 0 {
+		if file, err := l.ReadJsonFile(path, desc); err == nil {
+			utils.SetFields(fields, file.Content, target)
+			return file, true, nil
+		} else {
+			return nil, false, err
+		}
+	}
+
+	return nil, false, nil
+}
+
+// ReadJsonMapTo tagged field in target struct as ordered map.
+func (l *loader) ReadJsonMapTo(path, desc string, target interface{}, tag string) (*filesystem.JsonFile, bool, error) {
+	if field := utils.GetOneFieldWithTag(tag, target); field != nil {
+		if file, err := l.ReadJsonFile(path, desc); err == nil {
+			utils.SetField(field, file.Content, target)
+			return file, true, nil
+		} else {
+			// Set empty map if error occurred
+			utils.SetField(field, orderedmap.New(), target)
+			return nil, false, err
+		}
+	}
+	return nil, false, nil
+}
+
+// ReadFileContentTo to tagged field in target struct as string.
+func (l *loader) ReadFileContentTo(path, desc string, target interface{}, tag string) (*filesystem.File, bool, error) {
+	if field := utils.GetOneFieldWithTag(tag, target); field != nil {
+		if file, err := l.fs.ReadFile(path, desc); err == nil {
+			content := strings.TrimRight(file.Content, " \r\n\t")
+			utils.SetField(field, content, target)
+			return file, true, nil
+		} else {
+			return nil, false, err
+		}
+	}
+	return nil, false, nil
+}

--- a/internal/pkg/filesystem/fileloader/fileloader_test.go
+++ b/internal/pkg/filesystem/fileloader/fileloader_test.go
@@ -1,0 +1,211 @@
+package fileloader_test
+
+import (
+	"reflect"
+	"strings"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+
+	"github.com/keboola/keboola-as-code/internal/pkg/filesystem"
+	"github.com/keboola/keboola-as-code/internal/pkg/filesystem/aferofs"
+	"github.com/keboola/keboola-as-code/internal/pkg/filesystem/fileloader"
+	"github.com/keboola/keboola-as-code/internal/pkg/json"
+	"github.com/keboola/keboola-as-code/internal/pkg/log"
+	"github.com/keboola/keboola-as-code/internal/pkg/utils/orderedmap"
+)
+
+type myStruct struct {
+	Field1   string                 `json:"field1" mytag:"field"`
+	Field2   string                 `json:"field2" mytag:"field"`
+	FooField string                 `json:"foo"`
+	Map      *orderedmap.OrderedMap `mytag:"map"`
+	Content  string                 `mytag:"content"`
+}
+
+func TestLocalFilesystem(t *testing.T) {
+	t.Parallel()
+	createFs := func() (filesystem.Fs, log.DebugLogger) {
+		logger := log.NewDebugLogger()
+		fs, err := aferofs.NewLocalFs(logger, t.TempDir(), filesystem.Join("my", "dir"))
+		assert.NoError(t, err)
+		return fs, logger
+	}
+	cases := &testCases{createFs}
+	cases.runTests(t)
+}
+
+func TestMemoryFilesystem(t *testing.T) {
+	t.Parallel()
+	createFs := func() (filesystem.Fs, log.DebugLogger) {
+		logger := log.NewDebugLogger()
+		fs, err := aferofs.NewMemoryFs(logger, filesystem.Join("my", "dir"))
+		assert.NoError(t, err)
+		return fs, logger
+	}
+	cases := &testCases{createFs}
+	cases.runTests(t)
+}
+
+type testCases struct {
+	createFs func() (filesystem.Fs, log.DebugLogger)
+}
+
+func (tc *testCases) runTests(t *testing.T) {
+	t.Helper()
+	// Call all Test* methods
+	tp := reflect.TypeOf(tc)
+	prefix := `Test`
+	for i := 0; i < tp.NumMethod(); i++ {
+		method := tp.Method(i)
+		if strings.HasPrefix(method.Name, prefix) {
+			fs, logger := tc.createFs()
+			testName := strings.TrimPrefix(method.Name, prefix)
+			t.Run(testName, func(t *testing.T) {
+				t.Parallel()
+				reflect.ValueOf(tc).MethodByName(method.Name).Call([]reflect.Value{
+					reflect.ValueOf(t),
+					reflect.ValueOf(fs),
+					reflect.ValueOf(logger),
+				})
+			})
+		}
+	}
+}
+
+func (*testCases) TestFileLoader_ReadFile(t *testing.T, fs filesystem.Fs, logger log.DebugLogger) {
+	// Create file
+	filePath := "file.txt"
+	assert.NoError(t, fs.WriteFile(filesystem.NewFile(filePath, "foo\n")))
+
+	// Read
+	logger.Truncate()
+	file, err := fileloader.New(fs).ReadFile(filePath, "")
+	assert.NoError(t, err)
+	assert.NotNil(t, file)
+	assert.Equal(t, "foo\n", file.Content)
+	assert.Equal(t, `DEBUG  Loaded "file.txt"`, strings.TrimSpace(logger.AllMessages()))
+}
+
+func (*testCases) TestFileLoader_ReadFile_NotFound(t *testing.T, fs filesystem.Fs, logger log.DebugLogger) {
+	filePath := "file.txt"
+	file, err := fileloader.New(fs).ReadFile(filePath, "")
+	assert.Error(t, err)
+	assert.Nil(t, file)
+	assert.True(t, strings.HasPrefix(err.Error(), `missing file "file.txt"`))
+	assert.Equal(t, "", logger.AllMessages())
+}
+
+func (*testCases) TestFileLoader_ReadJsonFile(t *testing.T, fs filesystem.Fs, logger log.DebugLogger) {
+	// Create file
+	filePath := "file.txt"
+	assert.NoError(t, fs.WriteFile(filesystem.NewFile(filePath, `{"foo": "bar"}`)))
+
+	// Read
+	logger.Truncate()
+	file, err := fileloader.New(fs).ReadJsonFile(filePath, "")
+	assert.NoError(t, err)
+	assert.NotNil(t, file)
+	assert.Equal(t, `{"foo":"bar"}`, json.MustEncodeString(file.Content, false))
+	assert.Equal(t, `DEBUG  Loaded "file.txt"`, strings.TrimSpace(logger.AllMessages()))
+}
+
+func (*testCases) TestFileLoader_ReadJsonFileTo(t *testing.T, fs filesystem.Fs, logger log.DebugLogger) {
+	// Create file
+	filePath := "file.txt"
+	assert.NoError(t, fs.WriteFile(filesystem.NewFile(filePath, `{"foo": "bar"}`)))
+
+	// Read
+	logger.Truncate()
+	target := &myStruct{}
+	file, err := fileloader.New(fs).ReadJsonFileTo(filePath, "", target)
+	assert.Equal(t, `{"foo": "bar"}`, file.Content)
+	assert.NoError(t, err)
+	assert.Equal(t, `bar`, target.FooField)
+	assert.Equal(t, `DEBUG  Loaded "file.txt"`, strings.TrimSpace(logger.AllMessages()))
+}
+
+func (*testCases) TestFileLoader_ReadJsonFileTo_Invalid(t *testing.T, fs filesystem.Fs, logger log.DebugLogger) {
+	// Create file
+	filePath := "file.txt"
+	assert.NoError(t, fs.WriteFile(filesystem.NewFile(filePath, `{"foo":`)))
+
+	// Read
+	logger.Truncate()
+	target := &myStruct{}
+	_, err := fileloader.New(fs).ReadJsonFileTo(filePath, "", target)
+	assert.Error(t, err)
+	expectedError := `
+file "file.txt" is invalid:
+  - unexpected end of JSON input, offset: 7
+`
+	assert.Equal(t, strings.TrimSpace(expectedError), err.Error())
+}
+
+func (*testCases) TestFileLoader_ReadJsonFile_Invalid(t *testing.T, fs filesystem.Fs, _ log.DebugLogger) {
+	// Create file
+	filePath := "file.txt"
+	assert.NoError(t, fs.WriteFile(filesystem.NewFile(filePath, `{"foo":`)))
+
+	// Read
+	file, err := fileloader.New(fs).ReadJsonFile(filePath, "")
+	assert.Error(t, err)
+	assert.Nil(t, file)
+	expectedError := `
+file "file.txt" is invalid:
+  - unexpected end of JSON input, offset: 7
+`
+	assert.Equal(t, strings.TrimSpace(expectedError), err.Error())
+}
+
+func (*testCases) TestFileLoader_ReadJsonFieldsTo(t *testing.T, fs filesystem.Fs, logger log.DebugLogger) {
+	// Create file
+	filePath := "file.txt"
+	assert.NoError(t, fs.WriteFile(filesystem.NewFile(filePath, `{"field1": "foo", "field2": "bar"}`)))
+
+	// Read
+	logger.Truncate()
+	target := &myStruct{}
+	file, tagFound, err := fileloader.New(fs).ReadJsonFieldsTo(filePath, "", target, `mytag:field`)
+	assert.NoError(t, err)
+	assert.True(t, tagFound)
+	assert.NotNil(t, file)
+	assert.Equal(t, `{"field1":"foo","field2":"bar"}`, json.MustEncodeString(file.Content, false))
+	assert.Equal(t, `foo`, target.Field1)
+	assert.Equal(t, `bar`, target.Field2)
+	assert.Equal(t, `DEBUG  Loaded "file.txt"`, strings.TrimSpace(logger.AllMessages()))
+}
+
+func (*testCases) TestFileLoader_ReadJsonMapTo(t *testing.T, fs filesystem.Fs, logger log.DebugLogger) {
+	// Create file
+	filePath := "file.txt"
+	assert.NoError(t, fs.WriteFile(filesystem.NewFile(filePath, `{"field1": "foo", "field2": "bar"}`)))
+
+	// Read
+	logger.Truncate()
+	target := &myStruct{}
+	file, tagFound, err := fileloader.New(fs).ReadJsonMapTo(filePath, "", target, `mytag:map`)
+	assert.NoError(t, err)
+	assert.True(t, tagFound)
+	assert.NotNil(t, file)
+	assert.Equal(t, `{"field1":"foo","field2":"bar"}`, json.MustEncodeString(file.Content, false))
+	assert.Equal(t, `{"field1":"foo","field2":"bar"}`, json.MustEncodeString(target.Map, false))
+	assert.Equal(t, `DEBUG  Loaded "file.txt"`, strings.TrimSpace(logger.AllMessages()))
+}
+
+func (*testCases) TestFileLoader_ReadFileContentTo(t *testing.T, fs filesystem.Fs, logger log.DebugLogger) {
+	// Create file
+	filePath := "file.txt"
+	assert.NoError(t, fs.WriteFile(filesystem.NewFile(filePath, `{"field1": "foo", "field2": "bar"}`)))
+
+	// Read
+	logger.Truncate()
+	target := &myStruct{}
+	file, tagFound, err := fileloader.New(fs).ReadFileContentTo(filePath, "", target, `mytag:content`)
+	assert.NoError(t, err)
+	assert.True(t, tagFound)
+	assert.NotNil(t, file)
+	assert.Equal(t, `{"field1": "foo", "field2": "bar"}`, file.Content)
+	assert.Equal(t, `{"field1": "foo", "field2": "bar"}`, target.Content)
+	assert.Equal(t, `DEBUG  Loaded "file.txt"`, strings.TrimSpace(logger.AllMessages()))
+}

--- a/internal/pkg/filesystem/filesystem.go
+++ b/internal/pkg/filesystem/filesystem.go
@@ -48,15 +48,19 @@ type Fs interface {
 	Move(src, dst string) error
 	MoveForce(src, dst string) error
 	Remove(path string) error
-	ReadJsonFieldsTo(path, desc string, target interface{}, tag string) (*JsonFile, error)
-	ReadJsonMapTo(path, desc string, target interface{}, tag string) (*JsonFile, error)
-	ReadFileContentTo(path, desc string, target interface{}, tag string) (*File, error)
-	ReadJsonFile(path, desc string) (*JsonFile, error)
-	ReadJsonFileTo(path, desc string, target interface{}) error
 	ReadFile(path, desc string) (*File, error)
 	WriteFile(file *File) error
 	WriteJsonFile(file *JsonFile) error
 	CreateOrUpdateFile(path, desc string, lines []FileLine) (updated bool, err error)
+}
+
+type FileLoader interface {
+	ReadFile(path, desc string) (*File, error)
+	ReadJsonFieldsTo(path, desc string, target interface{}, tag string) (*JsonFile, bool, error)
+	ReadJsonMapTo(path, desc string, target interface{}, tag string) (*JsonFile, bool, error)
+	ReadFileContentTo(path, desc string, target interface{}, tag string) (*File, bool, error)
+	ReadJsonFile(path, desc string) (*JsonFile, error)
+	ReadJsonFileTo(path, desc string, target interface{}) (*File, error)
 }
 
 func FromSlash(path string) string {

--- a/internal/pkg/local/load.go
+++ b/internal/pkg/local/load.go
@@ -18,13 +18,13 @@ func (m *Manager) loadObject(ctx context.Context, manifest model.ObjectManifest,
 
 	// Call mappers
 	errors := utils.NewMultiError()
-	recipe := model.NewLocalLoadRecipe(manifest, object)
+	recipe := model.NewLocalLoadRecipe(m.FileLoader(), manifest, object)
 	if err := m.mapper.MapAfterLocalLoad(recipe); err != nil {
 		errors.Append(err)
 	}
 
 	// Set related paths
-	for _, file := range recipe.Files.All() {
+	for _, file := range recipe.Files.Loaded() {
 		manifest.AddRelatedPath(file.Path())
 	}
 

--- a/internal/pkg/local/local_test.go
+++ b/internal/pkg/local/local_test.go
@@ -6,6 +6,7 @@ import (
 	"github.com/stretchr/testify/assert"
 
 	"github.com/keboola/keboola-as-code/internal/pkg/filesystem/aferofs"
+	"github.com/keboola/keboola-as-code/internal/pkg/filesystem/fileloader"
 	"github.com/keboola/keboola-as-code/internal/pkg/filesystem/knownpaths"
 	"github.com/keboola/keboola-as-code/internal/pkg/log"
 	"github.com/keboola/keboola-as-code/internal/pkg/mapper"
@@ -21,6 +22,7 @@ func newTestLocalManager(t *testing.T) *Manager {
 	logger := log.NewDebugLogger()
 	fs, err := aferofs.NewMemoryFs(logger, "")
 	assert.NoError(t, err)
+	fileLoader := fileloader.New(fs)
 
 	manifest := projectManifest.New(1, "foo.bar")
 	components := model.NewComponentsMap(nil)
@@ -29,5 +31,5 @@ func newTestLocalManager(t *testing.T) *Manager {
 	namingTemplate := naming.TemplateWithIds()
 	namingRegistry := naming.NewRegistry()
 	namingGenerator := naming.NewGenerator(namingTemplate, namingRegistry)
-	return NewManager(logger, fs, manifest, namingGenerator, projectState, mapper.New())
+	return NewManager(logger, fs, fileLoader, manifest, namingGenerator, projectState, mapper.New())
 }

--- a/internal/pkg/local/manager.go
+++ b/internal/pkg/local/manager.go
@@ -22,6 +22,7 @@ type Manager struct {
 	logger          log.Logger
 	state           model.ObjectStates
 	fs              filesystem.Fs
+	fileLoader      filesystem.FileLoader
 	manifest        manifest.Manifest
 	namingGenerator *naming.Generator
 	mapper          *mapper.Mapper
@@ -39,11 +40,12 @@ type UnitOfWork struct {
 	invoked         bool
 }
 
-func NewManager(logger log.Logger, fs filesystem.Fs, m manifest.Manifest, namingGenerator *naming.Generator, objects model.ObjectStates, mapper *mapper.Mapper) *Manager {
+func NewManager(logger log.Logger, fs filesystem.Fs, fileLoader filesystem.FileLoader, m manifest.Manifest, namingGenerator *naming.Generator, objects model.ObjectStates, mapper *mapper.Mapper) *Manager {
 	return &Manager{
 		logger:          logger,
 		state:           objects,
 		fs:              fs,
+		fileLoader:      fileLoader,
 		manifest:        m,
 		namingGenerator: namingGenerator,
 		mapper:          mapper,
@@ -60,6 +62,10 @@ func (m *Manager) NamingGenerator() *naming.Generator {
 
 func (m *Manager) Fs() filesystem.Fs {
 	return m.fs
+}
+
+func (m *Manager) FileLoader() filesystem.FileLoader {
+	return m.fileLoader
 }
 
 func (m *Manager) NewUnitOfWork(ctx context.Context) *UnitOfWork {

--- a/internal/pkg/mapper/corefiles/local_load.go
+++ b/internal/pkg/mapper/corefiles/local_load.go
@@ -22,46 +22,33 @@ func (m *coreFilesMapper) MapAfterLocalLoad(recipe *model.LocalLoadRecipe) error
 
 // loadMetaFile from meta.json.
 func (m *coreFilesMapper) loadMetaFile(recipe *model.LocalLoadRecipe) error {
-	path := m.state.NamingGenerator().MetaFilePath(recipe.ObjectManifest.Path())
-	desc := recipe.ObjectManifest.Kind().Name + " metadata"
-	if file, err := m.state.Fs().ReadJsonFieldsTo(path, desc, recipe.Object, model.MetaFileFieldsTag); err != nil {
-		return err
-	} else if file != nil {
-		recipe.Files.
-			Add(file).
-			AddTag(model.FileTypeJson).
-			AddTag(model.FileKindObjectMeta)
-	}
-	return nil
+	_, _, err := recipe.Files.
+		Load(m.state.NamingGenerator().MetaFilePath(recipe.ObjectManifest.Path())).
+		SetDescription(recipe.ObjectManifest.Kind().Name+" metadata").
+		AddTag(model.FileTypeJson).
+		AddTag(model.FileKindObjectMeta).
+		ReadJsonFieldsTo(recipe.Object, model.MetaFileFieldsTag)
+	return err
 }
 
 // loadConfigFile from config.json.
 func (m *coreFilesMapper) loadConfigFile(recipe *model.LocalLoadRecipe) error {
-	// config.json
-	path := m.state.NamingGenerator().ConfigFilePath(recipe.ObjectManifest.Path())
-	desc := recipe.ObjectManifest.Kind().Name
-	if file, err := m.state.Fs().ReadJsonMapTo(path, desc, recipe.Object, model.ConfigFileFieldTag); err != nil {
-		return err
-	} else if file != nil {
-		recipe.Files.
-			Add(file).
-			AddTag(model.FileTypeJson).
-			AddTag(model.FileKindObjectConfig)
-	}
-	return nil
+	_, _, err := recipe.Files.
+		Load(m.state.NamingGenerator().ConfigFilePath(recipe.ObjectManifest.Path())).
+		SetDescription(recipe.ObjectManifest.Kind().Name).
+		AddTag(model.FileTypeJson).
+		AddTag(model.FileKindObjectConfig).
+		ReadJsonMapTo(recipe.Object, model.ConfigFileFieldTag)
+	return err
 }
 
 // loadDescriptionFile from description.md.
 func (m *coreFilesMapper) loadDescriptionFile(recipe *model.LocalLoadRecipe) error {
-	path := m.state.NamingGenerator().DescriptionFilePath(recipe.ObjectManifest.Path())
-	desc := recipe.ObjectManifest.Kind().Name + " description"
-	if file, err := m.state.Fs().ReadFileContentTo(path, desc, recipe.Object, model.DescriptionFileFieldTag); err != nil {
-		return err
-	} else if file != nil {
-		recipe.Files.
-			Add(file).
-			AddTag(model.FileTypeMarkdown).
-			AddTag(model.FileKindObjectDescription)
-	}
-	return nil
+	_, _, err := recipe.Files.
+		Load(m.state.NamingGenerator().DescriptionFilePath(recipe.ObjectManifest.Path())).
+		SetDescription(recipe.ObjectManifest.Kind().Name+" description").
+		AddTag(model.FileTypeMarkdown).
+		AddTag(model.FileKindObjectDescription).
+		ReadFileContentTo(recipe.Object, model.DescriptionFileFieldTag)
+	return err
 }

--- a/internal/pkg/mapper/corefiles/local_load_test.go
+++ b/internal/pkg/mapper/corefiles/local_load_test.go
@@ -38,7 +38,7 @@ func TestLoadCoreFiles(t *testing.T) {
 	assert.NoError(t, fs.WriteFile(filesystem.NewFile(state.NamingGenerator().ConfigFilePath(manifest.Path()), configFile)))
 
 	// Call mapper
-	recipe := model.NewLocalLoadRecipe(manifest, object)
+	recipe := model.NewLocalLoadRecipe(d.FileLoader(), manifest, object)
 	assert.NoError(t, state.Mapper().MapAfterLocalLoad(recipe))
 
 	// Values are loaded and set

--- a/internal/pkg/mapper/corefiles/local_save_test.go
+++ b/internal/pkg/mapper/corefiles/local_save_test.go
@@ -32,7 +32,7 @@ func TestSaveCoreFiles(t *testing.T) {
 	recipe := model.NewLocalSaveRecipe(manifest, object, model.NewChangedFields())
 
 	// No files
-	assert.Empty(t, recipe.Files)
+	assert.Empty(t, recipe.Files.All())
 
 	// Call mapper
 	assert.NoError(t, state.Mapper().MapBeforeLocalSave(recipe))

--- a/internal/pkg/mapper/corefiles/local_save_test.go
+++ b/internal/pkg/mapper/corefiles/local_save_test.go
@@ -38,7 +38,7 @@ func TestSaveCoreFiles(t *testing.T) {
 	assert.NoError(t, state.Mapper().MapBeforeLocalSave(recipe))
 
 	// Files are generated
-	expectedFiles := model.ObjectFiles{}
+	expectedFiles := model.NewFilesToSave()
 	expectedFiles.
 		Add(
 			filesystem.NewJsonFile(state.NamingGenerator().MetaFilePath(manifest.Path()),

--- a/internal/pkg/mapper/defaultbucket/local_load_test.go
+++ b/internal/pkg/mapper/defaultbucket/local_load_test.go
@@ -109,7 +109,7 @@ func TestDefaultBucketMapper_MapBeforeLocalLoadConfig(t *testing.T) {
 	// Invoke
 	changes := model.NewLocalChanges()
 	changes.AddLoaded(configState2)
-	recipe := model.NewLocalLoadRecipe(configState2.ConfigManifest, configState2.Local)
+	recipe := model.NewLocalLoadRecipe(d.FileLoader(), configState2.ConfigManifest, configState2.Local)
 	assert.NoError(t, state.Mapper().OnLocalChange(changes))
 
 	// Check warning of missing default bucket config
@@ -213,7 +213,7 @@ func TestDefaultBucketMapper_MapBeforeLocalLoadRow(t *testing.T) {
 	// Invoke
 	changes := model.NewLocalChanges()
 	changes.AddLoaded(rowState)
-	recipe := model.NewLocalLoadRecipe(rowState.ConfigRowManifest, rowState.Local)
+	recipe := model.NewLocalLoadRecipe(d.FileLoader(), rowState.ConfigRowManifest, rowState.Local)
 	assert.NoError(t, state.Mapper().OnLocalChange(changes))
 
 	// Check warning of missing default bucket config

--- a/internal/pkg/mapper/relations/local_load_test.go
+++ b/internal/pkg/mapper/relations/local_load_test.go
@@ -16,7 +16,7 @@ func TestRelationsMapperLocalLoad(t *testing.T) {
 
 	manifest := &fixtures.MockedManifest{}
 	object := &fixtures.MockedObject{}
-	recipe := model.NewLocalLoadRecipe(manifest, object)
+	recipe := model.NewLocalLoadRecipe(d.FileLoader(), manifest, object)
 
 	relation := &fixtures.MockedManifestSideRelation{}
 	manifest.Relations = append(manifest.Relations, relation)

--- a/internal/pkg/mapper/sharedcode/codes/local_load.go
+++ b/internal/pkg/mapper/sharedcode/codes/local_load.go
@@ -67,15 +67,15 @@ func (m *mapper) onRowLocalLoad(config *model.Config, row *model.ConfigRow, reci
 	}
 
 	// Load file
-	codeFilePath := m.state.NamingGenerator().SharedCodeFilePath(recipe.Path(), config.SharedCode.Target)
-	codeFile, err := m.state.Fs().ReadFile(codeFilePath, `shared code`)
+	codeFile, err := recipe.Files.
+		Load(m.state.NamingGenerator().SharedCodeFilePath(recipe.Path(), config.SharedCode.Target)).
+		SetDescription("shared code").
+		AddTag(model.FileTypeOther).
+		AddTag(model.FileKindNativeSharedCode).
+		ReadFile()
 	if err != nil {
 		return err
 	}
-	recipe.Files.
-		Add(codeFile).
-		AddTag(model.FileTypeOther).
-		AddTag(model.FileKindNativeSharedCode)
 
 	// Store scripts to struct
 	row.SharedCode = &model.SharedCodeRow{

--- a/internal/pkg/mapper/sharedcode/codes/local_load_test.go
+++ b/internal/pkg/mapper/sharedcode/codes/local_load_test.go
@@ -24,13 +24,13 @@ func TestSharedCodeLocalLoad(t *testing.T) {
 	logger.Truncate()
 
 	// Load config
-	configRecipe := model.NewLocalLoadRecipe(configState.Manifest(), configState.Local)
+	configRecipe := model.NewLocalLoadRecipe(d.FileLoader(), configState.Manifest(), configState.Local)
 	err := state.Mapper().MapAfterLocalLoad(configRecipe)
 	assert.NoError(t, err)
 	assert.Empty(t, logger.WarnAndErrorMessages())
 
 	// Load row
-	rowRecipe := model.NewLocalLoadRecipe(rowState.Manifest(), rowState.Local)
+	rowRecipe := model.NewLocalLoadRecipe(d.FileLoader(), rowState.Manifest(), rowState.Local)
 	err = state.Mapper().MapAfterLocalLoad(rowRecipe)
 	assert.NoError(t, err)
 	assert.Equal(t, "DEBUG  Loaded \"branch/config/row/code.py\"\n", logger.AllMessages())
@@ -60,13 +60,13 @@ func TestSharedCodeLocalLoad_MissingCodeFile(t *testing.T) {
 	configState, rowState := createLocalSharedCode(t, targetComponentId, state)
 
 	// Load config
-	configRecipe := model.NewLocalLoadRecipe(configState.Manifest(), configState.Local)
+	configRecipe := model.NewLocalLoadRecipe(d.FileLoader(), configState.Manifest(), configState.Local)
 	err := state.Mapper().MapAfterLocalLoad(configRecipe)
 	assert.NoError(t, err)
 	assert.Empty(t, logger.WarnAndErrorMessages())
 
 	// Load row
-	rowRecipe := model.NewLocalLoadRecipe(rowState.Manifest(), rowState.Local)
+	rowRecipe := model.NewLocalLoadRecipe(d.FileLoader(), rowState.Manifest(), rowState.Local)
 	err = state.Mapper().MapAfterLocalLoad(rowRecipe)
 	assert.Error(t, err)
 	assert.Equal(t, `missing shared code file "branch/config/row/code.py"`, err.Error())

--- a/internal/pkg/mapper/template/jsonnetfiles/save_test.go
+++ b/internal/pkg/mapper/template/jsonnetfiles/save_test.go
@@ -34,7 +34,7 @@ func TestJsonNetMapper_MapBeforeLocalSave(t *testing.T) {
 	// Json file is converted to JsonNet
 	expectedAst, err := jsonnet.ToAst("{\n  \"key\": \"value\"\n}\n")
 	assert.NoError(t, err)
-	expected := model.ObjectFiles{}
+	expected := model.NewFilesToSave()
 	expected.
 		Add(filesystem.NewJsonNetFile(`foo.jsonnet`, expectedAst)). // <<<<<<<
 		AddTag(model.FileTypeJsonNet)

--- a/internal/pkg/mapper/transformation/local_load.go
+++ b/internal/pkg/mapper/transformation/local_load.go
@@ -125,44 +125,42 @@ func (l *localLoader) addScripts(code *model.Code) {
 	}
 
 	// Load file content
-	codeFilePath := l.NamingGenerator().CodeFilePath(code)
-	file, err := l.Fs().ReadFile(codeFilePath, "code file")
+	file, err := l.Files.
+		Load(l.NamingGenerator().CodeFilePath(code)).
+		SetDescription("code file").
+		AddTag(model.FileKindNativeCode).
+		ReadFile()
 	if err != nil {
 		l.errors.Append(err)
 		return
 	}
-	l.Files.
-		Add(file).
-		AddTag(model.FileKindNativeCode)
 
 	// Split to scripts
 	code.Scripts = model.ScriptsFromStr(file.Content, l.config.ComponentId)
-	l.logger.Debugf(`Parsed "%d" scripts from "%s"`, len(code.Scripts), codeFilePath)
+	l.logger.Debugf(`Parsed "%d" scripts from "%s"`, len(code.Scripts), file.Path)
 }
 
 func (l *localLoader) loadBlockMetaFile(block *model.Block) {
-	path := l.NamingGenerator().MetaFilePath(block.Path())
-	desc := "block metadata"
-	if file, err := l.Fs().ReadJsonFieldsTo(path, desc, block, model.MetaFileFieldsTag); err != nil {
+	_, _, err := l.Files.
+		Load(l.NamingGenerator().MetaFilePath(block.Path())).
+		SetDescription("block metadata").
+		AddTag(model.FileTypeJson).
+		AddTag(model.FileKindBlockMeta).
+		ReadJsonFieldsTo(block, model.MetaFileFieldsTag)
+	if err != nil {
 		l.errors.Append(err)
-	} else if file != nil {
-		l.Files.
-			Add(file).
-			AddTag(model.FileTypeJson).
-			AddTag(model.FileKindBlockMeta)
 	}
 }
 
 func (l *localLoader) loadCodeMetaFile(code *model.Code) {
-	path := l.NamingGenerator().MetaFilePath(code.Path())
-	desc := "code metadata"
-	if file, err := l.Fs().ReadJsonFieldsTo(path, desc, code, model.MetaFileFieldsTag); err != nil {
+	_, _, err := l.Files.
+		Load(l.NamingGenerator().MetaFilePath(code.Path())).
+		SetDescription("code metadata").
+		AddTag(model.FileTypeJson).
+		AddTag(model.FileKindCodeMeta).
+		ReadJsonFieldsTo(code, model.MetaFileFieldsTag)
+	if err != nil {
 		l.errors.Append(err)
-	} else if file != nil {
-		l.Files.
-			Add(file).
-			AddTag(model.FileTypeJson).
-			AddTag(model.FileKindCodeMeta)
 	}
 }
 

--- a/internal/pkg/mapper/transformation/local_load_test.go
+++ b/internal/pkg/mapper/transformation/local_load_test.go
@@ -99,7 +99,7 @@ func TestLoadTransformationMissingBlockMetaSql(t *testing.T) {
 	logger := d.DebugLogger()
 
 	configState := createTestFixtures(t, "keboola.snowflake-transformation")
-	recipe := model.NewLocalLoadRecipe(configState.Manifest(), configState.Local)
+	recipe := model.NewLocalLoadRecipe(d.FileLoader(), configState.Manifest(), configState.Local)
 
 	// Create files/dirs
 	blocksDir := filesystem.Join(`branch`, `config`, `blocks`)
@@ -121,7 +121,7 @@ func TestLoadTransformationMissingCodeMeta(t *testing.T) {
 	logger := d.DebugLogger()
 
 	configState := createTestFixtures(t, "keboola.snowflake-transformation")
-	recipe := model.NewLocalLoadRecipe(configState.Manifest(), configState.Local)
+	recipe := model.NewLocalLoadRecipe(d.FileLoader(), configState.Manifest(), configState.Local)
 
 	// Create files/dirs
 	blocksDir := filesystem.Join(`branch`, `config`, `blocks`)
@@ -149,7 +149,7 @@ func TestLoadLocalTransformationSql(t *testing.T) {
 	logger := d.DebugLogger()
 
 	configState := createTestFixtures(t, "keboola.snowflake-transformation")
-	recipe := model.NewLocalLoadRecipe(configState.Manifest(), configState.Local)
+	recipe := model.NewLocalLoadRecipe(d.FileLoader(), configState.Manifest(), configState.Local)
 
 	// Create files/dirs
 	blocksDir := filesystem.Join(`branch`, `config`, `blocks`)
@@ -292,7 +292,7 @@ func TestLoadLocalTransformationPy(t *testing.T) {
 	logger := d.DebugLogger()
 
 	configState := createTestFixtures(t, `keboola.python-transformation-v2`)
-	recipe := model.NewLocalLoadRecipe(configState.Manifest(), configState.Local)
+	recipe := model.NewLocalLoadRecipe(d.FileLoader(), configState.Manifest(), configState.Local)
 
 	// Create files/dirs
 	blocksDir := filesystem.Join(`branch`, `config`, `blocks`)

--- a/internal/pkg/plan/rename/executor_test.go
+++ b/internal/pkg/plan/rename/executor_test.go
@@ -9,6 +9,7 @@ import (
 
 	"github.com/keboola/keboola-as-code/internal/pkg/filesystem"
 	"github.com/keboola/keboola-as-code/internal/pkg/filesystem/aferofs"
+	"github.com/keboola/keboola-as-code/internal/pkg/filesystem/fileloader"
 	"github.com/keboola/keboola-as-code/internal/pkg/filesystem/knownpaths"
 	"github.com/keboola/keboola-as-code/internal/pkg/fixtures"
 	"github.com/keboola/keboola-as-code/internal/pkg/local"
@@ -53,7 +54,7 @@ func TestRename(t *testing.T) {
 
 	// NewPlan
 	projectState := state.NewRegistry(knownpaths.NewNop(), naming.NewRegistry(), model.NewComponentsMap(nil), model.SortByPath)
-	localManager := local.NewManager(logger, fs, manifest, nil, projectState, mapper.New())
+	localManager := local.NewManager(logger, fs, fileloader.New(fs), manifest, nil, projectState, mapper.New())
 	executor := newRenameExecutor(context.Background(), localManager, plan)
 	assert.NoError(t, executor.invoke())
 	logsStr := logger.AllMessages()
@@ -122,7 +123,7 @@ func TestRenameFailedKeepOldState(t *testing.T) {
 
 	// NewPlan
 	projectState := state.NewRegistry(knownpaths.NewNop(), naming.NewRegistry(), model.NewComponentsMap(nil), model.SortByPath)
-	localManager := local.NewManager(logger, fs, manifest, nil, projectState, mapper.New())
+	localManager := local.NewManager(logger, fs, fileloader.New(fs), manifest, nil, projectState, mapper.New())
 	executor := newRenameExecutor(context.Background(), localManager, plan)
 	err = executor.invoke()
 	assert.Error(t, err)

--- a/internal/pkg/project/manifest/file.go
+++ b/internal/pkg/project/manifest/file.go
@@ -6,6 +6,7 @@ import (
 
 	"github.com/keboola/keboola-as-code/internal/pkg/build"
 	"github.com/keboola/keboola-as-code/internal/pkg/filesystem"
+	"github.com/keboola/keboola-as-code/internal/pkg/filesystem/fileloader"
 	"github.com/keboola/keboola-as-code/internal/pkg/json"
 	"github.com/keboola/keboola-as-code/internal/pkg/model"
 	"github.com/keboola/keboola-as-code/internal/pkg/naming"
@@ -56,7 +57,7 @@ func loadFile(fs filesystem.Fs) (*file, error) {
 
 	// Read JSON file
 	content := newFile(0, "")
-	if err := fs.ReadJsonFileTo(path, "manifest", content); err != nil {
+	if _, err := fileloader.New(fs).ReadJsonFileTo(path, "manifest", content); err != nil {
 		return nil, err
 	}
 

--- a/internal/pkg/project/project.go
+++ b/internal/pkg/project/project.go
@@ -4,6 +4,7 @@ import (
 	"context"
 
 	"github.com/keboola/keboola-as-code/internal/pkg/filesystem"
+	"github.com/keboola/keboola-as-code/internal/pkg/filesystem/fileloader"
 	"github.com/keboola/keboola-as-code/internal/pkg/log"
 	"github.com/keboola/keboola-as-code/internal/pkg/manifest"
 	"github.com/keboola/keboola-as-code/internal/pkg/mapper"
@@ -29,20 +30,26 @@ type dependencies interface {
 
 type Project struct {
 	dependencies
-	fs       filesystem.Fs
-	manifest *Manifest
+	fs         filesystem.Fs
+	fileLoader filesystem.FileLoader
+	manifest   *Manifest
 }
 
 func New(fs filesystem.Fs, manifest *Manifest, d dependencies) *Project {
 	return &Project{
 		dependencies: d,
 		fs:           fs,
+		fileLoader:   fileloader.New(fs),
 		manifest:     manifest,
 	}
 }
 
 func (p *Project) Fs() filesystem.Fs {
 	return p.fs
+}
+
+func (p *Project) FileLoader() filesystem.FileLoader {
+	return p.fileLoader
 }
 
 func (p *Project) Manifest() manifest.Manifest {

--- a/internal/pkg/remote/manager_test.go
+++ b/internal/pkg/remote/manager_test.go
@@ -13,6 +13,7 @@ import (
 	"github.com/stretchr/testify/assert"
 
 	"github.com/keboola/keboola-as-code/internal/pkg/filesystem/aferofs"
+	"github.com/keboola/keboola-as-code/internal/pkg/filesystem/fileloader"
 	"github.com/keboola/keboola-as-code/internal/pkg/filesystem/knownpaths"
 	"github.com/keboola/keboola-as-code/internal/pkg/json"
 	"github.com/keboola/keboola-as-code/internal/pkg/local"
@@ -203,5 +204,5 @@ func newTestLocalManager(t *testing.T, mappers []interface{}) (*local.Manager, *
 	namingTemplate := naming.TemplateWithIds()
 	namingRegistry := naming.NewRegistry()
 	namingGenerator := naming.NewGenerator(namingTemplate, namingRegistry)
-	return local.NewManager(logger, fs, m, namingGenerator, projectState, mapper.New().AddMapper(mappers...)), projectState
+	return local.NewManager(logger, fs, fileloader.New(fs), m, namingGenerator, projectState, mapper.New().AddMapper(mappers...)), projectState
 }

--- a/internal/pkg/template/repository/manifest/file.go
+++ b/internal/pkg/template/repository/manifest/file.go
@@ -6,6 +6,7 @@ import (
 
 	"github.com/keboola/keboola-as-code/internal/pkg/build"
 	"github.com/keboola/keboola-as-code/internal/pkg/filesystem"
+	"github.com/keboola/keboola-as-code/internal/pkg/filesystem/fileloader"
 	"github.com/keboola/keboola-as-code/internal/pkg/json"
 	"github.com/keboola/keboola-as-code/internal/pkg/utils"
 	"github.com/keboola/keboola-as-code/internal/pkg/validator"
@@ -39,7 +40,7 @@ func loadFile(fs filesystem.Fs) (*file, error) {
 
 	// Read JSON file
 	content := newFile()
-	if err := fs.ReadJsonFileTo(path, "manifest", content); err != nil {
+	if _, err := fileloader.New(fs).ReadJsonFileTo(path, "manifest", content); err != nil {
 		return nil, err
 	}
 

--- a/internal/pkg/template/template.go
+++ b/internal/pkg/template/template.go
@@ -4,6 +4,7 @@ import (
 	"context"
 
 	"github.com/keboola/keboola-as-code/internal/pkg/filesystem"
+	"github.com/keboola/keboola-as-code/internal/pkg/filesystem/fileloader"
 	"github.com/keboola/keboola-as-code/internal/pkg/log"
 	"github.com/keboola/keboola-as-code/internal/pkg/manifest"
 	"github.com/keboola/keboola-as-code/internal/pkg/mapper"
@@ -45,6 +46,7 @@ type dependencies interface {
 type Template struct {
 	dependencies
 	fs           filesystem.Fs
+	fileLoader   filesystem.FileLoader
 	manifest     *Manifest
 	inputs       *Inputs
 	replacements replacekeys.Keys
@@ -54,6 +56,7 @@ func New(fs filesystem.Fs, manifest *Manifest, inputs *Inputs, replacements repl
 	return &Template{
 		dependencies: d,
 		fs:           fs,
+		fileLoader:   fileloader.New(fs),
 		manifest:     manifest,
 		inputs:       inputs,
 		replacements: replacements,
@@ -62,6 +65,10 @@ func New(fs filesystem.Fs, manifest *Manifest, inputs *Inputs, replacements repl
 
 func (t *Template) Fs() filesystem.Fs {
 	return t.fs
+}
+
+func (t *Template) FileLoader() filesystem.FileLoader {
+	return t.fileLoader
 }
 
 func (t *Template) Manifest() manifest.Manifest {

--- a/internal/pkg/testdeps/dependencies.go
+++ b/internal/pkg/testdeps/dependencies.go
@@ -10,6 +10,7 @@ import (
 	"github.com/keboola/keboola-as-code/internal/pkg/dependencies"
 	"github.com/keboola/keboola-as-code/internal/pkg/env"
 	"github.com/keboola/keboola-as-code/internal/pkg/filesystem"
+	"github.com/keboola/keboola-as-code/internal/pkg/filesystem/fileloader"
 	"github.com/keboola/keboola-as-code/internal/pkg/log"
 	"github.com/keboola/keboola-as-code/internal/pkg/remote"
 	"github.com/keboola/keboola-as-code/internal/pkg/scheduler"
@@ -110,6 +111,10 @@ func (v *testDependencies) DebugLogger() log.DebugLogger {
 
 func (v *testDependencies) Fs() filesystem.Fs {
 	return v.fs
+}
+
+func (v *testDependencies) FileLoader() filesystem.FileLoader {
+	return fileloader.New(v.fs)
 }
 
 func (v *testDependencies) Envs() *env.Map {

--- a/internal/pkg/testdeps/objects.go
+++ b/internal/pkg/testdeps/objects.go
@@ -4,6 +4,7 @@ import (
 	"context"
 
 	"github.com/keboola/keboola-as-code/internal/pkg/filesystem"
+	"github.com/keboola/keboola-as-code/internal/pkg/filesystem/fileloader"
 	"github.com/keboola/keboola-as-code/internal/pkg/manifest"
 	"github.com/keboola/keboola-as-code/internal/pkg/mapper"
 	"github.com/keboola/keboola-as-code/internal/pkg/state"
@@ -28,6 +29,10 @@ func (p *ObjectsContainer) Ctx() context.Context {
 
 func (p *ObjectsContainer) Fs() filesystem.Fs {
 	return p.FsValue
+}
+
+func (p *ObjectsContainer) FileLoader() filesystem.FileLoader {
+	return fileloader.New(p.FsValue)
 }
 
 func (p *ObjectsContainer) Manifest() manifest.Manifest {


### PR DESCRIPTION
Part of: https://keboola.atlassian.net/browse/COM-1254

Pracujem na nacitani a aplikovani sablony do projektu (generovanie uz funguje cele).
Potrebujem aby sa pre `template` namiesto Json suborov citali JsonNet.

Preto som z `filesystem.Fs` interface, oddelil tieto metody:
https://github.com/keboola/keboola-as-code/blob/0df63f636a9e63a9de4979711c0ba62a9016fe77/internal/pkg/filesystem/filesystem.go#L51-L56

A spravil som novy interface `filesystem.FileLoader`:
https://github.com/keboola/keboola-as-code/blob/edc27f8d34b44773fb5e69a4577ce8a9658ea4c8/internal/pkg/filesystem/filesystem.go#L57-L64

Tak mozem mat pre `template` modifikovany `FileLoader`, v dalsom PR.
