### PR TITLE
Enter inputs in use template dialog by steps (KAC-94)

### DIFF
--- a/internal/pkg/cli/dialog/inputs_detail.go
+++ b/internal/pkg/cli/dialog/inputs_detail.go
@@ -211,12 +211,12 @@ Preview of steps and groups you created:
 `
 	var defaultStepId string
 	for gIdx, group := range stepsGroups {
-		fileHeader += fmt.Sprintf(`- Group %d
-`, gIdx+1)
-		for sIdx := range group.Steps {
+		fileHeader += fmt.Sprintf(`- Group %d: %s
+`, gIdx+1, group.Description)
+		for sIdx, step := range group.Steps {
 			index := input.StepIndex{Step: sIdx, Group: gIdx}
-			fileHeader += fmt.Sprintf(`  - Step "%s"
-`, stepsToIds[index])
+			fileHeader += fmt.Sprintf(`  - Step "%s": %s - %s
+`, stepsToIds[index], step.Name, step.Description)
 			if gIdx == 0 && sIdx == 0 {
 				defaultStepId = stepsToIds[index]
 			}

--- a/internal/pkg/cli/dialog/inputs_detail_test.go
+++ b/internal/pkg/cli/dialog/inputs_detail_test.go
@@ -19,7 +19,7 @@ func TestInputsDetailDialog_DefaultValue(t *testing.T) {
 		&input.StepsGroup{Description: "desc", Required: "all", Steps: []*input.Step{
 			{Icon: "common", Name: "Step One", Description: "Description"},
 		}},
-		&input.StepsGroup{Required: "all", Steps: []*input.Step{
+		&input.StepsGroup{Description: "desc2", Required: "all", Steps: []*input.Step{
 			{Icon: "common", Name: "Step Two", Description: "Description"},
 			{Icon: "common", Name: "Step Three", Description: "Description"},
 		}},
@@ -243,11 +243,11 @@ Options format:
      options: {"id1":"Option 1","id2":"Option 2","id3":"Option 3"}
 
 Preview of steps and groups you created:
-- Group 1
-  - Step "s1"
-- Group 2
-  - Step "s2"
-  - Step "s3"
+- Group 1: desc
+  - Step "s1": Step One - Description
+- Group 2: desc2
+  - Step "s2": Step Two - Description
+  - Step "s3": Step Three - Description
 
 -->
 

--- a/internal/pkg/cli/dialog/steps.go
+++ b/internal/pkg/cli/dialog/steps.go
@@ -199,7 +199,7 @@ Please create steps and groups for the user inputs.
 There is one group and one step predefined. Feel free to change them and/or create others.
 
 "required" option for group specifies how many steps need to be filled by user of the template
-	allowed values: all, atLeastOne, exactOne, zeroOrOne, optional
+	allowed values: all, atLeastOne, exactlyOne, zeroOrOne, optional
 -->
 
 ## Group

--- a/internal/pkg/cli/dialog/steps_test.go
+++ b/internal/pkg/cli/dialog/steps_test.go
@@ -105,12 +105,12 @@ description: Description
 - line 2: there needs to be a group definition before step "s0"
 - line 12: required is not valid option for a step
 - line 21: step with id "s1" is already defined
-- group 1: required must be one of [all atLeastOne exactOne zeroOrOne optional]
+- group 1: required must be one of [all atLeastOne exactlyOne zeroOrOne optional]
 - group 1, step 1: icon is a required field
 - group 1, step 1: name must be a maximum of 20 characters in length
-- group 2: required must be one of [all atLeastOne exactOne zeroOrOne optional]
+- group 2: required must be one of [all atLeastOne exactlyOne zeroOrOne optional]
 - group 2: steps must contain at least 1 step
-- group 3: required must be one of [all atLeastOne exactOne zeroOrOne optional]
+- group 3: required must be one of [all atLeastOne exactlyOne zeroOrOne optional]
 - group 3, step 2: icon is a required field
 - group 3, step 3: icon is a required field
 `

--- a/internal/pkg/cli/dialog/use_template.go
+++ b/internal/pkg/cli/dialog/use_template.go
@@ -133,12 +133,11 @@ func (d *useTmplDialog) selectStepsToShow(group *input.StepsGroup) ([]int, bool)
 	var stepsToShow []int
 	announceGroup := true
 	if group.ShowStepsSelect() {
-		d.Printf("Group \"%s\"\n", group.Description)
+		d.Printf("%s\n", group.Description)
 		announceGroup = false
 		multiSelect := &prompt.MultiSelectIndex{
-			Label:       "Select steps",
-			Description: fmt.Sprintf("Select steps, %s\n", group.RequiredDescription()),
-			Options:     group.Steps.Names(),
+			Label:   "Select steps",
+			Options: group.Steps.SelectOptions(),
 			Validator: func(answersRaw interface{}) error {
 				answers := answersRaw.([]survey.OptionAnswer)
 				values := make([]string, len(answers))
@@ -168,11 +167,11 @@ func (d *useTmplDialog) askInput(inputDef input.Input, groupToAnnounce *input.St
 	}
 
 	if groupToAnnounce != nil {
-		d.Printf("Group \"%s\"\n", groupToAnnounce.Description)
+		d.Printf("%s\n", groupToAnnounce.Description)
 	}
 
 	if stepToAnnounce != nil {
-		d.Printf("Enter inputs for step \"%s\"\n%s", stepToAnnounce.Name, stepToAnnounce.Description)
+		d.Printf("%s\n%s", stepToAnnounce.NameFoDialog(), stepToAnnounce.DescriptionForDialog())
 	}
 
 	// Ask for input

--- a/internal/pkg/template/input/step.go
+++ b/internal/pkg/template/input/step.go
@@ -85,8 +85,6 @@ const (
 	requiredAtLeastOne            = "atLeastOne"
 	requiredExactlyOne            = "exactlyOne"
 	requiredZeroOrOne             = "zeroOrOne"
-	requiredOptional              = "optional"
-	requiredOptionalDescription   = "any number of steps can be selected"
 	requiredAtLeastOneDescription = "at least one step must be selected"
 	requiredExactlyOneDescription = "exactly one step must be selected"
 	requiredZeroOrOneDescription  = "zero or one step must be selected"
@@ -110,27 +108,13 @@ func (g StepsGroup) ValidateSelectedSteps(selected int) error {
 	return nil
 }
 
-func (g StepsGroup) RequiredDescription() string {
-	switch g.Required {
-	case requiredOptional:
-		return requiredOptionalDescription
-	case requiredAtLeastOne:
-		return requiredAtLeastOneDescription
-	case requiredExactlyOne:
-		return requiredExactlyOneDescription
-	case requiredZeroOrOne:
-		return requiredZeroOrOneDescription
-	}
-	return ""
-}
-
 // Steps.
 type Steps []*Step
 
-func (s Steps) Names() []string {
+func (s Steps) SelectOptions() []string {
 	res := make([]string, 0)
 	for _, step := range s {
-		res = append(res, step.Name)
+		res = append(res, fmt.Sprintf("%s - %s", step.Name, step.Description))
 	}
 	return res
 }
@@ -143,4 +127,18 @@ type Step struct {
 	DialogName        string `json:"dialogName,omitempty" validate:"omitempty,max=20"`
 	DialogDescription string `json:"dialogDescription,omitempty" validate:"omitempty,max=200"`
 	Inputs            Inputs `json:"inputs" validate:"omitempty,dive"`
+}
+
+func (s Step) NameFoDialog() string {
+	if s.DialogName != "" {
+		return s.DialogName
+	}
+	return s.Name
+}
+
+func (s Step) DescriptionForDialog() string {
+	if s.DialogDescription != "" {
+		return s.DialogDescription
+	}
+	return s.Description
 }

--- a/internal/pkg/template/input/step.go
+++ b/internal/pkg/template/input/step.go
@@ -6,8 +6,6 @@ import (
 	"github.com/keboola/keboola-as-code/internal/pkg/filesystem"
 )
 
-type StepsGroups []*StepsGroup
-
 func Load(fs filesystem.Fs) (StepsGroups, error) {
 	f, err := loadFile(fs)
 	if err != nil {
@@ -20,6 +18,9 @@ type StepIndex struct {
 	Step  int
 	Group int
 }
+
+// StepsGroups.
+type StepsGroups []*StepsGroup
 
 func (g StepsGroups) Indices(stepsToIds map[StepIndex]string) map[string]StepIndex {
 	res := make(map[string]StepIndex)
@@ -72,12 +73,69 @@ func (g StepsGroups) Validate() error {
 	return validate(g)
 }
 
+// StepsGroup.
 type StepsGroup struct {
-	Description string  `json:"description" validate:"max=80"`
-	Required    string  `json:"required" validate:"oneof=all atLeastOne exactOne zeroOrOne optional"`
-	Steps       []*Step `json:"steps" validate:"min=1,dive"`
+	Description string `json:"description" validate:"max=80"`
+	Required    string `json:"required" validate:"oneof=all atLeastOne exactlyOne zeroOrOne optional"`
+	Steps       Steps  `json:"steps" validate:"min=1,dive"`
 }
 
+const (
+	requiredAll                   = "all"
+	requiredAtLeastOne            = "atLeastOne"
+	requiredExactlyOne            = "exactlyOne"
+	requiredZeroOrOne             = "zeroOrOne"
+	requiredOptional              = "optional"
+	requiredOptionalDescription   = "any number of steps can be selected"
+	requiredAtLeastOneDescription = "at least one step must be selected"
+	requiredExactlyOneDescription = "exactly one step must be selected"
+	requiredZeroOrOneDescription  = "zero or one step must be selected"
+)
+
+func (g StepsGroup) ShowStepsSelect() bool {
+	return g.Required != requiredAll &&
+		(len(g.Steps) > 1 || (g.Required != requiredAtLeastOne && g.Required != requiredExactlyOne))
+}
+
+func (g StepsGroup) ValidateSelectedSteps(selected int) error {
+	if g.Required == requiredAtLeastOne && selected < 1 {
+		return fmt.Errorf(requiredAtLeastOneDescription)
+	}
+	if g.Required == requiredExactlyOne && selected != 1 {
+		return fmt.Errorf(requiredExactlyOneDescription)
+	}
+	if g.Required == requiredZeroOrOne && selected > 1 {
+		return fmt.Errorf(requiredZeroOrOneDescription)
+	}
+	return nil
+}
+
+func (g StepsGroup) RequiredDescription() string {
+	switch g.Required {
+	case requiredOptional:
+		return requiredOptionalDescription
+	case requiredAtLeastOne:
+		return requiredAtLeastOneDescription
+	case requiredExactlyOne:
+		return requiredExactlyOneDescription
+	case requiredZeroOrOne:
+		return requiredZeroOrOneDescription
+	}
+	return ""
+}
+
+// Steps.
+type Steps []*Step
+
+func (s Steps) Names() []string {
+	res := make([]string, 0)
+	for _, step := range s {
+		res = append(res, step.Name)
+	}
+	return res
+}
+
+// Step.
 type Step struct {
 	Icon              string `json:"icon" validate:"required"`
 	Name              string `json:"name" validate:"required,max=20"`

--- a/internal/pkg/template/input/step_test.go
+++ b/internal/pkg/template/input/step_test.go
@@ -1,0 +1,89 @@
+package input
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+)
+
+func TestStepsGroup_ShowStepsSelect(t *testing.T) {
+	t.Parallel()
+
+	// Do not show select for required == "all"
+	g := StepsGroup{
+		Description: "description",
+		Required:    "all",
+		Steps: Steps{
+			{Name: "Step 1"},
+			{Name: "Step 2"},
+		},
+	}
+	assert.False(t, g.ShowStepsSelect())
+
+	// Do not show select for required == "exactlyOne" and one step
+	g = StepsGroup{
+		Description: "description",
+		Required:    "exactlyOne",
+		Steps: Steps{
+			{Name: "Step 1"},
+		},
+	}
+	assert.False(t, g.ShowStepsSelect())
+
+	// Do not show select for required == "atLeastOne" and one step
+	g = StepsGroup{
+		Description: "description",
+		Required:    "atLeastOne",
+		Steps: Steps{
+			{Name: "Step 1"},
+		},
+	}
+	assert.False(t, g.ShowStepsSelect())
+
+	// Show select for required == "optional"
+	g = StepsGroup{
+		Description: "description",
+		Required:    "optional",
+		Steps: Steps{
+			{Name: "Step 1"},
+		},
+	}
+	assert.True(t, g.ShowStepsSelect())
+
+	// Show select for required == "zeroOrOne"
+	g = StepsGroup{
+		Description: "description",
+		Required:    "zeroOrOne",
+		Steps: Steps{
+			{Name: "Step 1"},
+		},
+	}
+	assert.True(t, g.ShowStepsSelect())
+}
+
+func TestStepsGroup_ValidateSelectedSteps(t *testing.T) {
+	t.Parallel()
+
+	g := StepsGroup{
+		Description: "description",
+		Required:    "atLeastOne",
+	}
+	assert.NoError(t, g.ValidateSelectedSteps(2))
+	assert.Error(t, g.ValidateSelectedSteps(0))
+
+	g = StepsGroup{
+		Description: "description",
+		Required:    "zeroOrOne",
+	}
+	assert.NoError(t, g.ValidateSelectedSteps(0))
+	assert.NoError(t, g.ValidateSelectedSteps(1))
+	assert.Error(t, g.ValidateSelectedSteps(2))
+
+	g = StepsGroup{
+		Description: "description",
+		Required:    "exactlyOne",
+	}
+	assert.NoError(t, g.ValidateSelectedSteps(1))
+	assert.Error(t, g.ValidateSelectedSteps(0))
+	assert.Error(t, g.ValidateSelectedSteps(2))
+}

--- a/internal/pkg/template/input/step_test.go
+++ b/internal/pkg/template/input/step_test.go
@@ -69,7 +69,9 @@ func TestStepsGroup_ValidateSelectedSteps(t *testing.T) {
 		Required:    "atLeastOne",
 	}
 	assert.NoError(t, g.ValidateSelectedSteps(2))
-	assert.Error(t, g.ValidateSelectedSteps(0))
+	err := g.ValidateSelectedSteps(0)
+	assert.Error(t, err)
+	assert.Equal(t, "at least one step must be selected", err.Error())
 
 	g = StepsGroup{
 		Description: "description",
@@ -77,13 +79,19 @@ func TestStepsGroup_ValidateSelectedSteps(t *testing.T) {
 	}
 	assert.NoError(t, g.ValidateSelectedSteps(0))
 	assert.NoError(t, g.ValidateSelectedSteps(1))
-	assert.Error(t, g.ValidateSelectedSteps(2))
+	err = g.ValidateSelectedSteps(2)
+	assert.Error(t, err)
+	assert.Equal(t, "zero or one step must be selected", err.Error())
 
 	g = StepsGroup{
 		Description: "description",
 		Required:    "exactlyOne",
 	}
 	assert.NoError(t, g.ValidateSelectedSteps(1))
-	assert.Error(t, g.ValidateSelectedSteps(0))
-	assert.Error(t, g.ValidateSelectedSteps(2))
+	err = g.ValidateSelectedSteps(0)
+	assert.Error(t, err)
+	assert.Equal(t, "exactly one step must be selected", err.Error())
+	err = g.ValidateSelectedSteps(2)
+	assert.Error(t, err)
+	assert.Equal(t, "exactly one step must be selected", err.Error())
 }


### PR DESCRIPTION
Pro tenhle jednoduchý inputs.jsonnet
![CleanShot 2022-03-31 at 18 22 46](https://user-images.githubusercontent.com/215660/161103626-7caa64c5-1fa8-4b4c-8e4d-826b37f27c46.jpg)

Vypadá dialog takto (select se u první groupy přeskakuje kvůli required = all):

![CleanShot 2022-03-31 at 18 12 28](https://user-images.githubusercontent.com/215660/161103292-573962d6-6dcf-4e8a-81ab-a4eb0b601907.jpg)
![CleanShot 2022-03-31 at 18 13 05](https://user-images.githubusercontent.com/215660/161103303-b4180d10-1496-48e4-bad9-9cd714a2ff31.jpg)
