### PR TITLE
Template inputs dialog: default text

### DIFF
--- a/internal/pkg/cli/dialog/template_inputs.go
+++ b/internal/pkg/cli/dialog/template_inputs.go
@@ -1,0 +1,282 @@
+// nolint: unused
+package dialog
+
+import (
+	"fmt"
+	"reflect"
+	"sort"
+	"strings"
+
+	"github.com/spf13/cast"
+
+	"github.com/keboola/keboola-as-code/internal/pkg/api/encryptionapi"
+	"github.com/keboola/keboola-as-code/internal/pkg/cli/prompt"
+	"github.com/keboola/keboola-as-code/internal/pkg/model"
+	"github.com/keboola/keboola-as-code/internal/pkg/template/input"
+	"github.com/keboola/keboola-as-code/internal/pkg/utils"
+	"github.com/keboola/keboola-as-code/internal/pkg/utils/orderedmap"
+	"github.com/keboola/keboola-as-code/internal/pkg/utils/strhelper"
+)
+
+type templateInputsDialog struct {
+	prompt         prompt.Prompt
+	configs        []*model.ConfigWithRows
+	fieldsByObject map[model.Key]inputFields
+}
+
+// askTemplateInputs - dialog to define user inputs for a new template.
+// Used in AskCreateTemplateOpts.
+func (p *Dialogs) askTemplateInputs(configs []*model.ConfigWithRows) (input.Inputs, error) {
+	return (&templateInputsDialog{prompt: p.Prompt, configs: configs}).ask()
+}
+
+func (d *templateInputsDialog) ask() (input.Inputs, error) {
+	result, _ := d.prompt.Editor("md", &prompt.Question{
+		Description: `Please define user inputs.`,
+		Default:     d.defaultValue(),
+		Validator: func(val interface{}) error {
+			if _, err := d.parse(val.(string)); err != nil {
+				// Print errors to new line
+				return utils.PrefixError("\n", err)
+			}
+			return nil
+		},
+	})
+	return d.parse(result)
+}
+
+func (d *templateInputsDialog) parse(result string) (input.Inputs, error) {
+	return input.Inputs{}, nil
+}
+
+func (d *templateInputsDialog) defaultValue() string {
+	// Detect potential inputs in each config and config row
+	d.detectInputs()
+
+	// File header - info for user
+	fileHeader := `
+<!--
+Please define user inputs for the template.
+Edit lines below "## Config ..." and "### Row ...".
+Do not edit "<field.path>" and lines starting with "#"!
+
+Line format: <mark> <input-id> <field.path> <example>
+
+1. Mark which fields will be user inputs.
+[x] "input-id" "field.path"   <<< this field will be user input
+[ ] "input-id" "field.path"   <<< this field will be scalar value
+
+2. Modify "<input-id>" if needed.
+Allowed characters: a-z, A-Z, 0-9, "-".
+-->
+
+
+`
+
+	// Add definitions
+	var lines strings.Builder
+	lines.WriteString(fileHeader)
+	for _, c := range d.configs {
+		// Config
+		fields := d.fieldsByObject[c.ConfigKey]
+		if len(fields) > 0 {
+			lines.WriteString(fmt.Sprintf("## Config \"%s\" %s:%s\n", c.Name, c.ComponentId, c.Id))
+			fields.Write(&lines)
+			lines.WriteString("\n")
+		}
+
+		// Rows
+		for _, r := range c.Rows {
+			fields := d.fieldsByObject[r.ConfigRowKey]
+			if len(fields) > 0 {
+				lines.WriteString(fmt.Sprintf("### Row \"%s\" %s:%s:%s\n", r.Name, r.ComponentId, r.ConfigId, r.Id))
+				fields.Write(&lines)
+				lines.WriteString("\n")
+			}
+		}
+	}
+
+	return lines.String()
+}
+
+// detectInputs - detects potential inputs in each config and config row.
+func (d *templateInputsDialog) detectInputs() {
+	d.fieldsByObject = make(map[model.Key]inputFields)
+	for _, c := range d.configs {
+		d.detectInputsFor(c.ConfigKey, c.ComponentId, c.Content)
+		for _, r := range c.Rows {
+			d.detectInputsFor(r.ConfigRowKey, c.ComponentId, r.Content)
+		}
+	}
+}
+
+// detectInputsFor config or config row.
+func (d *templateInputsDialog) detectInputsFor(objectKey model.Key, componentId model.ComponentId, content *orderedmap.OrderedMap) {
+	content.VisitAllRecursive(func(fieldPath orderedmap.Key, value interface{}, parent interface{}) {
+		// Root key must be "parameters"
+		if len(fieldPath) < 2 || fieldPath.First() != orderedmap.MapStep("parameters") {
+			return
+		}
+
+		// Must be object field
+		fieldKey, isObjectField := fieldPath.Last().(orderedmap.MapStep)
+		if !isObjectField {
+			return
+		}
+
+		isSecret := encryptionapi.IsKeyToEncrypt(string(fieldKey))
+
+		// Detect type, kind and default value
+		var inputType input.Type
+		var inputKind input.Kind
+		var inputOptions input.Options
+		var defaultValue interface{}
+		valRef := reflect.ValueOf(value)
+		switch valRef.Kind() {
+		case reflect.String:
+			inputType = input.TypeString
+			if isSecret {
+				inputKind = input.KindHidden
+			} else {
+				inputKind = input.KindInput
+			}
+
+			// Use as default value, if it is not a secret
+			if !isSecret && len(value.(string)) > 0 {
+				defaultValue = value
+			}
+		case reflect.Int:
+			inputType = input.TypeInt
+			inputKind = input.KindInput
+			if !isSecret && value.(int) != 0 {
+				defaultValue = value
+			}
+		case reflect.Float64:
+			inputType = input.TypeDouble
+			inputKind = input.KindInput
+			if !isSecret && value.(float64) != 0.0 {
+				defaultValue = value
+			}
+		case reflect.Bool:
+			inputType = input.TypeBool
+			inputKind = input.KindConfirm
+			defaultValue = value
+		case reflect.Slice:
+			inputType = input.TypeStringArray
+			inputKind = input.KindMultiSelect
+			// Each element must be string
+			for i := 0; i < valRef.Len(); i++ {
+				item := valRef.Index(i)
+				// Unwrap interface
+				if item.Type().Kind() == reflect.Interface {
+					item = item.Elem()
+				}
+				// Check item type
+				if itemKind := item.Kind(); itemKind != reflect.String {
+					// Value is not array of strings
+					return
+				}
+				inputOptions = append(inputOptions, input.Option{
+					Id:   item.String(),
+					Name: item.String(),
+				})
+			}
+			if !isSecret && valRef.Len() > 0 {
+				defaultValue = value
+			}
+		default:
+			return
+		}
+
+		// Example
+		example := ""
+		if !isSecret {
+			example = strhelper.Truncate(cast.ToString(value), 20, "…")
+		}
+
+		// Add
+		d.addInputForField(objectKey, fieldPath, example, input.Input{
+			Id:      utils.NormalizeName(componentId.WithoutVendor() + "-" + fieldPath[1:].String()),
+			Type:    inputType,
+			Kind:    inputKind,
+			Default: defaultValue,
+			Options: inputOptions,
+		})
+	})
+}
+
+func (d *templateInputsDialog) addInputForField(objectKey model.Key, path orderedmap.Key, example string, i input.Input) {
+	if d.fieldsByObject[objectKey] == nil {
+		d.fieldsByObject[objectKey] = make(map[string]inputField)
+	}
+	d.fieldsByObject[objectKey][path.String()] = inputField{path: path, example: example, input: i}
+}
+
+type inputFields map[string]inputField
+
+func (f inputFields) Write(out *strings.Builder) {
+	var table []inputFieldLine
+	var inputIdMaxLength int
+	var fieldPathMaxLength int
+
+	// Convert and get max lengths for padding
+	for _, field := range f {
+		line := field.Line()
+		table = append(table, line)
+
+		if len(line.inputId) > inputIdMaxLength {
+			inputIdMaxLength = len(line.inputId)
+		}
+
+		if len(line.fieldPath) > fieldPathMaxLength {
+			fieldPathMaxLength = len(line.fieldPath)
+		}
+	}
+
+	// Sort by field path
+	sort.SliceStable(table, func(i, j int) bool {
+		return table[i].fieldPath < table[j].fieldPath
+	})
+
+	// Format with padding
+	format := fmt.Sprintf("%%s %%-%ds  %%-%ds %%s", inputIdMaxLength, fieldPathMaxLength)
+
+	// Write
+	for _, line := range table {
+		example := ""
+		if len(line.example) > 0 {
+			example = "<!-- " + line.example + " -->"
+		}
+		out.WriteString(strings.TrimSpace(fmt.Sprintf(format, line.mark, line.inputId, line.fieldPath, example)))
+		out.WriteString("\n")
+	}
+}
+
+type inputField struct {
+	path    orderedmap.Key
+	example string
+	input   input.Input
+}
+
+func (f inputField) Line() inputFieldLine {
+	mark := "[ ]"
+
+	// Pre-select secrets
+	if f.input.Kind == input.KindHidden {
+		mark = "[x]"
+	}
+
+	return inputFieldLine{
+		mark:      mark,
+		inputId:   f.input.Id,
+		fieldPath: f.path.String(),
+		example:   f.example,
+	}
+}
+
+type inputFieldLine struct {
+	mark      string
+	inputId   string
+	fieldPath string
+	example   string
+}

--- a/internal/pkg/cli/dialog/template_inputs_test.go
+++ b/internal/pkg/cli/dialog/template_inputs_test.go
@@ -1,0 +1,130 @@
+package dialog
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+
+	nopPrompt "github.com/keboola/keboola-as-code/internal/pkg/cli/prompt/nop"
+	"github.com/keboola/keboola-as-code/internal/pkg/json"
+	"github.com/keboola/keboola-as-code/internal/pkg/model"
+	"github.com/keboola/keboola-as-code/internal/pkg/utils/orderedmap"
+)
+
+func TestTemplateInputsDialog_DefaultValue(t *testing.T) {
+	t.Parallel()
+
+	configJson := `
+{
+  "storage": {
+    "foo": "bar"
+  },
+  "parameters": {
+    "string": "my string",
+    "#password": "my password",
+    "int": 123,
+    "double": 78.90,
+    "bool": false,
+    "strings": ["foo", "bar"]
+  }
+}
+`
+	rowJson := `
+{
+  "storage": {
+    "foo": "bar"
+  },
+ "parameters": {
+    "object": {
+      "array": [
+        123,
+        {
+          "string": "Lorem ipsum dolor sit amet, consectetur adipiscing elit, sed do eiusmod tempor incididunt ut labore et dolore",
+          "#password": "my password",
+          "int": 123,
+          "double": 78.90,
+          "bool": false
+        }
+      ]
+    }
+  }
+}
+`
+	configContent := orderedmap.New()
+	rowContent := orderedmap.New()
+	json.MustDecodeString(configJson, configContent)
+	json.MustDecodeString(rowJson, rowContent)
+
+	configs := []*model.ConfigWithRows{
+		{
+			Config: &model.Config{
+				ConfigKey: model.ConfigKey{ComponentId: "keboola.foo.bar", Id: "my-config-1"},
+				Name:      "My Config 1",
+				Content:   configContent,
+			},
+		},
+		{
+			Config: &model.Config{
+				ConfigKey: model.ConfigKey{ComponentId: "keboola.foo.bar", Id: "my-config-2"},
+				Name:      "My Config 2",
+				Content:   orderedmap.New(),
+			},
+			Rows: []*model.ConfigRow{
+				{
+					ConfigRowKey: model.ConfigRowKey{ComponentId: "keboola.foo.bar", ConfigId: "my-config-2", Id: "row-1"},
+					Name:         "My Row",
+					Content:      orderedmap.New(),
+				},
+				{
+					ConfigRowKey: model.ConfigRowKey{ComponentId: "keboola.foo.bar", ConfigId: "my-config-2", Id: "row-2"},
+					Name:         "My Row",
+					Content:      rowContent,
+				},
+				{
+					ConfigRowKey: model.ConfigRowKey{ComponentId: "keboola.foo.bar", ConfigId: "my-config-2", Id: "row-3"},
+					Name:         "My Row",
+					Content:      orderedmap.New(),
+				},
+			},
+		},
+	}
+
+	// Expected default value
+	expected := `
+<!--
+Please define user inputs for the template.
+Edit lines below "## Config ..." and "### Row ...".
+Do not edit "<field.path>" and lines starting with "#"!
+
+Line format: <mark> <input-id> <field.path> <example>
+
+1. Mark which fields will be user inputs.
+[x] "input-id" "field.path"   <<< this field will be user input
+[ ] "input-id" "field.path"   <<< this field will be scalar value
+
+2. Modify "<input-id>" if needed.
+Allowed characters: a-z, A-Z, 0-9, "-".
+-->
+
+
+## Config "My Config 1" keboola.foo.bar:my-config-1
+[x] foo-bar-password  parameters.#password
+[ ] foo-bar-bool      parameters.bool      <!-- false -->
+[ ] foo-bar-double    parameters.double    <!-- 78.9 -->
+[ ] foo-bar-int       parameters.int       <!-- 123 -->
+[ ] foo-bar-string    parameters.string    <!-- my string -->
+[ ] foo-bar-strings   parameters.strings
+
+### Row "My Row" keboola.foo.bar:my-config-2:row-2
+[x] foo-bar-object-array-1-password  parameters.object.array[1].#password
+[ ] foo-bar-object-array-1-bool      parameters.object.array[1].bool      <!-- false -->
+[ ] foo-bar-object-array-1-double    parameters.object.array[1].double    <!-- 78.9 -->
+[ ] foo-bar-object-array-1-int       parameters.object.array[1].int       <!-- 123 -->
+[ ] foo-bar-object-array-1-string    parameters.object.array[1].string    <!-- Lorem ipsum dolor si… -->
+
+`
+
+	// Check default value
+	d := templateInputsDialog{prompt: nopPrompt.New(), configs: configs}
+	assert.Equal(t, expected, d.defaultValue())
+}

--- a/internal/pkg/model/keys.go
+++ b/internal/pkg/model/keys.go
@@ -3,6 +3,7 @@ package model
 import (
 	"fmt"
 	"strconv"
+	"strings"
 
 	"github.com/spf13/cast"
 )
@@ -60,6 +61,15 @@ func (v ConfigId) String() string {
 
 func (v RowId) String() string {
 	return string(v)
+}
+
+func (v ComponentId) WithoutVendor() string {
+	parts := strings.SplitN(string(v), ".", 2)
+	if len(parts) == 1 {
+		// A component without vendor
+		return parts[0]
+	}
+	return parts[1]
 }
 
 type BranchKey struct {

--- a/internal/pkg/utils/orderedmap/key.go
+++ b/internal/pkg/utils/orderedmap/key.go
@@ -58,6 +58,13 @@ func (v Key) WithoutLast() Key {
 	return v[0 : l-1]
 }
 
+func (v Key) First() Step {
+	if len(v) == 0 {
+		return nil
+	}
+	return v[0]
+}
+
 func (v Key) Last() Step {
 	l := len(v)
 	if l == 0 {

--- a/internal/pkg/utils/strhelper/strhelper.go
+++ b/internal/pkg/utils/strhelper/strhelper.go
@@ -79,3 +79,10 @@ func StripHtmlComments(str string) string {
 			return strings.Repeat("\n", strings.Count(s, "\n"))
 		})
 }
+
+func Truncate(str string, max int, suffix string) string {
+	if len(str) <= max {
+		return str
+	}
+	return str[0:max] + suffix
+}

--- a/internal/pkg/utils/strhelper/strhelper_test.go
+++ b/internal/pkg/utils/strhelper/strhelper_test.go
@@ -118,3 +118,26 @@ func TestStripHtmlComments(t *testing.T) {
 		assert.Equal(t, c.expected, StripHtmlComments(c.in), "case "+cast.ToString(i))
 	}
 }
+
+func TestTruncate(t *testing.T) {
+	t.Parallel()
+
+	cases := []struct {
+		in       string
+		max      int
+		suffix   string
+		expected string
+	}{
+		{"", 5, "", ""},
+		{"abc", 5, "", "abc"},
+		{"abcde", 5, "", "abcde"},
+		{"abcdef", 5, "", "abcde"},
+		{"abc", 5, "…", "abc"},
+		{"abcde", 5, "…", "abcde"},
+		{"abcdef", 5, "…", "abcde…"},
+	}
+
+	for i, c := range cases {
+		assert.Equal(t, c.expected, Truncate(c.in, c.max, c.suffix), "case "+cast.ToString(i))
+	}
+}


### PR DESCRIPTION
Part of: https://keboola.atlassian.net/browse/KAC-6

Changes:
- Generate default file content, to define inputs for the template.

------ 
![image](https://user-images.githubusercontent.com/19371734/153622757-da430b4c-4fb7-43fb-8dbf-97721d221d4e.png)

- vypisuju sa iba tie config/row, ktore maju nejake fields
- beru sa iba hodnoty z `parameters`
- vystup je zarovnany a obsahu priklad hodnoty
- bude sa to editovat ako subor, kedze tam moze byt toho relativne dost vela