### PR TITLE
Unify macOS release env vars

### DIFF
--- a/.github/workflows/push.yml
+++ b/.github/workflows/push.yml
@@ -49,11 +49,11 @@ env:
   # WinGet packages
   WINGET_PACKAGES_REPO_FORK: "JakubMatejka/winget-pkgs"
 
-  # Mac Os notarization
-  APPLE_USERNAME: "apple@keboola.com"
-  APPLE_TEAM_ID: "46P6KJ65M2"
+  # macOS notarization
+  APPLE_ACCOUNT_USERNAME: "apple@keboola.com"
   APPLE_BUNDLE_ID: "com.keboola.kbc"
-  APPLE_APP_IDENTITY: "Developer ID Application: Keboola Industries SE"
+  APPLE_TEAM_ID: "46P6KJ65M2"
+  APPLE_TEAM_NAME: "Keboola Industries SE"
 
   DIST_BASE_URL: "https://keboola-as-code-dist.s3.amazonaws.com"
 
@@ -246,9 +246,7 @@ jobs:
           DEB_KEY_PRIVATE_PATH: /tmp/keys/deb.key
           RPM_KEY_PRIVATE_PATH: /tmp/keys/rpm.key
           APK_KEY_PRIVATE_PATH: /tmp/keys/apk.key
-          AC_USERNAME: ${{ secrets.AC_USERNAME }}
-          AC_PASSWORD: ${{ secrets.AC_PASSWORD }}
-          AC_PROVIDER: ${{ env.APPLE_TEAM_ID }}
+          APPLE_ACCOUNT_PASSWORD: ${{ secrets.APPLE_ACCOUNT_PASSWORD }}
       - name: Upload artifact to release
         uses: svenstaro/upload-release-action@v2
         with:

--- a/build/package/mac-os/gon/notarize.sh
+++ b/build/package/mac-os/gon/notarize.sh
@@ -28,8 +28,8 @@ cat <<EOT >> "./${GON_CONFIG_FILE}"
 {
     "source": ["${ARTIFACT_PATH}"],
     "bundle_id": "${APPLE_BUNDLE_ID}",
-    "apple_id": {"username": "${APPLE_USERNAME}", "password": "@env:AC_PASSWORD"},
-    "sign": { "application_identity": "${APPLE_APP_IDENTITY}" },
+    "apple_id": {"username": "${APPLE_ACCOUNT_USERNAME}", "password": "@env:APPLE_ACCOUNT_PASSWORD", "provider": "${APPLE_TEAM_ID}"},
+    "sign": { "application_identity": "Developer ID Application: ${APPLE_TEAM_NAME}" },
     "zip": { "output_path": "${TARGET_PATH}" }
 }
 EOT


### PR DESCRIPTION
Zkusil jsem popsat release proces pro Mac a jak ho nasetupovat: https://keboola.atlassian.net/wiki/spaces/KB/pages/2709422095/Release+Process (ještě musím doplnit tvorbu certifikátu) a přišlo by mi přehlednější trochu nějak takto sjednotit pojmenování těch env varů a secretů. 

V GH Secrets je `AC_USERNAME` který se imho teď vůbec nepoužije (přepíše se z aktuálního `APPLE_USERNAME`) a `AC_PASSWORD` který bych nahradil tím `APPLE_ACCOUNT_PASSWORD`