### PR TITLE
ETCD: use a longer connect timeout when starting the API server

### DIFF
--- a/internal/pkg/api/server/templates/dependencies/dependencies.go
+++ b/internal/pkg/api/server/templates/dependencies/dependencies.go
@@ -221,6 +221,7 @@ func (v *forServer) EtcdClient(ctx context.Context) (*etcd.Client, error) {
 		}
 
 		// Create client
+		startTime := time.Now()
 		v.logger.Infof("connecting to etcd, timeout=%s", connectTimeout)
 		c, err := etcd.New(etcd.Config{
 			Context:              v.serverCtx, // !!! a long-lived context must be used, client exists as long as the entire server
@@ -258,7 +259,7 @@ func (v *forServer) EtcdClient(ctx context.Context) (*etcd.Client, error) {
 			}
 		}()
 
-		v.logger.Infof(`connected to etcd cluster "%s"`, c.Endpoints()[0])
+		v.logger.Infof(`connected to etcd cluster "%s" | %s`, c.Endpoints()[0], time.Since(startTime))
 		return c, nil
 	})
 }

--- a/internal/pkg/api/server/templates/dependencies/dependencies.go
+++ b/internal/pkg/api/server/templates/dependencies/dependencies.go
@@ -51,7 +51,10 @@ type ctxKey string
 
 const ForPublicRequestCtxKey = ctxKey("ForPublicRequest")
 const ForProjectRequestCtxKey = ctxKey("ForProjectRequest")
-const EtcdTestConnectionTimeout = 1 * time.Second
+const EtcdConnectionTimeoutCtxKey = ctxKey("EtcdConnectionTimeout")
+const EtcdDefaultConnectionTimeout = 2 * time.Second
+const EtcdKeepAliveTimeout = 2 * time.Second
+const EtcdKeepAliveInterval = 10 * time.Second
 
 // ForServer interface provides dependencies for Templates API server.
 // The container exists during the entire run of the API server.
@@ -62,7 +65,7 @@ type ForServer interface {
 	ServerWaitGroup() *sync.WaitGroup
 	PrefixLogger() log.PrefixLogger
 	RepositoryManager() *repository.Manager
-	EtcdClient() (*etcd.Client, error)
+	EtcdClient(ctx context.Context) (*etcd.Client, error)
 }
 
 // ForPublicRequest interface provides dependencies for a public request that does not contain the Storage API token.
@@ -147,7 +150,9 @@ func NewServerDeps(serverCtx context.Context, envs env.Provider, logger log.Pref
 	}
 
 	// Test connection to etcd at server startup
-	if _, err := d.EtcdClient(); err != nil {
+	// We use a longer timeout when starting the server, because ETCD could be restarted at the same time as the API.
+	etcdCtx := context.WithValue(serverCtx, EtcdConnectionTimeoutCtxKey, 30*time.Second)
+	if _, err := d.EtcdClient(etcdCtx); err != nil {
 		d.Logger().Warnf("cannot connect to etcd: %s", err.Error())
 	}
 
@@ -196,7 +201,7 @@ func (v *forServer) RepositoryManager() *repository.Manager {
 	return v.repositoryManager
 }
 
-func (v *forServer) EtcdClient() (*etcd.Client, error) {
+func (v *forServer) EtcdClient(ctx context.Context) (*etcd.Client, error) {
 	return v.etcdClient.InitAndGet(func() (*etcd.Client, error) {
 		// Check if etcd is enabled
 		if v.Envs().Get("ETCD_ENABLED") == "false" {
@@ -209,13 +214,20 @@ func (v *forServer) EtcdClient() (*etcd.Client, error) {
 			return nil, fmt.Errorf("ETCD_HOST is not set")
 		}
 
+		// Get timeout
+		connectTimeout := EtcdDefaultConnectionTimeout
+		if v, found := ctx.Value(EtcdConnectionTimeoutCtxKey).(time.Duration); found {
+			connectTimeout = v
+		}
+
 		// Create client
+		v.logger.Infof("connecting to etcd, timeout=%s", connectTimeout)
 		c, err := etcd.New(etcd.Config{
-			Context:              v.serverCtx,
+			Context:              v.serverCtx, // !!! a long-lived context must be used, client exists as long as the entire server
 			Endpoints:            []string{endpoint},
-			DialTimeout:          2 * time.Second,
-			DialKeepAliveTimeout: 2 * time.Second,
-			DialKeepAliveTime:    10 * time.Second,
+			DialTimeout:          connectTimeout,
+			DialKeepAliveTimeout: EtcdKeepAliveTimeout,
+			DialKeepAliveTime:    EtcdKeepAliveInterval,
 			Username:             v.Envs().Get("ETCD_USERNAME"), // optional
 			Password:             v.Envs().Get("ETCD_PASSWORD"), // optional
 		})
@@ -223,9 +235,11 @@ func (v *forServer) EtcdClient() (*etcd.Client, error) {
 			return nil, err
 		}
 
-		// Sync endpoints list from cluster (also serves as a connection check)
-		syncCtx, syncCancelFn := context.WithTimeout(v.ServerCtx(), EtcdTestConnectionTimeout)
+		// Context for connection test
+		syncCtx, syncCancelFn := context.WithTimeout(ctx, connectTimeout)
 		defer syncCancelFn()
+
+		// Sync endpoints list from cluster (also serves as a connection check)
 		if err := c.Sync(syncCtx); err != nil {
 			c.Close()
 			return nil, err

--- a/internal/pkg/api/server/templates/dependencies/locks.go
+++ b/internal/pkg/api/server/templates/dependencies/locks.go
@@ -16,7 +16,7 @@ const LockReleaseTimeout = 5 * time.Second // the lock must be released in 5 sec
 
 type lockerDeps interface {
 	Logger() log.Logger
-	EtcdClient() (*etcd.Client, error)
+	EtcdClient(ctx context.Context) (*etcd.Client, error)
 }
 
 type Locker struct {
@@ -32,7 +32,7 @@ func NewLocker(d lockerDeps, ttl int) *Locker {
 
 func (l *Locker) Lock(requestCtx context.Context, lockName string) (bool, UnlockFn) {
 	// Get client
-	c, err := l.d.EtcdClient()
+	c, err := l.d.EtcdClient(requestCtx)
 	if err != nil {
 		l.d.Logger().Warnf(`cannot acquire etcd lock "%s" (continues without lock): cannot get etcd client: %s`, lockName, err.Error())
 		return true, func() {}

--- a/internal/pkg/api/server/templates/dependencies/locks_test.go
+++ b/internal/pkg/api/server/templates/dependencies/locks_test.go
@@ -24,7 +24,7 @@ func (d *testDeps) Logger() log.Logger {
 	return d.logger
 }
 
-func (d *testDeps) EtcdClient() (*etcd.Client, error) {
+func (d *testDeps) EtcdClient(_ context.Context) (*etcd.Client, error) {
 	if d.etcdClient == nil {
 		return nil, fmt.Errorf("some etcd client error")
 	}

--- a/internal/pkg/api/server/templates/service/cron.go
+++ b/internal/pkg/api/server/templates/service/cron.go
@@ -16,7 +16,7 @@ func StartRepositoriesPullCron(ctx context.Context, d dependencies.ForServer) er
 
 	// Start background work
 	go func() {
-		d.Logger().Infof("repository pull cron prepared")
+		d.Logger().Infof("repository pull cron ready")
 
 		// Delay start to a rounded time
 		interval := TemplateRepositoriesPullInterval
@@ -46,7 +46,7 @@ func StartComponentsCron(ctx context.Context, d dependencies.ForServer) error {
 
 	// Start background work
 	go func() {
-		d.Logger().Infof("components cron prepared")
+		d.Logger().Infof("components update cron ready")
 
 		// Delay start to a rounded time
 		interval := ComponentsUpdateInterval


### PR DESCRIPTION
Part of: https://keboola.atlassian.net/browse/KAC-173

------

Nedavno boli nejaky incidenty v Azure stacku, do logov nam prislo `etcd connection failed: context deadline exceeded`
https://keboola.slack.com/archives/C037T3A2HLG/p1662114023919549

Bolo to preto, lebo sa restartoval cely server, a prakticky naraz nabehlo aj API aj ETCD, a timeout `1s` na spojenie nebol dostatocny.

Zmeny:
- Timeout som zdvihol na `2s`, kedze re-connect do etcd moze nastat pocas requestu na nase API, tak viac tam byt uz nemoze, kedze gateway timeout je `30s`.
- Pri starte serveru som timeout zdvihol na `30s`, kedze tam s tym nie je problem.

Testoval som to manualne:

- s vypnutym `etcd` sa cakalo `30s` a potom server nabehol:
![image](https://user-images.githubusercontent.com/19371734/188404089-d011a8d2-deb1-447b-989c-8291935c0464.png)


- ak som pocas cakania zapol `etcd`, tak sa uspesne vytvorilo spojenie (etcd client ma zabudovane retry):
![image](https://user-images.githubusercontent.com/19371734/188404172-95cd975b-8b01-44f3-a3ba-09c7a9dfa676.png)
