### PR TITLE
JsonNet: support function call placeholders

### DIFF
--- a/internal/pkg/jsonnet/context.go
+++ b/internal/pkg/jsonnet/context.go
@@ -21,6 +21,30 @@ type (
 	localAliases    map[string]ast.Node
 )
 
+// ValueToLiteral converts Go value to jsonnet.Ast literal.
+func ValueToLiteral(v interface{}) ast.Node {
+	if v == nil {
+		return &ast.LiteralNull{}
+	}
+
+	switch v := v.(type) {
+	case bool:
+		return &ast.LiteralBoolean{Value: v}
+	case int:
+		return &ast.LiteralNumber{OriginalString: cast.ToString(v)}
+	case int32:
+		return &ast.LiteralNumber{OriginalString: cast.ToString(v)}
+	case int64:
+		return &ast.LiteralNumber{OriginalString: cast.ToString(v)}
+	case float32:
+		return &ast.LiteralNumber{OriginalString: cast.ToString(v)}
+	case float64:
+		return &ast.LiteralNumber{OriginalString: cast.ToString(v)}
+	default:
+		return &ast.LiteralString{Value: cast.ToString(v), Kind: ast.StringDouble}
+	}
+}
+
 func NewContext() *Context {
 	return &Context{
 		extVariables: make(variablesValues),
@@ -132,26 +156,6 @@ func (v variablesValues) add(name string, value interface{}) {
 
 func (v variablesValues) registerTo(vm *jsonnet.VM) {
 	for k, v := range v {
-		if v == nil {
-			vm.ExtNode(k, &ast.LiteralNull{})
-			continue
-		}
-
-		switch v := v.(type) {
-		case bool:
-			vm.ExtNode(k, &ast.LiteralBoolean{Value: v})
-		case int:
-			vm.ExtNode(k, &ast.LiteralNumber{OriginalString: cast.ToString(v)})
-		case int32:
-			vm.ExtNode(k, &ast.LiteralNumber{OriginalString: cast.ToString(v)})
-		case int64:
-			vm.ExtNode(k, &ast.LiteralNumber{OriginalString: cast.ToString(v)})
-		case float32:
-			vm.ExtNode(k, &ast.LiteralNumber{OriginalString: cast.ToString(v)})
-		case float64:
-			vm.ExtNode(k, &ast.LiteralNumber{OriginalString: cast.ToString(v)})
-		default:
-			vm.ExtVar(k, cast.ToString(v))
-		}
+		vm.ExtNode(k, ValueToLiteral(v))
 	}
 }

--- a/internal/pkg/jsonnet/jsonnet.go
+++ b/internal/pkg/jsonnet/jsonnet.go
@@ -63,7 +63,11 @@ func MustEvaluateAst(input ast.Node, ctx *Context) (jsonOut string) {
 }
 
 func Format(code string) (string, error) {
-	return formatter.Format(``, code, DefaultOptions())
+	node, err := ToAst(code)
+	if err != nil {
+		return "", err
+	}
+	return FormatAst(node)
 }
 
 func MustFormat(code string) string {
@@ -75,6 +79,8 @@ func MustFormat(code string) string {
 }
 
 func FormatAst(node ast.Node) (string, error) {
+	node = ast.Clone(node)
+	ReplacePlaceholdersRecursive(node)
 	return formatter.FormatAst(node, DefaultOptions())
 }
 

--- a/internal/pkg/jsonnet/placeholder.go
+++ b/internal/pkg/jsonnet/placeholder.go
@@ -1,0 +1,177 @@
+package jsonnet
+
+import (
+	"fmt"
+	"regexp"
+	"strings"
+
+	"github.com/google/go-jsonnet/ast"
+	"github.com/umisama/go-regexpcache"
+
+	"github.com/keboola/keboola-as-code/internal/pkg/json"
+	"github.com/keboola/keboola-as-code/third_party/jsonnet/lib/parser"
+)
+
+const (
+	placeholderStart = "<<~~func:"
+	placeholderEnd   = "~~>>"
+	configIdFunc     = "ConfigId"
+	configRowIdFunc  = "ConfigRowId"
+)
+
+// nolint: gochecknoglobals
+var placeholderRegexp = regexpcache.MustCompile(fmt.Sprintf("%s([^:]+):([^~]+)%s",
+	regexp.QuoteMeta(placeholderStart),
+	regexp.QuoteMeta(placeholderEnd),
+))
+
+// ConfigIdPlaceholder generates <<~~func:ConfigId:["<ID>"]~~>>.
+func ConfigIdPlaceholder(id string) string {
+	return functionCallPlaceholder(configIdFunc, id)
+}
+
+// ConfigRowIdPlaceholder generates <<~~func:ConfigRowId:["<ID>"]~~>>.
+func ConfigRowIdPlaceholder(id string) string {
+	return functionCallPlaceholder(configRowIdFunc, id)
+}
+
+// functionCallPlaceholder generates <<~~func:<FUNC_NAME>>:["<ARG1>","<ARG2>"]~~>>.
+func functionCallPlaceholder(funcName string, args ...interface{}) string {
+	return fmt.Sprintf(`%s%s:%s%s`, placeholderStart, funcName, json.MustEncode(args, false), placeholderEnd)
+}
+
+func ReplacePlaceholdersRecursive(node ast.Node) {
+	VisitAst(&node, func(nodePtr *ast.Node) {
+		if v, ok := (*nodePtr).(*ast.LiteralString); ok {
+			*nodePtr = ReplacePlaceholders(v)
+		}
+	})
+}
+
+// ReplacePlaceholders in a string AST node.
+// Example input:  "before <<~~func:ConfigId:["my-id"]~~>> middle <<~~func:FuncName:["foo", "bar", 123]~~>> end"
+// Example output: "before " + ConfigId("my-id") + " middle " + FuncName("foo", "bar", 123) + " end".
+func ReplacePlaceholders(node *ast.LiteralString) ast.Node {
+	// Unescape if needed
+	unescaped := node.Value
+	if node.Kind.FullyEscaped() {
+		if v, err := parser.StringUnescape(node.Loc(), node.Value); err == nil {
+			unescaped = v
+		}
+	}
+
+	// No placeholder, bypass
+	if !strings.Contains(unescaped, placeholderStart) {
+		return node
+	}
+
+	// Replace placeholders with function call
+	replaceCallback := func(funcName string, args []interface{}) ast.Node {
+		// Arguments definition, map args -> funcArgs
+		var funcArgs []ast.CommaSeparatedExpr
+		for _, value := range args {
+			funcArgs = append(funcArgs, ast.CommaSeparatedExpr{
+				Expr: ValueToLiteral(value),
+			})
+		}
+
+		// Function call definition: FuncName(funcArgs...)
+		return &ast.Apply{
+			Target:    &ast.Var{Id: ast.Identifier(funcName)},
+			Arguments: ast.Arguments{Positional: funcArgs},
+		}
+	}
+
+	// Concat nodes with + operation
+	return concatWithBinaryOp(splitPlaceholders(unescaped, replaceCallback), ast.BopPlus)
+}
+
+// splitPlaceholders from str, see ReplacePlaceholders.
+func splitPlaceholders(str string, replace func(funcName string, args []interface{}) ast.Node) []ast.Node {
+	matches := placeholderRegexp.FindAllStringSubmatchIndex(str, -1)
+
+	output := make([]ast.Node, 0)
+	prevEnd := 0
+	for _, indices := range matches {
+		// indices: (0)start, (1)end, (2-3)group1, (4-5)group2
+		before := str[prevEnd:indices[0]]
+		if len(before) > 0 {
+			output = append(output, ValueToLiteral(before))
+		}
+
+		funcName := str[indices[2]:indices[3]]
+		var args []interface{}
+		json.MustDecodeString(str[indices[4]:indices[5]], &args)
+		output = append(output, replace(funcName, args))
+
+		prevEnd = indices[1]
+	}
+
+	lastPart := str[prevEnd:]
+	if len(lastPart) > 0 {
+		output = append(output, ValueToLiteral(lastPart))
+	}
+
+	return output
+}
+
+// concatWithBinaryOp joins nodes with a binary operation.
+// For example: nodes[0] <OP> nodes[1] <OP> nodes[2].
+func concatWithBinaryOp(nodes []ast.Node, op ast.BinaryOp) ast.Node {
+	var output ast.Node
+	for _, node := range nodes {
+		// Fist node
+		if output == nil {
+			output = node
+			continue
+		}
+
+		// Other nodes
+		output = &ast.Binary{
+			Op:    op,
+			Left:  output,
+			Right: node,
+		}
+	}
+	return output
+}
+
+// StripIdPlaceholder converts ConfigId/ConfigRowId placeholder to the value.
+// It is used to remove placeholders from objects paths,
+// if {config_id} or {config_row_id} is used in the naming template.
+// Example input: <<~~func:ConfigId:["my-id"]~~>>
+// Example output: my-id.
+func StripIdPlaceholder(str string) string {
+	funcName, args, found := parsePlaceholder(str)
+
+	// ConfigId/ConfigRowId function and one string argument - ID
+	if found && len(args) == 1 && (funcName == configIdFunc || funcName == configRowIdFunc) {
+		if id, ok := args[0].(string); ok {
+			return id
+		}
+	}
+	return str
+}
+
+func parsePlaceholder(str string) (funcName string, args []interface{}, found bool) {
+	if !isPlaceholder(str) {
+		return "", nil, false
+	}
+
+	// Trim prefix and suffix
+	str = strings.TrimPrefix(str, placeholderStart)
+	str = strings.TrimSuffix(str, placeholderEnd)
+
+	// Split to funcName and args
+	parts := strings.SplitN(str, ":", 2)
+	if len(parts) < 2 {
+		return "", nil, false
+	}
+	funcName = parts[0]
+	json.MustDecodeString(parts[1], &args)
+	return funcName, args, true
+}
+
+func isPlaceholder(str string) bool {
+	return strings.HasPrefix(str, placeholderStart) && strings.HasSuffix(str, placeholderEnd)
+}

--- a/internal/pkg/jsonnet/placeholder_test.go
+++ b/internal/pkg/jsonnet/placeholder_test.go
@@ -30,7 +30,6 @@ func TestStripIdPlaceholder_ConfigRowId(t *testing.T) {
 
 func TestConfigRowIdPlaceholder(t *testing.T) {
 	t.Parallel()
-	t.Parallel()
 	assert.Equal(t, `<<~~func:ConfigRowId:["my-config-row-id"]~~>>`, ConfigRowIdPlaceholder("my-config-row-id"))
 }
 

--- a/internal/pkg/jsonnet/placeholder_test.go
+++ b/internal/pkg/jsonnet/placeholder_test.go
@@ -1,0 +1,80 @@
+package jsonnet
+
+import (
+	"testing"
+
+	"github.com/google/go-jsonnet/ast"
+	"github.com/stretchr/testify/assert"
+)
+
+func TestConfigIdPlaceholder(t *testing.T) {
+	t.Parallel()
+	assert.Equal(t, `<<~~func:ConfigId:["my-config-id"]~~>>`, ConfigIdPlaceholder("my-config-id"))
+}
+
+func TestStripIdPlaceholder_NotFound(t *testing.T) {
+	t.Parallel()
+	assert.Equal(t, "", StripIdPlaceholder(""))
+	assert.Equal(t, "foo bar", StripIdPlaceholder("foo bar"))
+}
+
+func TestStripIdPlaceholder_ConfigId(t *testing.T) {
+	t.Parallel()
+	assert.Equal(t, "my-config-id", StripIdPlaceholder(ConfigIdPlaceholder("my-config-id")))
+}
+
+func TestStripIdPlaceholder_ConfigRowId(t *testing.T) {
+	t.Parallel()
+	assert.Equal(t, "my-config-row-id", StripIdPlaceholder(ConfigIdPlaceholder("my-config-row-id")))
+}
+
+func TestConfigRowIdPlaceholder(t *testing.T) {
+	t.Parallel()
+	t.Parallel()
+	assert.Equal(t, `<<~~func:ConfigRowId:["my-config-row-id"]~~>>`, ConfigRowIdPlaceholder("my-config-row-id"))
+}
+
+func TestReplaceFuncCallPlaceholders(t *testing.T) {
+	t.Parallel()
+
+	cases := []struct{ input, expected string }{
+		{
+			input:    ``,
+			expected: `""`,
+		},
+		{
+			input:    `<<~~func:FuncName:["foo", "bar", 123]~~>>`,
+			expected: `FuncName("foo", "bar", 123)`,
+		},
+		{
+			input:    `in.c-keboola-ex-aws-s3-<<~~func:ConfigId:["om-default-bucket"]~~>>.table`,
+			expected: `"in.c-keboola-ex-aws-s3-" + ConfigId("om-default-bucket") + ".table"`,
+		},
+		{
+			input:    `<<~~func:ConfigId:["my-id"]~~>>`,
+			expected: `ConfigId("my-id")`,
+		},
+		{
+			input:    `  <<~~func:ConfigId:["my-id"]~~>>  `,
+			expected: `"  " + ConfigId("my-id") + "  "`,
+		},
+		{
+			input:    `before <<~~func:ConfigId:["my-id"]~~>>`,
+			expected: `"before " + ConfigId("my-id")`,
+		},
+		{
+			input:    `<<~~func:ConfigId:["my-id"]~~>> after`,
+			expected: `ConfigId("my-id") + " after"`,
+		},
+		{
+			input:    `before <<~~func:ConfigId:["my-id"]~~>> middle <<~~func:ConfigId:["my-id"]~~>> end`,
+			expected: `"before " + ConfigId("my-id") + " middle " + ConfigId("my-id") + " end"`,
+		},
+	}
+
+	for i, c := range cases {
+		replaced, err := FormatAst(ReplacePlaceholders(&ast.LiteralString{Value: c.input}))
+		assert.NoError(t, err, i)
+		assert.Equal(t, c.expected+"\n", replaced, i)
+	}
+}

--- a/internal/pkg/naming/generator.go
+++ b/internal/pkg/naming/generator.go
@@ -4,6 +4,7 @@ import (
 	"fmt"
 
 	"github.com/keboola/keboola-as-code/internal/pkg/filesystem"
+	"github.com/keboola/keboola-as-code/internal/pkg/jsonnet"
 	. "github.com/keboola/keboola-as-code/internal/pkg/model"
 	"github.com/keboola/keboola-as-code/internal/pkg/utils"
 )
@@ -106,7 +107,7 @@ func (g Generator) ConfigPath(parentPath string, component *Component, config *C
 		"target_component_id": targetComponentId, // for shared code
 		"component_type":      component.Type,
 		"component_id":        component.Id,
-		"config_id":           config.Id,
+		"config_id":           jsonnet.StripIdPlaceholder(config.Id.String()),
 		"config_name":         utils.NormalizeName(config.Name),
 	}))
 	return g.registry.ensureUniquePath(config.Key(), p)
@@ -160,7 +161,7 @@ func (g Generator) ConfigRowPath(parentPath string, component *Component, row *C
 	p := AbsPath{}
 	p.SetParentPath(parentPath)
 	p.SetRelativePath(utils.ReplacePlaceholders(template, map[string]interface{}{
-		"config_row_id":   row.Id,
+		"config_row_id":   jsonnet.StripIdPlaceholder(row.Id.String()),
 		"config_row_name": utils.NormalizeName(name),
 	}))
 	return g.registry.ensureUniquePath(row.Key(), p)

--- a/pkg/lib/operation/template/local/create/operation.go
+++ b/pkg/lib/operation/template/local/create/operation.go
@@ -5,6 +5,7 @@ import (
 	"fmt"
 
 	"github.com/keboola/keboola-as-code/internal/pkg/filesystem"
+	"github.com/keboola/keboola-as-code/internal/pkg/jsonnet"
 	"github.com/keboola/keboola-as-code/internal/pkg/log"
 	"github.com/keboola/keboola-as-code/internal/pkg/mapper/template/replacekeys"
 	"github.com/keboola/keboola-as-code/internal/pkg/model"
@@ -62,16 +63,18 @@ func (o *Options) Replacements() replacekeys.Keys {
 
 	// Configs and rows
 	for _, config := range o.Configs {
-		newKey := config.Key
-		newKey.BranchId = 0
-		newKey.Id = model.ConfigId(config.TemplateId)
-		keys = append(keys, replacekeys.Key{Old: config.Key, New: newKey})
+		newConfigId := model.ConfigId(jsonnet.ConfigIdPlaceholder(config.TemplateId))
+		newConfigKey := config.Key
+		newConfigKey.BranchId = 0
+		newConfigKey.Id = newConfigId
+		keys = append(keys, replacekeys.Key{Old: config.Key, New: newConfigKey})
 		for _, row := range config.Rows {
-			newKey := row.Key
-			newKey.BranchId = 0
-			newKey.ConfigId = model.ConfigId(config.TemplateId)
-			newKey.Id = model.RowId(row.TemplateId)
-			keys = append(keys, replacekeys.Key{Old: row.Key, New: newKey})
+			newRowId := model.RowId(jsonnet.ConfigRowIdPlaceholder(row.TemplateId))
+			newRowKey := row.Key
+			newRowKey.BranchId = 0
+			newRowKey.ConfigId = newConfigId
+			newRowKey.Id = newRowId
+			keys = append(keys, replacekeys.Key{Old: row.Key, New: newRowKey})
 		}
 	}
 	return keys

--- a/test/template-create/out/my-template/v0/extractor/ex-generic-v2/om-config/config.jsonnet
+++ b/test/template-create/out/my-template/v0/extractor/ex-generic-v2/om-config/config.jsonnet
@@ -4,7 +4,7 @@
       tables: [
         {
           source: "table",
-          destination: "in.c-my-super-bucket-om-config.table",
+          destination: "in.c-my-super-bucket-" + ConfigId("om-config") + ".table",
         },
       ],
     },

--- a/test/template-create/out/my-template/v0/manifest.jsonnet
+++ b/test/template-create/out/my-template/v0/manifest.jsonnet
@@ -11,31 +11,31 @@
   configurations: [
     {
       componentId: "keboola.shared-code",
-      id: "shared-codes",
+      id: ConfigId("shared-codes"),
       path: "_shared/keboola.python-transformation-v2",
       rows: [
         {
-          id: "code-with-variables",
+          id: ConfigRowId("code-with-variables"),
           path: "codes/code-with-variables",
         },
         {
-          id: "my-code-1",
+          id: ConfigRowId("my-code-1"),
           path: "codes/my-code-1",
         },
         {
-          id: "my-code-2",
+          id: ConfigRowId("my-code-2"),
           path: "codes/my-code-2",
         },
       ],
     },
     {
       componentId: "keboola.variables",
-      id: "shared-code-variables",
+      id: ConfigId("shared-code-variables"),
       path: "variables",
       relations: [
         {
-          configId: "shared-codes",
-          rowId: "code-with-variables",
+          configId: ConfigId("shared-codes"),
+          rowId: ConfigRowId("code-with-variables"),
           type: "sharedCodeVariablesFor",
         },
       ],
@@ -43,61 +43,61 @@
     },
     {
       componentId: "ex-generic-v2",
-      id: "empty",
+      id: ConfigId("empty"),
       path: "extractor/ex-generic-v2/empty",
       rows: [],
     },
     {
       componentId: "ex-generic-v2",
-      id: "om-config",
+      id: ConfigId("om-config"),
       path: "extractor/ex-generic-v2/om-config",
       rows: [],
     },
     {
       componentId: "ex-generic-v2",
-      id: "without-rows",
+      id: ConfigId("without-rows"),
       path: "extractor/ex-generic-v2/without-rows",
       rows: [],
     },
     {
       componentId: "keboola.ex-aws-s3",
-      id: "om-default-bucket",
+      id: ConfigId("om-default-bucket"),
       path: "extractor/keboola.ex-aws-s3/om-default-bucket",
       rows: [],
     },
     {
       componentId: "keboola.ex-db-mysql",
-      id: "with-rows",
+      id: ConfigId("with-rows"),
       path: "extractor/keboola.ex-db-mysql/with-rows",
       rows: [
         {
-          id: "disabled",
+          id: ConfigRowId("disabled"),
           path: "rows/disabled",
         },
         {
-          id: "test-view",
+          id: ConfigRowId("test-view"),
           path: "rows/test-view",
         },
         {
-          id: "users",
+          id: ConfigRowId("users"),
           path: "rows/users",
         },
       ],
     },
     {
       componentId: "keboola.orchestrator",
-      id: "orchestrator",
+      id: ConfigId("orchestrator"),
       path: "other/keboola.orchestrator/orchestrator",
       rows: [],
     },
     {
       componentId: "keboola.scheduler",
-      id: "scheduler",
+      id: ConfigId("scheduler"),
       path: "schedules/scheduler",
       relations: [
         {
           componentId: "keboola.orchestrator",
-          configId: "orchestrator",
+          configId: ConfigId("orchestrator"),
           type: "schedulerFor",
         },
       ],
@@ -105,41 +105,41 @@
     },
     {
       componentId: "transformation",
-      id: "old-transformation",
+      id: ConfigId("old-transformation"),
       path: "other/transformation/old-transformation",
       rows: [
         {
-          id: "old-transformation-snfk",
+          id: ConfigRowId("old-transformation-snfk"),
           path: "rows/old-transformation-snfk",
         },
       ],
     },
     {
       componentId: "keboola.python-transformation-v2",
-      id: "python-transformation",
+      id: ConfigId("python-transformation"),
       path: "transformation/keboola.python-transformation-v2/python-transformation",
       rows: [],
     },
     {
       componentId: "keboola.python-transformation-v2",
-      id: "transformation-with-shared-code",
+      id: ConfigId("transformation-with-shared-code"),
       path: "transformation/keboola.python-transformation-v2/transformation-with-shared-code",
       rows: [],
     },
     {
       componentId: "keboola.variables",
-      id: "transformation-with-shared-code-variables",
+      id: ConfigId("transformation-with-shared-code-variables"),
       path: "variables",
       relations: [
         {
           componentId: "keboola.python-transformation-v2",
-          configId: "transformation-with-shared-code",
+          configId: ConfigId("transformation-with-shared-code"),
           type: "variablesFor",
         },
       ],
       rows: [
         {
-          id: "default-values",
+          id: ConfigRowId("default-values"),
           path: "values/default-values",
           relations: [
             {
@@ -151,24 +151,24 @@
     },
     {
       componentId: "keboola.snowflake-transformation",
-      id: "im-transformation",
+      id: ConfigId("im-transformation"),
       path: "transformation/keboola.snowflake-transformation/im-transformation",
       rows: [
         {
-          id: "test",
+          id: ConfigRowId("test"),
           path: "rows/test",
         },
       ],
     },
     {
       componentId: "keboola.snowflake-transformation",
-      id: "snowflake-transformation",
+      id: ConfigId("snowflake-transformation"),
       path: "transformation/keboola.snowflake-transformation/snowflake-transformation",
       rows: [],
     },
     {
       componentId: "keboola.wr-db-mysql",
-      id: "im-default-bucket",
+      id: ConfigId("im-default-bucket"),
       path: "writer/keboola.wr-db-mysql/im-default-bucket",
       rows: [],
     },

--- a/test/template-create/out/my-template/v0/transformation/keboola.snowflake-transformation/im-transformation/rows/test/config.jsonnet
+++ b/test/template-create/out/my-template/v0/transformation/keboola.snowflake-transformation/im-transformation/rows/test/config.jsonnet
@@ -4,7 +4,7 @@
     input: {
       tables: [
         {
-          source: "in.c-my-super-bucket-om-config.table",
+          source: "in.c-my-super-bucket-" + ConfigId("om-config") + ".table",
           destination: "table",
         },
       ],

--- a/test/template-create/out/my-template/v0/writer/keboola.wr-db-mysql/im-default-bucket/config.jsonnet
+++ b/test/template-create/out/my-template/v0/writer/keboola.wr-db-mysql/im-default-bucket/config.jsonnet
@@ -5,7 +5,7 @@
       tables: [
         {
           columns: [],
-          source: "in.c-keboola-ex-aws-s3-om-default-bucket.table",
+          source: "in.c-keboola-ex-aws-s3-" + ConfigId("om-default-bucket") + ".table",
           destination: "table",
           where_column: "",
           where_operator: "eq",


### PR DESCRIPTION
Part of: https://keboola.atlassian.net/browse/KAC-12

Changes:
- object IDs are no longer represented as a string, but as a custom function

----------
Pri aplikovani sablony do projektu som narazil este na jeden problem, ktory je potrebne fixnut pri jej vytvarani.

Majme nejaky objekt v projekte (pre jednoduchost vsetko v jednom subore):
```json
{
  "id": "6850436534",
  "path": "extractor/foo.bar/my-config",
  "name": "my-config"
}
```

Pri generovani sablony nahradime ID `6850436534 -> my-config`.
```jsonnet
{
  id: "my-config",
  path: "extractor/foo.bar/my-config",
  name: "my-config"
}
```

Pri pouziti sablony nahradime vsade `my-config -> 12345`:
```json
{
  "id": "12345",
  "path": "extractor/foo.bar/12345",
  "name": "12345"
}
```
**A tu uz nastava problem, pretoze sme dali `12345` aj do `name`, kde povodne ID nebolo.**

-----------------------

Jednoduche riesenie vyzera byt, ze sa pouzije nejaky `placeholder`, nie iba `ID`. Napr.
```
{
  id: "<id:my-config>",
  path: "extractor/foo.bar/<id:my-config>",
  name: "my-config"
}
```

To uz vytera lepsie, ... no v path template mame `{config_id}`, a tam ten placeholder nechceme.
Tak placeholder nepouzijeme v path:
```
{
  id: "<id:my-config>",
  path: "extractor/foo.bar/my-config",
  name: "my-config"
}
```

-----------
A este lepsie riesenie je, ked pouzijeme syntax `JsonNet` jazyka, a placeholder nebude iba nejaky string.
Preto si definujeme vlastnu funckiu `ConfigId`.

```
{
  id: ConfigId("my-config"),
  path: "extractor/foo.bar/my-config",
  name: "my-config"
}
```

-----------

A tym sme ziskali aj dalsiu vyhodu.
Pri aplikovani sablony uz iba staci, ... aby kazde volanie `ConfigId("my-config")` vratilo `12345`.

**Posledny commit su zmeny vo funkcionalnom teste, a tam je tieto zmeny nazorne vidiet.**

