### PR TITLE
Fix installation test on Ubuntu/Debian

### DIFF
--- a/.github/workflows/push.yml
+++ b/.github/workflows/push.yml
@@ -327,7 +327,7 @@ jobs:
           wget -P /etc/apt/trusted.gpg.d https://cli-dist.keboola.com/deb/keboola.gpg
           echo "deb https://cli-dist.keboola.com/deb /" | tee /etc/apt/sources.list.d/keboola.list
           apt-get update
-          apt-get install keboola-cli
+          apt-get install -y keboola-cli
           kbc --version | tee /dev/stderr | grep -q "Version:    ${{ env.VERSION }}"
           '
         env:
@@ -341,7 +341,7 @@ jobs:
           wget -P /etc/apt/trusted.gpg.d https://cli-dist.keboola.com/deb/keboola.gpg
           echo "deb https://cli-dist.keboola.com/deb /" | tee /etc/apt/sources.list.d/keboola.list
           apt-get update
-          apt-get install keboola-cli
+          apt-get install -y keboola-cli
           kbc --version | tee /dev/stderr | grep -q "Version:    ${{ env.VERSION }}"
           '
         env:


### PR DESCRIPTION
Release presiel, ale spadol test, ze je mozne CLI nainstalovat na `Debian/Ubuntu`.

Ak ma package nejake zavislosti (`git`), tak je to potrebne potvrdit:
![image](https://user-images.githubusercontent.com/19371734/151975444-61aa5841-5e03-48e7-ad8b-c19e11fe96a7.png)
