### PR TITLE
Fix pipeline, scoop test install (KAC-30)

### DIFF
--- a/.github/workflows/push.yml
+++ b/.github/workflows/push.yml
@@ -497,7 +497,7 @@ jobs:
     needs:
       - set-version
       - release
-      - update-repositories
+      - update-repositories-windows
     runs-on: windows-latest
     steps:
       - name: Install on Windows using Scoop


### PR DESCRIPTION
`update-repositories` step kvůli outputům nepotřebuje tak snad už ok