### PR TITLE
Fix push update to WinGet

### DIFF
--- a/.github/workflows/push.yml
+++ b/.github/workflows/push.yml
@@ -410,7 +410,7 @@ jobs:
         run: |
           curl -kLSs https://aka.ms/wingetcreate/latest -o wingetcreate.exe
           msiUrl="${DIST_BASE_URL}/msi/${MSI_FILE}"
-          ./wingetcreate.exe update -v $VERSION -u $msiUrl -t $GITHUB_TOKEN Keboola.KeboolaCLI
+          ./wingetcreate.exe update -v $VERSION -u $msiUrl -t $GITHUB_TOKEN Keboola.KeboolaCLI -s
 
   test-install-linux:
     needs:


### PR DESCRIPTION
Přišlo mi divný že po releasu nepřišla žádná notifikace od WinGetu a [z pipeliny](https://github.com/keboola/keboola-as-code/runs/5358289338?check_suite_focus=true) to vypadá že update command neodešle PR dokud se mu explicitně neřekne. Z dokumentace mi to teda vůbec nebylo jasný. 😕 (https://github.com/microsoft/winget-create/blob/main/doc/update.md)