### PR TITLE
Load JsonNet files instead of Json files in Template

### DIFF
--- a/internal/pkg/filesystem/fileloader/fileloader.go
+++ b/internal/pkg/filesystem/fileloader/fileloader.go
@@ -10,49 +10,79 @@ import (
 	"github.com/keboola/keboola-as-code/internal/pkg/utils/orderedmap"
 )
 
+// loadHandlerWithNext callback modifies file loading process.
+// In addition to filesystem.LoadHandler, it contains reference to the "next" handler.
+type loadHandlerWithNext func(def *filesystem.FileDef, fileType filesystem.FileType, next filesystem.LoadHandler) (filesystem.File, error)
+
+// loader implements filesystem.FileLoader.
 type loader struct {
-	fs filesystem.Fs
+	fs      filesystem.Fs
+	handler loadHandlerWithNext
 }
 
+// New creates FileLoader to load files from the filesystem.
 func New(fs filesystem.Fs) filesystem.FileLoader {
 	return &loader{fs: fs}
 }
 
-func (l *loader) ReadFile(def *filesystem.FileDef) (*filesystem.RawFile, error) {
-	return l.fs.ReadFile(def)
+// NewWithHandler creates FileLoader to load files from the filesystem.
+// File load process can be modified by the custom handler callback.
+func NewWithHandler(fs filesystem.Fs, handler loadHandlerWithNext) filesystem.FileLoader {
+	return &loader{fs: fs, handler: handler}
 }
 
-// ReadJsonFile to ordered map.
+// ReadRawFile - file content is loaded as a string.
+func (l *loader) ReadRawFile(def *filesystem.FileDef) (*filesystem.RawFile, error) {
+	file, err := l.loadFile(def, filesystem.FileTypeRaw)
+	if err != nil {
+		return nil, err
+	}
+
+	// Convert to RawFile
+	if f, ok := file.(*filesystem.RawFile); ok {
+		return f, nil
+	}
+	return file.ToRawFile()
+}
+
+// ReadFileContentTo to tagged field in target struct as string.
+func (l *loader) ReadFileContentTo(def *filesystem.FileDef, target interface{}, tag string) (*filesystem.RawFile, bool, error) {
+	if field := utils.GetOneFieldWithTag(tag, target); field != nil {
+		if file, err := l.ReadRawFile(def); err == nil {
+			content := strings.TrimRight(file.Content, " \r\n\t")
+			utils.SetField(field, content, target)
+			return file, true, nil
+		} else {
+			return nil, false, err
+		}
+	}
+	return nil, false, nil
+}
+
+// ReadJsonFile as an ordered map.
 func (l *loader) ReadJsonFile(def *filesystem.FileDef) (*filesystem.JsonFile, error) {
-	file, err := l.fs.ReadFile(def)
+	file, err := l.loadFile(def, filesystem.FileTypeJson)
 	if err != nil {
 		return nil, err
 	}
-
-	jsonFile, err := file.ToJsonFile()
-	if err != nil {
-		return nil, err
-	}
-
-	return jsonFile, nil
+	return file.(*filesystem.JsonFile), nil
 }
 
-// ReadJsonFileTo to target struct.
+// ReadJsonFileTo to the target struct.
 func (l *loader) ReadJsonFileTo(def *filesystem.FileDef, target interface{}) (*filesystem.RawFile, error) {
-	file, err := l.fs.ReadFile(def)
+	file, err := l.ReadRawFile(def)
 	if err != nil {
 		return nil, err
 	}
 
 	if err := json.DecodeString(file.Content, target); err != nil {
-		fileDesc := strings.TrimSpace(file.Description() + " file")
-		return nil, utils.PrefixError(fmt.Sprintf("%s \"%s\" is invalid", fileDesc, file.Path()), err)
+		return nil, formatFileError(def, err)
 	}
 
 	return file, nil
 }
 
-// ReadJsonFieldsTo target struct by tag.
+// ReadJsonFieldsTo tagged fields in the target struct.
 func (l *loader) ReadJsonFieldsTo(def *filesystem.FileDef, target interface{}, tag string) (*filesystem.JsonFile, bool, error) {
 	if fields := utils.GetFieldsWithTag(tag, target); len(fields) > 0 {
 		if file, err := l.ReadJsonFile(def); err == nil {
@@ -66,7 +96,7 @@ func (l *loader) ReadJsonFieldsTo(def *filesystem.FileDef, target interface{}, t
 	return nil, false, nil
 }
 
-// ReadJsonMapTo tagged field in target struct as ordered map.
+// ReadJsonMapTo tagged field in the target struct as ordered map.
 func (l *loader) ReadJsonMapTo(def *filesystem.FileDef, target interface{}, tag string) (*filesystem.JsonFile, bool, error) {
 	if field := utils.GetOneFieldWithTag(tag, target); field != nil {
 		if file, err := l.ReadJsonFile(def); err == nil {
@@ -81,16 +111,62 @@ func (l *loader) ReadJsonMapTo(def *filesystem.FileDef, target interface{}, tag 
 	return nil, false, nil
 }
 
-// ReadFileContentTo to tagged field in target struct as string.
-func (l *loader) ReadFileContentTo(def *filesystem.FileDef, target interface{}, tag string) (*filesystem.RawFile, bool, error) {
-	if field := utils.GetOneFieldWithTag(tag, target); field != nil {
-		if file, err := l.fs.ReadFile(def); err == nil {
-			content := strings.TrimRight(file.Content, " \r\n\t")
-			utils.SetField(field, content, target)
-			return file, true, nil
-		} else {
-			return nil, false, err
-		}
+// ReadJsonNetFile as AST.
+func (l *loader) ReadJsonNetFile(def *filesystem.FileDef) (*filesystem.JsonNetFile, error) {
+	file, err := l.loadFile(def, filesystem.FileTypeJsonNet)
+	if err != nil {
+		return nil, err
 	}
-	return nil, false, nil
+	return file.(*filesystem.JsonNetFile), nil
+}
+
+// ReadJsonNetFileTo the target struct.
+func (l *loader) ReadJsonNetFileTo(def *filesystem.FileDef, target interface{}) (*filesystem.JsonNetFile, error) {
+	jsonNetFile, err := l.ReadJsonNetFile(def)
+	if err != nil {
+		return nil, formatFileError(def, err)
+	}
+
+	jsonFile, err := jsonNetFile.ToJsonRawFile()
+	if err != nil {
+		return nil, formatFileError(def, err)
+	}
+
+	if err := json.DecodeString(jsonFile.Content, target); err != nil {
+		return nil, formatFileError(def, err)
+	}
+
+	return jsonNetFile, nil
+}
+
+func formatFileError(def *filesystem.FileDef, err error) error {
+	fileDesc := strings.TrimSpace(def.Description() + " file")
+	return utils.PrefixError(fmt.Sprintf("%s \"%s\" is invalid", fileDesc, def.Path()), err)
+}
+
+func (l *loader) loadFile(def *filesystem.FileDef, fileType filesystem.FileType) (filesystem.File, error) {
+	if l.handler != nil {
+		return l.handler(def, fileType, l.defaultHandler)
+	}
+	return l.defaultHandler(def, fileType)
+}
+
+func (l *loader) defaultHandler(def *filesystem.FileDef, fileType filesystem.FileType) (filesystem.File, error) {
+	// Load
+	rawFile, err := l.fs.ReadFile(def)
+	if err != nil {
+		return nil, err
+	}
+
+	// Convert
+	switch fileType {
+	case filesystem.FileTypeRaw:
+		return rawFile, nil
+	case filesystem.FileTypeJson:
+		return rawFile.ToJsonFile()
+	case filesystem.FileTypeJsonNet:
+		return rawFile.ToJsonNetFile()
+	default:
+		panic(fmt.Errorf(`unexpected filesystem.FileType = %v`, fileType))
+	}
 }

--- a/internal/pkg/filesystem/filesystem.go
+++ b/internal/pkg/filesystem/filesystem.go
@@ -48,18 +48,24 @@ type Fs interface {
 	Move(src, dst string) error
 	MoveForce(src, dst string) error
 	Remove(path string) error
+	FileLoader() FileLoader
 	ReadFile(file *FileDef) (*RawFile, error)
 	WriteFile(file File) error
 	CreateOrUpdateFile(file *FileDef, lines []FileLine) (updated bool, err error)
 }
 
+// LoadHandler callback modifies file loading process, see "fileloader" package.
+type LoadHandler func(def *FileDef, fileType FileType) (File, error)
+
 type FileLoader interface {
-	ReadFile(file *FileDef) (*RawFile, error)
-	ReadJsonFieldsTo(file *FileDef, target interface{}, structTag string) (*JsonFile, bool, error)
-	ReadJsonMapTo(file *FileDef, target interface{}, structTag string) (*JsonFile, bool, error)
+	ReadRawFile(file *FileDef) (*RawFile, error)
 	ReadFileContentTo(file *FileDef, target interface{}, structTag string) (*RawFile, bool, error)
 	ReadJsonFile(file *FileDef) (*JsonFile, error)
 	ReadJsonFileTo(file *FileDef, target interface{}) (*RawFile, error)
+	ReadJsonFieldsTo(file *FileDef, target interface{}, structTag string) (*JsonFile, bool, error)
+	ReadJsonMapTo(file *FileDef, target interface{}, structTag string) (*JsonFile, bool, error)
+	ReadJsonNetFile(file *FileDef) (*JsonNetFile, error)
+	ReadJsonNetFileTo(file *FileDef, target interface{}) (*JsonNetFile, error)
 }
 
 func FromSlash(path string) string {

--- a/internal/pkg/jsonnet/jsonnet.go
+++ b/internal/pkg/jsonnet/jsonnet.go
@@ -21,6 +21,14 @@ func Evaluate(code string) (jsonOut string, err error) {
 	return EvaluateAst(node)
 }
 
+func MustEvaluate(code string) (jsonOut string) {
+	jsonOut, err := Evaluate(code)
+	if err != nil {
+		panic(err)
+	}
+	return jsonOut
+}
+
 func EvaluateAst(input ast.Node) (jsonOut string, err error) {
 	// Pre-process
 	node := ast.Clone(input)
@@ -42,12 +50,36 @@ func EvaluateAst(input ast.Node) (jsonOut string, err error) {
 	return out.String(), nil
 }
 
+func MustEvaluateAst(input ast.Node) (jsonOut string) {
+	jsonOut, err := EvaluateAst(input)
+	if err != nil {
+		panic(err)
+	}
+	return jsonOut
+}
+
 func Format(code string) (string, error) {
 	return formatter.Format(``, code, DefaultOptions())
 }
 
+func MustFormat(code string) string {
+	out, err := Format(code)
+	if err != nil {
+		panic(err)
+	}
+	return out
+}
+
 func FormatAst(node ast.Node) (string, error) {
 	return formatter.FormatAst(node, DefaultOptions())
+}
+
+func MustFormatAst(node ast.Node) string {
+	out, err := FormatAst(node)
+	if err != nil {
+		panic(err)
+	}
+	return out
 }
 
 func ToAst(code string) (ast.Node, error) {

--- a/internal/pkg/local/local_test.go
+++ b/internal/pkg/local/local_test.go
@@ -6,7 +6,6 @@ import (
 	"github.com/stretchr/testify/assert"
 
 	"github.com/keboola/keboola-as-code/internal/pkg/filesystem/aferofs"
-	"github.com/keboola/keboola-as-code/internal/pkg/filesystem/fileloader"
 	"github.com/keboola/keboola-as-code/internal/pkg/filesystem/knownpaths"
 	"github.com/keboola/keboola-as-code/internal/pkg/log"
 	"github.com/keboola/keboola-as-code/internal/pkg/mapper"
@@ -22,7 +21,7 @@ func newTestLocalManager(t *testing.T) *Manager {
 	logger := log.NewDebugLogger()
 	fs, err := aferofs.NewMemoryFs(logger, "")
 	assert.NoError(t, err)
-	fileLoader := fileloader.New(fs)
+	fileLoader := fs.FileLoader()
 
 	manifest := projectManifest.New(1, "foo.bar")
 	components := model.NewComponentsMap(nil)

--- a/internal/pkg/mapper/mapper_test.go
+++ b/internal/pkg/mapper/mapper_test.go
@@ -2,9 +2,14 @@ package mapper
 
 import (
 	"fmt"
+	"strings"
 	"testing"
 
 	"github.com/stretchr/testify/assert"
+
+	"github.com/keboola/keboola-as-code/internal/pkg/filesystem"
+	"github.com/keboola/keboola-as-code/internal/pkg/filesystem/aferofs"
+	"github.com/keboola/keboola-as-code/internal/pkg/log"
 )
 
 func TestMappers_ForEach_StopOnFailure(t *testing.T) {
@@ -57,4 +62,93 @@ func TestMappers_ForEachReverse_DontStopOnFailure(t *testing.T) {
 	assert.Error(t, err)
 	assert.Equal(t, "- error 5\n- error 4\n- error 3\n- error 2\n- error 1", err.Error())
 	assert.Equal(t, []string{`5`, `4`, `3`, `2`, `1`}, callOrder)
+}
+
+func TestMapper_LoadLocalFile_DefaultHandler(t *testing.T) {
+	t.Parallel()
+	expectedLogs := `
+INFO  Handler 1
+INFO  Handler 2
+INFO  Handler 3
+DEBUG  Loaded "file.txt"
+`
+	invokeLoadLocalFile(
+		t,
+		filesystem.NewFileDef(`file.txt`),
+		filesystem.NewRawFile(`file.txt`, `default`),
+		expectedLogs,
+	)
+}
+
+func TestMapper_LoadLocalFile_CustomHandler(t *testing.T) {
+	t.Parallel()
+	expectedLogs := `
+INFO  Handler 1
+INFO  Handler 2
+`
+	invokeLoadLocalFile(
+		t,
+		filesystem.NewFileDef(`file2.txt`),
+		filesystem.NewRawFile(`file2.txt`, `handler2`),
+		expectedLogs,
+	)
+}
+
+type testFileLoadMapper struct {
+	callback func(def *filesystem.FileDef, fileType filesystem.FileType, next filesystem.LoadHandler) (filesystem.File, error)
+}
+
+func (m *testFileLoadMapper) LoadLocalFile(def *filesystem.FileDef, fileType filesystem.FileType, next filesystem.LoadHandler) (filesystem.File, error) {
+	return m.callback(def, fileType, next)
+}
+
+func invokeLoadLocalFile(t *testing.T, input *filesystem.FileDef, expected filesystem.File, expectedLogs string) {
+	t.Helper()
+	logger := log.NewDebugLogger()
+
+	// File load handlers
+	handler1 := func(def *filesystem.FileDef, fileType filesystem.FileType, next filesystem.LoadHandler) (filesystem.File, error) {
+		// Match file path "file1.txt"
+		logger.Info(`Handler 1`)
+		if def.Path() == "file1.txt" {
+			return filesystem.NewRawFile("file1.txt", "handler1"), nil
+		}
+		return next(def, fileType)
+	}
+	handler2 := func(def *filesystem.FileDef, fileType filesystem.FileType, next filesystem.LoadHandler) (filesystem.File, error) {
+		// Match file path "file2.txt"
+		logger.Info(`Handler 2`)
+		if def.Path() == "file2.txt" {
+			return filesystem.NewRawFile("file2.txt", "handler2"), nil
+		}
+		return next(def, fileType)
+	}
+	handler3 := func(def *filesystem.FileDef, fileType filesystem.FileType, next filesystem.LoadHandler) (filesystem.File, error) {
+		// Match file path "file3.txt"
+		logger.Info(`Handler 3`)
+		if def.Path() == "file3.txt" {
+			return filesystem.NewRawFile("file3.txt", "handler3"), nil
+		}
+		return next(def, fileType)
+	}
+
+	// Default file
+	fs, err := aferofs.NewMemoryFs(logger, `/`)
+	assert.NoError(t, err)
+	assert.NoError(t, fs.WriteFile(filesystem.NewRawFile("file.txt", "default")))
+	logger.Truncate()
+
+	// Create mapper
+	mapper := New()
+	mapper.AddMapper(
+		&testFileLoadMapper{callback: handler1},
+		&testFileLoadMapper{callback: handler2},
+		&testFileLoadMapper{callback: handler3},
+	)
+
+	// Invoke
+	output, err := mapper.NewFileLoader(fs).ReadRawFile(input)
+	assert.NoError(t, err)
+	assert.Equal(t, expected, output)
+	assert.Equal(t, strings.TrimLeft(expectedLogs, "\n"), logger.AllMessages())
 }

--- a/internal/pkg/mapper/template/jsonnetfiles/load.go
+++ b/internal/pkg/mapper/template/jsonnetfiles/load.go
@@ -1,0 +1,38 @@
+package jsonnetfiles
+
+import (
+	"fmt"
+	"strings"
+
+	"github.com/keboola/keboola-as-code/internal/pkg/filesystem"
+	"github.com/keboola/keboola-as-code/internal/pkg/model"
+)
+
+func (m *jsonNetMapper) LoadLocalFile(def *filesystem.FileDef, fileType filesystem.FileType, next filesystem.LoadHandler) (filesystem.File, error) {
+	// Load JsonNet file instead of Json file
+	if def.HasTag(model.FileTypeJson) {
+		// Modify metadata
+		def.RemoveTag(model.FileTypeJson)
+		def.AddTag(model.FileTypeJsonNet)
+		def.SetPath(strings.TrimSuffix(def.Path(), `.json`) + `.jsonnet`)
+
+		// Load JsonNet file
+		f, err := next(def, filesystem.FileTypeJsonNet)
+		if err != nil {
+			return nil, err
+		}
+		jsonNetFile := f.(*filesystem.JsonNetFile)
+
+		// Convert to Json/Raw
+		switch fileType {
+		case filesystem.FileTypeRaw:
+			return jsonNetFile.ToRawFile()
+		case filesystem.FileTypeJson:
+			return jsonNetFile.ToJsonFile()
+		default:
+			panic(fmt.Errorf(`unexpected filesystem.FileType = %v`, fileType))
+		}
+	}
+
+	return next(def, fileType)
+}

--- a/internal/pkg/mapper/template/jsonnetfiles/load_test.go
+++ b/internal/pkg/mapper/template/jsonnetfiles/load_test.go
@@ -1,0 +1,37 @@
+package jsonnetfiles_test
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+
+	"github.com/keboola/keboola-as-code/internal/pkg/filesystem"
+	"github.com/keboola/keboola-as-code/internal/pkg/model"
+	"github.com/keboola/keboola-as-code/internal/pkg/utils/orderedmap"
+)
+
+func TestJsonNetMapper_LoadLocalFile(t *testing.T) {
+	t.Parallel()
+	state := createStateWithMapper(t)
+
+	// Write JsonNet file
+	fs := state.Fs()
+	jsonNetContent := `{ foo: "bar"}`
+	assert.NoError(t, fs.WriteFile(filesystem.NewRawFile(`my/dir/file.jsonnet`, jsonNetContent)))
+
+	// Create file loader
+	fileLoader := state.Mapper().NewFileLoader(fs)
+
+	// Load file
+	fileDef := filesystem.NewFileDef(`my/dir/file.json`)
+	fileDef.AddTag(model.FileTypeJson)
+	jsonFile, err := fileLoader.ReadJsonFile(fileDef)
+	assert.NoError(t, err)
+
+	// JsonNet file is loaded and converted to a Json file
+	assert.Equal(t, `my/dir/file.jsonnet`, jsonFile.Path())
+	assert.Equal(t, []string{model.FileTypeJsonNet}, jsonFile.AllTags())
+	assert.Equal(t, orderedmap.FromPairs([]orderedmap.Pair{
+		{Key: "foo", Value: "bar"},
+	}), jsonFile.Content)
+}

--- a/internal/pkg/model/mapper.go
+++ b/internal/pkg/model/mapper.go
@@ -87,7 +87,7 @@ func (f *fileToLoad) RemoveTag(tag string) *fileToLoad {
 }
 
 func (f *fileToLoad) ReadFile() (*filesystem.RawFile, error) {
-	file, err := f.fsLoader.ReadFile(f.FileDef)
+	file, err := f.fsLoader.ReadRawFile(f.FileDef)
 	if err != nil {
 		return nil, err
 	}

--- a/internal/pkg/model/mapper_test.go
+++ b/internal/pkg/model/mapper_test.go
@@ -6,7 +6,6 @@ import (
 	"github.com/stretchr/testify/assert"
 
 	"github.com/keboola/keboola-as-code/internal/pkg/filesystem"
-	"github.com/keboola/keboola-as-code/internal/pkg/filesystem/fileloader"
 	"github.com/keboola/keboola-as-code/internal/pkg/testfs"
 	"github.com/keboola/keboola-as-code/internal/pkg/utils/orderedmap"
 )
@@ -80,7 +79,7 @@ type myStruct struct {
 func TestFilesLoader(t *testing.T) {
 	t.Parallel()
 	fs := testfs.NewMemoryFs()
-	files := NewFilesLoader(fileloader.New(fs))
+	files := NewFilesLoader(fs.FileLoader())
 
 	// No files
 	assert.Empty(t, files.Loaded())

--- a/internal/pkg/plan/rename/executor_test.go
+++ b/internal/pkg/plan/rename/executor_test.go
@@ -9,7 +9,6 @@ import (
 
 	"github.com/keboola/keboola-as-code/internal/pkg/filesystem"
 	"github.com/keboola/keboola-as-code/internal/pkg/filesystem/aferofs"
-	"github.com/keboola/keboola-as-code/internal/pkg/filesystem/fileloader"
 	"github.com/keboola/keboola-as-code/internal/pkg/filesystem/knownpaths"
 	"github.com/keboola/keboola-as-code/internal/pkg/fixtures"
 	"github.com/keboola/keboola-as-code/internal/pkg/local"
@@ -54,7 +53,7 @@ func TestRename(t *testing.T) {
 
 	// NewPlan
 	projectState := state.NewRegistry(knownpaths.NewNop(), naming.NewRegistry(), model.NewComponentsMap(nil), model.SortByPath)
-	localManager := local.NewManager(logger, fs, fileloader.New(fs), manifest, nil, projectState, mapper.New())
+	localManager := local.NewManager(logger, fs, fs.FileLoader(), manifest, nil, projectState, mapper.New())
 	executor := newRenameExecutor(context.Background(), localManager, plan)
 	assert.NoError(t, executor.invoke())
 	logsStr := logger.AllMessages()
@@ -123,7 +122,7 @@ func TestRenameFailedKeepOldState(t *testing.T) {
 
 	// NewPlan
 	projectState := state.NewRegistry(knownpaths.NewNop(), naming.NewRegistry(), model.NewComponentsMap(nil), model.SortByPath)
-	localManager := local.NewManager(logger, fs, fileloader.New(fs), manifest, nil, projectState, mapper.New())
+	localManager := local.NewManager(logger, fs, fs.FileLoader(), manifest, nil, projectState, mapper.New())
 	executor := newRenameExecutor(context.Background(), localManager, plan)
 	err = executor.invoke()
 	assert.Error(t, err)

--- a/internal/pkg/project/manifest/file.go
+++ b/internal/pkg/project/manifest/file.go
@@ -6,7 +6,6 @@ import (
 
 	"github.com/keboola/keboola-as-code/internal/pkg/build"
 	"github.com/keboola/keboola-as-code/internal/pkg/filesystem"
-	"github.com/keboola/keboola-as-code/internal/pkg/filesystem/fileloader"
 	"github.com/keboola/keboola-as-code/internal/pkg/json"
 	"github.com/keboola/keboola-as-code/internal/pkg/model"
 	"github.com/keboola/keboola-as-code/internal/pkg/naming"
@@ -57,7 +56,7 @@ func loadFile(fs filesystem.Fs) (*file, error) {
 
 	// Read JSON file
 	content := newFile(0, "")
-	if _, err := fileloader.New(fs).ReadJsonFileTo(filesystem.NewFileDef(path).SetDescription("manifest"), content); err != nil {
+	if _, err := fs.FileLoader().ReadJsonFileTo(filesystem.NewFileDef(path).SetDescription("manifest"), content); err != nil {
 		return nil, err
 	}
 

--- a/internal/pkg/project/project.go
+++ b/internal/pkg/project/project.go
@@ -4,7 +4,6 @@ import (
 	"context"
 
 	"github.com/keboola/keboola-as-code/internal/pkg/filesystem"
-	"github.com/keboola/keboola-as-code/internal/pkg/filesystem/fileloader"
 	"github.com/keboola/keboola-as-code/internal/pkg/log"
 	"github.com/keboola/keboola-as-code/internal/pkg/manifest"
 	"github.com/keboola/keboola-as-code/internal/pkg/mapper"
@@ -39,7 +38,7 @@ func New(fs filesystem.Fs, manifest *Manifest, d dependencies) *Project {
 	return &Project{
 		dependencies: d,
 		fs:           fs,
-		fileLoader:   fileloader.New(fs),
+		fileLoader:   fs.FileLoader(),
 		manifest:     manifest,
 	}
 }

--- a/internal/pkg/project/project.go
+++ b/internal/pkg/project/project.go
@@ -47,10 +47,6 @@ func (p *Project) Fs() filesystem.Fs {
 	return p.fs
 }
 
-func (p *Project) FileLoader() filesystem.FileLoader {
-	return p.fileLoader
-}
-
 func (p *Project) Manifest() manifest.Manifest {
 	return p.manifest
 }

--- a/internal/pkg/remote/manager_test.go
+++ b/internal/pkg/remote/manager_test.go
@@ -13,7 +13,6 @@ import (
 	"github.com/stretchr/testify/assert"
 
 	"github.com/keboola/keboola-as-code/internal/pkg/filesystem/aferofs"
-	"github.com/keboola/keboola-as-code/internal/pkg/filesystem/fileloader"
 	"github.com/keboola/keboola-as-code/internal/pkg/filesystem/knownpaths"
 	"github.com/keboola/keboola-as-code/internal/pkg/json"
 	"github.com/keboola/keboola-as-code/internal/pkg/local"
@@ -204,5 +203,5 @@ func newTestLocalManager(t *testing.T, mappers []interface{}) (*local.Manager, *
 	namingTemplate := naming.TemplateWithIds()
 	namingRegistry := naming.NewRegistry()
 	namingGenerator := naming.NewGenerator(namingTemplate, namingRegistry)
-	return local.NewManager(logger, fs, fileloader.New(fs), m, namingGenerator, projectState, mapper.New().AddMapper(mappers...)), projectState
+	return local.NewManager(logger, fs, fs.FileLoader(), m, namingGenerator, projectState, mapper.New().AddMapper(mappers...)), projectState
 }

--- a/internal/pkg/state/state.go
+++ b/internal/pkg/state/state.go
@@ -28,6 +28,7 @@ func NewRegistry(paths *knownpaths.Paths, namingRegistry *naming.Registry, compo
 type State struct {
 	*Registry
 	container       ObjectsContainer
+	fileLoader      filesystem.FileLoader
 	logger          log.Logger
 	manifest        manifest.Manifest
 	mapper          *mapper.Mapper
@@ -49,7 +50,6 @@ type LoadOptions struct {
 type ObjectsContainer interface {
 	Ctx() context.Context
 	Fs() filesystem.Fs
-	FileLoader() filesystem.FileLoader
 	Manifest() manifest.Manifest
 	MappersFor(state *State) mapper.Mappers
 }
@@ -147,7 +147,7 @@ func (s *State) Fs() filesystem.Fs {
 }
 
 func (s *State) FileLoader() filesystem.FileLoader {
-	return s.container.FileLoader()
+	return s.fileLoader
 }
 
 func (s *State) Manifest() manifest.Manifest {

--- a/internal/pkg/state/state.go
+++ b/internal/pkg/state/state.go
@@ -86,12 +86,16 @@ func New(container ObjectsContainer, d dependencies) (*State, error) {
 		pathMatcher:     pathMatcher,
 	}
 
+	// Create mapper
 	s.mapper = mapper.New()
 
-	// Local manager for load,save,delete ... operations
-	s.localManager = local.NewManager(s.logger, container.Fs(), container.FileLoader(), m, s.namingGenerator, s.Registry, s.mapper)
+	// Create file loader
+	s.fileLoader = s.mapper.NewFileLoader(container.Fs())
 
-	// Local manager for API operations
+	// Local manager for load,save,delete ... operations
+	s.localManager = local.NewManager(s.logger, container.Fs(), s.fileLoader, m, s.namingGenerator, s.Registry, s.mapper)
+
+	// Remote manager for API operations
 	s.remoteManager = remote.NewManager(s.localManager, storageApi, s.Registry, s.mapper)
 
 	s.mapper.AddMapper(container.MappersFor(s)...)

--- a/internal/pkg/template/input/file.go
+++ b/internal/pkg/template/input/file.go
@@ -36,20 +36,9 @@ func loadFile(fs filesystem.Fs) (*file, error) {
 	}
 
 	// Read file
-	f, err := fs.ReadFile(filesystem.NewFileDef(path).SetDescription("inputs"))
-	if err != nil {
-		return nil, err
-	}
-
-	// Decode JsonNet
-	jsonContent, err := jsonnet.Evaluate(f.Content)
-	if err != nil {
-		return nil, err
-	}
-
-	// Decode Json
+	fileDef := filesystem.NewFileDef(path).SetDescription("inputs")
 	content := newFile()
-	if err := json.DecodeString(jsonContent, content); err != nil {
+	if _, err := fs.FileLoader().ReadJsonNetFileTo(fileDef, content); err != nil {
 		return nil, err
 	}
 

--- a/internal/pkg/template/manifest/file.go
+++ b/internal/pkg/template/manifest/file.go
@@ -42,20 +42,9 @@ func loadFile(fs filesystem.Fs) (*file, error) {
 	}
 
 	// Read file
-	f, err := fs.ReadFile(filesystem.NewFileDef(path).SetDescription("manifest"))
-	if err != nil {
-		return nil, err
-	}
-
-	// Decode JsonNet
-	jsonContent, err := jsonnet.Evaluate(f.Content)
-	if err != nil {
-		return nil, err
-	}
-
-	// Decode Json
+	fileDef := filesystem.NewFileDef(path).SetDescription("manifest")
 	content := newFile()
-	if err := json.DecodeString(jsonContent, content); err != nil {
+	if _, err := fs.FileLoader().ReadJsonNetFileTo(fileDef, content); err != nil {
 		return nil, err
 	}
 

--- a/internal/pkg/template/repository/manifest/file.go
+++ b/internal/pkg/template/repository/manifest/file.go
@@ -6,7 +6,6 @@ import (
 
 	"github.com/keboola/keboola-as-code/internal/pkg/build"
 	"github.com/keboola/keboola-as-code/internal/pkg/filesystem"
-	"github.com/keboola/keboola-as-code/internal/pkg/filesystem/fileloader"
 	"github.com/keboola/keboola-as-code/internal/pkg/json"
 	"github.com/keboola/keboola-as-code/internal/pkg/utils"
 	"github.com/keboola/keboola-as-code/internal/pkg/validator"
@@ -40,7 +39,7 @@ func loadFile(fs filesystem.Fs) (*file, error) {
 
 	// Read JSON file
 	content := newFile()
-	if _, err := fileloader.New(fs).ReadJsonFileTo(filesystem.NewFileDef(path).SetDescription("manifest"), content); err != nil {
+	if _, err := fs.FileLoader().ReadJsonFileTo(filesystem.NewFileDef(path).SetDescription("manifest"), content); err != nil {
 		return nil, err
 	}
 

--- a/internal/pkg/template/template.go
+++ b/internal/pkg/template/template.go
@@ -66,10 +66,6 @@ func (t *Template) Fs() filesystem.Fs {
 	return t.fs
 }
 
-func (t *Template) FileLoader() filesystem.FileLoader {
-	return t.fileLoader
-}
-
 func (t *Template) Manifest() manifest.Manifest {
 	return t.manifest
 }

--- a/internal/pkg/template/template.go
+++ b/internal/pkg/template/template.go
@@ -4,7 +4,6 @@ import (
 	"context"
 
 	"github.com/keboola/keboola-as-code/internal/pkg/filesystem"
-	"github.com/keboola/keboola-as-code/internal/pkg/filesystem/fileloader"
 	"github.com/keboola/keboola-as-code/internal/pkg/log"
 	"github.com/keboola/keboola-as-code/internal/pkg/manifest"
 	"github.com/keboola/keboola-as-code/internal/pkg/mapper"
@@ -56,7 +55,7 @@ func New(fs filesystem.Fs, manifest *Manifest, inputs *Inputs, replacements repl
 	return &Template{
 		dependencies: d,
 		fs:           fs,
-		fileLoader:   fileloader.New(fs),
+		fileLoader:   fs.FileLoader(),
 		manifest:     manifest,
 		inputs:       inputs,
 		replacements: replacements,

--- a/internal/pkg/testdeps/dependencies.go
+++ b/internal/pkg/testdeps/dependencies.go
@@ -10,7 +10,6 @@ import (
 	"github.com/keboola/keboola-as-code/internal/pkg/dependencies"
 	"github.com/keboola/keboola-as-code/internal/pkg/env"
 	"github.com/keboola/keboola-as-code/internal/pkg/filesystem"
-	"github.com/keboola/keboola-as-code/internal/pkg/filesystem/fileloader"
 	"github.com/keboola/keboola-as-code/internal/pkg/log"
 	"github.com/keboola/keboola-as-code/internal/pkg/remote"
 	"github.com/keboola/keboola-as-code/internal/pkg/scheduler"
@@ -114,7 +113,7 @@ func (v *testDependencies) Fs() filesystem.Fs {
 }
 
 func (v *testDependencies) FileLoader() filesystem.FileLoader {
-	return fileloader.New(v.fs)
+	return v.fs.FileLoader()
 }
 
 func (v *testDependencies) Envs() *env.Map {

--- a/internal/pkg/testdeps/objects.go
+++ b/internal/pkg/testdeps/objects.go
@@ -4,11 +4,16 @@ import (
 	"context"
 
 	"github.com/keboola/keboola-as-code/internal/pkg/filesystem"
-	"github.com/keboola/keboola-as-code/internal/pkg/filesystem/fileloader"
 	"github.com/keboola/keboola-as-code/internal/pkg/manifest"
 	"github.com/keboola/keboola-as-code/internal/pkg/mapper"
 	"github.com/keboola/keboola-as-code/internal/pkg/state"
 )
+
+// ObjectsContainer implementation for tests.
+type ObjectsContainer struct {
+	FsValue       filesystem.Fs
+	ManifestValue manifest.Manifest
+}
 
 func NewObjectsContainer(fs filesystem.Fs, m manifest.Manifest) *ObjectsContainer {
 	return &ObjectsContainer{
@@ -17,28 +22,18 @@ func NewObjectsContainer(fs filesystem.Fs, m manifest.Manifest) *ObjectsContaine
 	}
 }
 
-// ObjectsContainer implementation for tests.
-type ObjectsContainer struct {
-	FsValue       filesystem.Fs
-	ManifestValue manifest.Manifest
-}
-
-func (p *ObjectsContainer) Ctx() context.Context {
+func (c *ObjectsContainer) Ctx() context.Context {
 	return context.Background()
 }
 
-func (p *ObjectsContainer) Fs() filesystem.Fs {
-	return p.FsValue
+func (c *ObjectsContainer) Fs() filesystem.Fs {
+	return c.FsValue
 }
 
-func (p *ObjectsContainer) FileLoader() filesystem.FileLoader {
-	return fileloader.New(p.FsValue)
+func (c *ObjectsContainer) Manifest() manifest.Manifest {
+	return c.ManifestValue
 }
 
-func (p *ObjectsContainer) Manifest() manifest.Manifest {
-	return p.ManifestValue
-}
-
-func (p *ObjectsContainer) MappersFor(_ *state.State) mapper.Mappers {
+func (c *ObjectsContainer) MappersFor(_ *state.State) mapper.Mappers {
 	return mapper.Mappers{}
 }


### PR DESCRIPTION
Part of: https://keboola.atlassian.net/browse/KAC-10

V tomto PR sa pridava do `jsonnetfiles` mapper podpora pre nacitavanie JsonNet suborov, namiesto Json.