### PR TITLE
Remove keboola-dev from default repositories (KAC-142)

### DIFF
--- a/Dockerfile-api
+++ b/Dockerfile-api
@@ -17,5 +17,4 @@ ENV HOST 0.0.0.0
 ENV PORT 8000
 EXPOSE 8000
 
-# Note: keboola-dev is temporary repository, until we will know to switch repositories by a project feature.
-CMD ["/app/server", "--http-host=0.0.0.0", "--http-port=8000", "--repositories", "keboola|https://github.com/keboola/keboola-as-code-templates.git|main;keboola-dev|https://github.com/keboola/keboola-as-code-templates.git|dev"]
+CMD ["/app/server", "--http-host=0.0.0.0", "--http-port=8000", "--repositories", "keboola|https://github.com/keboola/keboola-as-code-templates.git|main"]


### PR DESCRIPTION
`/repositories` request vrací už jen `keboola` repozitář:
![CleanShot 2022-06-23 at 10 40 55](https://user-images.githubusercontent.com/215660/175256385-e0f46464-1751-4d13-ac32-479338da350e.jpg)
