### PR TITLE
Fix git sparse checkout

### DIFF
--- a/internal/pkg/git/git.go
+++ b/internal/pkg/git/git.go
@@ -146,7 +146,7 @@ func (r *Repository) Load(ctx context.Context, path string) error {
 	if !r.sparse {
 		return fmt.Errorf("sparse checkout is not allowed")
 	}
-	if _, err := r.runGitCmd(ctx, "sparse-checkout", "add", fmt.Sprintf("/%s", path)); err != nil {
+	if _, err := r.runGitCmd(ctx, "sparse-checkout", "add", path); err != nil {
 		return err
 	}
 	if _, err := r.runGitCmd(ctx, "checkout"); err != nil {


### PR DESCRIPTION
Ve CLI na Macu začalo mně i Monice failovat použití šablony. `verbose` ukázal tohle:

![CleanShot 2022-06-28 at 15 30 13](https://user-images.githubusercontent.com/215660/176191061-fedb4ae2-24ab-4a05-aced-4cde8adf9431.jpg)

Já mám Git 2.37 ale v Docker imagi je 2.30. A vzhledemk tomu, že sparse-checkout je experimentální feature, tak tam zřejmě něco změnili. 🙂 Jako parametr se dává cesta k adresáři a zjevně funguje i relativně. (Respektive vlastně nevím proč tam bylo to počáteční lomítko pro absolutní cestu, to asi ani nedává smysl. 😅)

Po týhle úpravě už mi to funguje ok:
![CleanShot 2022-06-28 at 15 33 48](https://user-images.githubusercontent.com/215660/176191859-cdca703e-02a3-4f7a-876b-2c97652409ec.jpg)
