### PR TITLE
k8s: add livenessProbe

### DIFF
--- a/provisioning/kubernetes/templates/templates-api.yaml
+++ b/provisioning/kubernetes/templates/templates-api.yaml
@@ -78,6 +78,16 @@ spec:
                 - name: Host
                   value: KubernetesReadinessProbe
             periodSeconds: 10
+            failureThreshold: 1
+          livenessProbe:
+            httpGet:
+              path: /health-check
+              port: 8000
+              httpHeaders:
+                - name: Host
+                  value: KubernetesLivenessProbe
+            periodSeconds: 10
+            failureThreshold: 3
       tolerations:
         - key: app
           operator: Exists


### PR DESCRIPTION
Changes:
- Added liveness probe to K8S config, container is restarted if health check failed `3x10s`.