### PR TITLE
Non-blocking components update

### DIFF
--- a/internal/pkg/api/server/templates/dependencies/dependencies_test.go
+++ b/internal/pkg/api/server/templates/dependencies/dependencies_test.go
@@ -1,0 +1,60 @@
+package dependencies
+
+import (
+	"context"
+	"fmt"
+	"io"
+	stdLog "log"
+	"net/http"
+	"testing"
+
+	"github.com/jarcoal/httpmock"
+	"github.com/keboola/go-client/pkg/storageapi"
+	"github.com/stretchr/testify/assert"
+
+	"github.com/keboola/keboola-as-code/internal/pkg/dependencies"
+	"github.com/keboola/keboola-as-code/internal/pkg/log"
+)
+
+// TestForPublicRequest_Components_Cached tests that the value of the component does not change during the entire request.
+func TestForPublicRequest_Components_Cached(t *testing.T) {
+	t.Parallel()
+
+	// Mocked components
+	components1 := storageapi.Components{
+		{ComponentKey: storageapi.ComponentKey{ID: "foo1.bar1"}, Type: "other", Name: "Foo1 Bar1"},
+	}
+	components2 := storageapi.Components{
+		{ComponentKey: storageapi.ComponentKey{ID: "foo2.bar2"}, Type: "other", Name: "Foo2 Bar2"},
+	}
+	assert.NotEqual(t, components1, components2)
+
+	// Create mocked dependencies for server with "components1"
+	nopApiLogger := log.NewApiLogger(stdLog.New(io.Discard, "", 0), "", false)
+	mockedDeps := dependencies.NewMockedDeps(dependencies.WithMockedComponents(components1))
+	serverDeps := &forServer{Base: mockedDeps, Public: mockedDeps, serverCtx: context.Background(), logger: nopApiLogger}
+
+	// Request 1 gets "components1"
+	req1Deps := NewDepsForPublicRequest(serverDeps, context.Background(), "req1")
+	assert.Equal(t, components1, req1Deps.Components().All())
+	assert.Equal(t, components1, req1Deps.Components().All())
+
+	// Components are updated to "components2"
+	mockedDeps.MockedHttpTransport().RegisterResponder(
+		http.MethodGet,
+		fmt.Sprintf("https://%s/v2/storage/", mockedDeps.StorageApiHost()),
+		httpmock.NewJsonResponderOrPanic(200, &storageapi.IndexComponents{
+			Components: components2,
+		}).Once(),
+	)
+	assert.NoError(t, mockedDeps.ComponentsProvider().Update(context.Background()))
+
+	// Request 1 still gets "components1"
+	assert.Equal(t, components1, req1Deps.Components().All())
+	assert.Equal(t, components1, req1Deps.Components().All())
+
+	// But request2 gets "components2"
+	req2Deps := NewDepsForPublicRequest(serverDeps, context.Background(), "req2")
+	assert.Equal(t, components2, req2Deps.Components().All())
+	assert.Equal(t, components2, req2Deps.Components().All())
+}

--- a/internal/pkg/api/server/templates/dependencies/locks_test.go
+++ b/internal/pkg/api/server/templates/dependencies/locks_test.go
@@ -152,11 +152,6 @@ func newTestEtcdClient(t *testing.T) *etcd.Client {
 		t.Skipf("etcd disabled")
 	}
 
-	// Check if etcd is enabled
-	if envs.Get("ETCD_ENABLED") == "false" {
-		t.Skipf("etcd disabled")
-	}
-
 	// Create etcd client
 	etcdClient, err := etcd.New(etcd.Config{
 		Context:              context.Background(),

--- a/internal/pkg/api/server/templates/service/cron.go
+++ b/internal/pkg/api/server/templates/service/cron.go
@@ -53,13 +53,13 @@ func StartComponentsCron(ctx context.Context, d dependencies.ForServer) error {
 		// Start ticker
 		d.Logger().Infof("components updater started at %s, interval=%s", time.Now().Format("15:04:05"), interval)
 		ticker := time.NewTicker(interval)
-		provider.Update(ctx)
+		provider.UpdateAsync(ctx)
 		for {
 			select {
 			case <-ctx.Done():
 				return
 			case <-ticker.C:
-				provider.Update(ctx)
+				provider.UpdateAsync(ctx)
 			}
 		}
 	}()

--- a/internal/pkg/api/server/templates/service/cron.go
+++ b/internal/pkg/api/server/templates/service/cron.go
@@ -44,6 +44,8 @@ func StartComponentsCron(ctx context.Context, d dependencies.ForServer) error {
 
 	// Start background work
 	go func() {
+		d.Logger().Infof("components cron prepared")
+
 		// Delay start to a rounded time
 		interval := ComponentsUpdateInterval
 		startAt := time.Now().Truncate(interval).Add(interval)
@@ -51,7 +53,7 @@ func StartComponentsCron(ctx context.Context, d dependencies.ForServer) error {
 		<-timer.C
 
 		// Start ticker
-		d.Logger().Infof("components updater started at %s, interval=%s", time.Now().Format("15:04:05"), interval)
+		d.Logger().Infof("components cron started at %s, interval=%s", time.Now().Format("15:04:05"), interval)
 		ticker := time.NewTicker(interval)
 		provider.UpdateAsync(ctx)
 		for {

--- a/internal/pkg/model/component.go
+++ b/internal/pkg/model/component.go
@@ -32,18 +32,9 @@ func NewComponentsProvider(index *storageapi.IndexComponents, logger log.Logger,
 	}
 }
 
-// RLock acquire read lock, before getting Components().
-// Update() is blocked until the read is finished.
-func (p *ComponentsProvider) RLock() {
-	p.updateLock.RLock()
-}
-
-// RUnlock release read lock.
-func (p *ComponentsProvider) RUnlock() {
-	p.updateLock.RUnlock()
-}
-
 func (p *ComponentsProvider) Components() *ComponentsMap {
+	p.updateLock.RLock()
+	defer p.updateLock.RUnlock()
 	return p.value
 }
 
@@ -51,17 +42,13 @@ func (p *ComponentsProvider) Update(ctx context.Context) {
 	go func() {
 		startTime := time.Now()
 		p.logger.Infof("components update started")
-		p.updateLock.Lock()
-
-		defer p.updateLock.Unlock()
-		p.logger.Infof("components update: acquired lock")
-		lockTime := time.Now()
-
 		ctx, cancel := context.WithTimeout(ctx, ComponentsUpdateTimeout)
 		defer cancel()
 		if index, err := p.index(ctx); err == nil {
+			p.updateLock.Lock()
+			defer p.updateLock.Unlock()
 			p.value = NewComponentsMap(index.Components)
-			p.logger.Infof("components update finished | %s / %s", time.Since(startTime), time.Since(lockTime))
+			p.logger.Infof("components update finished | %s", time.Since(startTime))
 		} else {
 			p.logger.Errorf("components update failed: %w", err)
 		}


### PR DESCRIPTION
Changes:
- The component update lock is used only for exchanging values, not for the entire time of loading the component list.

--------------------

Odporucam pozriet samostatne 1. commit kde je implementacia (par riadkov), dalsi commit je potom test (tam je toho viac).