### PR TITLE
feat: release pipeline scaffold

### DIFF
--- a/provisioning/aws/scripts/deploy.sh
+++ b/provisioning/aws/scripts/deploy.sh
@@ -1,0 +1,14 @@
+#!/usr/bin/env bash
+set -Eeuo pipefail
+
+aws eks update-kubeconfig --name "$AWS_EKS_CLUSTER_NAME" --region "$AWS_REGION"
+kubectl config set-context --current --namespace default
+
+./provisioning/kubernetes/build.sh
+
+kubectl apply -f ./provisioning/kubernetes/deploy/config-map.yaml
+kubectl apply -f ./provisioning/kubernetes/deploy/templates-api.yaml
+kubectl apply -f ./provisioning/kubernetes/deploy/aws/service.yaml
+kubectl apply -f ./provisioning/kubernetes/deploy/aws/ingress.yaml
+kubectl rollout status deployment/templates-api --timeout=900s
+

--- a/provisioning/azure-devops-deploy.sh
+++ b/provisioning/azure-devops-deploy.sh
@@ -1,0 +1,12 @@
+#!/usr/bin/env bash
+set -Eeuo pipefail
+
+# Checkout correct commit
+if [ "$RELEASE_ARTIFACTS__KEBOOLA_KEBOOLA_AS_CODE_SOURCEBRANCH" == "master" ]; then
+  COMMIT=$(echo "$BUILD_BUILDID" | cut -d'-' -f 2)
+  git checkout "$COMMIT" -f
+fi
+
+export RELEASE_ID="$BUILD_BUILDID-$RELEASE_RELEASENAME"
+
+./provisioning/"$CLOUD_PROVIDER"/scripts/deploy.sh

--- a/provisioning/azure/scripts/deploy.sh
+++ b/provisioning/azure/scripts/deploy.sh
@@ -1,0 +1,43 @@
+#!/usr/bin/env bash
+set -Eeuo pipefail
+
+CLUSTER_NAME=$(az deployment group show \
+  --resource-group "$RESOURCE_GROUP" \
+  --name kbc-aks \
+  --query "properties.outputs.clusterName.value" \
+  --output tsv)
+
+az aks get-credentials --name "$CLUSTER_NAME" --resource-group "$RESOURCE_GROUP" --overwrite-existing
+kubectl config set-context --current --namespace default
+
+./provisioning/kubernetes/build.sh
+
+kubectl apply -f ./provisioning/kubernetes/deploy/config-map.yaml
+kubectl apply -f ./provisioning/kubernetes/deploy/templates-api.yaml
+kubectl apply -f ./provisioning/kubernetes/deploy/azure/service.yaml
+kubectl rollout status deployment/templates-api --timeout=900s
+
+TEMPLATES_API_IP=$(kubectl get services \
+  --selector "app=templates-api" \
+  --namespace default \
+  --no-headers \
+  --output jsonpath="{.items[0].status.loadBalancer.ingress[0].ip}")
+
+APPLICATION_GATEWAY_NAME=$(az deployment group show \
+  --resource-group "$RESOURCE_GROUP" \
+  --name kbc-application-gateway \
+  --query "properties.outputs.appGatewayName.value" \
+  --output tsv)
+
+az network application-gateway address-pool update \
+  --gateway-name="$APPLICATION_GATEWAY_NAME" \
+  --resource-group "$RESOURCE_GROUP" \
+  --name=templates \
+  --servers "$TEMPLATES_API_IP"
+
+az network application-gateway probe update \
+  --gateway-name="$APPLICATION_GATEWAY_NAME" \
+  --resource-group "$RESOURCE_GROUP" \
+  --name=templates-health-probe \
+  --host "$TEMPLATES_API_IP"
+

--- a/provisioning/kubernetes/build.sh
+++ b/provisioning/kubernetes/build.sh
@@ -1,0 +1,10 @@
+#!/usr/bin/env bash
+set -Eeuo pipefail
+
+envsubst < provisioning/kubernetes/templates/config-map.yaml > provisioning/kubernetes/deploy/config-map.yaml
+envsubst < provisioning/kubernetes/templates/templates-api.yaml > provisioning/kubernetes/deploy/templates-api.yaml
+envsubst < provisioning/kubernetes/templates/"$CLOUD_PROVIDER"/service.yaml > provisioning/kubernetes/deploy/"$CLOUD_PROVIDER"/service.yaml
+
+if [[ "$CLOUD_PROVIDER" == "aws" ]]; then
+  envsubst < provisioning/kubernetes/templates/aws/ingress.yaml > provisioning/kubernetes/deploy/aws/ingress.yaml
+fi

--- a/provisioning/kubernetes/deploy/.gitignore
+++ b/provisioning/kubernetes/deploy/.gitignore
@@ -1,0 +1,4 @@
+*
+!azure/
+!aws/
+!.gitignore

--- a/provisioning/kubernetes/deploy/aws/.gitignore
+++ b/provisioning/kubernetes/deploy/aws/.gitignore
@@ -1,0 +1,2 @@
+*
+!.gitignore

--- a/provisioning/kubernetes/deploy/azure/.gitignore
+++ b/provisioning/kubernetes/deploy/azure/.gitignore
@@ -1,0 +1,2 @@
+*
+!.gitignore

--- a/provisioning/kubernetes/templates/aws/ingress.yaml
+++ b/provisioning/kubernetes/templates/aws/ingress.yaml
@@ -1,0 +1,17 @@
+---
+apiVersion: networking.k8s.io/v1beta1
+kind: Ingress
+metadata:
+  annotations:
+    kubernetes.io/ingress.class: "nginx"
+  name: templates-api
+  namespace: default
+spec:
+  rules:
+    - host: "templates.${HOSTNAME_SUFFIX}"
+      http:
+        paths:
+          - backend:
+              serviceName: templates-api
+              servicePort: 80
+            path: /

--- a/provisioning/kubernetes/templates/aws/service.yaml
+++ b/provisioning/kubernetes/templates/aws/service.yaml
@@ -1,0 +1,17 @@
+---
+kind: Service
+apiVersion: v1
+metadata:
+  labels:
+    app: templates-api
+  name: templates-api
+  namespace: default
+spec:
+  type: ClusterIP
+  selector:
+    app: templates-api
+  ports:
+    - port: 80
+      targetPort: 8000
+      protocol: TCP
+      name: http

--- a/provisioning/kubernetes/templates/azure/service.yaml
+++ b/provisioning/kubernetes/templates/azure/service.yaml
@@ -1,0 +1,19 @@
+---
+kind: Service
+apiVersion: v1
+metadata:
+  name: templates-api
+  namespace: default
+  labels:
+    app: templates-api
+  annotations:
+    service.beta.kubernetes.io/azure-load-balancer-internal: "true"
+spec:
+  type: LoadBalancer
+  selector:
+    app: templates-api
+  ports:
+    - port: 80
+      targetPort: 8000
+      protocol: TCP
+      name: http

--- a/provisioning/kubernetes/templates/config-map.yaml
+++ b/provisioning/kubernetes/templates/config-map.yaml
@@ -1,0 +1,10 @@
+---
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: templates-api
+  namespace: default
+data:
+  storageApiUrl: "https://connection.$HOSTNAME_SUFFIX"
+  keboolaStack: "$KEBOOLA_STACK"
+  keboolaRevision: "$RELEASE_ID"

--- a/provisioning/kubernetes/templates/templates-api.yaml
+++ b/provisioning/kubernetes/templates/templates-api.yaml
@@ -1,0 +1,89 @@
+---
+kind: Deployment
+apiVersion: apps/v1
+metadata:
+  name: templates-api
+  namespace: default
+  labels:
+    app: templates-api
+    releaseId: $RELEASE_ID
+spec:
+  replicas: $TEMPLATES_API_API_REPLICAS
+  selector:
+    matchLabels:
+      app: templates-api
+  template:
+    metadata:
+      labels:
+        app: templates-api
+        releaseId: $RELEASE_ID
+        tags.datadoghq.com/env: "$KEBOOLA_STACK"
+        tags.datadoghq.com/service: "templates-api"
+        tags.datadoghq.com/version: "$RELEASE_ID"
+      annotations:
+        log: "true"
+    spec:
+      containers:
+        - name: templates-api
+          image: $TEMPLATES_API_REPOSITORY:$TEMPLATES_API_IMAGE_TAG
+          resources:
+            requests:
+              cpu: "500m"
+              memory: "500Mi"
+            limits:
+              cpu: "1000m"
+              memory: "1000Mi"
+          ports:
+            - containerPort: 8000
+          env:
+            - name: storage_api_url
+              valueFrom:
+                configMapKeyRef:
+                  name: templates-api
+                  key: storageApiUrl
+            - name: DD_AGENT_HOST
+              valueFrom:
+                fieldRef:
+                  fieldPath: status.hostIP
+            - name: DD_TRACE_ANALYTICS_ENABLED
+              value: "true"
+            - name: DD_PROFILING_ENABLED
+              value: "true"
+            - name: DD_ENV
+              valueFrom:
+                fieldRef:
+                  fieldPath: metadata.labels['tags.datadoghq.com/env']
+            - name: DD_SERVICE
+              valueFrom:
+                fieldRef:
+                  fieldPath: metadata.labels['tags.datadoghq.com/service']
+            - name: DD_VERSION
+              valueFrom:
+                fieldRef:
+                  fieldPath: metadata.labels['tags.datadoghq.com/version']
+          readinessProbe:
+            httpGet:
+              path: /health-check
+              port: 8000
+              httpHeaders:
+                - name: Host
+                  value: KubernetesReadinessProbe
+            initialDelaySeconds: 5
+            periodSeconds: 10
+      tolerations:
+        - key: app
+          operator: Exists
+          effect: NoSchedule
+      nodeSelector:
+        nodepool: main
+---
+apiVersion: policy/v1
+kind: PodDisruptionBudget
+metadata:
+  name: templates-api-pdb
+  namespace: default
+spec:
+  maxUnavailable: 1
+  selector:
+    matchLabels:
+      app: templates-api


### PR DESCRIPTION
Zatím deployuju jen do testovacího Azure a AWS

- https://dev.azure.com/keboola-prod/Keboola%20Connection%20Azure/_releaseDefinition?definitionId=378&_a=environments-editor-preview
- https://dev.azure.com/keboola-prod/Keboola%20Connection%20AWS/_release?definitionId=192&view=mine&_a=releases

![image](https://user-images.githubusercontent.com/497675/156547287-4fb15628-b8ba-41c1-85d8-499558026aa4.png)
![image](https://user-images.githubusercontent.com/497675/156547302-14dedb93-93d2-429b-a850-47169c8d2b16.png)

Jakmile se tohle mergne, pustil bych release ručně zbuilděného image do všech multitenant stacků (použiju ty stejné pipeliny, jen je přejmenuju a napojím na main branch v githubu). Ale aby se vše fakt otestovalo, bylo by dobrý udělat jeden full release. Máte tušení, kdy by se to mohlo stát? 

Zároveň upozorňuju na jednu věc - release (do AWS i Azure) je triggerovaný novým imagem v Azure. Push do Azure tedy musí být úplně poslední. Na oba cloudy se nasadí stejný tag image a k tomu se použije poslední commit z `main` branche. Dřív jsme se snažili použít totožný commit jako pro build image, ale to se ukázalo, že asi není úplně potřeba. Z té `main` branche se použijí pouze deploy skripty, nic jiného, samotná aplikace je zapečená v image s příslušným tagem. 
