### PR TITLE
Fix default value for oauth inputs (KAC-148)

### DIFF
--- a/internal/pkg/cli/dialog/use_template.go
+++ b/internal/pkg/cli/dialog/use_template.go
@@ -375,7 +375,7 @@ func (d *useTmplInputsDialog) askInput(inputDef *input.Input) error {
 		return d.addInputValue(selectedValues, inputDef, true)
 	case input.KindOAuth:
 		// Save value
-		return d.addInputValue(nil, inputDef, true)
+		return d.addInputValue(map[string]interface{}{}, inputDef, true)
 	}
 
 	return nil

--- a/test/cli/template-use/steps/expected-stderr
+++ b/test/cli/template-use/steps/expected-stderr
@@ -1,0 +1,2 @@
+The template generated configurations that need oAuth authorization. Please follow the links and complete the setup:
+- https://%%TEST_KBC_STORAGE_API_HOST%%/admin/projects/%%TEST_KBC_PROJECT_ID%%/components/ex-generic-v2/%s

--- a/test/cli/template-use/steps/in/repository/my-template/v1/src/extractor/ex-generic-v2/shopify/config.jsonnet
+++ b/test/cli/template-use/steps/in/repository/my-template/v1/src/extractor/ex-generic-v2/shopify/config.jsonnet
@@ -1,4 +1,7 @@
 {
+  authorization: {
+    oauth_api: Input("shopify-oauth")
+  },
   parameters: {
     token: Input("shopify-token"),
     shop: Input("shopify-shop-name"),

--- a/test/cli/template-use/steps/in/repository/my-template/v1/src/inputs.jsonnet
+++ b/test/cli/template-use/steps/in/repository/my-template/v1/src/inputs.jsonnet
@@ -25,6 +25,15 @@
               kind: "input",
               rules: "required",
             },
+            {
+              id: "shopify-oauth",
+              name: "Shopify oAuth",
+              description: "Please authorize your account",
+              type: "object",
+              kind: "oauth",
+              componentId: "keboola.ex-shopify"
+            }
+
           ],
         },
         {

--- a/test/cli/template-use/steps/out/project/.keboola/manifest.json
+++ b/test/cli/template-use/steps/out/project/.keboola/manifest.json
@@ -46,7 +46,7 @@
       "path": "extractor/ex-generic-v2/shopify",
       "metadata": {
         "KBC.KAC.templates.configId": "{\"idInTemplate\":\"shopify\"}",
-        "KBC.KAC.templates.configInputs": "[{\"input\":\"shopify-shop-name\",\"key\":\"parameters.shop\"},{\"input\":\"shopify-token\",\"key\":\"parameters.token\"}]",
+        "KBC.KAC.templates.configInputs": "[{\"input\":\"shopify-oauth\",\"key\":\"authorization.oauth_api\"},{\"input\":\"shopify-shop-name\",\"key\":\"parameters.shop\"},{\"input\":\"shopify-token\",\"key\":\"parameters.token\"}]",
         "KBC.KAC.templates.instanceId": "%s",
         "KBC.KAC.templates.repository": "keboola",
         "KBC.KAC.templates.templateId": "my-template-id"

--- a/test/cli/template-use/steps/out/project/main/extractor/ex-generic-v2/shopify/config.json
+++ b/test/cli/template-use/steps/out/project/main/extractor/ex-generic-v2/shopify/config.json
@@ -1,4 +1,7 @@
 {
+  "authorization": {
+    "oauth_api": {}
+  },
   "parameters": {
     "shop": "shop",
     "token": "token"

--- a/test/cli/template-use/steps/out/repository/my-template/v1/src/extractor/ex-generic-v2/shopify/config.jsonnet
+++ b/test/cli/template-use/steps/out/repository/my-template/v1/src/extractor/ex-generic-v2/shopify/config.jsonnet
@@ -1,4 +1,7 @@
 {
+  authorization: {
+    oauth_api: Input("shopify-oauth")
+  },
   parameters: {
     token: Input("shopify-token"),
     shop: Input("shopify-shop-name"),

--- a/test/cli/template-use/steps/out/repository/my-template/v1/src/inputs.jsonnet
+++ b/test/cli/template-use/steps/out/repository/my-template/v1/src/inputs.jsonnet
@@ -25,6 +25,15 @@
               kind: "input",
               rules: "required",
             },
+            {
+              id: "shopify-oauth",
+              name: "Shopify oAuth",
+              description: "Please authorize your account",
+              type: "object",
+              kind: "oauth",
+              componentId: "keboola.ex-shopify"
+            }
+
           ],
         },
         {


### PR DESCRIPTION
Ve CLIčku se oAuthový inputy nevyplňují, jen se do nich dá default value. Ta by ale měla být prázdný objekt (`{}`, tj. v Go mapa `map[string]interface{}`) a ne null. 

Před:

![CleanShot 2022-06-30 at 11 26 25@2x](https://user-images.githubusercontent.com/215660/176643469-65414dbd-e726-4078-b865-183a2c95fcbb.jpg)

Po:

![CleanShot 2022-06-30 at 11 31 36@2x](https://user-images.githubusercontent.com/215660/176643747-a98a2783-ec08-451a-83d0-5e65ebba2f40.jpg)
