### PR TITLE
Inputs details dialog

### DIFF
--- a/internal/pkg/cli/dialog/create_template.go
+++ b/internal/pkg/cli/dialog/create_template.go
@@ -9,6 +9,7 @@ import (
 	"github.com/keboola/keboola-as-code/internal/pkg/api/storageapi"
 	"github.com/keboola/keboola-as-code/internal/pkg/cli/options"
 	"github.com/keboola/keboola-as-code/internal/pkg/cli/prompt"
+	"github.com/keboola/keboola-as-code/internal/pkg/log"
 	"github.com/keboola/keboola-as-code/internal/pkg/model"
 	"github.com/keboola/keboola-as-code/internal/pkg/template"
 	"github.com/keboola/keboola-as-code/internal/pkg/utils"
@@ -17,8 +18,10 @@ import (
 )
 
 type createTmplDialogDeps interface {
+	Logger() log.Logger
 	Options() *options.Options
 	StorageApi() (*storageapi.Api, error)
+	Components() (*model.ComponentsMap, error)
 }
 
 type createTmplDialog struct {
@@ -133,7 +136,7 @@ func (d *createTmplDialog) ask() (createTemplate.Options, error) {
 	}
 
 	// Ask for user inputs
-	objectInputs, allInputs, err := d.askTemplateInputs(opts, d.selectedBranch, d.selectedConfigs)
+	objectInputs, allInputs, err := d.askTemplateInputs(d.deps, d.selectedBranch, d.selectedConfigs)
 	if err != nil {
 		return d.out, err
 	}

--- a/internal/pkg/cli/dialog/create_template_test.go
+++ b/internal/pkg/cli/dialog/create_template_test.go
@@ -130,7 +130,14 @@ func TestAskCreateTemplateInteractive(t *testing.T) {
 		_, err = console.Send(testhelper.Enter) // -> start editor
 		assert.NoError(t, err)
 
-		_, err = console.ExpectString("Please define user inputs.")
+		_, err = console.ExpectString("Please select which fields in the configurations should be user inputs.")
+		assert.NoError(t, err)
+
+		time.Sleep(20 * time.Millisecond)
+		_, err = console.Send(testhelper.Enter) // -> start editor
+		assert.NoError(t, err)
+
+		_, err = console.ExpectString("Please complete the user inputs specification.")
 		assert.NoError(t, err)
 
 		time.Sleep(20 * time.Millisecond)
@@ -192,6 +199,7 @@ func TestAskCreateTemplateInteractive(t *testing.T) {
 		Inputs: &template.Inputs{
 			{
 				Id:   "my-component-password",
+				Name: "Password",
 				Type: input.TypeString,
 				Kind: input.KindHidden,
 			},
@@ -273,17 +281,20 @@ func TestAskCreateTemplateNonInteractive(t *testing.T) {
 		Inputs: &template.Inputs{
 			{
 				Id:   "my-component-password",
+				Name: "Password",
 				Type: input.TypeString,
 				Kind: input.KindHidden,
 			},
 			{
 				Id:      "my-component-int",
+				Name:    "Int",
 				Type:    input.TypeInt,
 				Kind:    input.KindInput,
 				Default: 123,
 			},
 			{
 				Id:      "my-component-string",
+				Name:    "String",
 				Type:    input.TypeString,
 				Kind:    input.KindInput,
 				Default: "my string",
@@ -365,6 +376,7 @@ func TestAskCreateTemplateAllConfigs(t *testing.T) {
 		Inputs: &template.Inputs{
 			{
 				Id:   "my-component-password",
+				Name: "Password",
 				Type: input.TypeString,
 				Kind: input.KindHidden,
 			},

--- a/internal/pkg/cli/dialog/inputs.go
+++ b/internal/pkg/cli/dialog/inputs.go
@@ -66,8 +66,9 @@ func (f inputFields) Write(out *strings.Builder) {
 			inputIdMaxLength = len(line.inputId)
 		}
 
-		if len(line.fieldPath) > fieldPathMaxLength {
-			fieldPathMaxLength = len(line.fieldPath)
+		fieldPathLength := len(line.fieldPath) + 2
+		if fieldPathLength > fieldPathMaxLength {
+			fieldPathMaxLength = fieldPathLength
 		}
 	}
 
@@ -85,7 +86,8 @@ func (f inputFields) Write(out *strings.Builder) {
 		if len(line.example) > 0 {
 			example = "<!-- " + line.example + " -->"
 		}
-		out.WriteString(strings.TrimSpace(fmt.Sprintf(format, line.mark, line.inputId, line.fieldPath, example)))
+		// Field path is escaped, it can contain MarkDown special chars, eg. _ []
+		out.WriteString(strings.TrimSpace(fmt.Sprintf(format, line.mark, line.inputId, "`"+line.fieldPath+"`", example)))
 		out.WriteString("\n")
 	}
 }

--- a/internal/pkg/cli/dialog/inputs_detail.go
+++ b/internal/pkg/cli/dialog/inputs_detail.go
@@ -1,7 +1,20 @@
 package dialog
 
 import (
+	"bufio"
+	"fmt"
+	"sort"
+	"strings"
+
+	"github.com/spf13/cast"
+	"github.com/umisama/go-regexpcache"
+
 	"github.com/keboola/keboola-as-code/internal/pkg/cli/prompt"
+	"github.com/keboola/keboola-as-code/internal/pkg/json"
+	"github.com/keboola/keboola-as-code/internal/pkg/template"
+	"github.com/keboola/keboola-as-code/internal/pkg/template/input"
+	"github.com/keboola/keboola-as-code/internal/pkg/utils"
+	"github.com/keboola/keboola-as-code/internal/pkg/utils/strhelper"
 )
 
 // inputsDetailDialog to define name/description for each user input.
@@ -15,5 +28,213 @@ func newInputsDetailsDialog(prompt prompt.Prompt, inputs inputsMap) *inputsDetai
 }
 
 func (d *inputsDetailDialog) ask() error {
-	return nil
+	result, _ := d.prompt.Editor("md", &prompt.Question{
+		Description: `Please complete the user inputs specification.`,
+		Default:     d.defaultValue(),
+		Validator: func(val interface{}) error {
+			if err := d.parse(val.(string)); err != nil {
+				// Print errors to new line
+				return utils.PrefixError("\n", err)
+			}
+			return nil
+		},
+	})
+	return d.parse(result)
+}
+
+func (d *inputsDetailDialog) parse(result string) error {
+	result = strhelper.StripHtmlComments(result)
+	scanner := bufio.NewScanner(strings.NewReader(result))
+	errors := utils.NewMultiError()
+	lineNum := 0
+
+	order := make(map[string]int)
+	orderVal := 0
+
+	var currentInput *template.Input
+	var invalidDefinition bool
+
+	for scanner.Scan() {
+		lineNum++
+		line := strings.TrimSpace(scanner.Text())
+
+		// Skip empty lines
+		if len(line) == 0 {
+			continue
+		}
+
+		// Parse line
+		switch {
+		case strings.HasPrefix(line, `## Input`):
+			// Input definition
+			m := regexpcache.MustCompile(`"([^"]+)"`).FindStringSubmatch(line)
+			if m == nil {
+				errors.Append(fmt.Errorf(`line %d: cannot parse config "%s"`, lineNum, line))
+				invalidDefinition = true
+				continue
+			}
+			i, found := d.inputs.get(m[1])
+			if !found {
+				errors.Append(fmt.Errorf(`line %d: input "%s" not found`, lineNum, m[1]))
+				invalidDefinition = true
+				continue
+			}
+			currentInput = i
+			invalidDefinition = false
+			orderVal++
+			order[currentInput.Id] = orderVal
+		case invalidDefinition:
+			// Skip lines after invalid definition
+		case strings.HasPrefix(line, `name:`):
+			currentInput.Name = strings.TrimSpace(strings.TrimPrefix(line, `name:`))
+		case strings.HasPrefix(line, `description:`):
+			currentInput.Description = strings.TrimSpace(strings.TrimPrefix(line, `description:`))
+		case strings.HasPrefix(line, `kind:`):
+			currentInput.Kind = input.Kind(strings.TrimSpace(strings.TrimPrefix(line, `kind:`)))
+		case strings.HasPrefix(line, `rules:`):
+			currentInput.Rules = input.Rules(strings.TrimSpace(strings.TrimPrefix(line, `rules:`)))
+		case strings.HasPrefix(line, `showIf:`):
+			currentInput.If = input.If(strings.TrimSpace(strings.TrimPrefix(line, `showIf:`)))
+		case strings.HasPrefix(line, `default:`):
+			defaultStr := strings.TrimSpace(strings.TrimPrefix(line, `default:`))
+			if defaultStr == "" {
+				currentInput.Default = nil
+			} else if v, err := currentInput.Type.ParseValue(defaultStr); err == nil {
+				currentInput.Default = v
+			} else {
+				errors.Append(fmt.Errorf(`line %d: %w`, lineNum, err))
+				continue
+			}
+		case strings.HasPrefix(line, `options:`):
+			if currentInput.Kind == input.KindSelect || currentInput.Kind == input.KindMultiSelect {
+				optionsStr := strings.TrimSpace(strings.TrimPrefix(line, `options:`))
+				if v, err := input.OptionsFromString(optionsStr); err == nil {
+					currentInput.Options = v
+				} else {
+					errors.Append(fmt.Errorf(`line %d: %w`, lineNum, err))
+					continue
+				}
+			} else {
+				errors.Append(fmt.Errorf(`line %d: options are not expected for kind "%s"`, lineNum, currentInput.Kind))
+				continue
+			}
+		default:
+			// Expected object definition
+			errors.Append(fmt.Errorf(`line %d: cannot parse "%s"`, lineNum, strhelper.Truncate(line, 10, "...")))
+			continue
+		}
+	}
+
+	// Validate
+	allInputs := d.inputs.all()
+	if e := allInputs.Validate(); e != nil {
+		// nolint: errorlint
+		err := e.(*utils.MultiError)
+		for index, item := range err.Errors {
+			// Replace input index by input ID. Example:
+			//   before: [123].default
+			//   after:  input "my-input": default
+			msg := regexpcache.
+				MustCompile(`^\[(\d+)\].`).
+				ReplaceAllStringFunc(item.Error(), func(s string) string {
+					return fmt.Sprintf(`input "%s": `, allInputs.GetIndex(cast.ToInt(strings.Trim(s, "[]."))).Id)
+				})
+			err.Errors[index] = fmt.Errorf(msg)
+		}
+		errors.Append(err)
+	}
+
+	// Sort
+	d.inputs.data.SortKeys(func(keys []string) {
+		sort.SliceStable(keys, func(i, j int) bool {
+			return order[keys[i]] < order[keys[j]]
+		})
+	})
+
+	return errors.ErrorOrNil()
+}
+
+func (d *inputsDetailDialog) defaultValue() string {
+	// File header - info for user
+	fileHeader := `
+<!--
+Please complete the define of the user inputs.
+Edit lines below "## Input ...".
+Do not edit lines starting with "#"!
+
+1. Adjust the name, description, ... for each user input.
+
+2. Sort the user inputs - move text blocks. 
+   User will be asked for inputs in the specified order.
+
+Allowed combinations of input type and kind (visual style):
+   string:        text
+    input         one line text
+    hidden        one line text, characters are masked
+    textarea      multi-line text
+    select        drop-down list, one option must be selected
+
+   int:           whole number
+    input         one line text
+
+   double:        decimal number
+    input         one line text
+
+   bool:          true/false
+    confirm       yes/no prompt
+
+   string[]:      array of strings
+    multiselect   drop-down list, multiple options can be selected
+
+Rules example, see: https://github.com/go-playground/validator/blob/master/README.md
+    rules: required,email
+
+ShowIf example, see: https://github.com/Knetic/govaluate/blob/master/MANUAL.md
+    showIf: [some-previous-input] == "value"
+
+Options format:
+     kind: select
+     default: id1
+     options: {"id1":"Option 1","id2":"Option 2","id3":"Option 3"}
+
+     kind: multiselect
+     default: id1, id3
+     options: {"id1":"Option 1","id2":"Option 2","id3":"Option 3"}
+-->
+
+
+`
+
+	// Add definitions
+	var lines strings.Builder
+	lines.WriteString(fileHeader)
+	for _, inputId := range d.inputs.ids() {
+		i, _ := d.inputs.get(inputId)
+		lines.WriteString(fmt.Sprintf("## Input \"%s\" (%s)\n", i.Id, i.Type))
+		lines.WriteString(fmt.Sprintf("name: %s\n", i.Name))
+		lines.WriteString(fmt.Sprintf("description: %s\n", i.Description))
+		lines.WriteString(fmt.Sprintf("kind: %s\n", i.Kind))
+		lines.WriteString(fmt.Sprintf("rules: %s\n", i.Rules))
+		lines.WriteString(fmt.Sprintf("showIf: %s\n", i.If))
+
+		// Default
+		if slice, ok := i.Default.([]interface{}); ok && i.Kind == input.KindMultiSelect {
+			var items []string
+			for _, item := range slice {
+				items = append(items, item.(string))
+			}
+			lines.WriteString(fmt.Sprintf("default: %s\n", strings.Join(items, ", ")))
+		} else {
+			lines.WriteString(fmt.Sprintf("default: %s\n", cast.ToString(i.Default)))
+		}
+
+		// Options
+		if i.Options != nil {
+			lines.WriteString(fmt.Sprintf("options: %s\n", json.MustEncode(i.Options.Map(), false)))
+		}
+
+		lines.WriteString("\n")
+	}
+
+	return lines.String()
 }

--- a/internal/pkg/cli/dialog/inputs_detail.go
+++ b/internal/pkg/cli/dialog/inputs_detail.go
@@ -158,7 +158,7 @@ func (d *inputsDetailDialog) defaultValue() string {
 	// File header - info for user
 	fileHeader := `
 <!--
-Please complete the define of the user inputs.
+Please complete definition of the user inputs.
 Edit lines below "## Input ...".
 Do not edit lines starting with "#"!
 

--- a/internal/pkg/cli/dialog/inputs_detail_test.go
+++ b/internal/pkg/cli/dialog/inputs_detail_test.go
@@ -1,1 +1,297 @@
 package dialog
+
+import (
+	"strings"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/umisama/go-regexpcache"
+
+	nopPrompt "github.com/keboola/keboola-as-code/internal/pkg/cli/prompt/nop"
+	"github.com/keboola/keboola-as-code/internal/pkg/template"
+	"github.com/keboola/keboola-as-code/internal/pkg/template/input"
+)
+
+func TestInputsDetailDialog_DefaultValue(t *testing.T) {
+	t.Parallel()
+
+	// Check default value
+	d := newInputsDetailsDialog(nopPrompt.New(), testInputs())
+	actual := d.defaultValue()
+	actual = regexpcache.MustCompile(` +\n`).ReplaceAllString(actual, "\n") // trim trailing spaces
+	assert.Equal(t, inputsDetailDialogDefaultValue, actual)
+}
+
+func TestInputsDetailDialog_Parse_NoChange(t *testing.T) {
+	t.Parallel()
+
+	// Parse
+	d := newInputsDetailsDialog(nopPrompt.New(), testInputs())
+	err := d.parse(inputsDetailDialogDefaultValue)
+	assert.NoError(t, err)
+	assert.Equal(t, testInputs().all(), d.inputs.all())
+}
+
+func TestInputsDetailDialog_Parse_Errors(t *testing.T) {
+	t.Parallel()
+
+	result := `
+## Input "string-input" (string)
+name: String Input
+description: 
+kind: confirm <!-- invalid kind -->
+rules: foobar <!-- invalid rule -->
+showIf: [invalid <!-- invalid condition -->
+default:
+
+## Input "bool-confirm" (bool)
+name: Bool Confirm
+description: Description
+kind: confirm
+rules:
+showIf:
+default: true
+
+
+## Input "string-select" (string)
+name: String Select
+description:
+kind: select
+rules:
+showIf:
+default: id1
+options: {"id1":"Op... <!-- invalid options -->
+
+## Input "string-array-multiselect" (string[])
+name: String Array
+description: Description
+kind: multiselect
+rules:
+showIf:
+default: id5, id6 <!-- invalid values -->
+options: {"id1":"Option 1","id2":"Option 2","id3":123}  <!-- invalid options -->
+`
+
+	expected := `
+- line 26: value "{"id1":"Op..." is not valid: unexpected end of JSON input, offset: 13
+- line 35: value "{"id1":"Option 1","id2":"Option 2","id3":123}" is not valid: value of key "id3" must be string
+- input "string-input": type string is not allowed for the specified kind
+- input "string-input": rules is not valid: undefined validation function 'foobar'
+- input "string-input": showIf cannot compile condition:
+  - expression: [invalid
+  - error: Unclosed parameter bracket
+- input "string-array-multiselect": default can only contain values from the specified options
+`
+
+	// Parse
+	d := newInputsDetailsDialog(nopPrompt.New(), testInputs())
+	err := d.parse(result)
+	assert.Error(t, err)
+	assert.Equal(t, strings.Trim(expected, "\n"), err.Error())
+}
+
+func testInputs() inputsMap {
+	inputs := newInputsMap()
+	inputs.add(&template.Input{
+		Id:          "string-input",
+		Name:        "String Input",
+		Description: "Description",
+		Type:        input.TypeString,
+		Kind:        input.KindInput,
+		Default:     "default",
+	})
+	inputs.add(&template.Input{
+		Id:          "string-hidden",
+		Name:        "String Hidden",
+		Description: "Description",
+		Type:        input.TypeString,
+		Kind:        input.KindHidden,
+	})
+	inputs.add(&template.Input{
+		Id:          "string-textarea",
+		Name:        "String Textarea",
+		Description: "Description",
+		Type:        input.TypeString,
+		Kind:        input.KindTextarea,
+	})
+	inputs.add(&template.Input{
+		Id:          "string-select",
+		Name:        "String Select",
+		Description: "Description",
+		Type:        input.TypeString,
+		Kind:        input.KindSelect,
+		Default:     "id1",
+		Options: input.Options{
+			{
+				Id:   "id1",
+				Name: "Option 1",
+			},
+			{
+				Id:   "id2",
+				Name: "Option 2",
+			},
+		},
+	})
+	inputs.add(&template.Input{
+		Id:          "string-int",
+		Name:        "String Double",
+		Description: "Description",
+		Type:        input.TypeInt,
+		Kind:        input.KindInput,
+		Default:     123,
+	})
+	inputs.add(&template.Input{
+		Id:          "string-double",
+		Name:        "String Double",
+		Description: "Description",
+		Type:        input.TypeDouble,
+		Kind:        input.KindInput,
+		Default:     12.34,
+	})
+	inputs.add(&template.Input{
+		Id:          "bool-confirm",
+		Name:        "Bool Confirm",
+		Description: "Description",
+		Type:        input.TypeBool,
+		Kind:        input.KindConfirm,
+		Default:     true,
+	})
+	inputs.add(&template.Input{
+		Id:          "string-array-multiselect",
+		Name:        "String Array",
+		Description: "Description",
+		Type:        input.TypeStringArray,
+		Kind:        input.KindMultiSelect,
+		Default:     []interface{}{"id1", "id3"},
+		Options: input.Options{
+			{
+				Id:   "id1",
+				Name: "Option 1",
+			},
+			{
+				Id:   "id2",
+				Name: "Option 2",
+			},
+			{
+				Id:   "id3",
+				Name: "Option 3",
+			},
+		},
+	})
+	return inputs
+}
+
+const inputsDetailDialogDefaultValue = `
+<!--
+Please complete the define of the user inputs.
+Edit lines below "## Input ...".
+Do not edit lines starting with "#"!
+
+1. Adjust the name, description, ... for each user input.
+
+2. Sort the user inputs - move text blocks.
+   User will be asked for inputs in the specified order.
+
+Allowed combinations of input type and kind (visual style):
+   string:        text
+    input         one line text
+    hidden        one line text, characters are masked
+    textarea      multi-line text
+    select        drop-down list, one option must be selected
+
+   int:           whole number
+    input         one line text
+
+   double:        decimal number
+    input         one line text
+
+   bool:          true/false
+    confirm       yes/no prompt
+
+   string[]:      array of strings
+    multiselect   drop-down list, multiple options can be selected
+
+Rules example, see: https://github.com/go-playground/validator/blob/master/README.md
+    rules: required,email
+
+ShowIf example, see: https://github.com/Knetic/govaluate/blob/master/MANUAL.md
+    showIf: [some-previous-input] == "value"
+
+Options format:
+     kind: select
+     default: id1
+     options: {"id1":"Option 1","id2":"Option 2","id3":"Option 3"}
+
+     kind: multiselect
+     default: id1, id3
+     options: {"id1":"Option 1","id2":"Option 2","id3":"Option 3"}
+-->
+
+
+## Input "string-input" (string)
+name: String Input
+description: Description
+kind: input
+rules:
+showIf:
+default: default
+
+## Input "string-hidden" (string)
+name: String Hidden
+description: Description
+kind: hidden
+rules:
+showIf:
+default:
+
+## Input "string-textarea" (string)
+name: String Textarea
+description: Description
+kind: textarea
+rules:
+showIf:
+default:
+
+## Input "string-select" (string)
+name: String Select
+description: Description
+kind: select
+rules:
+showIf:
+default: id1
+options: {"id1":"Option 1","id2":"Option 2"}
+
+## Input "string-int" (int)
+name: String Double
+description: Description
+kind: input
+rules:
+showIf:
+default: 123
+
+## Input "string-double" (double)
+name: String Double
+description: Description
+kind: input
+rules:
+showIf:
+default: 12.34
+
+## Input "bool-confirm" (bool)
+name: Bool Confirm
+description: Description
+kind: confirm
+rules:
+showIf:
+default: true
+
+## Input "string-array-multiselect" (string[])
+name: String Array
+description: Description
+kind: multiselect
+rules:
+showIf:
+default: id1, id3
+options: {"id1":"Option 1","id2":"Option 2","id3":"Option 3"}
+
+`

--- a/internal/pkg/cli/dialog/inputs_detail_test.go
+++ b/internal/pkg/cli/dialog/inputs_detail_test.go
@@ -183,7 +183,7 @@ func testInputs() inputsMap {
 
 const inputsDetailDialogDefaultValue = `
 <!--
-Please complete the define of the user inputs.
+Please complete definition of the user inputs.
 Edit lines below "## Input ...".
 Do not edit lines starting with "#"!
 

--- a/internal/pkg/cli/dialog/inputs_select.go
+++ b/internal/pkg/cli/dialog/inputs_select.go
@@ -225,10 +225,18 @@ Allowed characters: a-z, A-Z, 0-9, "-".
 func (d *inputsSelectDialog) detectInputs() error {
 	d.objectFields = make(map[model.Key]inputFields)
 	for _, c := range d.configs {
+		// Get component
 		component, err := d.components.Get(c.ComponentKey())
 		if err != nil {
 			return err
 		}
+
+		// Skip special component
+		if component.IsTransformation() || component.IsOrchestrator() || component.IsScheduler() || component.IsSharedCode() {
+			continue
+		}
+
+		// Find user inputs in config and rows
 		for _, item := range input.Find(c.ConfigKey, component, c.Content) {
 			d.addInputForField(item)
 		}

--- a/internal/pkg/cli/dialog/inputs_select.go
+++ b/internal/pkg/cli/dialog/inputs_select.go
@@ -132,7 +132,7 @@ func (d *inputsSelectDialog) parseInputLine(objectKey model.Key, line string, li
 		return fmt.Errorf(`line %d: expected "<mark> <input-id> <field.path>", found  "%s"`, lineNum, line)
 	}
 	inputId := strings.TrimSpace(parts[0])
-	fieldPath := strings.TrimSpace(parts[1])
+	fieldPath := strings.Trim(parts[1], " `")
 
 	// Process
 	switch {

--- a/internal/pkg/cli/dialog/inputs_select_test.go
+++ b/internal/pkg/cli/dialog/inputs_select_test.go
@@ -6,13 +6,13 @@ import (
 
 	"github.com/stretchr/testify/assert"
 
-	"github.com/keboola/keboola-as-code/internal/pkg/cli/options"
 	nopPrompt "github.com/keboola/keboola-as-code/internal/pkg/cli/prompt/nop"
 	"github.com/keboola/keboola-as-code/internal/pkg/json"
 	"github.com/keboola/keboola-as-code/internal/pkg/model"
 	"github.com/keboola/keboola-as-code/internal/pkg/template"
 	"github.com/keboola/keboola-as-code/internal/pkg/template/input"
 	"github.com/keboola/keboola-as-code/internal/pkg/utils/orderedmap"
+	"github.com/keboola/keboola-as-code/internal/pkg/utils/testapi"
 )
 
 func TestInputsSelectDialog_DefaultValue(t *testing.T) {
@@ -55,8 +55,10 @@ Allowed characters: a-z, A-Z, 0-9, "-".
 `
 
 	// Check default value
-	d := newInputsSelectDialog(nopPrompt.New(), options.New(), branch, configs, newInputsMap())
-	assert.Equal(t, expected, d.defaultValue())
+	components := model.NewComponentsMap(testapi.NewMockedComponentsProvider())
+	dialog, err := newInputsSelectDialog(nopPrompt.New(), false, components, branch, configs, newInputsMap())
+	assert.NoError(t, err)
+	assert.Equal(t, expected, dialog.defaultValue())
 }
 
 func TestInputsSelectDialog_DefaultValue_AllInputs(t *testing.T) {
@@ -99,10 +101,10 @@ Allowed characters: a-z, A-Z, 0-9, "-".
 `
 
 	// Check default value
-	opts := options.New()
-	opts.Set("all-inputs", true)
-	d := newInputsSelectDialog(nopPrompt.New(), opts, branch, configs, newInputsMap())
-	assert.Equal(t, expected, d.defaultValue())
+	components := model.NewComponentsMap(testapi.NewMockedComponentsProvider())
+	dialog, err := newInputsSelectDialog(nopPrompt.New(), true, components, branch, configs, newInputsMap())
+	assert.NoError(t, err)
+	assert.Equal(t, expected, dialog.defaultValue())
 }
 
 func TestInputsSelectDialog_Parse(t *testing.T) {
@@ -127,17 +129,18 @@ func TestInputsSelectDialog_Parse(t *testing.T) {
 `
 
 	// Parse
-	d := newInputsSelectDialog(nopPrompt.New(), options.New(), branch, configs, newInputsMap())
-	err := d.parse(result)
+	components := model.NewComponentsMap(testapi.NewMockedComponentsProvider())
+	dialog, err := newInputsSelectDialog(nopPrompt.New(), false, components, branch, configs, newInputsMap())
 	assert.NoError(t, err)
+	assert.NoError(t, dialog.parse(result))
 
 	// Assert inputs definitions
 	configKey := model.ConfigKey{BranchId: 123, ComponentId: "keboola.foo.bar", Id: "my-config-1"}
 	rowKey := model.ConfigRowKey{BranchId: 123, ComponentId: "keboola.foo.bar", ConfigId: "my-config-2", Id: "row-2"}
 	assert.Equal(t, &template.Inputs{
-		{Id: "foo-bar-password", Type: input.TypeString, Kind: input.KindHidden},
-		{Id: "foo-bar-object-array-1-password", Type: input.TypeString, Kind: input.KindHidden},
-	}, d.inputs.all())
+		{Id: "foo-bar-password", Type: input.TypeString, Kind: input.KindHidden, Name: "Password"},
+		{Id: "foo-bar-object-array-1-password", Type: input.TypeString, Kind: input.KindHidden, Name: "Object Array Password"},
+	}, dialog.inputs.all())
 
 	// Assert object inputs
 	assert.Equal(t, objectInputsMap{
@@ -153,7 +156,7 @@ func TestInputsSelectDialog_Parse(t *testing.T) {
 				InputId: "foo-bar-object-array-1-password",
 			},
 		},
-	}, d.objectInputs)
+	}, dialog.objectInputs)
 }
 
 func TestInputsSelectDialog_Parse_All(t *testing.T) {
@@ -178,21 +181,23 @@ func TestInputsSelectDialog_Parse_All(t *testing.T) {
 `
 
 	// Parse
-	d := newInputsSelectDialog(nopPrompt.New(), options.New(), branch, configs, newInputsMap())
-	err := d.parse(result)
+	components := model.NewComponentsMap(testapi.NewMockedComponentsProvider())
+	dialog, err := newInputsSelectDialog(nopPrompt.New(), false, components, branch, configs, newInputsMap())
 	assert.NoError(t, err)
+	assert.NoError(t, dialog.parse(result))
 
 	// Assert inputs definitions
 	configKey := model.ConfigKey{BranchId: 123, ComponentId: "keboola.foo.bar", Id: "my-config-1"}
 	rowKey := model.ConfigRowKey{BranchId: 123, ComponentId: "keboola.foo.bar", ConfigId: "my-config-2", Id: "row-2"}
 	assert.Equal(t, &template.Inputs{
-		{Id: "foo-bar-password", Type: input.TypeString, Kind: input.KindHidden},
-		{Id: "foo-bar-bool", Type: input.TypeBool, Kind: input.KindConfirm, Default: false},
-		{Id: "foo-bar-double", Type: input.TypeDouble, Kind: input.KindInput, Default: 78.9},
-		{Id: "foo-bar-int", Type: input.TypeInt, Kind: input.KindInput, Default: 123},
-		{Id: "foo-bar-string", Type: input.TypeString, Kind: input.KindInput, Default: "my string"},
+		{Id: "foo-bar-password", Type: input.TypeString, Kind: input.KindHidden, Name: "Password"},
+		{Id: "foo-bar-bool", Type: input.TypeBool, Kind: input.KindConfirm, Default: false, Name: "Bool"},
+		{Id: "foo-bar-double", Type: input.TypeDouble, Kind: input.KindInput, Default: 78.9, Name: "Double"},
+		{Id: "foo-bar-int", Type: input.TypeInt, Kind: input.KindInput, Default: 123, Name: "Int"},
+		{Id: "foo-bar-string", Type: input.TypeString, Kind: input.KindInput, Default: "my string", Name: "String"},
 		{
 			Id:      "foo-bar-strings",
+			Name:    "Strings",
 			Type:    input.TypeStringArray,
 			Kind:    input.KindMultiSelect,
 			Default: []interface{}{"foo", "bar"},
@@ -207,10 +212,10 @@ func TestInputsSelectDialog_Parse_All(t *testing.T) {
 				},
 			},
 		},
-		{Id: "foo-bar-object-array-1-double", Type: input.TypeDouble, Kind: input.KindInput, Default: 78.9},
-		{Id: "foo-bar-object-array-1-int", Type: input.TypeInt, Kind: input.KindInput, Default: 123},
-		{Id: "foo-bar-object-array-1-string", Type: input.TypeString, Kind: input.KindInput, Default: "Lorem ipsum dolor sit amet, consectetur adipiscing elit, sed do eiusmod tempor incididunt ut labore et dolore"},
-	}, d.inputs.all())
+		{Id: "foo-bar-object-array-1-double", Type: input.TypeDouble, Kind: input.KindInput, Default: 78.9, Name: "Object Array Double"},
+		{Id: "foo-bar-object-array-1-int", Type: input.TypeInt, Kind: input.KindInput, Default: 123, Name: "Object Array Int"},
+		{Id: "foo-bar-object-array-1-string", Type: input.TypeString, Kind: input.KindInput, Name: "Object Array String", Default: "Lorem ipsum dolor sit amet, consectetur adipiscing elit, sed do eiusmod tempor incididunt ut labore et dolore"},
+	}, dialog.inputs.all())
 
 	// Assert object inputs
 	assert.Equal(t, objectInputsMap{
@@ -262,7 +267,7 @@ func TestInputsSelectDialog_Parse_All(t *testing.T) {
 				InputId: "foo-bar-object-array-1-string",
 			},
 		},
-	}, d.objectInputs)
+	}, dialog.objectInputs)
 }
 
 func TestInputsSelectDialog_Parse_Errors(t *testing.T) {
@@ -295,8 +300,10 @@ invalid
 `
 
 	// Parse
-	d := newInputsSelectDialog(nopPrompt.New(), options.New(), branch, configs, newInputsMap())
-	err := d.parse(result)
+	components := model.NewComponentsMap(testapi.NewMockedComponentsProvider())
+	dialog, err := newInputsSelectDialog(nopPrompt.New(), false, components, branch, configs, newInputsMap())
+	assert.NoError(t, err)
+	err = dialog.parse(result)
 
 	// Assert
 	expected := `

--- a/internal/pkg/cli/dialog/inputs_select_test.go
+++ b/internal/pkg/cli/dialog/inputs_select_test.go
@@ -58,7 +58,9 @@ Allowed characters: a-z, A-Z, 0-9, "-".
 	components := model.NewComponentsMap(testapi.NewMockedComponentsProvider())
 	dialog, err := newInputsSelectDialog(nopPrompt.New(), false, components, branch, configs, newInputsMap())
 	assert.NoError(t, err)
-	assert.Equal(t, expected, dialog.defaultValue())
+	actual := dialog.defaultValue()
+	actual = strings.ReplaceAll(actual, "`", "")
+	assert.Equal(t, expected, actual)
 }
 
 func TestInputsSelectDialog_DefaultValue_AllInputs(t *testing.T) {
@@ -104,7 +106,9 @@ Allowed characters: a-z, A-Z, 0-9, "-".
 	components := model.NewComponentsMap(testapi.NewMockedComponentsProvider())
 	dialog, err := newInputsSelectDialog(nopPrompt.New(), true, components, branch, configs, newInputsMap())
 	assert.NoError(t, err)
-	assert.Equal(t, expected, dialog.defaultValue())
+	actual := dialog.defaultValue()
+	actual = strings.ReplaceAll(actual, "`", "")
+	assert.Equal(t, expected, actual)
 }
 
 func TestInputsSelectDialog_Parse(t *testing.T) {

--- a/internal/pkg/dependencies/abstract.go
+++ b/internal/pkg/dependencies/abstract.go
@@ -48,6 +48,7 @@ type AbstractDeps interface {
 // It is implemented by dependencies.common struct.
 type CommonDeps interface {
 	Ctx() context.Context
+	Components() (*model.ComponentsMap, error)
 	StorageApi() (*storageapi.Api, error)
 	EncryptionApi() (*encryptionapi.Api, error)
 	SchedulerApi() (*schedulerapi.Api, error)

--- a/internal/pkg/dependencies/common.go
+++ b/internal/pkg/dependencies/common.go
@@ -9,6 +9,7 @@ import (
 	"github.com/keboola/keboola-as-code/internal/pkg/api/storageapi"
 	"github.com/keboola/keboola-as-code/internal/pkg/api/storageapi/eventsender"
 	"github.com/keboola/keboola-as-code/internal/pkg/filesystem"
+	"github.com/keboola/keboola-as-code/internal/pkg/model"
 	"github.com/keboola/keboola-as-code/internal/pkg/project"
 	"github.com/keboola/keboola-as-code/internal/pkg/utils"
 )
@@ -34,6 +35,14 @@ type common struct {
 
 func (c *common) Ctx() context.Context {
 	return c.ctx
+}
+
+func (c *common) Components() (*model.ComponentsMap, error) {
+	storageApi, err := c.StorageApi()
+	if err != nil {
+		return nil, err
+	}
+	return storageApi.Components(), nil
 }
 
 func (c *common) StorageApi() (*storageapi.Api, error) {

--- a/internal/pkg/dependencies/template.go
+++ b/internal/pkg/dependencies/template.go
@@ -96,7 +96,7 @@ func (c *common) Template(reference model.TemplateRef) (*template.Template, erro
 	}
 
 	// Load inputs
-	inputs, err := loadInputsOp.Run(fs)
+	inputs, err := loadInputsOp.Run(fs, c)
 	if err != nil {
 		return nil, err
 	}

--- a/internal/pkg/json/json.go
+++ b/internal/pkg/json/json.go
@@ -7,6 +7,8 @@ import (
 	"fmt"
 )
 
+type RawMessage = json.RawMessage
+
 func Encode(v interface{}, pretty bool) ([]byte, error) {
 	var data []byte
 	var err error

--- a/internal/pkg/json/schema/meta.go
+++ b/internal/pkg/json/schema/meta.go
@@ -33,7 +33,7 @@ func FieldMeta(schemaDef []byte, path orderedmap.Key) (out FieldMetadata, found 
 
 func getFieldMeta(schema *jsonschema.Schema, path orderedmap.Key) (out FieldMetadata, found bool) {
 	// Skip first step: component schema starts at "properties"
-	if path.First() != orderedmap.MapStep("properties") {
+	if path.First() != orderedmap.MapStep("parameters") {
 		return
 	}
 	path = path.WithoutFirst()

--- a/internal/pkg/json/schema/meta_test.go
+++ b/internal/pkg/json/schema/meta_test.go
@@ -63,7 +63,7 @@ func TestFieldMeta_Complex(t *testing.T) {
 	assert.Nil(t, err)
 
 	// Found object
-	meta, found, err = schema.FieldMeta([]byte(componentSchema), orderedmap.KeyFromStr("properties.db"))
+	meta, found, err = schema.FieldMeta([]byte(componentSchema), orderedmap.KeyFromStr("parameters.db"))
 	assert.NotEmpty(t, meta)
 	assert.True(t, found)
 	assert.Nil(t, err)
@@ -73,7 +73,7 @@ func TestFieldMeta_Complex(t *testing.T) {
 	assert.False(t, meta.Required)
 
 	// Found string, required field
-	meta, found, err = schema.FieldMeta([]byte(componentSchema), orderedmap.KeyFromStr("properties.db.#connectionString"))
+	meta, found, err = schema.FieldMeta([]byte(componentSchema), orderedmap.KeyFromStr("parameters.db.#connectionString"))
 	assert.NotEmpty(t, meta)
 	assert.True(t, found)
 	assert.Nil(t, err)
@@ -83,7 +83,7 @@ func TestFieldMeta_Complex(t *testing.T) {
 	assert.True(t, meta.Required)
 
 	// Found int, default field
-	meta, found, err = schema.FieldMeta([]byte(componentSchema), orderedmap.KeyFromStr("properties.db.limit"))
+	meta, found, err = schema.FieldMeta([]byte(componentSchema), orderedmap.KeyFromStr("parameters.db.limit"))
 	assert.NotEmpty(t, meta)
 	assert.True(t, found)
 	assert.Nil(t, err)

--- a/internal/pkg/template/input/input.go
+++ b/internal/pkg/template/input/input.go
@@ -33,6 +33,10 @@ func (i *Inputs) Add(input Input) {
 	*i = append(*i, input)
 }
 
+func (i *Inputs) GetIndex(index int) Input {
+	return (*i)[index]
+}
+
 // Save inputs to the FileName.
 func (i *Inputs) Save(fs filesystem.Fs) error {
 	if err := saveFile(fs, &file{Inputs: *i}); err != nil {

--- a/internal/pkg/template/input/input.go
+++ b/internal/pkg/template/input/input.go
@@ -66,7 +66,7 @@ type Value struct {
 type Input struct {
 	Id          string      `json:"id" validate:"required,template-input-id"`
 	Name        string      `json:"name" validate:"required"`
-	Description string      `json:"description" validate:"required"`
+	Description string      `json:"description"`
 	Type        Type        `json:"type" validate:"required,template-input-type,template-input-type-for-kind"`
 	Kind        Kind        `json:"kind" validate:"required,template-input-kind"`
 	Default     interface{} `json:"default,omitempty" validate:"omitempty,template-input-default-value,template-input-default-options"`

--- a/internal/pkg/template/input/type.go
+++ b/internal/pkg/template/input/type.go
@@ -158,11 +158,13 @@ func (t Type) ParseValue(value interface{}) (interface{}, error) {
 
 		if v, ok := value.(string); ok {
 			// Split items by comma, if needed
-			if v == "" {
-				value = []string{}
-			} else {
-				value = strings.Split(v, ",")
+			var items []string
+			if v != "" {
+				for _, item := range strings.Split(v, ",") {
+					items = append(items, strings.TrimSpace(item))
+				}
 			}
+			value = items
 		}
 
 		if items, ok := value.([]string); ok {

--- a/internal/pkg/utils/testapi/testapi.go
+++ b/internal/pkg/utils/testapi/testapi.go
@@ -97,6 +97,7 @@ func mockedComponents() []MockedComponent {
 	return []MockedComponent{
 		{"foo.bar", "other", "Foo Bar", model.ComponentData{}},
 		{"ex-generic-v2", "extractor", "Generic", model.ComponentData{}},
+		{"keboola.foo.bar", "other", "Foo Bar", model.ComponentData{}},
 		{"keboola.wr-db-mysql", "writer", "MySQL", model.ComponentData{}},
 		{"keboola.ex-db-mysql", "extractor", "MySQL", model.ComponentData{}},
 		{"keboola.ex-aws-s3", "extractor", "AWS S3", model.ComponentData{DefaultBucket: true, DefaultBucketStage: "in"}},

--- a/internal/pkg/validator/validator.go
+++ b/internal/pkg/validator/validator.go
@@ -198,8 +198,8 @@ func (v *wrapper) registerDefaultErrorMessages() {
 }
 
 // formatError creates human-readable error message.
-func (v *wrapper) formatError(err validator.ValidationErrors, namespace string, value reflect.Value) error {
-	result := utils.NewMultiError()
+func (v *wrapper) formatError(err validator.ValidationErrors, namespace string, value reflect.Value) *utils.MultiError {
+	errors := utils.NewMultiError()
 	for _, e := range err {
 		// Translate error
 		errString := strings.TrimSpace(e.Translate(v.translator))
@@ -209,10 +209,10 @@ func (v *wrapper) formatError(err validator.ValidationErrors, namespace string, 
 		}
 
 		// Prefix error with namespace
-		result.Append(fmt.Errorf("%s", prefixErrorWithNamespace(e, errString, namespace, value)))
+		errors.Append(fmt.Errorf("%s", prefixErrorWithNamespace(e, errString, namespace, value)))
 	}
 
-	return result.ErrorOrNil()
+	return errors
 }
 
 // processNamespace removes struct name (first part), field name (last part) and anonymous fields.

--- a/pkg/lib/operation/template/local/create/operation.go
+++ b/pkg/lib/operation/template/local/create/operation.go
@@ -12,6 +12,7 @@ import (
 	repositoryManifest "github.com/keboola/keboola-as-code/internal/pkg/template/repository/manifest"
 	createTemplateDir "github.com/keboola/keboola-as-code/pkg/lib/operation/template/local/dir/create"
 	createTemplateInputs "github.com/keboola/keboola-as-code/pkg/lib/operation/template/local/inputs/create"
+	saveInputs "github.com/keboola/keboola-as-code/pkg/lib/operation/template/local/inputs/save"
 	createTemplateManifest "github.com/keboola/keboola-as-code/pkg/lib/operation/template/local/manifest/create"
 	saveRepositoryManifest "github.com/keboola/keboola-as-code/pkg/lib/operation/template/local/repository/manifest/save"
 	loadStateOp "github.com/keboola/keboola-as-code/pkg/lib/operation/template/state/load"
@@ -84,6 +85,11 @@ func Run(o Options, d dependencies) (err error) {
 
 	// Pull remote objects
 	if err := pull.Run(pull.Options{Template: tmpl, Context: templateCtx}, d); err != nil {
+		return err
+	}
+
+	// Save inputs
+	if err := saveInputs.Run(o.Inputs, tmpl.Fs(), d); err != nil {
 		return err
 	}
 

--- a/pkg/lib/operation/template/local/inputs/load/operation.go
+++ b/pkg/lib/operation/template/local/inputs/load/operation.go
@@ -2,9 +2,20 @@ package load
 
 import (
 	"github.com/keboola/keboola-as-code/internal/pkg/filesystem"
+	"github.com/keboola/keboola-as-code/internal/pkg/log"
 	"github.com/keboola/keboola-as-code/internal/pkg/template"
 )
 
-func Run(fs filesystem.Fs) (*template.Inputs, error) {
-	return template.LoadInputs(fs)
+type dependencies interface {
+	Logger() log.Logger
+}
+
+func Run(fs filesystem.Fs, d dependencies) (*template.Inputs, error) {
+	inputs, err := template.LoadInputs(fs)
+	if err != nil {
+		return nil, err
+	}
+
+	d.Logger().Debugf(`Template inputs have been loaded.`)
+	return inputs, nil
 }

--- a/pkg/lib/operation/template/local/inputs/save/operation.go
+++ b/pkg/lib/operation/template/local/inputs/save/operation.go
@@ -2,22 +2,19 @@ package save
 
 import (
 	"github.com/keboola/keboola-as-code/internal/pkg/filesystem"
+	"github.com/keboola/keboola-as-code/internal/pkg/log"
 	"github.com/keboola/keboola-as-code/internal/pkg/template"
 )
 
 type dependencies interface {
-	TemplateSrcDir() (filesystem.Fs, error)
-	TemplateInputs() (inputs template.Inputs, err error)
+	Logger() log.Logger
 }
 
-func Run(d dependencies) (err error) {
-	inputs, err := d.TemplateInputs()
-	if err != nil {
+func Run(inputs *template.Inputs, fs filesystem.Fs, d dependencies) (err error) {
+	if err := inputs.Save(fs); err != nil {
 		return err
 	}
-	fs, err := d.TemplateSrcDir()
-	if err != nil {
-		return err
-	}
-	return inputs.Save(fs)
+
+	d.Logger().Debugf(`Template inputs have been saved.`)
+	return nil
 }

--- a/pkg/lib/operation/template/local/manifest/load/operation.go
+++ b/pkg/lib/operation/template/local/manifest/load/operation.go
@@ -19,6 +19,6 @@ func Run(fs filesystem.Fs, context template.Context, d dependencies) (*manifest.
 		return nil, err
 	}
 
-	logger.Debugf(`Template manifest loaded.`)
+	logger.Debugf(`Template manifest has been loaded.`)
 	return m, nil
 }

--- a/pkg/lib/operation/template/sync/pull/operation.go
+++ b/pkg/lib/operation/template/sync/pull/operation.go
@@ -69,10 +69,6 @@ func Run(o Options, d dependencies) (err error) {
 		if _, err := saveManifest.Run(templateState.TemplateManifest(), templateState.Fs(), d); err != nil {
 			return err
 		}
-
-		// Normalize paths
-
-		// Validate schemas and encryption
 	}
 
 	if !plan.Empty() {

--- a/test/template-create/inputs/out/my-template/v0/src/inputs.jsonnet
+++ b/test/template-create/inputs/out/my-template/v0/src/inputs.jsonnet
@@ -1,3 +1,28 @@
 {
-  inputs: [],
+  inputs: [
+    {
+      id: "ex-generic-v2-api-base-url",
+      name: "Api BaseUrl",
+      description: "",
+      type: "string",
+      kind: "input",
+      default: "https://jsonplaceholder.typicode.com",
+    },
+    {
+      id: "ex-db-mysql-db-host",
+      name: "Db Host",
+      description: "",
+      type: "string",
+      kind: "input",
+      default: "mysql.example.com",
+    },
+    {
+      id: "ex-db-mysql-incremental",
+      name: "Incremental",
+      description: "",
+      type: "bool",
+      kind: "confirm",
+      default: false,
+    },
+  ],
 }


### PR DESCRIPTION
Part of: https://keboola.atlassian.net/browse/KAC-6

Cely proces vyzera teraz takto:

1. Definovanie IDs pre objekty:
![image](https://user-images.githubusercontent.com/19371734/154270250-4c591a60-28f8-4b1a-89d3-990a1391a711.png)

2. Vyber toho, ktore z automaticky detekovanych vstupov sa pouziju
![image](https://user-images.githubusercontent.com/19371734/154270282-70bd0cae-3a2c-4155-950e-0581b2b10fc2.png)

3. Doplnenie podrobnosti k vybranym vstupom:
![image](https://user-images.githubusercontent.com/19371734/154270369-ef817cf7-1f62-4bd9-ae30-bf96aee425b9.png)


4. Vysledkom je subor `inputs.jsonnet`:
https://github.com/keboola/keboola-as-code/blob/000f0abf2045f2275fb6ff2b6be8eb797786599d/test/template-create/inputs/out/my-template/v0/src/inputs.jsonnet#L1-L28

5. Myslim, ze na prvu verziu je to OK. Nejake lepsie CLI UI by zabralo o dost viac casu.