### PR TITLE
Add support for link to the previous phase by "<previous>" keyword

### DIFF
--- a/test/cli/template-use/complex/in/repository/my-template/v1/src/other/keboola.orchestrator/orchestrator/phases/001-phase-1/phase.jsonnet
+++ b/test/cli/template-use/complex/in/repository/my-template/v1/src/other/keboola.orchestrator/orchestrator/phases/001-phase-1/phase.jsonnet
@@ -1,4 +1,6 @@
 {
   name: "Phase 1",
-  dependsOn: [],
+  dependsOn: [
+    "<previous>",
+  ],
 }

--- a/test/cli/template-use/complex/in/repository/my-template/v1/src/other/keboola.orchestrator/orchestrator/phases/002-phase-2/phase.jsonnet
+++ b/test/cli/template-use/complex/in/repository/my-template/v1/src/other/keboola.orchestrator/orchestrator/phases/002-phase-2/phase.jsonnet
@@ -1,6 +1,6 @@
 {
   name: "Phase 2",
   dependsOn: [
-    "001-phase-1",
+    "<previous>",
   ],
 }

--- a/test/cli/template-use/complex/out/repository/my-template/v1/src/other/keboola.orchestrator/orchestrator/phases/001-phase-1/phase.jsonnet
+++ b/test/cli/template-use/complex/out/repository/my-template/v1/src/other/keboola.orchestrator/orchestrator/phases/001-phase-1/phase.jsonnet
@@ -1,4 +1,6 @@
 {
   name: "Phase 1",
-  dependsOn: [],
+  dependsOn: [
+    "<previous>",
+  ],
 }

--- a/test/cli/template-use/complex/out/repository/my-template/v1/src/other/keboola.orchestrator/orchestrator/phases/002-phase-2/phase.jsonnet
+++ b/test/cli/template-use/complex/out/repository/my-template/v1/src/other/keboola.orchestrator/orchestrator/phases/002-phase-2/phase.jsonnet
@@ -1,6 +1,6 @@
 {
   name: "Phase 2",
   dependsOn: [
-    "001-phase-1",
+    "<previous>",
   ],
 }


### PR DESCRIPTION
Slack: https://keboolaglobal.slack.com/archives/CHPE0FPU5/p1651741732456299

Minule sme pridali podporu pre `conditional phases`, pomocou `kbcdir.jsonnet`.

Takto nejak vyzeraju `phases`, niektore z nich su `conditional`.
![image](https://user-images.githubusercontent.com/19371734/166896738-b9e63458-6daa-4b8d-9dde-06fcc9b3725f.png)

-------------------------------------------

Takto vyzera definicia `phase.jsonnet`:
```
{
  name: "Transformation",
  dependsOn: [
    "001-extraction", // <<<<<<<<<<<<<<<<<<
  ],
}
```

-----------------------------

No a tu nastava problem, ze ako napojit `dependsOn`, kedze nevies, ktora `phase` je predchadzahjuca, kedze pri niektorych bude vysledkom podmienky `false`, a ako keby neexistovali.

Preto sme s Monikou vymysleli, ze pridame nove klucove slovo `<previous>`, ktore tento problem riesi.
```
{
  name: "Transformation",
  dependsOn: [
    "<previous>",  // <<<<<<<<<<<<<<<<<<
  ],
}
```

Potom staci mat `phases` spravne zoradene v adresary, vid prvy obrazok.