### PR TITLE
Support flags in test template command (KAC-155 KAC-179)

### DIFF
--- a/internal/pkg/cli/cmd/template/test.go
+++ b/internal/pkg/cli/cmd/template/test.go
@@ -41,14 +41,22 @@ func TestCommand(p dependencies.Provider) *cobra.Command {
 				return err
 			}
 
+			// Options
+			options := testOp.Options{
+				LocalOnly:  d.Options().GetBool("local-only"),
+				RemoteOnly: d.Options().GetBool("remote-only"),
+				TestName:   d.Options().GetString("test-name"),
+			}
+
 			// Test template
-			return testOp.Run(template, d)
+			return testOp.Run(template, options, d)
 		},
 	}
 
 	cmd.Flags().SortFlags = true
 	cmd.Flags().String("test-name", "", "name of a single test to be run")
-	cmd.Flags().Bool("local-test", false, "run a local test only")
+	cmd.Flags().Bool("local-only", false, "run a local test only")
+	cmd.Flags().Bool("remote-only", false, "run a remote test only")
 
 	return cmd
 }

--- a/test/cli/template-test/local/args
+++ b/test/cli/template-test/local/args
@@ -1,1 +1,1 @@
-template test my-template 0.0.1
+template test my-template 0.0.1 --local-only


### PR DESCRIPTION
Propagace flagů test template commandu do kódu a rovnou použití toho na spuštění jednoho testu.