### PR TITLE
Empty path cannot be used in fs.SubDirFs method

### DIFF
--- a/internal/pkg/filesystem/aferofs/basepathfs/basepathfs.go
+++ b/internal/pkg/filesystem/aferofs/basepathfs/basepathfs.go
@@ -27,6 +27,11 @@ type basePathProvider interface {
 }
 
 func New(rootFs aferoFs, basePath string) (*BasePathFs, error) {
+	// Base path cannot be empty
+	if strings.TrimSpace(basePath) == "" {
+		return nil, fmt.Errorf("path cannot be empty")
+	}
+
 	// Check target dir
 	if stat, err := rootFs.Stat(basePath); err != nil {
 		return nil, err

--- a/internal/pkg/filesystem/aferofs/filesystem.go
+++ b/internal/pkg/filesystem/aferofs/filesystem.go
@@ -58,7 +58,7 @@ func (f *Fs) SubDirFs(path string) (filesystem.Fs, error) {
 
 	subDirFs, err := f.fs.SubDirFs(f.fs.FromSlash(path))
 	if err != nil {
-		return nil, err
+		return nil, fmt.Errorf(`cannot get sub directory "%s": %w`, path, err)
 	}
 
 	return New(f.logger, subDirFs.(abstract.Backend), f.fs.FromSlash(workingDir)), nil

--- a/internal/pkg/filesystem/aferofs/filesystem_test.go
+++ b/internal/pkg/filesystem/aferofs/filesystem_test.go
@@ -141,6 +141,11 @@ func (*testCases) TestSubDirFs(t *testing.T, fs filesystem.Fs, _ log.DebugLogger
 	assert.NoError(t, fs.WriteFile(filesystem.NewRawFile("sub/dir1/dir2/file.txt", "foo\n")))
 	assert.True(t, fs.IsFile(`sub/dir1/dir2/file.txt`))
 
+	// Empty path is not allowed
+	_, err := fs.SubDirFs("  ")
+	assert.Error(t, err)
+	assert.Equal(t, `cannot get sub directory "  ": path cannot be empty`, err.Error())
+
 	// /sub/dir1
 	subDirFs1, err := fs.SubDirFs(`/sub/dir1`)
 	assert.NoError(t, err)
@@ -166,7 +171,7 @@ func (*testCases) TestSubDirFs(t *testing.T, fs filesystem.Fs, _ log.DebugLogger
 	// file
 	subDirFs3, err := subDirFs2.SubDirFs(`/file.txt`)
 	assert.Error(t, err)
-	assert.Equal(t, `path "file.txt" is not directory`, err.Error())
+	assert.Equal(t, `cannot get sub directory "file.txt": path "file.txt" is not directory`, err.Error())
 	assert.Nil(t, subDirFs3)
 
 	// not found


### PR DESCRIPTION
See: https://github.com/keboola/keboola-as-code/pull/783#discussion_r962471743