### PR TITLE
Do not fail on errors during getting commit hash (KAC-158)

### DIFF
--- a/internal/pkg/template/repository/manager.go
+++ b/internal/pkg/template/repository/manager.go
@@ -95,6 +95,8 @@ func pullRepo(ctx context.Context, logger log.Logger, repo *git.Repository) erro
 	newHash, err := repo.CommitHash(ctx)
 	if err != nil {
 		logger.Errorf("cannot get new commit hash", err)
+		logger.Infof(`repository "%s" update finished | %s`, repo, time.Since(startTime))
+		return nil
 	}
 
 	if oldHash == newHash {


### PR DESCRIPTION
Ten problém se syncem git repozitáře (https://keboola.slack.com/archives/CL11GKH6H/p1655889893163869) vyfailuje na jednom z těch `repo.CommitHash(ctx)` buď na ř. 85 nebo 95. 

V tý `pullRepo()` funkci se zjistí aktuální commit hash, provede checkout změn, znovu se zjistí commit hash a pokud jsou různý, tak se zaloguje že jsme stáhli nějaký změny. K ničemu jinýmu to není. 

Tak bych teď případnou chybu zkusil ignorovat a jen ji zalogoval a počkal co to udělá. 🙂