### PR TITLE
CI: Job "build-and-push-templates-api" doesn't depends on "release" job

### DIFF
--- a/.github/workflows/push.yml
+++ b/.github/workflows/push.yml
@@ -571,6 +571,9 @@ jobs:
       id-token: write
     needs:
       - set-version
+      - test
+      - lint
+      - cross-compile
     if: startsWith(github.ref, 'refs/tags/templates-api-v')
     steps:
       - name: Checkout

--- a/.github/workflows/push.yml
+++ b/.github/workflows/push.yml
@@ -571,7 +571,6 @@ jobs:
       id-token: write
     needs:
       - set-version
-      - release
     if: startsWith(github.ref, 'refs/tags/templates-api-v')
     steps:
       - name: Checkout


### PR DESCRIPTION
Slack: https://keboola.slack.com/archives/C02JAQXLY92/p1646396733366399?thread_ts=1646315144.645389&cid=C02JAQXLY92