### PR TITLE
Fix pipeline, push msi to s3 (KAC-30)

### DIFF
--- a/.github/workflows/push.yml
+++ b/.github/workflows/push.yml
@@ -304,7 +304,7 @@ jobs:
           filename="$(basename "$ZIP_FILE" ".zip")"
           "${MSBUILD_PATH}\MSBuild.exe" ./build/package/windows/msi.wixproj -p:SourceDir="$PWD" -p:OutputPath="./msi" -p:OutputName="$filename" -p:ProductVersion="${VERSION}"
           echo "::set-output name=msi_file::${filename}.msi"
-          aws s3 cp "./build/package/windows/msi/${name}.msi" s3://${AWS_BUCKET_NAME}/msi/
+          aws s3 cp "./build/package/windows/msi/${filename}.msi" s3://${AWS_BUCKET_NAME}/msi/
           
           choco install checksum
           checksum=$(checksum -t=sha256 -f="./build/package/windows/msi/${filename}.msi")


### PR DESCRIPTION
Ach jo, měnil jsem název tý proměnný `name` na `filename` (https://github.com/keboola/keboola-as-code/blob/0de869616f2957492ffe1b3325e5a3ca96c75538/.github/workflows/push.yml#L304), ale tady ten push do s3 jsem měl zakomentovaný, tak mi to ušlo 😕