### PR TITLE
Templates API: error handling

### DIFF
--- a/api/templates/design.go
+++ b/api/templates/design.go
@@ -349,17 +349,22 @@ var _ = Service("templates", func() {
 // Error -------------------------------------------------------------------------------------------------------
 
 var GenericErrorType = Type("GenericError", func() {
+	Description("Generic error")
 	Attribute("statusCode", Int, "HTTP status code.", func() {
+		Meta("struct:tag:json", "statusCode")
 		Example(500)
 	})
 	ErrorName("error", String, "Name of error.", func() {
 		Meta("struct:field:name", "name")
+		Meta("struct:tag:json", "error")
 		Example("Internal Error")
 	})
 	Attribute("message", String, "Error message.", func() {
+		Meta("struct:tag:json", "message")
 		Example("Internal Error")
 	})
 	Attribute("exceptionId", String, "ID of the error if an internal error occurred.", func() {
+		Meta("struct:tag:json", "exceptionId,omitempty")
 		Example("templates-9db938dd6a8054189a9bd969248aeb48")
 	})
 	Required("statusCode", "error", "message")

--- a/cmd/templates-api/decode.go
+++ b/cmd/templates-api/decode.go
@@ -1,0 +1,12 @@
+package main
+
+import (
+	"net/http"
+
+	goaHTTP "goa.design/goa/v3/http"
+)
+
+// decider decodes request.
+func decoder(r *http.Request) goaHTTP.Decoder {
+	return goaHTTP.RequestDecoder(r)
+}

--- a/cmd/templates-api/encode.go
+++ b/cmd/templates-api/encode.go
@@ -1,0 +1,30 @@
+package main
+
+import (
+	"context"
+	"net/http"
+
+	goaHTTP "goa.design/goa/v3/http"
+)
+
+type encoderWrapper struct {
+	writer http.ResponseWriter
+	ctx    context.Context
+	parent goaHTTP.Encoder
+}
+
+// encoder encodes responses.
+func encoder(ctx context.Context, w http.ResponseWriter) goaHTTP.Encoder {
+	return encoderWrapper{
+		writer: w,
+		ctx:    ctx,
+		parent: goaHTTP.ResponseEncoder(ctx, w),
+	}
+}
+
+func (w encoderWrapper) Encode(v interface{}) error {
+	if err, ok := v.(error); ok {
+		return writeError(w.ctx, w.writer, err)
+	}
+	return w.parent.Encode(v)
+}

--- a/cmd/templates-api/error.go
+++ b/cmd/templates-api/error.go
@@ -1,0 +1,220 @@
+// nolint: errorlint
+package main
+
+import (
+	"context"
+	"errors"
+	"fmt"
+	"net/http"
+	"runtime/debug"
+	"strings"
+
+	"github.com/iancoleman/strcase"
+	goaHTTP "goa.design/goa/v3/http"
+	"goa.design/goa/v3/middleware"
+	goa "goa.design/goa/v3/pkg"
+
+	"github.com/keboola/keboola-as-code/internal/pkg/json"
+	"github.com/keboola/keboola-as-code/internal/pkg/template/api/dependencies"
+	"github.com/keboola/keboola-as-code/internal/pkg/template/api/gen/templates"
+	"github.com/keboola/keboola-as-code/internal/pkg/utils/strhelper"
+)
+
+const (
+	ExceptionIdPrefix   = "keboola-templates-"
+	ErrorNamePrefix     = "templates."
+	DefaultErrorName    = "internalError"
+	DefaultErrorMessage = "Application error. Please contact our support support@keboola.com with exception id (%s) attached."
+)
+
+type NotFoundError struct{}
+
+type PanicError struct {
+	Value interface{}
+}
+
+func (NotFoundError) StatusCode() int {
+	return http.StatusNotFound
+}
+
+func (NotFoundError) Error() string {
+	return "endpoint not found"
+}
+
+func (NotFoundError) ErrorName() string {
+	return "endpointNotFound"
+}
+
+func (NotFoundError) ErrorUserMessage() string {
+	return "Endpoint not found."
+}
+
+func (PanicError) StatusCode() int {
+	return http.StatusInternalServerError
+}
+
+func (e PanicError) Error() string {
+	return fmt.Sprintf("%s", e.Value)
+}
+
+func (e PanicError) ErrorLogMessage() string {
+	return fmt.Sprintf("panic=%s stacktrace=%s", e.Value, string(debug.Stack()))
+}
+
+func (PanicError) ErrorName() string {
+	return "panicError"
+}
+
+type errorWithName interface {
+	ErrorName() string
+}
+
+type errorWithUserMessage interface {
+	ErrorUserMessage() string
+}
+
+type errorWithExceptionId interface {
+	ErrorExceptionId() string
+}
+
+type errorWithLogMessage interface {
+	ErrorLogMessage() string
+}
+
+type errorWithStatusCode struct {
+	error
+	httpCode int
+}
+
+func (w errorWithStatusCode) StatusCode() int {
+	return w.httpCode
+}
+
+func (w errorWithStatusCode) Unwrap() error {
+	return w.error
+}
+
+// errorHandler returns a function that writes and logs the given error.
+func errorHandler() func(context.Context, http.ResponseWriter, error) {
+	return handleError
+}
+
+// errorFormatter returns a function that adds HTTP status code to the given error.
+func errorFormatter() func(err error) goaHTTP.Statuser {
+	return formatError
+}
+
+// handleError handles an unexpected error.
+func handleError(_ context.Context, w http.ResponseWriter, err error) {
+	formattedErr := formatError(err)
+	w.WriteHeader(formattedErr.StatusCode())
+	_, _ = w.Write([]byte(json.MustEncodeString(formattedErr, true)))
+}
+
+// formatError sets HTTP status code to error.
+func formatError(err error) goaHTTP.Statuser {
+	// Http status.
+	httpCode := 500
+	var httpCodeProvider goaHTTP.Statuser
+	var serviceError *goa.ServiceError
+	if errors.As(err, &httpCodeProvider) {
+		httpCode = httpCodeProvider.StatusCode()
+	} else if errors.As(err, &serviceError) {
+		httpCode = http.StatusBadRequest
+	}
+
+	return errorWithStatusCode{
+		error:    err,
+		httpCode: httpCode,
+	}
+}
+
+// writeError to HTTP response.
+func writeError(ctx context.Context, w http.ResponseWriter, err error) error {
+	// Default values
+	response := &templates.GenericError{
+		StatusCode:  http.StatusInternalServerError,
+		Name:        DefaultErrorName,
+		Message:     err.Error(),
+		ExceptionID: nil,
+	}
+
+	// HTTP status code
+	if v, ok := err.(errorWithStatusCode); ok {
+		response.StatusCode = v.StatusCode()
+		err = v.Unwrap()
+	} else if v, ok := err.(goaHTTP.Statuser); ok {
+		response.StatusCode = v.StatusCode()
+	}
+
+	// Error name
+	var nameProvider errorWithName
+	if errors.As(err, &nameProvider) {
+		response.Name = nameProvider.ErrorName()
+	}
+
+	// Normalize error name
+	if !strings.Contains(response.Name, ".") {
+		// Normalize error name, eg., "missing_field" to "templates.missingField"
+		response.Name = ErrorNamePrefix + strcase.ToLowerCamel(response.Name)
+	}
+
+	// Re-use exception ID from Storage or other API, if possible.
+	// Otherwise, generate custom exception ID.
+	var exceptionIdProvider errorWithExceptionId
+	if errors.As(err, &exceptionIdProvider) {
+		v := exceptionIdProvider.ErrorExceptionId()
+		response.ExceptionID = &v
+	} else {
+		v := ExceptionIdPrefix + ctx.Value(middleware.RequestIDKey).(string)
+		response.ExceptionID = &v
+	}
+
+	// Error message
+	var messageProvider errorWithUserMessage
+	switch {
+	case errors.As(err, &messageProvider):
+		response.Message = messageProvider.ErrorUserMessage()
+	case response.StatusCode > 499:
+		response.Message = fmt.Sprintf(DefaultErrorMessage, *response.ExceptionID)
+	default:
+		response.Message = err.Error()
+	}
+
+	// Normalize error message
+	response.Message = strings.TrimSuffix(response.Message, ".") + "."
+	response.Message = strhelper.FirstUpper(response.Message)
+
+	// Log error
+	d := ctx.Value(dependencies.CtxKey).(dependencies.Container)
+	logger := d.Logger()
+	if response.StatusCode > 499 {
+		logger.Error(errorLogMessage(err, response))
+	} else {
+		logger.Info(errorLogMessage(err, response))
+	}
+
+	// Write response
+	w.WriteHeader(response.StatusCode)
+	_, wErr := w.Write([]byte(json.MustEncodeString(response, true)))
+	return wErr
+}
+
+func errorLogMessage(err error, response *templates.GenericError) string {
+	// Log exception ID if it is present
+	exceptionIdValue := ""
+	if response.ExceptionID != nil {
+		exceptionIdValue = "exceptionId=" + *response.ExceptionID + " "
+	}
+
+	// Custom log message
+	if v, ok := err.(errorWithLogMessage); ok {
+		return exceptionIdValue + v.ErrorLogMessage()
+	}
+
+	// Format message
+	return fmt.Sprintf(
+		"%s | %serrorName=%s errorType=%T response=%s",
+		err.Error(), exceptionIdValue, response.Name, err, json.MustEncodeString(response, false),
+	)
+}

--- a/cmd/templates-api/error.go
+++ b/cmd/templates-api/error.go
@@ -113,19 +113,9 @@ func handleError(_ context.Context, w http.ResponseWriter, err error) {
 
 // formatError sets HTTP status code to error.
 func formatError(err error) goaHTTP.Statuser {
-	// Http status.
-	httpCode := 500
-	var httpCodeProvider goaHTTP.Statuser
-	var serviceError *goa.ServiceError
-	if errors.As(err, &httpCodeProvider) {
-		httpCode = httpCodeProvider.StatusCode()
-	} else if errors.As(err, &serviceError) {
-		httpCode = http.StatusBadRequest
-	}
-
 	return errorWithStatusCode{
 		error:    err,
-		httpCode: httpCode,
+		httpCode: errorHttpCode(err),
 	}
 }
 
@@ -217,4 +207,16 @@ func errorLogMessage(err error, response *templates.GenericError) string {
 		"%s | %serrorName=%s errorType=%T response=%s",
 		err.Error(), exceptionIdValue, response.Name, err, json.MustEncodeString(response, false),
 	)
+}
+
+func errorHttpCode(err error) int {
+	httpCode := 500
+	var httpCodeProvider goaHTTP.Statuser
+	var serviceError *goa.ServiceError
+	if errors.As(err, &httpCodeProvider) {
+		httpCode = httpCodeProvider.StatusCode()
+	} else if errors.As(err, &serviceError) {
+		httpCode = http.StatusBadRequest
+	}
+	return httpCode
 }

--- a/cmd/templates-api/http.go
+++ b/cmd/templates-api/http.go
@@ -3,7 +3,6 @@ package main
 import (
 	"context"
 	"log"
-	"net"
 	"net/http"
 	"net/url"
 	"os"
@@ -12,7 +11,6 @@ import (
 
 	goaHTTP "goa.design/goa/v3/http"
 	httpMiddleware "goa.design/goa/v3/http/middleware"
-	"goa.design/goa/v3/middleware"
 	dataDog "gopkg.in/DataDog/dd-trace-go.v1/contrib/net/http"
 
 	"github.com/keboola/keboola-as-code/internal/pkg/template/api/dependencies"
@@ -25,26 +23,17 @@ import (
 // handleHTTPServer starts configures and starts a HTTP server on the given
 // URL. It shuts down the server if any error is received in the error channel.
 func handleHTTPServer(ctx context.Context, wg *sync.WaitGroup, d dependencies.Container, u *url.URL, endpoints *templates.Endpoints, errCh chan error, logger *log.Logger, debug bool) {
-	// Provide the transport specific request decoder and response encoder.
-	// The goa http package has built-in support for JSON, XML and gob.
-	// Other encodings can be used by providing the corresponding functions,
-	// see goa.design/implement/encoding.
-	dec := goaHTTP.RequestDecoder
-	enc := goaHTTP.ResponseEncoder
-
 	// Build the service HTTP request multiplexer and configure it to serve
 	// HTTP requests to the service endpoints.
-	mux := goaHTTP.NewMuxer()
+	mux := newMuxer()
 
 	// Wrap the endpoints with the transport specific layers. The generated
 	// server packages contains code generated from the design which maps
 	// the service input and output data structures to HTTP requests and
 	// responses.
-
-	eh := errorHandler(logger)
-	docsFS := http.FS(openapi.Fs)
-	swaggerFS := http.FS(swaggerui.SwaggerFS)
-	templatesServer := templatesSvr.New(endpoints, mux, dec, enc, eh, nil, docsFS, docsFS, docsFS, docsFS, swaggerFS)
+	docsFs := http.FS(openapi.Fs)
+	swaggerUiFs := http.FS(swaggerui.SwaggerFS)
+	templatesServer := templatesSvr.New(endpoints, mux, decoder, encoder, errorHandler(), errorFormatter(), docsFs, docsFs, docsFs, docsFs, swaggerUiFs)
 	if debug {
 		servers := goaHTTP.Servers{templatesServer}
 		servers.Use(httpMiddleware.Debug(mux, os.Stdout))
@@ -56,15 +45,13 @@ func handleHTTPServer(ctx context.Context, wg *sync.WaitGroup, d dependencies.Co
 	// Wrap the multiplexer with additional middlewares. Middlewares mounted
 	// here apply to all the service endpoints.
 	var handler http.Handler = mux
-	handler = httpMiddleware.Log(middleware.NewLogger(logger))(handler)
-	handler = httpMiddleware.RequestID()(handler)
 	handler = dataDog.WrapHandler(handler, "templates-api", "")
+	handler = LogMiddleware(handler)
+	handler = ContextMiddleware(d, handler)
 
 	// Start HTTP server using default configuration, change the code to
 	// configure the server as required by your service.
-	requestCtx := context.WithValue(context.Background(), dependencies.CtxKey, d)
-	ctxProvider := func(_ net.Listener) context.Context { return requestCtx }
-	srv := &http.Server{Addr: u.Host, Handler: handler, BaseContext: ctxProvider}
+	srv := &http.Server{Addr: u.Host, Handler: handler}
 	for _, m := range templatesServer.Mounts {
 		logger.Printf("HTTP %q mounted on %s %s", m.Method, m.Verb, m.Pattern)
 	}
@@ -88,15 +75,4 @@ func handleHTTPServer(ctx context.Context, wg *sync.WaitGroup, d dependencies.Co
 
 		_ = srv.Shutdown(ctx)
 	}()
-}
-
-// errorHandler returns a function that writes and logs the given error.
-// The function also writes and logs the error unique ID so that it's possible
-// to correlate.
-func errorHandler(logger *log.Logger) func(context.Context, http.ResponseWriter, error) {
-	return func(ctx context.Context, w http.ResponseWriter, err error) {
-		id := ctx.Value(middleware.RequestIDKey).(string)
-		_, _ = w.Write([]byte("[" + id + "] encoding: " + err.Error()))
-		logger.Printf("[%s] ERROR: %s", id, err.Error())
-	}
 }

--- a/cmd/templates-api/main.go
+++ b/cmd/templates-api/main.go
@@ -48,7 +48,12 @@ func main() {
 
 	// Start DataDog tracer.
 	if envs.Get("DATADOG_ENABLED") != "false" {
-		tracer.Start(tracer.WithServiceName("templates-api"), tracer.WithLogger(ddLogger{logger}))
+		tracer.Start(
+			tracer.WithServiceName("templates-api"),
+			tracer.WithLogger(ddLogger{logger}),
+			tracer.WithRuntimeMetrics(),
+			tracer.WithAnalytics(true),
+		)
 		defer tracer.Stop()
 	}
 

--- a/cmd/templates-api/main.go
+++ b/cmd/templates-api/main.go
@@ -37,7 +37,7 @@ func main() {
 	flag.Parse()
 
 	// Setup logger.
-	logger := log.New(os.Stderr, "[templatesApi][server]", 0)
+	logger := log.New(os.Stderr, "[templatesApi]", 0)
 
 	// Envs.
 	envs, err := env.FromOs()

--- a/cmd/templates-api/middleware.go
+++ b/cmd/templates-api/middleware.go
@@ -56,7 +56,7 @@ func ContextMiddleware(d dependencies.Container, h http.Handler) http.Handler {
 		if span, ok := tracer.SpanFromContext(ctx); ok {
 			span.SetTag(ext.ResourceName, r.URL.Path)
 			span.SetTag("http.request.id", requestId)
-			if host, err := d.StorageApiHost(); err != nil {
+			if host, err := d.StorageApiHost(); err == nil {
 				span.SetTag("storage.host", host)
 			}
 		}

--- a/cmd/templates-api/middleware.go
+++ b/cmd/templates-api/middleware.go
@@ -9,22 +9,59 @@ import (
 
 	httpMiddleware "goa.design/goa/v3/http/middleware"
 	"goa.design/goa/v3/middleware"
+	goa "goa.design/goa/v3/pkg"
+	"gopkg.in/DataDog/dd-trace-go.v1/ddtrace/ext"
+	"gopkg.in/DataDog/dd-trace-go.v1/ddtrace/tracer"
 
 	"github.com/keboola/keboola-as-code/internal/pkg/idgenerator"
 	"github.com/keboola/keboola-as-code/internal/pkg/template/api/dependencies"
 )
 
+func TraceEndpointsMiddleware() func(endpoint goa.Endpoint) goa.Endpoint {
+	return func(endpoint goa.Endpoint) goa.Endpoint {
+		return func(ctx context.Context, request interface{}) (response interface{}, err error) {
+			// Start operation
+			resourceName := tracer.ResourceName(fmt.Sprintf("%s.%s", ctx.Value(goa.ServiceKey), ctx.Value(goa.MethodKey)))
+			span, ctx := tracer.StartSpanFromContext(ctx, "endpoint.request", resourceName)
+
+			// Finis operation and log internal error
+			defer func() {
+				// Is internal error?
+				if err != nil && errorHttpCode(err) > 499 {
+					span.Finish(tracer.WithError(err))
+					return
+				}
+
+				// No internal error
+				span.Finish()
+			}()
+
+			// Handle
+			response, err = endpoint(ctx, request)
+			return response, err
+		}
+	}
+}
+
 func ContextMiddleware(d dependencies.Container, h http.Handler) http.Handler {
 	return http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 		// Generate unique request ID
 		requestId := idgenerator.RequestId()
-		ctx := context.WithValue(d.Ctx(), middleware.RequestIDKey, requestId)
+		ctx := context.WithValue(r.Context(), middleware.RequestIDKey, requestId)
 		// Include request ID in all log messages
 		loggerPrefix := fmt.Sprintf("[requestId=%s]", requestId)
-		// Add dependencies to the context
-		ctx = context.WithValue(ctx, dependencies.CtxKey, d.WithLoggerPrefix(loggerPrefix))
 		// Add request ID to headers
 		w.Header().Add("X-Request-Id", requestId)
+		// Add request ID to DD span
+		if span, ok := tracer.SpanFromContext(ctx); ok {
+			span.SetTag(ext.ResourceName, r.URL.Path)
+			span.SetTag("http.request.id", requestId)
+			if host, err := d.StorageApiHost(); err != nil {
+				span.SetTag("storage.host", host)
+			}
+		}
+		// Add dependencies to the context
+		ctx = context.WithValue(ctx, dependencies.CtxKey, d.WithCtx(ctx).WithLoggerPrefix(loggerPrefix))
 		// Handle
 		h.ServeHTTP(w, r.WithContext(ctx))
 	})

--- a/cmd/templates-api/middleware.go
+++ b/cmd/templates-api/middleware.go
@@ -1,0 +1,65 @@
+package main
+
+import (
+	"context"
+	"fmt"
+	"net"
+	"net/http"
+	"time"
+
+	httpMiddleware "goa.design/goa/v3/http/middleware"
+	"goa.design/goa/v3/middleware"
+
+	"github.com/keboola/keboola-as-code/internal/pkg/idgenerator"
+	"github.com/keboola/keboola-as-code/internal/pkg/template/api/dependencies"
+)
+
+func ContextMiddleware(d dependencies.Container, h http.Handler) http.Handler {
+	return http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		// Generate unique request ID
+		requestId := idgenerator.RequestId()
+		ctx := context.WithValue(d.Ctx(), middleware.RequestIDKey, requestId)
+		// Include request ID in all log messages
+		loggerPrefix := fmt.Sprintf("[requestId=%s]", requestId)
+		// Add dependencies to the context
+		ctx = context.WithValue(ctx, dependencies.CtxKey, d.WithLoggerPrefix(loggerPrefix))
+		// Add request ID to headers
+		w.Header().Add("X-Request-Id", requestId)
+		// Handle
+		h.ServeHTTP(w, r.WithContext(ctx))
+	})
+}
+
+func LogMiddleware(h http.Handler) http.Handler {
+	return http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		started := time.Now()
+		logger := r.Context().Value(dependencies.CtxKey).(dependencies.Container).PrefixLogger()
+
+		// Log request
+		logger.
+			WithAdditionalPrefix("[request]").
+			Infof("%s %s %s", r.Method, r.URL.String(), from(r))
+
+		// Capture response
+		rw := httpMiddleware.CaptureResponse(w)
+		h.ServeHTTP(rw, r)
+
+		// Log response
+		logger.
+			WithAdditionalPrefix("[response]").
+			Infof("status=%d bytes=%d time=%s", rw.StatusCode, rw.ContentLength, time.Since(started).String())
+	})
+}
+
+// from computes the request client IP.
+func from(req *http.Request) string {
+	if f := req.Header.Get("X-Forwarded-For"); f != "" {
+		return f
+	}
+	f := req.RemoteAddr
+	ip, _, err := net.SplitHostPort(f)
+	if err != nil {
+		return f
+	}
+	return ip
+}

--- a/cmd/templates-api/muxer.go
+++ b/cmd/templates-api/muxer.go
@@ -1,0 +1,48 @@
+package main
+
+import (
+	"net/http"
+	"regexp"
+
+	"github.com/dimfeld/httptreemux/v5"
+	goaHTTP "goa.design/goa/v3/http"
+)
+
+type muxer struct {
+	*httptreemux.ContextMux
+}
+
+// newMuxer returns a Muxer implementation with custom 404 not found error handler.
+func newMuxer() goaHTTP.Muxer {
+	r := httptreemux.NewContextMux()
+
+	r.EscapeAddedRoutes = true
+	r.NotFoundHandler = func(w http.ResponseWriter, req *http.Request) {
+		_ = writeError(req.Context(), w, NotFoundError{})
+	}
+	r.PanicHandler = func(w http.ResponseWriter, req *http.Request, value interface{}) {
+		_ = writeError(req.Context(), w, PanicError{Value: value})
+	}
+	return &muxer{r}
+}
+
+// Handle maps the wildcard format used by goa to the one used by httptreemux.
+func (m *muxer) Handle(method, pattern string, handler http.HandlerFunc) {
+	m.ContextMux.Handle(method, treemuxify(pattern), handler)
+}
+
+// Vars extracts the path variables from the request context.
+func (m *muxer) Vars(r *http.Request) map[string]string {
+	return httptreemux.ContextParams(r.Context())
+}
+
+var (
+	wildSeg  = regexp.MustCompile(`/{([a-zA-Z0-9_]+)}`)
+	wildPath = regexp.MustCompile(`/{\*([a-zA-Z0-9_]+)}`)
+)
+
+func treemuxify(pattern string) string {
+	pattern = wildSeg.ReplaceAllString(pattern, "/:$1")
+	pattern = wildPath.ReplaceAllString(pattern, "/*$1")
+	return pattern
+}

--- a/go.mod
+++ b/go.mod
@@ -50,7 +50,6 @@ require (
 	github.com/DataDog/sketches-go v1.0.0 // indirect
 	github.com/Microsoft/go-winio v0.5.1 // indirect
 	github.com/cespare/xxhash/v2 v2.1.2 // indirect
-	github.com/davecgh/go-spew v1.1.1
 	github.com/dgraph-io/ristretto v0.1.0 // indirect
 	github.com/dimfeld/httppath v0.0.0-20170720192232-ee938bf73598 // indirect
 	github.com/dimfeld/httptreemux/v5 v5.4.0
@@ -100,3 +99,5 @@ require (
 	gopkg.in/yaml.v3 v3.0.0-20210107192922-496545a6307b // indirect
 	sigs.k8s.io/yaml v1.2.0 // indirect
 )
+
+require github.com/davecgh/go-spew v1.1.1 // indirect

--- a/go.mod
+++ b/go.mod
@@ -50,9 +50,10 @@ require (
 	github.com/DataDog/sketches-go v1.0.0 // indirect
 	github.com/Microsoft/go-winio v0.5.1 // indirect
 	github.com/cespare/xxhash/v2 v2.1.2 // indirect
+	github.com/davecgh/go-spew v1.1.1
 	github.com/dgraph-io/ristretto v0.1.0 // indirect
 	github.com/dimfeld/httppath v0.0.0-20170720192232-ee938bf73598 // indirect
-	github.com/dimfeld/httptreemux/v5 v5.4.0 // indirect
+	github.com/dimfeld/httptreemux/v5 v5.4.0
 	github.com/dustin/go-humanize v1.0.0 // indirect
 	github.com/fsnotify/fsnotify v1.4.9 // indirect
 	github.com/golang/glog v0.0.0-20160126235308-23def4e6c14b // indirect
@@ -60,6 +61,7 @@ require (
 	github.com/gorilla/websocket v1.5.0 // indirect
 	github.com/hashicorp/errwrap v1.0.0 // indirect
 	github.com/hashicorp/hcl v1.0.0 // indirect
+	github.com/iancoleman/strcase v0.2.0
 	github.com/inconshreveable/mousetrap v1.0.0 // indirect
 	github.com/josharian/intern v1.0.0 // indirect
 	github.com/kballard/go-shellquote v0.0.0-20180428030007-95032a82bc51 // indirect
@@ -98,5 +100,3 @@ require (
 	gopkg.in/yaml.v3 v3.0.0-20210107192922-496545a6307b // indirect
 	sigs.k8s.io/yaml v1.2.0 // indirect
 )
-
-require github.com/davecgh/go-spew v1.1.1 // indirect

--- a/go.sum
+++ b/go.sum
@@ -326,6 +326,8 @@ github.com/hinshun/vt10x v0.0.0-20180809195222-d55458df857c h1:kp3AxgXgDOmIJFR7b
 github.com/hinshun/vt10x v0.0.0-20180809195222-d55458df857c/go.mod h1:DqJ97dSdRW1W22yXSB90986pcOyQ7r45iio1KN2ez1A=
 github.com/hpcloud/tail v1.0.0/go.mod h1:ab1qPbhIpdTxEkNHXyeSf5vhxWSCs/tWer42PpOxQnU=
 github.com/hudl/fargo v1.4.0/go.mod h1:9Ai6uvFy5fQNq6VPKtg+Ceq1+eTY4nKUlR2JElEOcDo=
+github.com/iancoleman/strcase v0.2.0 h1:05I4QRnGpI0m37iZQRuskXh+w77mr6Z41lwQzuHLwW0=
+github.com/iancoleman/strcase v0.2.0/go.mod h1:iwCmte+B7n89clKwxIoIXy/HfoL7AsD47ZCWhYzw7ho=
 github.com/ianlancetaylor/demangle v0.0.0-20181102032728-5e5cf60278f6/go.mod h1:aSSvb/t6k1mPoxDqO4vJh6VOCGPwU4O0C2/Eqndh1Sc=
 github.com/ianlancetaylor/demangle v0.0.0-20200824232613-28f6c0f3b639/go.mod h1:aSSvb/t6k1mPoxDqO4vJh6VOCGPwU4O0C2/Eqndh1Sc=
 github.com/inconshreveable/mousetrap v1.0.0 h1:Z8tu5sraLXCXIcARxBp/8cbvlwVa7Z1NHg9XEKhtSvM=

--- a/internal/pkg/api/encryptionapi/api.go
+++ b/internal/pkg/api/encryptionapi/api.go
@@ -2,7 +2,6 @@ package encryptionapi
 
 import (
 	"context"
-	"fmt"
 
 	"github.com/go-resty/resty/v2"
 	"github.com/spf13/cast"
@@ -17,21 +16,6 @@ type Api struct {
 	projectId int
 	client    *client.Client
 	logger    log.Logger
-}
-
-// Error represents Encryption API error structure.
-type Error struct {
-	Message     string `json:"error"`
-	ErrCode     int    `json:"code"`
-	ExceptionId string `json:"exceptionId"`
-}
-
-func (e *Error) Error() string {
-	msg := fmt.Sprintf(`"%v", errCode: "%v"`, e.Message, e.ErrCode)
-	if len(e.ExceptionId) > 0 {
-		msg += fmt.Sprintf(`, exceptionId: "%s"`, e.ExceptionId)
-	}
-	return msg
 }
 
 func New(ctx context.Context, logger log.Logger, hostUrl string, projectId int, verbose bool) *Api {

--- a/internal/pkg/api/encryptionapi/error.go
+++ b/internal/pkg/api/encryptionapi/error.go
@@ -1,0 +1,38 @@
+package encryptionapi
+
+import (
+	"net/http"
+
+	"github.com/go-resty/resty/v2"
+)
+
+// Error represents Encryption API error structure.
+type Error struct {
+	Message     string `json:"error"`
+	ErrCode     int    `json:"code"`
+	ExceptionId string `json:"exceptionId"`
+	response    *resty.Response
+}
+
+func (e *Error) ErrorName() string {
+	return http.StatusText(e.ErrCode)
+}
+
+func (e *Error) ErrorUserMessage() string {
+	return e.Message
+}
+
+func (e *Error) ErrorExceptionId() string {
+	return e.ExceptionId
+}
+
+func (e *Error) SetResponse(response *resty.Response) {
+	e.response = response
+}
+
+func (e *Error) StatusCode() int {
+	if e.response == nil {
+		return 500
+	}
+	return e.response.StatusCode()
+}

--- a/internal/pkg/api/schedulerapi/api.go
+++ b/internal/pkg/api/schedulerapi/api.go
@@ -2,7 +2,6 @@ package schedulerapi
 
 import (
 	"context"
-	"fmt"
 	"net/http"
 	"time"
 
@@ -17,21 +16,6 @@ type Api struct {
 	hostUrl string
 	client  *client.Client
 	logger  log.Logger
-}
-
-// Error represents Scheduler API error structure.
-type Error struct {
-	Message     string `json:"error"`
-	ErrCode     int    `json:"code"`
-	ExceptionId string `json:"exceptionId"`
-}
-
-func (e *Error) Error() string {
-	msg := fmt.Sprintf(`"%v", errCode: "%v"`, e.Message, e.ErrCode)
-	if len(e.ExceptionId) > 0 {
-		msg += fmt.Sprintf(`, exceptionId: "%s"`, e.ExceptionId)
-	}
-	return msg
 }
 
 func New(ctx context.Context, logger log.Logger, hostUrl string, token string, verbose bool) *Api {

--- a/internal/pkg/api/schedulerapi/error.go
+++ b/internal/pkg/api/schedulerapi/error.go
@@ -1,0 +1,38 @@
+package schedulerapi
+
+import (
+	"net/http"
+
+	"github.com/go-resty/resty/v2"
+)
+
+// Error represents Scheduler API error structure.
+type Error struct {
+	Message     string `json:"error"`
+	ErrCode     int    `json:"code"`
+	ExceptionId string `json:"exceptionId"`
+	response    *resty.Response
+}
+
+func (e *Error) ErrorName() string {
+	return http.StatusText(e.ErrCode)
+}
+
+func (e *Error) ErrorUserMessage() string {
+	return e.Message
+}
+
+func (e *Error) ErrorExceptionId() string {
+	return e.ExceptionId
+}
+
+func (e *Error) SetResponse(response *resty.Response) {
+	e.response = response
+}
+
+func (e *Error) StatusCode() int {
+	if e.response == nil {
+		return 500
+	}
+	return e.response.StatusCode()
+}

--- a/internal/pkg/api/storageapi/api.go
+++ b/internal/pkg/api/storageapi/api.go
@@ -36,7 +36,7 @@ func NewWithToken(ctx context.Context, logger log.Logger, host, tokenStr string,
 	token, err := storageApi.GetToken(tokenStr)
 	if err != nil {
 		var errWithResponse client.ErrorWithResponse
-		if errors.As(err, &errWithResponse) && errWithResponse.IsUnauthorized() {
+		if errors.As(err, &errWithResponse) && errWithResponse.StatusCode() == http.StatusUnauthorized {
 			return nil, fmt.Errorf("the specified storage API token is not valid")
 		} else {
 			return nil, utils.PrefixError("token verification failed", err)

--- a/internal/pkg/api/storageapi/error.go
+++ b/internal/pkg/api/storageapi/error.go
@@ -8,11 +8,7 @@ import (
 
 type ErrorWithResponse interface {
 	SetResponse(response *resty.Response)
-	HttpStatus() int
-	IsBadRequest() bool
-	IsUnauthorized() bool
-	IsForbidden() bool
-	IsNotFound() bool
+	StatusCode() int
 }
 
 // Error represents Storage API error structure.
@@ -25,7 +21,7 @@ type Error struct {
 
 func (e *Error) Error() string {
 	req := e.response.Request
-	msg := fmt.Sprintf(`%s, method: "%s", url: "%s", httpCode: "%d"`, e.Message, req.Method, req.URL, e.HttpStatus())
+	msg := fmt.Sprintf(`%s, method: "%s", url: "%s", httpCode: "%d"`, e.Message, req.Method, req.URL, e.StatusCode())
 	if len(e.ErrCode) > 0 {
 		msg += fmt.Sprintf(`, errCode: "%s"`, e.ErrCode)
 	}
@@ -35,26 +31,25 @@ func (e *Error) Error() string {
 	return msg
 }
 
+func (e *Error) ErrorName() string {
+	return e.ErrCode
+}
+
+func (e *Error) ErrorUserMessage() string {
+	return e.Message
+}
+
+func (e *Error) ErrorExceptionId() string {
+	return e.ExceptionId
+}
+
 func (e *Error) SetResponse(response *resty.Response) {
 	e.response = response
 }
 
-func (e *Error) HttpStatus() int {
+func (e *Error) StatusCode() int {
+	if e.response == nil {
+		return 500
+	}
 	return e.response.StatusCode()
-}
-
-func (e *Error) IsBadRequest() bool {
-	return e.HttpStatus() == 400
-}
-
-func (e *Error) IsUnauthorized() bool {
-	return e.HttpStatus() == 401
-}
-
-func (e *Error) IsForbidden() bool {
-	return e.HttpStatus() == 403
-}
-
-func (e *Error) IsNotFound() bool {
-	return e.HttpStatus() == 404
 }

--- a/internal/pkg/api/storageapi/error_test.go
+++ b/internal/pkg/api/storageapi/error_test.go
@@ -24,43 +24,7 @@ func TestErrorHttpStatus(t *testing.T) {
 	t.Parallel()
 	e := &Error{}
 	e.SetResponse(newResponseWithStatusCode(123))
-	assert.Equal(t, 123, e.HttpStatus())
-}
-
-func TestErrorIsBadRequest(t *testing.T) {
-	t.Parallel()
-	e := &Error{}
-	e.SetResponse(newResponseWithStatusCode(123))
-	assert.False(t, e.IsBadRequest())
-	e.SetResponse(newResponseWithStatusCode(400))
-	assert.True(t, e.IsBadRequest())
-}
-
-func TestErrorIsUnauthorized(t *testing.T) {
-	t.Parallel()
-	e := &Error{}
-	e.SetResponse(newResponseWithStatusCode(123))
-	assert.False(t, e.IsUnauthorized())
-	e.SetResponse(newResponseWithStatusCode(401))
-	assert.True(t, e.IsUnauthorized())
-}
-
-func TestErrorIsForbidden(t *testing.T) {
-	t.Parallel()
-	e := &Error{}
-	e.SetResponse(newResponseWithStatusCode(123))
-	assert.False(t, e.IsForbidden())
-	e.SetResponse(newResponseWithStatusCode(403))
-	assert.True(t, e.IsForbidden())
-}
-
-func TestErrorIsNotFound(t *testing.T) {
-	t.Parallel()
-	e := &Error{}
-	e.SetResponse(newResponseWithStatusCode(123))
-	assert.False(t, e.IsNotFound())
-	e.SetResponse(newResponseWithStatusCode(404))
-	assert.True(t, e.IsNotFound())
+	assert.Equal(t, 123, e.StatusCode())
 }
 
 func newResponseWithStatusCode(code int) *resty.Response {

--- a/internal/pkg/api/storageapi/token_test.go
+++ b/internal/pkg/api/storageapi/token_test.go
@@ -53,7 +53,7 @@ func TestGetTokenEmpty(t *testing.T) {
 	apiErr := err.(*Error)
 	assert.Equal(t, "Access token must be set", apiErr.Message)
 	assert.Equal(t, "", apiErr.ErrCode)
-	assert.Equal(t, 401, apiErr.HttpStatus())
+	assert.Equal(t, 401, apiErr.StatusCode())
 	assert.Empty(t, token)
 }
 
@@ -69,6 +69,6 @@ func TestGetTokenInvalid(t *testing.T) {
 	apiErr := err.(*Error)
 	assert.Equal(t, "Invalid access token", apiErr.Message)
 	assert.Equal(t, "storage.tokenInvalid", apiErr.ErrCode)
-	assert.Equal(t, 401, apiErr.HttpStatus())
+	assert.Equal(t, 401, apiErr.StatusCode())
 	assert.Empty(t, token)
 }

--- a/internal/pkg/dependencies/common.go
+++ b/internal/pkg/dependencies/common.go
@@ -25,6 +25,7 @@ import (
 
 // Abstract provides dependencies which are obtained in different in CLI and templates API.
 type Abstract interface {
+	Ctx() context.Context
 	Logger() log.Logger
 	Envs() *env.Map
 	ApiVerboseLogs() bool
@@ -35,7 +36,6 @@ type Abstract interface {
 // Common provides common dependencies for CLI and templates API.
 type Common interface {
 	Abstract
-	Ctx() context.Context
 	Components() (*model.ComponentsMap, error)
 	StorageApi() (*storageapi.Api, error)
 	EncryptionApi() (*encryptionapi.Api, error)
@@ -46,22 +46,17 @@ type Common interface {
 }
 
 // NewCommonContainer returns dependencies container for production.
-func NewCommonContainer(d Abstract, ctx context.Context) Common {
-	return &commonContainer{Abstract: d, ctx: ctx}
+func NewCommonContainer(d Abstract) Common {
+	return &commonContainer{Abstract: d}
 }
 
 type commonContainer struct {
 	Abstract
-	ctx           context.Context
 	serviceUrls   map[storageapi.ServiceId]storageapi.ServiceUrl
 	storageApi    *storageapi.Api
 	encryptionApi *encryptionapi.Api
 	schedulerApi  *schedulerapi.Api
 	eventSender   *eventsender.Sender
-}
-
-func (v *commonContainer) Ctx() context.Context {
-	return v.ctx
 }
 
 func (v *commonContainer) Components() (*model.ComponentsMap, error) {

--- a/internal/pkg/dependencies/test.go
+++ b/internal/pkg/dependencies/test.go
@@ -29,6 +29,7 @@ import (
 
 type TestContainer struct {
 	*commonContainer
+	ctx                         context.Context
 	logger                      log.DebugLogger
 	envs                        *env.Map
 	fs                          filesystem.Fs
@@ -46,8 +47,8 @@ type TestContainer struct {
 }
 
 func NewTestContainer() *TestContainer {
-	c := &TestContainer{}
-	c.commonContainer = NewCommonContainer(c, context.Background()).(*commonContainer)
+	c := &TestContainer{ctx: context.Background()}
+	c.commonContainer = NewCommonContainer(c).(*commonContainer)
 	c.logger = log.NewDebugLogger()
 	c.envs = env.Empty()
 	c.fs = testfs.NewMemoryFsWithLogger(c.logger)
@@ -66,6 +67,10 @@ func (v *TestContainer) InitFromTestProject(project *testproject.Project) {
 	v.SetStorageApi(storageApi)
 	v.SetSchedulerApi(project.SchedulerApi())
 	v.SetEncryptionApi(project.EncryptionApi())
+}
+
+func (v *TestContainer) Ctx() context.Context {
+	return v.ctx
 }
 
 func (v *TestContainer) Logger() log.Logger {

--- a/internal/pkg/http/client/error.go
+++ b/internal/pkg/http/client/error.go
@@ -4,9 +4,5 @@ import "github.com/go-resty/resty/v2"
 
 type ErrorWithResponse interface {
 	SetResponse(response *resty.Response)
-	HttpStatus() int
-	IsBadRequest() bool
-	IsUnauthorized() bool
-	IsForbidden() bool
-	IsNotFound() bool
+	StatusCode() int
 }

--- a/internal/pkg/http/client/pool_test.go
+++ b/internal/pkg/http/client/pool_test.go
@@ -221,9 +221,11 @@ func TestErrorInSubRequest_ParallelRequests(t *testing.T) {
 
 	// Register callbacks
 	request1.OnResponse(func(response *Response) {
+		time.Sleep(1 * time.Millisecond)
 		logger.Info("Request1 processed.")
 	})
 	request2.OnResponse(func(response *Response) {
+		time.Sleep(1 * time.Millisecond)
 		logger.Info("Request2 processed.")
 	})
 

--- a/internal/pkg/idgenerator/idgenerator.go
+++ b/internal/pkg/idgenerator/idgenerator.go
@@ -1,0 +1,20 @@
+// nolint: gochecknoglobals
+package idgenerator
+
+import gonanoid "github.com/matoous/go-nanoid/v2"
+
+const (
+	RequestIdLength          = 15
+	TemplateInstanceIdLength = 25
+)
+
+// alphabet used in ID generation.
+var alphabet = "0123456789abcdefghijklmnopqrstuvwxyzABCDEFGHIJKLMNOPQRSTUVWXYZ"
+
+func RequestId() string {
+	return gonanoid.MustGenerate(alphabet, RequestIdLength)
+}
+
+func TemplateInstanceId() string {
+	return gonanoid.MustGenerate(alphabet, TemplateInstanceIdLength)
+}

--- a/internal/pkg/idgenerator/idgenerator_test.go
+++ b/internal/pkg/idgenerator/idgenerator_test.go
@@ -1,0 +1,19 @@
+package idgenerator_test
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+
+	. "github.com/keboola/keboola-as-code/internal/pkg/idgenerator"
+)
+
+func TestRequestId(t *testing.T) {
+	t.Parallel()
+	assert.Len(t, RequestId(), RequestIdLength)
+}
+
+func TestTemplateInstanceId(t *testing.T) {
+	t.Parallel()
+	assert.Len(t, TemplateInstanceId(), TemplateInstanceIdLength)
+}

--- a/internal/pkg/log/api.go
+++ b/internal/pkg/log/api.go
@@ -23,6 +23,11 @@ func (l *apiLogger) WithPrefix(prefix string) PrefixLogger {
 	return NewApiLogger(l.base, prefix, l.verbose)
 }
 
+// WithAdditionalPrefix returns a new logger with the added prefix.
+func (l *apiLogger) WithAdditionalPrefix(prefix string) PrefixLogger {
+	return NewApiLogger(l.base, l.prefix+prefix, l.verbose)
+}
+
 // NewApiLogger new production zapLogger for API.
 func NewApiLogger(base *stdLog.Logger, prefix string, verbose bool) PrefixLogger {
 	var cores []zapcore.Core

--- a/internal/pkg/log/log.go
+++ b/internal/pkg/log/log.go
@@ -23,6 +23,7 @@ type PrefixLogger interface {
 	Logger
 	Prefix() string
 	WithPrefix(prefix string) PrefixLogger
+	WithAdditionalPrefix(prefix string) PrefixLogger
 }
 
 type loggerWithZapCore interface {

--- a/internal/pkg/template/api/dependencies/dependencies.go
+++ b/internal/pkg/template/api/dependencies/dependencies.go
@@ -18,8 +18,9 @@ const CtxKey = ctxKey("dependencies")
 type Container interface {
 	dependencies.Common
 	CtxCancelFn() context.CancelFunc
+	PrefixLogger() log.PrefixLogger
 	LoggerPrefix() string
-	WithLoggerPrefix(prefix string) (*container, error)
+	WithLoggerPrefix(prefix string) *container
 	WithStorageApi(api *storageapi.Api) (*container, error)
 }
 
@@ -51,10 +52,10 @@ func (v *container) LoggerPrefix() string {
 }
 
 // WithLoggerPrefix returns dependencies clone with modified logger.
-func (v *container) WithLoggerPrefix(prefix string) (*container, error) {
+func (v *container) WithLoggerPrefix(prefix string) *container {
 	clone := *v
 	clone.logger = v.logger.WithPrefix(prefix)
-	return &clone, nil
+	return &clone
 }
 
 // WithStorageApi returns dependencies clone with modified Storage API.
@@ -65,6 +66,10 @@ func (v *container) WithStorageApi(api *storageapi.Api) (*container, error) {
 }
 
 func (v *container) Logger() log.Logger {
+	return v.logger
+}
+
+func (v *container) PrefixLogger() log.PrefixLogger {
 	return v.logger
 }
 

--- a/internal/pkg/template/api/dependencies/dependencies.go
+++ b/internal/pkg/template/api/dependencies/dependencies.go
@@ -8,6 +8,7 @@ import (
 	"github.com/keboola/keboola-as-code/internal/pkg/dependencies"
 	"github.com/keboola/keboola-as-code/internal/pkg/env"
 	"github.com/keboola/keboola-as-code/internal/pkg/log"
+	"github.com/keboola/keboola-as-code/internal/pkg/utils/strhelper"
 )
 
 type ctxKey string
@@ -17,7 +18,9 @@ const CtxKey = ctxKey("dependencies")
 // Container provides dependencies used only in the API + common dependencies.
 type Container interface {
 	dependencies.Common
+	Ctx() context.Context
 	CtxCancelFn() context.CancelFunc
+	WithCtx(ctx context.Context) Container
 	PrefixLogger() log.PrefixLogger
 	LoggerPrefix() string
 	WithLoggerPrefix(prefix string) *container
@@ -27,8 +30,8 @@ type Container interface {
 // NewContainer returns dependencies for API and add them to the context.
 func NewContainer(ctx context.Context, debug bool, logger *stdLog.Logger, envs *env.Map) Container {
 	ctx, cancel := context.WithCancel(ctx)
-	c := &container{ctxCancelFn: cancel, debug: debug, envs: envs, logger: log.NewApiLogger(logger, "", debug)}
-	c.commonDeps = dependencies.NewCommonContainer(c, ctx)
+	c := &container{ctx: ctx, ctxCancelFn: cancel, debug: debug, envs: envs, logger: log.NewApiLogger(logger, "", debug)}
+	c.commonDeps = dependencies.NewCommonContainer(c)
 	return c
 }
 
@@ -36,6 +39,7 @@ type commonDeps = dependencies.Common
 
 type container struct {
 	commonDeps
+	ctx         context.Context
 	ctxCancelFn context.CancelFunc
 	debug       bool
 	logger      log.PrefixLogger
@@ -43,8 +47,18 @@ type container struct {
 	storageApi  *storageapi.Api
 }
 
+func (v *container) Ctx() context.Context {
+	return v.ctx
+}
+
 func (v *container) CtxCancelFn() context.CancelFunc {
 	return v.ctxCancelFn
+}
+
+func (v *container) WithCtx(ctx context.Context) Container {
+	clone := *v
+	clone.ctx = ctx
+	return &clone
 }
 
 func (v *container) LoggerPrefix() string {
@@ -95,7 +109,7 @@ func (v *container) StorageApi() (*storageapi.Api, error) {
 }
 
 func (v *container) StorageApiHost() (string, error) {
-	return v.envs.MustGet("KBC_STORAGE_API_HOST"), nil
+	return strhelper.NormalizeHost(v.envs.MustGet("KBC_STORAGE_API_HOST")), nil
 }
 
 func (v *container) StorageApiToken() (string, error) {

--- a/internal/pkg/template/api/service/auth.go
+++ b/internal/pkg/template/api/service/auth.go
@@ -5,6 +5,7 @@ import (
 	"fmt"
 
 	"goa.design/goa/v3/security"
+	"gopkg.in/DataDog/dd-trace-go.v1/ddtrace/tracer"
 
 	"github.com/keboola/keboola-as-code/internal/pkg/template/api/dependencies"
 )
@@ -31,6 +32,12 @@ func (s *service) APIKeyAuth(ctx context.Context, tokenStr string, scheme *secur
 
 		// Modify logger
 		d = d.WithLoggerPrefix(fmt.Sprintf("[project=%d][token=%s]", token.ProjectId(), token.Id))
+
+		// Add tags to DD span
+		if span, ok := tracer.SpanFromContext(ctx); ok {
+			span.SetTag("storage.project.id", token.ProjectId())
+			span.SetTag("storage.token.id", token.Id)
+		}
 
 		// Update context
 		return context.WithValue(ctx, dependencies.CtxKey, d), nil

--- a/internal/pkg/template/api/service/auth.go
+++ b/internal/pkg/template/api/service/auth.go
@@ -30,10 +30,7 @@ func (s *service) APIKeyAuth(ctx context.Context, tokenStr string, scheme *secur
 		}
 
 		// Modify logger
-		d, err = d.WithLoggerPrefix(fmt.Sprintf("[project=%d][token=%s]", token.ProjectId(), token.Id))
-		if err != nil {
-			return nil, err
-		}
+		d = d.WithLoggerPrefix(fmt.Sprintf("[project=%d][token=%s]", token.ProjectId(), token.Id))
 
 		// Update context
 		return context.WithValue(ctx, dependencies.CtxKey, d), nil

--- a/internal/pkg/template/api/service/error.go
+++ b/internal/pkg/template/api/service/error.go
@@ -1,0 +1,15 @@
+package service
+
+type NotImplementedError struct{}
+
+func (NotImplementedError) ErrorName() string {
+	return "notImplemented"
+}
+
+func (NotImplementedError) Error() string {
+	return "operation not implemented"
+}
+
+func (NotImplementedError) ErrorUserMessage() string {
+	return "Operation not implemented."
+}

--- a/internal/pkg/template/api/service/service.go
+++ b/internal/pkg/template/api/service/service.go
@@ -1,7 +1,6 @@
 package service
 
 import (
-	"fmt"
 	"sync"
 	"time"
 
@@ -79,61 +78,61 @@ func (s *service) HealthCheck(dependencies.Container) (res string, err error) {
 }
 
 func (s *service) RepositoriesIndex(dependencies.Container, *RepositoriesIndexPayload) (res *Repositories, err error) {
-	return nil, fmt.Errorf("not implemented")
+	return nil, NotImplementedError{}
 }
 
 func (s *service) RepositoryIndex(dependencies.Container, *RepositoryIndexPayload) (res *Repository, err error) {
-	return nil, fmt.Errorf("not implemented")
+	return nil, NotImplementedError{}
 }
 
 func (s *service) TemplatesIndex(dependencies.Container, *TemplatesIndexPayload) (res *Templates, err error) {
-	return nil, fmt.Errorf("not implemented")
+	return nil, NotImplementedError{}
 }
 
 func (s *service) TemplateIndex(dependencies.Container, *TemplateIndexPayload) (res *TemplateDetail, err error) {
-	return nil, fmt.Errorf("not implemented")
+	return nil, NotImplementedError{}
 }
 
 func (s *service) VersionIndex(dependencies.Container, *VersionIndexPayload) (res *TemplateVersionDetail, err error) {
-	return nil, fmt.Errorf("not implemented")
+	return nil, NotImplementedError{}
 }
 
 func (s *service) Inputs(dependencies.Container, *InputsPayload) (res *InputsIndex, err error) {
-	return nil, fmt.Errorf("not implemented")
+	return nil, NotImplementedError{}
 }
 
 func (s *service) InputsValidate(dependencies.Container, *InputsValidatePayload) (res *ValidationDetail, err error) {
-	return nil, fmt.Errorf("not implemented")
+	return nil, NotImplementedError{}
 }
 
 func (s *service) VersionUse(dependencies.Container, *VersionUsePayload) (res *UseTemplateDetail, err error) {
-	return nil, fmt.Errorf("not implemented")
+	return nil, NotImplementedError{}
 }
 
 func (s *service) InstancesIndex(dependencies.Container, *InstancesIndexPayload) (err error) {
-	return fmt.Errorf("not implemented")
+	return NotImplementedError{}
 }
 
 func (s *service) InstanceIndex(dependencies.Container, *InstanceIndexPayload) (err error) {
-	return fmt.Errorf("not implemented")
+	return NotImplementedError{}
 }
 
 func (s *service) InstanceUpdate(dependencies.Container, *InstanceUpdatePayload) (err error) {
-	return fmt.Errorf("not implemented")
+	return NotImplementedError{}
 }
 
 func (s *service) InstanceDelete(dependencies.Container, *InstanceDeletePayload) (err error) {
-	return fmt.Errorf("not implemented")
+	return NotImplementedError{}
 }
 
 func (s *service) Upgrade(dependencies.Container, *UpgradePayload) (err error) {
-	return fmt.Errorf("not implemented")
+	return NotImplementedError{}
 }
 
 func (s *service) UpgradeInputs(dependencies.Container, *UpgradeInputsPayload) (err error) {
-	return fmt.Errorf("not implemented")
+	return NotImplementedError{}
 }
 
 func (s *service) UpgradeInputsValidate(dependencies.Container, *UpgradeInputsValidatePayload) (err error) {
-	return fmt.Errorf("not implemented")
+	return NotImplementedError{}
 }

--- a/pkg/lib/operation/project/local/template/use/operation.go
+++ b/pkg/lib/operation/project/local/template/use/operation.go
@@ -5,11 +5,10 @@ import (
 	"fmt"
 	"sort"
 
-	gonanoid "github.com/matoous/go-nanoid/v2"
-
 	"github.com/keboola/keboola-as-code/internal/pkg/api/encryptionapi"
 	"github.com/keboola/keboola-as-code/internal/pkg/api/storageapi"
 	"github.com/keboola/keboola-as-code/internal/pkg/diff"
+	"github.com/keboola/keboola-as-code/internal/pkg/idgenerator"
 	"github.com/keboola/keboola-as-code/internal/pkg/log"
 	"github.com/keboola/keboola-as-code/internal/pkg/model"
 	"github.com/keboola/keboola-as-code/internal/pkg/project"
@@ -70,7 +69,7 @@ func Run(projectState *project.State, tmpl *template.Template, o Options, d depe
 	tickets := storageApi.NewTicketProvider()
 
 	// Generate ID for the template instance
-	instanceId := gonanoid.Must()
+	instanceId := idgenerator.TemplateInstanceId()
 
 	// Load template
 	ctx := template.NewUseContext(d.Ctx(), tmpl.Reference(), instanceId, o.TargetBranch, o.Inputs, tickets)

--- a/provisioning/kubernetes/templates/config-map.yaml
+++ b/provisioning/kubernetes/templates/config-map.yaml
@@ -5,6 +5,6 @@ metadata:
   name: templates-api
   namespace: default
 data:
-  storageApiUrl: "https://connection.$HOSTNAME_SUFFIX"
+  storageApiHost: "connection.$HOSTNAME_SUFFIX"
   keboolaStack: "$KEBOOLA_STACK"
   keboolaRevision: "$RELEASE_ID"

--- a/provisioning/kubernetes/templates/templates-api.yaml
+++ b/provisioning/kubernetes/templates/templates-api.yaml
@@ -40,7 +40,7 @@ spec:
               valueFrom:
                 configMapKeyRef:
                   name: templates-api
-                  key: storageApiUrl
+                  key: storageApiHost
             - name: DD_AGENT_HOST
               valueFrom:
                 fieldRef:


### PR DESCRIPTION
Jira: https://keboola.atlassian.net/browse/KAC-72

### 1. request ID

Kazdy request dostane na zaciatku requestId, to je potom sucastou vsetkych logov + posiela sa klientovi ako header `x-request-id`, takze aj ked request prejde, ale nieco sa nam nezda, tak to najdeme v logoch (napr. `pull plan` pri aplikovani sablony).

![image](https://user-images.githubusercontent.com/19371734/162243935-2df37306-9dc9-4f4b-aeb9-b5e2712105be.png)

### 2. internal server error

Klientovy sa vrati `500` s generickym textom, panic sa zaloguje aj so stack trace.

![image](https://user-images.githubusercontent.com/19371734/162243558-af350cec-40fe-4be6-bbde-75d9e78db962.png)

### 3. not found error (http error)

`404`, tu si mozes vsimnut, ze `exceptionId` generujeme pri kazdej chybe, a vyhadza z `requestId`.
Tato chyba je zalogovana ako `INFO`, iba interne chyby `>499` logujeme ako `ERROR`.

![image](https://user-images.githubusercontent.com/19371734/162243632-dc7cc6da-08c1-454b-a015-c743078a6408.png)

### 4. bad request (goa `ServiceError`)

![image](https://user-images.githubusercontent.com/19371734/162243688-63e0ed52-dbc2-4181-8c18-9a387327c3f7.png)

### 5. Custom `500` error - not  implemented

![image](https://user-images.githubusercontent.com/19371734/162243747-16d5266c-e78c-46ac-8cc6-30853e5c6d80.png)

### 6. Not Authorized from Storage API

Ak nastane chyba v Storage API, tak sa pouzije HTTP code a exceptionId zo Storage API, takze sa to da dohladat v celej platforme. Rovnako to funguje aj pre Encryption Api a Scheduler Api.

A tu mozes aj vidiet, ze vyzdy posielame `x-request-id`.

![image](https://user-images.githubusercontent.com/19371734/162243812-bde4587d-b490-4de7-ad27-57ca29d9d079.png)

### 7. DataDog

- Request ID sa posiela rovna aj do DataDog 
- Pri HTTP requeste sa vypise uz spravny nazov - URL
- Do DD sa posielaju aj neocakavane chyby spolu so stack trace.

![image](https://user-images.githubusercontent.com/19371734/162376319-b65cc515-6cef-4955-b7f7-b77b477f61c9.png)

![image](https://user-images.githubusercontent.com/19371734/162376340-d5bb816d-9812-4586-b282-66e37568f3c4.png)
