### PR TITLE
Update to Go 1.18

### DIFF
--- a/.github/workflows/push.yml
+++ b/.github/workflows/push.yml
@@ -1,7 +1,7 @@
 name: GitHub Actions
 on: [ push ]
 env:
-  GO_VERSION: 1.17
+  GO_VERSION: 1.18
 
   # DockerHub login
   DOCKERHUB_USER: "keboolabot"

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM golang:1.17
+FROM golang:1.18
 
 ENV HOME=/my-home
 ENV GOCACHE=/tmp/cache/go

--- a/Dockerfile-api
+++ b/Dockerfile-api
@@ -1,5 +1,5 @@
 # Build container
-FROM golang:1.17 AS buildContainer
+FROM golang:1.18 AS buildContainer
 WORKDIR /app
 COPY . .
 #flags: -s -w to remove symbol table and debug info

--- a/build/ci/golangci.yml
+++ b/build/ci/golangci.yml
@@ -16,7 +16,11 @@ linters-settings:
       - github.com/keboola/keboola-as-code/*
   # Gci - improved version of goimports
   gci:
-    local-prefixes: github.com/keboola/keboola-as-code
+    sections:
+      - standard # Captures all standard packages if they do not match another section.
+      - default # Contains all imports that could not be matched to another section type.
+      - prefix(github.com/keboola/keboola-as-code)
+
   gocyclo:
     # minimal code complexity to report, 30 by default (but we recommend 10-20)
     min-complexity: 10

--- a/build/ci/golangci.yml
+++ b/build/ci/golangci.yml
@@ -44,9 +44,12 @@ linters-settings:
 
 # https://golangci-lint.run/usage/linters
 linters:
+  disable-all: true
+  # Some linters are not compatible with go 1.18, so they are temporary disabled.
+  # See https://github.com/golangci/golangci-lint/issues/2649
   enable:
     - asciicheck
-    - bodyclose
+    #- bodyclose # Not compatible with go 1.18, temporary disable
     - deadcode
     - depguard
     - dogsled
@@ -61,53 +64,53 @@ linters:
     - gochecknoglobals
     - gochecknoinits
     - goconst
-    - gocritic
+    #- gocritic # Not compatible with go 1.18, temporary disable
     - godot
     - godox
-    - gofumpt
+    #- gofumpt
     - goheader
     - gomodguard
     - goprintffuncname
     - gosec
     - gosimple
-    - govet
+    #- govet # Not compatible with go 1.18, temporary disable
     - ifshort
     - importas
     - ineffassign
     - makezero
     - misspell
     - nakedret
-    - nilerr
-    - noctx
+    #- nilerr # Not compatible with go 1.18, temporary disable
+    #- noctx # Not compatible with go 1.18, temporary disable
     - predeclared
     - promlinter
-    - rowserrcheck
-    - sqlclosecheck
+    #- rowserrcheck # Not compatible with go 1.18, temporary disable
+    #- sqlclosecheck # Not compatible with go 1.18, temporary disable
     - staticcheck
-    - structcheck
+    #- structcheck # Not compatible with go 1.18, temporary disable
     - tagliatelle
     - thelper
-    - tparallel
+    #- tparallel # Not compatible with go 1.18, temporary disable
     - paralleltest
     - unconvert
-    - unparam
+    #- unparam # Not compatible with go 1.18, temporary disable
     - unused
     - varcheck
-    - wastedassign
+    #- wastedassign # Not compatible with go 1.18, temporary disable
     - whitespace
-  disable:
-    - goimports # replaced with gci
-    - gofmt # replaced with gofumpt
-    - nolintlint # strange behavior
-    - gomoddirectives # allow replace directive in go.mod
+    # DISABLED
+    #- goimports # replaced with gci
+    #- gofmt # replaced with gofumpt
+    #- nolintlint # strange behavior
+    #- gomoddirectives # allow replace directive in go.mod
     # TODO
-    - funlen
-    - gocyclo
-    - gocognit
-    - cyclop
-    - nestif
-    - lll
-    - gomnd
+    #- funlen
+    #- gocyclo
+    #- gocognit
+    #- cyclop
+    #- nestif
+    #- lll
+    #- gomnd
 
 issues:
   # List of regexps of issue texts to exclude

--- a/go.mod
+++ b/go.mod
@@ -1,6 +1,6 @@
 module github.com/keboola/keboola-as-code
 
-go 1.17
+go 1.18
 
 replace github.com/google/go-jsonnet v0.18.0 => github.com/keboola/go-jsonnet v0.18.1-0.20220516081243-59a46427c54f
 

--- a/go.sum
+++ b/go.sum
@@ -96,7 +96,6 @@ github.com/casbin/casbin/v2 v2.37.0/go.mod h1:vByNa/Fchek0KZUgG5wEsl7iFsiviAYKRt
 github.com/cenkalti/backoff/v4 v4.1.1 h1:G2HAfAmvm/GcKan2oOQpBXOd2tT2G57ZnZGWa1PxPBQ=
 github.com/cenkalti/backoff/v4 v4.1.1/go.mod h1:scbssz8iZGpm3xbr14ovlUdkxfGXNInqkPWOWmG2CLw=
 github.com/census-instrumentation/opencensus-proto v0.2.1/go.mod h1:f6KPmirojxKA12rnyqOA5BBL4O983OfeGPqjHWSTneU=
-github.com/cespare/xxhash v1.1.0 h1:a6HrQnmkObjyL+Gs60czilIUGqrzKutQD6XZog3p+ko=
 github.com/cespare/xxhash v1.1.0/go.mod h1:XrSqR1VqqWfGrhpAt58auRo0WTKS1nRRg3ghfAqPWnc=
 github.com/cespare/xxhash/v2 v2.1.1/go.mod h1:VGX0DQ3Q6kWi7AoAeZDth3/j3BFtOZR5XLFGgcrjCOs=
 github.com/cespare/xxhash/v2 v2.1.2 h1:YRXhKfTDauu4ajMg1TPgFO5jnlC2HCbmLXMcTG5cbYE=
@@ -399,7 +398,6 @@ github.com/manveru/faker v0.0.0-20171103152722-9fbc68a78c4d h1:Zj+PHjnhRYWBK6RqC
 github.com/manveru/faker v0.0.0-20171103152722-9fbc68a78c4d/go.mod h1:WZy8Q5coAB1zhY9AOBJP0O6J4BuDfbupUDavKY+I3+s=
 github.com/manveru/gobdd v0.0.0-20131210092515-f1a17fdd710b h1:3E44bLeN8uKYdfQqVQycPnaVviZdBLbizFhU49mtbe4=
 github.com/manveru/gobdd v0.0.0-20131210092515-f1a17fdd710b/go.mod h1:Bj8LjjP0ReT1eKt5QlKjwgi5AFm5mI6O1A2G4ChI0Ag=
-github.com/matoous/go-nanoid v1.5.0 h1:VRorl6uCngneC4oUQqOYtO3S0H5QKFtKuKycFG3euek=
 github.com/matoous/go-nanoid v1.5.0/go.mod h1:zyD2a71IubI24efhpvkJz+ZwfwagzgSO6UNiFsZKN7U=
 github.com/matoous/go-nanoid/v2 v2.0.0 h1:d19kur2QuLeHmJBkvYkFdhFBzLoo1XVm2GgTpL+9Tj0=
 github.com/matoous/go-nanoid/v2 v2.0.0/go.mod h1:FtS4aGPVfEkxKxhdWPAspZpZSh1cOjtM7Ej/So3hR0g=
@@ -453,7 +451,6 @@ github.com/nats-io/nuid v1.0.1/go.mod h1:19wcPz3Ph3q0Jbyiqsd0kePYG7A95tJPxeL+1OS
 github.com/nhatthm/aferocopy v1.0.2 h1:HGWGrmsZESpEECm9uZhu+jeReB+ple6/8ABfWR1aAyk=
 github.com/nhatthm/aferocopy v1.0.2/go.mod h1:KL35sFRDPSvdxcsCarAwaja69rsSnk7KYbf7SljBOGw=
 github.com/nhatthm/aferomock v0.3.0 h1:VaQORa7jawxeTi7yAAayE8ZUo7lYp5yyDn9j3wwKJNA=
-github.com/nhatthm/aferomock v0.3.0/go.mod h1:/oTcy0NDM+qQJEEOWiuiKuogilXvv/KZcdaXaP/rX3g=
 github.com/niemeyer/pretty v0.0.0-20200227124842-a10e7caefd8e/go.mod h1:zD1mROLANZcx1PVRCS0qkT7pwLkGfwJo4zjcN/Tysno=
 github.com/nxadm/tail v1.4.4/go.mod h1:kenIhsEOeOJmVchQTgglprH7qJGnHDVpk1VPCcaMI8A=
 github.com/nxadm/tail v1.4.8/go.mod h1:+ncqLTQzXmGhMZNUePPaPqPvBxHAIsmXswZKocGu+AU=
@@ -562,7 +559,6 @@ github.com/streadway/handy v0.0.0-20200128134331-0f66f006fb2e/go.mod h1:qNTQ5P5J
 github.com/stretchr/objx v0.1.0/go.mod h1:HFkY916IF+rwdDfMAkV7OtwuqBVzrE8GR6GFx+wExME=
 github.com/stretchr/objx v0.1.1/go.mod h1:HFkY916IF+rwdDfMAkV7OtwuqBVzrE8GR6GFx+wExME=
 github.com/stretchr/objx v0.3.0 h1:NGXK3lHquSN08v5vWalVI/L8XU9hdzE/G6xsrze47As=
-github.com/stretchr/objx v0.3.0/go.mod h1:qt09Ya8vawLte6SNmTgCsAVtYtaKzEcn8ATUoHMkEqE=
 github.com/stretchr/testify v1.2.1/go.mod h1:a8OnRcib4nhh0OaRAV+Yts87kKdq0PP7pXfy6kDkUVs=
 github.com/stretchr/testify v1.2.2/go.mod h1:a8OnRcib4nhh0OaRAV+Yts87kKdq0PP7pXfy6kDkUVs=
 github.com/stretchr/testify v1.3.0/go.mod h1:M5WIy9Dh21IEIfnGCwXGc5bZfKNJtfHm1UVUgZn+9EI=

--- a/internal/pkg/cli/dialog/host.go
+++ b/internal/pkg/cli/dialog/host.go
@@ -32,8 +32,7 @@ func (p *Dialogs) AskStorageApiHost(options *options.Options) (string, error) {
 }
 
 func StorageApiHostValidator(val interface{}) error {
-	str := val.(string)
-	if len(str) == 0 {
+	if str := val.(string); len(str) == 0 {
 		return errors.New("value is required")
 	} else if _, err := url.Parse(str); err != nil {
 		return errors.New("invalid host")

--- a/internal/pkg/filesystem/file.go
+++ b/internal/pkg/filesystem/file.go
@@ -282,8 +282,7 @@ func (f *Files) Add(file File) File {
 }
 
 func (f *Files) GetOneByTag(tag string) File {
-	files := f.GetByTag(tag)
-	if len(files) == 1 {
+	if files := f.GetByTag(tag); len(files) == 1 {
 		return files[0]
 	} else if len(files) > 1 {
 		var paths []string

--- a/internal/pkg/jsonnet/placeholder.go
+++ b/internal/pkg/jsonnet/placeholder.go
@@ -113,8 +113,7 @@ func splitPlaceholders(str string, replace func(funcName string, args []interfac
 		prevEnd = indices[1]
 	}
 
-	lastPart := str[prevEnd:]
-	if len(lastPart) > 0 {
+	if lastPart := str[prevEnd:]; len(lastPart) > 0 {
 		output = append(output, ValueToLiteral(lastPart))
 	}
 

--- a/internal/pkg/plan/delete-template/plan.go
+++ b/internal/pkg/plan/delete-template/plan.go
@@ -33,12 +33,10 @@ func (p *Plan) Name() string {
 func (p *Plan) Log(log log.Logger) {
 	writer := log.InfoWriter()
 	writer.WriteString(fmt.Sprintf(`Plan for "%s" operation:`, p.Name()))
-	actions := p.actions
-
-	if len(actions) == 0 {
+	if len(p.actions) == 0 {
 		writer.WriteStringIndent(1, "nothing to delete")
 	} else {
-		for _, action := range actions {
+		for _, action := range p.actions {
 			writer.WriteStringIndent(1, fmt.Sprintf("%s %s %s", diff.DeleteMark, model.ConfigAbbr, action.State.Path()))
 		}
 	}

--- a/internal/pkg/plan/persist/plan.go
+++ b/internal/pkg/plan/persist/plan.go
@@ -23,12 +23,10 @@ func (p *Plan) Name() string {
 func (p *Plan) Log(logger log.Logger) {
 	writer := logger.InfoWriter()
 	writer.WriteString(fmt.Sprintf(`Plan for "%s" operation:`, p.Name()))
-	actions := p.actions
-
-	if len(actions) == 0 {
+	if len(p.actions) == 0 {
 		writer.WriteStringIndent(1, "no new or deleted objects found")
 	} else {
-		for _, action := range actions {
+		for _, action := range p.actions {
 			writer.WriteStringIndent(1, action.String())
 		}
 	}

--- a/internal/pkg/plan/rename/plan.go
+++ b/internal/pkg/plan/rename/plan.go
@@ -24,12 +24,10 @@ func (p *Plan) Name() string {
 func (p *Plan) Log(log log.Logger) {
 	writer := log.InfoWriter()
 	writer.WriteString(fmt.Sprintf(`Plan for "%s" operation:`, p.Name()))
-	actions := p.actions
-
-	if len(actions) == 0 {
+	if len(p.actions) == 0 {
 		writer.WriteStringIndent(1, "no paths to rename")
 	} else {
-		for _, action := range actions {
+		for _, action := range p.actions {
 			writer.WriteStringIndent(1, "- "+action.String())
 		}
 	}

--- a/internal/pkg/utils/orderedmap/orderedmap.go
+++ b/internal/pkg/utils/orderedmap/orderedmap.go
@@ -88,8 +88,7 @@ func (o *OrderedMap) GetOrNil(key string) interface{} {
 }
 
 func (o *OrderedMap) Set(key string, value interface{}) {
-	_, exists := o.values[key]
-	if !exists {
+	if _, exists := o.values[key]; !exists {
 		o.keys = append(o.keys, key)
 	}
 	o.values[key] = value
@@ -242,8 +241,7 @@ func (o *OrderedMap) VisitAllRecursive(callback visitCallback) {
 
 func (o *OrderedMap) Delete(key string) {
 	// check key is in use
-	_, ok := o.values[key]
-	if !ok {
+	if _, ok := o.values[key]; !ok {
 		return
 	}
 	// remove from keys

--- a/scripts/tools.sh
+++ b/scripts/tools.sh
@@ -11,6 +11,7 @@ cd "$SCRIPT_DIR"
 
 ./install-gotestsum.sh -b $(go env GOPATH)/bin
 ./install-goreleaser.sh -b $(go env GOPATH)/bin v0.182.1
-curl -sSfL https://raw.githubusercontent.com/golangci/golangci-lint/master/install.sh | sh -s -- -b $(go env GOPATH)/bin v1.42.1
+#curl -sSfL https://raw.githubusercontent.com/golangci/golangci-lint/master/install.sh | sh -s -- -b $(go env GOPATH)/bin v1.42.2
+go install github.com/golangci/golangci-lint/cmd/golangci-lint@master
 curl -sSfL https://raw.githubusercontent.com/cosmtrek/air/master/install.sh | sh -s -- -b $(go env GOPATH)/bin
 go install goa.design/goa/v3/cmd/goa@v3


### PR DESCRIPTION
Part of: https://keboola.atlassian.net/browse/KAC-132

Changes:
- Updated to Go 1.18
- Temporary disable linters that are incompatible.