### PR TITLE
Convert openapi operationId to work with UI API generator

### DIFF
--- a/api/templates/design.go
+++ b/api/templates/design.go
@@ -9,6 +9,7 @@ import (
 	cors "goa.design/plugins/v3/cors/dsl"
 
 	_ "github.com/keboola/keboola-as-code/internal/pkg/api/server/templates/extension/dependencies"
+	_ "github.com/keboola/keboola-as-code/internal/pkg/api/server/templates/extension/operationid"
 	. "github.com/keboola/keboola-as-code/internal/pkg/api/server/templates/extension/token"
 )
 

--- a/internal/pkg/api/server/templates/extension/dependencies/dependencies.go
+++ b/internal/pkg/api/server/templates/extension/dependencies/dependencies.go
@@ -1,3 +1,4 @@
+// Package dependencies contains extension to inject dependencies to the service endpoint handlers.
 package dependencies
 
 import (
@@ -12,10 +13,10 @@ const PkgPath = "github.com/keboola/keboola-as-code/internal/pkg/api/server/temp
 
 // nolint: gochecknoinits
 func init() {
-	codegen.RegisterPluginFirst("api-dependencies", "gen", nil, Generate)
+	codegen.RegisterPluginFirst("api-dependencies", "gen", nil, generate)
 }
 
-func Generate(_ string, roots []eval.Root, files []*codegen.File) ([]*codegen.File, error) {
+func generate(_ string, roots []eval.Root, files []*codegen.File) ([]*codegen.File, error) {
 	for _, f := range files {
 		// nolint: forbidigo
 		switch filepath.Base(f.Path) {

--- a/internal/pkg/api/server/templates/extension/operationid/operationid.go
+++ b/internal/pkg/api/server/templates/extension/operationid/operationid.go
@@ -1,0 +1,74 @@
+// Package operationid contains extension to modify the "operationId" format to work with the UI API generator.
+// For example, "templates#instance-delete" is mapped to "InstanceDelete".
+package operationid
+
+import (
+	"strings"
+
+	"github.com/iancoleman/strcase"
+	"goa.design/goa/v3/codegen"
+	"goa.design/goa/v3/eval"
+	openapiv2 "goa.design/goa/v3/http/codegen/openapi/v2"
+	openapiv3 "goa.design/goa/v3/http/codegen/openapi/v3"
+)
+
+// nolint: gochecknoinits
+func init() {
+	codegen.RegisterPluginLast("operation-id", "gen", nil, generate)
+}
+
+func generate(_ string, _ []eval.Root, files []*codegen.File) ([]*codegen.File, error) {
+	for _, f := range files {
+		// Modify OpenApi2 files
+		for _, s := range f.Section("openapi") {
+			if source, ok := s.Data.(*openapiv2.V2); ok {
+				modifyOpenApiV2(source)
+			}
+		}
+		// Modify OpenApi3 files
+		for _, s := range f.Section("openapi_v3") {
+			if source, ok := s.Data.(*openapiv3.OpenAPI); ok {
+				modifyOpenApiV3(source)
+			}
+		}
+	}
+	return files, nil
+}
+
+func modifyOpenApiV2(data *openapiv2.V2) {
+	for _, path := range data.Paths {
+		if path, ok := path.(*openapiv2.Path); ok {
+			operations := []*openapiv2.Operation{path.Get, path.Put, path.Post, path.Delete, path.Options, path.Head, path.Patch}
+			for _, operation := range operations {
+				if operation != nil {
+					operation.OperationID = mapOperationId(operation.OperationID)
+				}
+			}
+		}
+	}
+}
+
+func modifyOpenApiV3(data *openapiv3.OpenAPI) {
+	for _, path := range data.Paths {
+		operations := []*openapiv3.Operation{path.Get, path.Put, path.Post, path.Delete, path.Options, path.Head, path.Patch}
+		for _, operation := range operations {
+			if operation != nil {
+				operation.OperationID = mapOperationId(operation.OperationID)
+			}
+		}
+	}
+}
+
+// mapOperationId for example, "templates#instance-delete" is mapped to "InstanceDelete".
+func mapOperationId(v string) string {
+	// Endpoint is string part after # delimiter
+	endpointName := v[strings.LastIndex(v, "#")+1:]
+
+	// If endpoint is a file, then use file name
+	if strings.Contains(endpointName, "/") {
+		endpointName = endpointName[strings.LastIndex(endpointName, "/")+1:]
+	}
+
+	// Convert to CamelCase
+	return strcase.ToCamel(endpointName)
+}

--- a/internal/pkg/api/server/templates/extension/operationid/operationid_test.go
+++ b/internal/pkg/api/server/templates/extension/operationid/operationid_test.go
@@ -1,0 +1,15 @@
+package operationid
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+)
+
+func TestMapOperationId(t *testing.T) {
+	t.Parallel()
+	assert.Equal(t, "FooBarBazXyzAbc", mapOperationId("templates#foo-bar_BazXyz-Abc"))
+	assert.Equal(t, "FooBarBazXyzAbc", mapOperationId("foo-bar_BazXyz-Abc"))
+	assert.Equal(t, "Openapi3Json", mapOperationId("templates#/v1/documentation/openapi3.json"))
+	assert.Equal(t, "Openapi3Json", mapOperationId("/v1/documentation/openapi3.json"))
+}

--- a/internal/pkg/api/server/templates/extension/token/token.go
+++ b/internal/pkg/api/server/templates/extension/token/token.go
@@ -1,4 +1,4 @@
-// Package extension contains extension for Goa API generator.
+// Package token contains extension to simplify setup of the Storage API Token security.
 package token
 
 import (
@@ -15,7 +15,7 @@ import (
 
 // nolint: gochecknoinits
 func init() {
-	codegen.RegisterPluginFirst("storage-api-token", "gen", nil, Generate)
+	codegen.RegisterPluginFirst("storage-api-token", "gen", nil, generate)
 }
 
 const (
@@ -117,7 +117,7 @@ func AddTokenHeaderToPayloads(tokenScheme *expr.SchemeExpr, field, header string
 	}
 }
 
-func Generate(_ string, roots []eval.Root, files []*codegen.File) ([]*codegen.File, error) {
+func generate(_ string, roots []eval.Root, files []*codegen.File) ([]*codegen.File, error) {
 	for _, f := range files {
 		// Modify OpenApi2 files
 		for _, s := range f.Section("openapi") {


### PR DESCRIPTION
Slack: https://keboola.slack.com/archives/CMTBFNLF8/p1649415549563649

Team UI nahlasil, ze im nevyhovuje openapi operationId, ktore generujeme, napr. `templates#instance-delete` ale namiesto toho potrebuju `InstanceDelete`, tak som upravil defaltne spravanie Goa lib.