### PR TITLE
Create template: Add flag all-inputs

### DIFF
--- a/internal/pkg/cli/cmd/template/create.go
+++ b/internal/pkg/cli/cmd/template/create.go
@@ -40,6 +40,7 @@ func CreateCommand(depsProvider dependencies.Provider) *cobra.Command {
 	cmd.Flags().StringP(`branch`, "b", ``, "branch ID or name")
 	cmd.Flags().StringP(`configs`, "c", ``, "comma separated list of {componentId}:{configId}")
 	cmd.Flags().BoolP(`all-configs`, "a", false, "use all configs from the branch")
+	cmd.Flags().Bool(`all-inputs`, false, "use all found config/row fields as user inputs")
 
 	return cmd
 }

--- a/internal/pkg/cli/dialog/template_inputs_test.go
+++ b/internal/pkg/cli/dialog/template_inputs_test.go
@@ -5,6 +5,7 @@ import (
 
 	"github.com/stretchr/testify/assert"
 
+	"github.com/keboola/keboola-as-code/internal/pkg/cli/options"
 	nopPrompt "github.com/keboola/keboola-as-code/internal/pkg/cli/prompt/nop"
 	"github.com/keboola/keboola-as-code/internal/pkg/json"
 	"github.com/keboola/keboola-as-code/internal/pkg/model"
@@ -13,7 +14,95 @@ import (
 
 func TestTemplateInputsDialog_DefaultValue(t *testing.T) {
 	t.Parallel()
+	configs := configsWithContent()
 
+	// Expected default value
+	expected := `
+<!--
+Please define user inputs for the template.
+Edit lines below "## Config ..." and "### Row ...".
+Do not edit "<field.path>" and lines starting with "#"!
+
+Line format: <mark> <input-id> <field.path> <example>
+
+1. Mark which fields will be user inputs.
+[x] "input-id" "field.path"   <<< this field will be user input
+[ ] "input-id" "field.path"   <<< this field will be scalar value
+
+2. Modify "<input-id>" if needed.
+Allowed characters: a-z, A-Z, 0-9, "-".
+-->
+
+
+## Config "My Config 1" keboola.foo.bar:my-config-1
+[x] foo-bar-password  parameters.#password
+[ ] foo-bar-bool      parameters.bool      <!-- false -->
+[ ] foo-bar-double    parameters.double    <!-- 78.9 -->
+[ ] foo-bar-int       parameters.int       <!-- 123 -->
+[ ] foo-bar-string    parameters.string    <!-- my string -->
+[ ] foo-bar-strings   parameters.strings
+
+### Row "My Row" keboola.foo.bar:my-config-2:row-2
+[x] foo-bar-object-array-1-password  parameters.object.array[1].#password
+[ ] foo-bar-object-array-1-bool      parameters.object.array[1].bool      <!-- false -->
+[ ] foo-bar-object-array-1-double    parameters.object.array[1].double    <!-- 78.9 -->
+[ ] foo-bar-object-array-1-int       parameters.object.array[1].int       <!-- 123 -->
+[ ] foo-bar-object-array-1-string    parameters.object.array[1].string    <!-- Lorem ipsum dolor si… -->
+
+`
+
+	// Check default value
+	d := templateInputsDialog{prompt: nopPrompt.New(), configs: configs, options: options.New()}
+	assert.Equal(t, expected, d.defaultValue())
+}
+
+func TestTemplateInputsDialog_DefaultValue_AllInputs(t *testing.T) {
+	t.Parallel()
+	configs := configsWithContent()
+
+	// Expected default value
+	expected := `
+<!--
+Please define user inputs for the template.
+Edit lines below "## Config ..." and "### Row ...".
+Do not edit "<field.path>" and lines starting with "#"!
+
+Line format: <mark> <input-id> <field.path> <example>
+
+1. Mark which fields will be user inputs.
+[x] "input-id" "field.path"   <<< this field will be user input
+[ ] "input-id" "field.path"   <<< this field will be scalar value
+
+2. Modify "<input-id>" if needed.
+Allowed characters: a-z, A-Z, 0-9, "-".
+-->
+
+
+## Config "My Config 1" keboola.foo.bar:my-config-1
+[x] foo-bar-password  parameters.#password
+[x] foo-bar-bool      parameters.bool      <!-- false -->
+[x] foo-bar-double    parameters.double    <!-- 78.9 -->
+[x] foo-bar-int       parameters.int       <!-- 123 -->
+[x] foo-bar-string    parameters.string    <!-- my string -->
+[x] foo-bar-strings   parameters.strings
+
+### Row "My Row" keboola.foo.bar:my-config-2:row-2
+[x] foo-bar-object-array-1-password  parameters.object.array[1].#password
+[x] foo-bar-object-array-1-bool      parameters.object.array[1].bool      <!-- false -->
+[x] foo-bar-object-array-1-double    parameters.object.array[1].double    <!-- 78.9 -->
+[x] foo-bar-object-array-1-int       parameters.object.array[1].int       <!-- 123 -->
+[x] foo-bar-object-array-1-string    parameters.object.array[1].string    <!-- Lorem ipsum dolor si… -->
+
+`
+
+	// Check default value
+	opts := options.New()
+	opts.Set("all-inputs", true)
+	d := templateInputsDialog{prompt: nopPrompt.New(), configs: configs, options: opts}
+	assert.Equal(t, expected, d.defaultValue())
+}
+
+func configsWithContent() []*model.ConfigWithRows {
 	configJson := `
 {
   "storage": {
@@ -55,7 +144,7 @@ func TestTemplateInputsDialog_DefaultValue(t *testing.T) {
 	json.MustDecodeString(configJson, configContent)
 	json.MustDecodeString(rowJson, rowContent)
 
-	configs := []*model.ConfigWithRows{
+	return []*model.ConfigWithRows{
 		{
 			Config: &model.Config{
 				ConfigKey: model.ConfigKey{ComponentId: "keboola.foo.bar", Id: "my-config-1"},
@@ -88,43 +177,4 @@ func TestTemplateInputsDialog_DefaultValue(t *testing.T) {
 			},
 		},
 	}
-
-	// Expected default value
-	expected := `
-<!--
-Please define user inputs for the template.
-Edit lines below "## Config ..." and "### Row ...".
-Do not edit "<field.path>" and lines starting with "#"!
-
-Line format: <mark> <input-id> <field.path> <example>
-
-1. Mark which fields will be user inputs.
-[x] "input-id" "field.path"   <<< this field will be user input
-[ ] "input-id" "field.path"   <<< this field will be scalar value
-
-2. Modify "<input-id>" if needed.
-Allowed characters: a-z, A-Z, 0-9, "-".
--->
-
-
-## Config "My Config 1" keboola.foo.bar:my-config-1
-[x] foo-bar-password  parameters.#password
-[ ] foo-bar-bool      parameters.bool      <!-- false -->
-[ ] foo-bar-double    parameters.double    <!-- 78.9 -->
-[ ] foo-bar-int       parameters.int       <!-- 123 -->
-[ ] foo-bar-string    parameters.string    <!-- my string -->
-[ ] foo-bar-strings   parameters.strings
-
-### Row "My Row" keboola.foo.bar:my-config-2:row-2
-[x] foo-bar-object-array-1-password  parameters.object.array[1].#password
-[ ] foo-bar-object-array-1-bool      parameters.object.array[1].bool      <!-- false -->
-[ ] foo-bar-object-array-1-double    parameters.object.array[1].double    <!-- 78.9 -->
-[ ] foo-bar-object-array-1-int       parameters.object.array[1].int       <!-- 123 -->
-[ ] foo-bar-object-array-1-string    parameters.object.array[1].string    <!-- Lorem ipsum dolor si… -->
-
-`
-
-	// Check default value
-	d := templateInputsDialog{prompt: nopPrompt.New(), configs: configs}
-	assert.Equal(t, expected, d.defaultValue())
 }


### PR DESCRIPTION
Part of: https://keboola.atlassian.net/browse/KAC-6

Added flag `all-inputes`, to pre-select all found config/row fields. Useful for testing without interactive prompt.
https://github.com/keboola/keboola-as-code/blob/73f5d45876258b8ef07b53cf05153af1829ac846/internal/pkg/cli/dialog/template_inputs_test.go#L81-L94