### PR TITLE
Better ENVs handling in E2E tests

### DIFF
--- a/internal/pkg/api/server/templates/dependencies/dependencies.go
+++ b/internal/pkg/api/server/templates/dependencies/dependencies.go
@@ -184,6 +184,11 @@ func (v *forServer) RepositoryManager() *repository.Manager {
 
 func (v *forServer) EtcdClient() (*etcd.Client, error) {
 	return v.etcdClient.InitAndGet(func() (*etcd.Client, error) {
+		// Check if etcd is enabled
+		if v.Envs().Get("ETCD_ENABLED") == "false" {
+			return nil, fmt.Errorf("etcd integration is disabled")
+		}
+
 		// Get endpoint
 		endpoint := v.Envs().Get("ETCD_ENDPOINT")
 		if endpoint == "" {

--- a/test/cli/cli_test.go
+++ b/test/cli/cli_test.go
@@ -162,15 +162,22 @@ func RunFunctionalTest(t *testing.T, testDir, workingDir string, binary string) 
 func CompileBinary(t *testing.T, projectDir string, tempDir string) string {
 	t.Helper()
 
-	var stdout, stderr bytes.Buffer
 	binaryPath := filepath.Join(tempDir, "/bin_func_tests")
 	if runtime.GOOS == "windows" {
 		binaryPath += `.exe`
 	}
 
+	// Envs
+	envs, err := env.FromOs()
+	assert.NoError(t, err)
+	envs.Set("TARGET_PATH", binaryPath)
+	envs.Set("SKIP_API_CODE_REGENERATION", "1")
+
+	// Build binary
+	var stdout, stderr bytes.Buffer
 	cmd := exec.Command("make", "build-local")
 	cmd.Dir = projectDir
-	cmd.Env = append(os.Environ(), "TARGET_PATH="+binaryPath, "SKIP_API_CODE_REGENERATION=1")
+	cmd.Env = envs.ToSlice()
 	cmd.Stdout = &stdout
 	cmd.Stderr = &stderr
 	if err := cmd.Run(); err != nil {


### PR DESCRIPTION
Po problemoch s ENVs v CLI E2E testoch som sa preventivne radsej pozrel aj na ENVs v API E2E testoch.