### PR TITLE
Update Storage client (KAC-161)

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -23,7 +23,7 @@ require (
 	github.com/jarcoal/httpmock v1.2.0
 	github.com/joho/godotenv v1.3.0
 	github.com/jpillora/longestcommon v0.0.0-20161227235612-adb9d91ee629
-	github.com/keboola/go-client v0.2.0
+	github.com/keboola/go-client v0.2.2
 	github.com/keboola/go-utils v0.1.1
 	github.com/kylelemons/godebug v1.1.0
 	github.com/nhatthm/aferocopy v1.0.2

--- a/go.sum
+++ b/go.sum
@@ -414,8 +414,8 @@ github.com/julienschmidt/httprouter v1.3.0/go.mod h1:JR6WtHb+2LUe8TCKY3cZOxFyyO8
 github.com/jung-kurt/gofpdf v1.0.3-0.20190309125859-24315acbbda5/go.mod h1:7Id9E/uU8ce6rXgefFLlgrJj/GYY22cpxn+r32jIOes=
 github.com/kballard/go-shellquote v0.0.0-20180428030007-95032a82bc51 h1:Z9n2FFNUXsshfwJMBgNA0RU6/i7WVaAegv3PtuIHPMs=
 github.com/kballard/go-shellquote v0.0.0-20180428030007-95032a82bc51/go.mod h1:CzGEWj7cYgsdH8dAjBGEr58BoE7ScuLd+fwFZ44+/x8=
-github.com/keboola/go-client v0.2.0 h1:b2EbI0orcZIZBCXivZ77QxOLJ+AeKFe10FWvcGfmFmE=
-github.com/keboola/go-client v0.2.0/go.mod h1:YPQenBSf8SQhXu8/KvpX/rcPgI7nE6p4iiI7sY5hL6U=
+github.com/keboola/go-client v0.2.2 h1:Umqj9QmAXujgfEIxuPXY71LdesmghFuCEIBzw5Vcc/g=
+github.com/keboola/go-client v0.2.2/go.mod h1:YPQenBSf8SQhXu8/KvpX/rcPgI7nE6p4iiI7sY5hL6U=
 github.com/keboola/go-jsonnet v0.18.1-0.20220516081243-59a46427c54f h1:EjbacWltPRtclVqU5dYTwuA0hh1xy0K3uFnonILzUVc=
 github.com/keboola/go-jsonnet v0.18.1-0.20220516081243-59a46427c54f/go.mod h1:C3fTzyVJDslXdiTqw/bTFk7vSGyCtH3MGRbDfvEwGd0=
 github.com/keboola/go-utils v0.1.1 h1:ZcwOrSejYbyFZ7WEZwiqAhN+Ew+7GLJA66tmJyEfPns=


### PR DESCRIPTION
viz. https://github.com/keboola/go-client/pull/10
(verze 0.2.1 mi někam uletěla 😅 je to v 0.2.2 https://github.com/keboola/go-client/releases/tag/v0.2.2)