### PR TITLE
KAC-20: Recommend git dependency

### DIFF
--- a/build/ci/goreleaser.yml
+++ b/build/ci/goreleaser.yml
@@ -55,6 +55,8 @@ nfpms:
       - apk
       - deb
       - rpm
+    recommends:
+      - git
     rpm:
       signature:
         key_file: '{{ if index .Env "DEB_KEY_PRIVATE_PATH"  }}{{ .Env.DEB_KEY_PRIVATE_PATH }}{{ end }}'

--- a/build/package/homebrew/homebrew.template.rb
+++ b/build/package/homebrew/homebrew.template.rb
@@ -24,6 +24,8 @@ class KeboolaCli < Formula
     sha256 "${LINUX_ARM64_TARGET_SHA256}"
   end
 
+  depends_on "git" => :recommended
+
   def install
     bin.install "kbc"
     bin.install_symlink Dir["#{libexec}/bin/*"]


### PR DESCRIPTION
Mno, v Linuxu jsou dvě možnosti optional dependencies: "recommended" a "suggested" (https://www.debian.org/doc/manuals/debian-faq/pkg-basics.en.html#depends) a řekl bych že náš případ je suggestion, tj. git rozšiřuje možnosti použití našeho toolu. 

Nicméně do toho vstupuje Brew, který má "recommended" a "optional" (https://docs.brew.sh/Formula-Cookbook#specifying-other-formulae-as-dependencies) a rozdíl je v tom že první se nainstaluje defaultně bez ptaní a druhý se nainstaluje jen explicitně. 

Tak bych to sjednotil ať to není u každé platformy jinak a předpokládám, že to budeme chtít u Brew instalovat bez ptaní.(?)

Jinak jsem zkontroloval že git se ve všech Linux distribucích jmenuje stejně. (https://git-scm.com/download/linux)