### PR TITLE
Fix Datadog Source Code Integration

### DIFF
--- a/provisioning/azure-devops-deploy.sh
+++ b/provisioning/azure-devops-deploy.sh
@@ -1,13 +1,14 @@
 #!/usr/bin/env bash
 set -Eeuo pipefail
 
-COMMIT=$(echo "$BUILD_BUILDID" | cut -d'-' -f 2)
-export COMMIT
-
 # Checkout correct commit
 if [ "$RELEASE_ARTIFACTS__KEBOOLA_KEBOOLA_AS_CODE_SOURCEBRANCH" == "master" ]; then
+  COMMIT=$(echo "$BUILD_BUILDID" | cut -d'-' -f 2)
   git checkout "$COMMIT" -f
 fi
+
+COMMIT_HASH=$(git rev-parse HEAD)
+export COMMIT_HASH
 
 export RELEASE_ID="$BUILD_BUILDID-$RELEASE_RELEASENAME"
 

--- a/provisioning/kubernetes/templates/templates-api.yaml
+++ b/provisioning/kubernetes/templates/templates-api.yaml
@@ -22,7 +22,7 @@ spec:
         tags.datadoghq.com/version: "$RELEASE_ID"
       annotations:
         log: "true"
-        ad.datadoghq.com/tags: '{"git.commit.sha": "$COMMIT", "git.repository_url": "https://github.com/keboola/keboola-as-code"}'
+        ad.datadoghq.com/tags: '{"git.commit.sha": "$COMMIT_HASH", "git.repository_url": "https://github.com/keboola/keboola-as-code"}'
     spec:
       containers:
         - name: templates-api


### PR DESCRIPTION
Tak to handlování `COMMIT` vracím zpět jak bylo a fixnu zvlášť. Přidávám `COMMIT_HASH` do kterýho načítám hash rovnou z git cli.