### PR TITLE
Fix logging request span with nil result type

### DIFF
--- a/internal/pkg/api/server/templates/dependencies/trace.go
+++ b/internal/pkg/api/server/templates/dependencies/trace.go
@@ -18,12 +18,17 @@ func DDApiClientTrace() client.TraceFactory {
 		var ctx context.Context
 		var apiReqSpan tracer.Span
 		t.GotRequest = func(c context.Context, request client.HTTPRequest) context.Context {
+			resultType := reflect.TypeOf(request.ResultDef())
+			resultTypeString := ""
+			if resultType != nil {
+				resultTypeString = resultType.String()
+			}
 			apiReqSpan, ctx = tracer.StartSpanFromContext(
 				c,
 				"api.client.request",
 				tracer.ResourceName("request"),
 				tracer.SpanType("api.client"),
-				tracer.Tag("result_type", reflect.TypeOf(request.ResultDef()).String()),
+				tracer.Tag("result_type", resultTypeString),
 			)
 			return ctx
 		}


### PR DESCRIPTION
Failuje nějak podivně API request na aplikování šablony. Při pushi aplikovaných změn do projektu to sletí a skončí s 502kou.
![CleanShot 2022-06-24 at 15 48 08](https://user-images.githubusercontent.com/215660/175550951-a08f10e4-061f-4642-9042-39628c400691.jpg)

V PT jsem našel tohle:
![CleanShot 2022-06-24 at 15 46 29](https://user-images.githubusercontent.com/215660/175550989-e23a3972-e6c0-4890-98ef-659b0cbbc197.jpg)

A rozborem toho kódu na který se odkazuje stack trace:

https://github.com/keboola/keboola-as-code/blob/5225abeb603c06ef9ecc896088bb7ec6b9ff96d9/internal/pkg/api/server/templates/dependencies/trace.go#L26

bych řekl, že `reflect.TypeOf(request.ResultDef())` vrátí `nil` a na tom potom nejde zavolat ta `String()` metoda.

![CleanShot 2022-06-24 at 15 58 36](https://user-images.githubusercontent.com/215660/175551243-7f4d3ec1-da36-4c38-948d-268c08f79978.jpg)

Lokálně to nezreplikuju, protože mi nejede DataDog a tím pádem to nefailuje, tak je to trochu výstřel naslepo. Ale imho by to mohlo vyjít. 😅