### PR TITLE
Create template: better templates ids dialog

### DIFF
--- a/internal/pkg/cli/prompt/interactive/interactive.go
+++ b/internal/pkg/cli/prompt/interactive/interactive.go
@@ -218,7 +218,7 @@ func (p *Prompt) Multiline(q *prompt.Question) (result string, ok bool) {
 	return result, p.handleError(err)
 }
 
-func (p *Prompt) Editor(q *prompt.Question) (result string, ok bool) {
+func (p *Prompt) Editor(fileExt string, q *prompt.Question) (result string, ok bool) {
 	// Print description
 	if len(q.Description) > 0 {
 		p.Printf("\n%s\n", q.Description)
@@ -232,7 +232,8 @@ func (p *Prompt) Editor(q *prompt.Question) (result string, ok bool) {
 		opts = append(opts, survey.WithValidator(q.Validator))
 	}
 
-	editor := &survey.Editor{Message: formatLabel(q.Label), Default: q.Default, Help: q.Help, HideDefault: true, AppendDefault: true, Editor: p.editor, FileName: `kbc-editor-*.txt`}
+	fileName := `kbc-editor-*.` + fileExt
+	editor := &survey.Editor{Message: formatLabel(q.Label), Default: q.Default, Help: q.Help, HideDefault: true, AppendDefault: true, Editor: p.editor, FileName: fileName}
 	err := survey.AskOne(editor, &result, opts...)
 	p.Printf("\n")
 	return result, p.handleError(err)

--- a/internal/pkg/cli/prompt/nop/nop.go
+++ b/internal/pkg/cli/prompt/nop/nop.go
@@ -46,6 +46,6 @@ func (p *Prompt) Multiline(q *prompt.Question) (result string, ok bool) {
 	return q.Default, true
 }
 
-func (p *Prompt) Editor(q *prompt.Question) (result string, ok bool) {
+func (p *Prompt) Editor(_ string, q *prompt.Question) (result string, ok bool) {
 	return q.Default, true
 }

--- a/internal/pkg/cli/prompt/prompt.go
+++ b/internal/pkg/cli/prompt/prompt.go
@@ -71,7 +71,9 @@ type Prompt interface {
 	MultiSelect(s *MultiSelect) (result []string, ok bool)
 	MultiSelectIndex(s *MultiSelectIndex) (result []int, ok bool)
 	Multiline(q *Question) (result string, ok bool)
-	Editor(q *Question) (result string, ok bool)
+	// Editor allows you to edit text using the editor specified via env EDITOR.
+	// fileExt is the extension of the temporary file, for syntax highlighting.
+	Editor(fileExt string, q *Question) (result string, ok bool)
 }
 
 func ValueRequired(val interface{}) error {

--- a/internal/pkg/utils/strhelper/strhelper.go
+++ b/internal/pkg/utils/strhelper/strhelper.go
@@ -69,3 +69,13 @@ func FirstLower(str string) string {
 func FirstUpper(str string) string {
 	return strings.ToUpper(string(str[0])) + str[1:]
 }
+
+// StripHtmlComments replaces HTML comments with empty lines.
+func StripHtmlComments(str string) string {
+	return regexpcache.
+		MustCompile("(?s)<!--(.*?)-->").
+		ReplaceAllStringFunc(str, func(s string) string {
+			// Replace comment with empty lines
+			return strings.Repeat("\n", strings.Count(s, "\n"))
+		})
+}

--- a/internal/pkg/utils/strhelper/strhelper_test.go
+++ b/internal/pkg/utils/strhelper/strhelper_test.go
@@ -96,3 +96,25 @@ func TestFirstUpper(t *testing.T) {
 	assert.Equal(t, "FOO", FirstUpper("FOO"))
 	assert.Equal(t, "Foo", FirstUpper("Foo"))
 }
+
+func TestStripHtmlComments(t *testing.T) {
+	t.Parallel()
+
+	cases := []struct{ in, expected string }{
+		{"", ""},
+		{"abc", "abc"},
+		{"<!---->", ""},
+		{"<!-- -->", ""},
+		{"<!-- abc -->", ""},
+		{"foo<!-- abc -->", "foo"},
+		{"<!-- abc -->bar", "bar"},
+		{"foo<!-- abc -->bar", "foobar"},
+		{"foo\n<!-- abc -->\nbar", "foo\n\nbar"},
+		{"foo\n<!-- abc\ndef -->\nbar", "foo\n\n\nbar"},
+		{"foo\n<!-- abc\ndef -->\nbar<!-- abc\ndef -->", "foo\n\n\nbar\n"},
+	}
+
+	for i, c := range cases {
+		assert.Equal(t, c.expected, StripHtmlComments(c.in), "case "+cast.ToString(i))
+	}
+}


### PR DESCRIPTION
Part of: https://keboola.atlassian.net/browse/KAC-6

Changes:
- Texts edited by system editor are better formatter.

-------------------------

Pri `create template` sa zadavaju IDs ako textovy subor, ktory sa edituje cez nejaky editor v OS.

Upravil som strukturu tohto suboru, aby to bol validny `markdown` a fungoval `syntax highlighting`:
- pridal som podporu pre komentare
- pridal som moznost nastavit priponu temp suboru.

Rovnaky format suboru pouzijem aj pre definiciu `inputs`.
Tak som to najprv vyskusal na existujucom subore.

![image](https://user-images.githubusercontent.com/19371734/153574225-d140e960-8f32-4b8a-b3b1-8f4a1e7c6bbd.png)
