### PR TITLE
migrate api aws insgress object to v1 version

### DIFF
--- a/provisioning/kubernetes/templates/aws/ingress.yaml
+++ b/provisioning/kubernetes/templates/aws/ingress.yaml
@@ -1,5 +1,5 @@
 ---
-apiVersion: networking.k8s.io/v1beta1
+apiVersion: networking.k8s.io/v1
 kind: Ingress
 metadata:
   annotations:

--- a/provisioning/kubernetes/templates/aws/ingress.yaml
+++ b/provisioning/kubernetes/templates/aws/ingress.yaml
@@ -12,6 +12,9 @@ spec:
       http:
         paths:
           - backend:
-              serviceName: templates-api
-              servicePort: 80
+              service:
+                name: templates-api
+                port: 
+                  number: 80
             path: /
+            pathType: Prefix


### PR DESCRIPTION
related to https://keboola.atlassian.net/browse/SRE-3648
Tato uprava migruje ingress object templates api do apiVersion v1 pre AWS stacky. Pre azure stacky tam nie je ziadna zmena.

### Deploy na testing
success deploy 
https://dev.azure.com/keboola-prod/Keboola%20Connection%20AWS/_releaseProgress?_a=release-environment-logs&releaseId=16102&environmentId=32292

funguje to:
https://templates.eu-west-1.aws.keboola.dev/v1
![image](https://user-images.githubusercontent.com/1412120/179536858-5a87bebf-c98a-4356-b187-b94b467c3ade.png)
