### PR TITLE
Test that config metadata from template are writtern to the project (KAC-97)

### DIFF
--- a/test/cli/template-use/complex/in/repository/my-template/v1/src/manifest.jsonnet
+++ b/test/cli/template-use/complex/in/repository/my-template/v1/src/manifest.jsonnet
@@ -41,6 +41,9 @@
       id: ConfigId("empty"),
       path: "extractor/ex-generic-v2/empty",
       rows: [],
+      metadata: {
+        "KBC.test": "value"
+      }
     },
     {
       componentId: "ex-generic-v2",

--- a/test/cli/template-use/complex/out/project/.keboola/manifest.json
+++ b/test/cli/template-use/complex/out/project/.keboola/manifest.json
@@ -95,7 +95,8 @@
         "KBC.KAC.templates.configId": "{\"idInTemplate\":\"empty\"}",
         "KBC.KAC.templates.instanceId": "%s",
         "KBC.KAC.templates.repository": "keboola",
-        "KBC.KAC.templates.templateId": "my-template-id"
+        "KBC.KAC.templates.templateId": "my-template-id",
+        "KBC.test": "value"
       },
       "rows": []
     },

--- a/test/cli/template-use/complex/out/repository/my-template/v1/src/manifest.jsonnet
+++ b/test/cli/template-use/complex/out/repository/my-template/v1/src/manifest.jsonnet
@@ -41,6 +41,9 @@
       id: ConfigId("empty"),
       path: "extractor/ex-generic-v2/empty",
       rows: [],
+      metadata: {
+        "KBC.test": "value"
+      }
     },
     {
       componentId: "ex-generic-v2",


### PR DESCRIPTION
Monika před pár měsíci reportovala, že když má metadata v nějakým konfigu v šabloně, tak se nepropíšou do projektu po jejím aplikování. Přidal jsem test který to nepotvrzuje, tak jsme to nejspíš už fixli. 🙂 (https://keboola.atlassian.net/browse/KAC-97)