### PR TITLE
Fix default bucket - get by table id

### DIFF
--- a/internal/pkg/model/component.go
+++ b/internal/pkg/model/component.go
@@ -177,7 +177,7 @@ func (c *ComponentsMap) addDefaultBucketPrefix(component *Component) {
 
 func (c *ComponentsMap) GetDefaultBucketByTableId(tableId string) (ComponentId, ConfigId, bool) {
 	dotIndex := strings.LastIndex(tableId, ".")
-	if dotIndex == 0 {
+	if dotIndex < 1 {
 		return "", "", false
 	}
 
@@ -186,8 +186,8 @@ func (c *ComponentsMap) GetDefaultBucketByTableId(tableId string) (ComponentId, 
 		return "", "", false
 	}
 
-	bucketPrefix := bucketId[0 : strings.LastIndex(tableId, "-")+1]
-	configId := ConfigId(bucketId[strings.LastIndex(tableId, "-")+1:])
+	bucketPrefix := bucketId[0 : strings.LastIndex(bucketId, "-")+1]
+	configId := ConfigId(bucketId[strings.LastIndex(bucketId, "-")+1:])
 
 	componentId, found := c.defaultBucketsByPrefix[bucketPrefix]
 	if !found {

--- a/internal/pkg/model/component_test.go
+++ b/internal/pkg/model/component_test.go
@@ -91,6 +91,11 @@ func TestMatchDefaultBucketInTableId(t *testing.T) {
 	assert.Equal(t, ConfigId("123456"), configId)
 	assert.True(t, matchesDefaultBucket)
 
+	componentId, configId, matchesDefaultBucket = componentsMap.GetDefaultBucketByTableId("in.c-keboola-ex-aws-s3-123456.my-orders")
+	assert.Equal(t, ComponentId("keboola.ex-aws-s3"), componentId)
+	assert.Equal(t, ConfigId("123456"), configId)
+	assert.True(t, matchesDefaultBucket)
+
 	componentId, configId, matchesDefaultBucket = componentsMap.GetDefaultBucketByTableId("in.c-keboola-ex-aws-s3.orders")
 	assert.Equal(t, ComponentId(""), componentId)
 	assert.Equal(t, ConfigId(""), configId)


### PR DESCRIPTION
Fixed bug in `TestMatchDefaultBucketInTableId`.