### PR TITLE
Templates: Fix input type=object validation

### DIFF
--- a/internal/pkg/cli/dialog/inputs_detail.go
+++ b/internal/pkg/cli/dialog/inputs_detail.go
@@ -164,7 +164,7 @@ func (d *inputsDetailDialog) parse(result string) (input.StepsGroupsExt, error) 
 	finalizeInput()
 
 	// Validate
-	if err := d.inputs.All().Validate(); err != nil {
+	if err := d.inputs.All().ValidateDefinitions(); err != nil {
 		errors.Append(err)
 	}
 

--- a/internal/pkg/cli/dialog/steps.go
+++ b/internal/pkg/cli/dialog/steps.go
@@ -147,7 +147,7 @@ func (d *stepsDialog) parse(result string) (input.StepsGroupsExt, error) {
 	}
 
 	// Validate
-	if err := stepsGroups.Validate(); err != nil {
+	if err := stepsGroups.ValidateDefinitions(); err != nil {
 		errors.Append(err)
 	}
 

--- a/internal/pkg/cli/dialog/use_template.go
+++ b/internal/pkg/cli/dialog/use_template.go
@@ -396,8 +396,8 @@ func (d *useTmplInputsDialog) addInputValue(value any, inputDef *input.Input, is
 		return fmt.Errorf("invalid template input: %w", err)
 	}
 
-	// Validate
-	if isFiled {
+	// Validate all except oauth inputs
+	if isFiled && inputDef.Kind != input.KindOAuth && inputDef.Kind != input.KindOAuthAccounts {
 		if err := inputDef.ValidateUserInput(value); err != nil {
 			return fmt.Errorf("invalid template input: %w", err)
 		}

--- a/internal/pkg/template/input/auxiliary.go
+++ b/internal/pkg/template/input/auxiliary.go
@@ -58,8 +58,8 @@ func (g StepsGroupsExt) ToValue() (out StepsGroups) {
 	return out
 }
 
-func (g StepsGroupsExt) Validate() error {
-	return g.ToValue().Validate()
+func (g StepsGroupsExt) ValidateDefinitions() error {
+	return g.ToValue().ValidateDefinitions()
 }
 
 type VisitStepsCallback func(group *StepsGroupExt, step *StepExt) error

--- a/internal/pkg/template/input/file.go
+++ b/internal/pkg/template/input/file.go
@@ -76,5 +76,5 @@ func saveFile(fs filesystem.Fs, content *file) error {
 }
 
 func (f file) validate() error {
-	return f.StepsGroups.Validate()
+	return f.StepsGroups.ValidateDefinitions()
 }

--- a/internal/pkg/template/input/input.go
+++ b/internal/pkg/template/input/input.go
@@ -120,11 +120,11 @@ type Input struct {
 }
 
 // ValidateUserInput validates input from the template user using Input.Rules.
-func (i Input) ValidateUserInput(userInput any) error {
-	if err := i.Type.ValidateValue(reflect.ValueOf(userInput)); err != nil {
+func (i Input) ValidateUserInput(value any) error {
+	if err := i.Type.ValidateValue(reflect.ValueOf(value)); err != nil {
 		return fmt.Errorf("%s %w", i.Name, err)
 	}
-	return i.Rules.ValidateValue(userInput, i.Id)
+	return i.Rules.ValidateValue(i, value)
 }
 
 // Available decides if the input should be visible to user according to Input.If.

--- a/internal/pkg/template/input/input.go
+++ b/internal/pkg/template/input/input.go
@@ -51,11 +51,11 @@ func NewInputs() *Inputs {
 	return &inputs
 }
 
-func (i Inputs) Validate() error {
+func (i Inputs) ValidateDefinitions() error {
 	errors := utils.NewMultiError()
 
 	// Validate rules
-	if err := validate(i); err != nil {
+	if err := validateDefinitions(i); err != nil {
 		errors.Append(err)
 	}
 

--- a/internal/pkg/template/input/rules_test.go
+++ b/internal/pkg/template/input/rules_test.go
@@ -16,16 +16,33 @@ func TestRules_ValidateValue(t *testing.T) {
 	t.Parallel()
 
 	// Valid
-	assert.NoError(t, Rules("").ValidateValue("foo bar", "my-field"))
-	assert.NoError(t, Rules("required").ValidateValue("foo bar", "my-field"))
+	assert.NoError(t, Rules("").ValidateValue(Input{Id: "my-field"}, "foo bar"))
+	assert.NoError(t, Rules("required").ValidateValue(Input{Id: "my-field"}, "foo bar"))
 
 	// Invalid
-	err := Rules("required").ValidateValue("", "my-field")
+	err := Rules("required").ValidateValue(Input{Id: "my-field"}, "")
 	assert.Error(t, err)
 	assert.Equal(t, "my-field is a required field", err.Error())
 
 	// Invalid rule
-	err = Rules("foo").ValidateValue("", "my-field")
+	err = Rules("foo").ValidateValue(Input{Id: "my-field"}, "")
 	assert.Error(t, err)
 	assert.Equal(t, InvalidRulesError("undefined validation function 'foo'"), err)
+}
+
+func TestRules_ValidateEmptyObject(t *testing.T) {
+	t.Parallel()
+
+	// Valid
+	assert.NoError(t, Rules("required").ValidateValue(Input{Id: "my-field", Type: TypeObject}, map[string]any{"foo": "bar"}))
+
+	// Invalid
+	err := Rules("required").ValidateValue(Input{Id: "my-field", Type: TypeObject}, map[string]any{})
+	assert.Error(t, err)
+	assert.Equal(t, "my-field is a required field", err.Error())
+
+	// Invalid - multiple rules
+	err = Rules("unique,required,min=1").ValidateValue(Input{Id: "my-field", Type: TypeObject}, map[string]any{})
+	assert.Error(t, err)
+	assert.Equal(t, "my-field is a required field", err.Error())
 }

--- a/internal/pkg/template/input/step.go
+++ b/internal/pkg/template/input/step.go
@@ -45,7 +45,7 @@ func (g StepsGroups) InputsMap() map[string]*Input {
 	return res
 }
 
-func (g StepsGroups) Validate() error {
+func (g StepsGroups) ValidateDefinitions() error {
 	errors := utils.NewMultiError()
 
 	if len(g) == 0 {
@@ -119,7 +119,7 @@ func (g StepsGroups) Validate() error {
 	}
 
 	// Validate other rules
-	if err := validate(g); err != nil {
+	if err := validateDefinitions(g); err != nil {
 		errors.Append(err)
 	}
 

--- a/internal/pkg/template/input/step_test.go
+++ b/internal/pkg/template/input/step_test.go
@@ -182,7 +182,7 @@ input "fb.extractor.username" is defined 4 times in:
   - group 2, step 2 "Step 3"
 `
 
-	err := groups.Validate()
+	err := groups.ValidateDefinitions()
 	assert.Error(t, err)
 	assert.Equal(t, strings.Trim(expectedErr, "\n"), err.Error())
 }
@@ -226,7 +226,7 @@ func TestStepsGroups_Validate_InputsErrors(t *testing.T) {
 - group 1, step 1, input "input2": type bar is not allowed, allowed values: string, int, double, bool, string[], object
 `
 
-	err := groups.Validate()
+	err := groups.ValidateDefinitions()
 	assert.Error(t, err)
 	assert.Equal(t, strings.Trim(expectedErr, "\n"), err.Error())
 }

--- a/internal/pkg/template/input/validation.go
+++ b/internal/pkg/template/input/validation.go
@@ -11,11 +11,11 @@ import (
 	"github.com/keboola/keboola-as-code/internal/pkg/validator"
 )
 
-func validate(value interface{}) error {
-	return validator.Validate(context.Background(), value, validationRules()...)
+func validateDefinitions(value any) error {
+	return validator.Validate(context.Background(), value, inputDefinitionExtraRules()...)
 }
 
-func validationRules() []validator.Rule {
+func inputDefinitionExtraRules() []validator.Rule {
 	return []validator.Rule{
 		{
 			Tag: "template-input-id",

--- a/internal/pkg/template/input/validation.go
+++ b/internal/pkg/template/input/validation.go
@@ -95,14 +95,14 @@ func inputDefinitionExtraRules() []validator.Rule {
 			Tag: "template-input-rules",
 			Func: func(fl goValidator.FieldLevel) (valid bool) {
 				// Run with an empty value to validate rules
-				err := fl.Field().Interface().(Rules).ValidateValue("", "")
+				err := fl.Field().Interface().(Rules).ValidateValue(Input{Id: "foo"}, "")
 				if _, ok := err.(InvalidRulesError); ok { // nolint: errorlint
 					return false
 				}
 				return true
 			},
 			ErrorMsgFunc: func(fe goValidator.FieldError) string {
-				err := fe.Value().(Rules).ValidateValue("", "")
+				err := fe.Value().(Rules).ValidateValue(Input{Id: "foo"}, "")
 				return fmt.Sprintf("%s is not valid: %s", fe.Field(), err.Error())
 			},
 		},

--- a/internal/pkg/template/input/validation_test.go
+++ b/internal/pkg/template/input/validation_test.go
@@ -331,7 +331,7 @@ func TestValidationRules(t *testing.T) {
 	// Test all cases
 	for _, c := range cases {
 		stepsGroups[0].Steps[0].Inputs = c.inputs
-		err := stepsGroups.Validate()
+		err := stepsGroups.ValidateDefinitions()
 		if c.error == "" {
 			// Expected nil *utils.MultiError
 			assert.Nil(t, err, c.description)


### PR DESCRIPTION
Jira: https://github.com/keboola/keboola-as-code/pull/764

Changes:
- Fixed validation of input `type=object` if value is an empty object.