### PR TITLE
Fix api docker image

### DIFF
--- a/Dockerfile-api
+++ b/Dockerfile-api
@@ -5,10 +5,6 @@ COPY . .
 #flags: -s -w to remove symbol table and debug info
 RUN CGO_ENABLED=0 GOOS=linux GOARCH=amd64 go build -v -mod mod -ldflags "-s -w" -o ./templatesapi ./cmd/templates
 
-# SSL certificates container
-FROM alpine as sslCerts
-RUN apk add -U --no-cache ca-certificates
-
 # Production container
 FROM alpine
 RUN apk add -U --no-cache ca-certificates git


### PR DESCRIPTION
S tou změnou base image pro běh API jsem sice začal instalovat `ca-certificates` ale zapomněl jsem odstranit tady ten mezikrok. 🙂 Teď už imho potřeba není.