### PR TITLE
Chocolatey init (KAC-30)

### DIFF
--- a/build/package/chocolatey/keboola-cli.nuspec
+++ b/build/package/chocolatey/keboola-cli.nuspec
@@ -1,0 +1,22 @@
+﻿<?xml version="1.0" encoding="utf-8"?>
+<!-- Do not remove this test for UTF-8: if “Ω” doesn’t appear as greek uppercase omega letter enclosed in quotation marks, you should use an editor that supports UTF-8, not this one. -->
+<package xmlns="http://schemas.microsoft.com/packaging/2015/06/nuspec.xsd">
+  <metadata>
+    <id>keboola-cli</id>
+    <version>2.2.0</version>
+    <packageSourceUrl>https://github.com/keboola/keboola-as-code/tree/main/build/package/chocolatey</packageSourceUrl>
+    <title>Keboola CLI</title>
+    <authors>Keboola</authors>
+    <licenseUrl>https://github.com/keboola/keboola-as-code/blob/main/LICENSE</licenseUrl>
+    <projectUrl>https://www.keboola.com/product/cli</projectUrl>
+    <projectSourceUrl>https://github.com/keboola/keboola-as-code</projectSourceUrl>
+    <docsUrl>https://developers.keboola.com/cli/</docsUrl>
+    <tags>keboola-cli</tags>
+    <summary>Operate your cloud data pipeline from the command line</summary>
+    <description>Keboola CLI (Command Line Interface), known also as “Keboola as Code”, is a set of commands for operating your cloud data pipeline.</description>
+    <releaseNotes>https://github.com/keboola/keboola-as-code/releases</releaseNotes>
+  </metadata>
+  <files>
+    <file src="tools\**" target="tools" />
+  </files>
+</package>

--- a/build/package/chocolatey/tools/chocolateyinstall.ps1
+++ b/build/package/chocolatey/tools/chocolateyinstall.ps1
@@ -1,0 +1,19 @@
+﻿$ErrorActionPreference = 'Stop';
+
+$toolsDir   = "$(Split-Path -parent $MyInvocation.MyCommand.Definition)"
+$url64      = 'https://keboola-as-code-dist.s3.amazonaws.com/msi/keboola-cli_2.2.0_windows_amd64.msi'
+$checksum64 = '8D87538FC26924B39B5C424F45287BFCA5B148DB038BF506F6146C789E8D5F6C'
+
+$packageArgs = @{
+  packageName   = $env:ChocolateyPackageName
+  unzipLocation = $toolsDir
+  fileType      = 'MSI'
+  url64bit      = $url64
+  softwareName  = 'Keboola CLI*'
+  checksum64    = $checksum64
+  checksumType64= 'sha256'
+  silentArgs    = "/qn /norestart /l*v `"$($env:TEMP)\$($packageName).$($env:chocolateyPackageVersion).MsiInstall.log`""
+  validExitCodes= @(0, 3010, 1641)
+}
+
+Install-ChocolateyPackage @packageArgs


### PR DESCRIPTION
Init statických souborů, protože tam chtějí mít odkaz na zdrojáky balíčku (`packageSourceUrl=https://github.com/keboola/keboola-as-code/tree/main/build/package/chocolatey`), tak aby skutečně existovaly než jim to pošlu na review.