### PR TITLE
Fix pipeline, push scoop (KAC-30)

### DIFF
--- a/.github/workflows/push.yml
+++ b/.github/workflows/push.yml
@@ -360,17 +360,6 @@ jobs:
         uses: ./.github/actions/mount-s3
       - name: Index Linux packages
         run: ./build/package/linux/index.sh /s3bucket
-
-  update-repositories-windows:
-    needs:
-      - set-version
-      - release
-      - release-msi-windows
-    runs-on: windows-latest
-    if: startsWith(github.ref, 'refs/tags/') && needs.set-version.outputs.is_semantic_tag == 'true'
-    steps:
-      - name: Check out the repo
-        uses: actions/checkout@v2
       - name: Download Scoop manifest
         uses: actions/download-artifact@v2
         with:
@@ -385,6 +374,17 @@ jobs:
           destination-github-username: "keboola"
           destination-repository-name: "scoop-keboola-cli"
           target-branch: main
+
+  update-repositories-windows:
+    needs:
+      - set-version
+      - release
+      - release-msi-windows
+    runs-on: windows-latest
+    if: startsWith(github.ref, 'refs/tags/') && needs.set-version.outputs.is_semantic_tag == 'true'
+    steps:
+      - name: Check out the repo
+        uses: actions/checkout@v2
       - name: Push Chocolatey
         env:
           CHOCOLATEY_KEY: ${{ secrets.CHOCOLATEY_KEY }}


### PR DESCRIPTION
To je zlej sen tohle, tak snad už opravdu naposled.
![CleanShot 2022-02-18 at 15 19 22](https://user-images.githubusercontent.com/215660/154699644-e9a48383-2c4f-424e-8a37-fb896edd28de.jpg)

Přesunul jsem push scoop manifestu do `update-repositories` který běží na linuxu. Artefakt manifestu se uploaduje v `release` na kterým  `update-repositories` závisí, tak by to mělo být ok.