### PR TITLE
Add locks to PUT, POST and DELETE requests

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -28,10 +28,19 @@ services:
       - "8000:8000"
       - "6060:6060"
   etcd:
+    hostname: etcd
     image: docker.io/bitnami/etcd:3.5.4-debian-11-r27
     environment:
       ALLOW_NONE_AUTHENTICATION: "no"
+      ETCD_NAME: "etcd"
       ETCD_ROOT_PASSWORD: "toor"
+      ETCD_ADVERTISE_CLIENT_URLS: "http://etcd:2379"
+      ETCD_INITIAL_ADVERTISE_PEER_URLS: "http://etcd:2380"
+      ETCD_INITIAL_CLUSTER_TOKEN: "cluster"
+      ETCD_INITIAL_CLUSTER": "default=http://etcd:2379"
+      ETCD_LISTEN_CLIENT_URLS: "http://0.0.0.0:2379"
+      ETCD_LISTEN_PEER_URLS: "http://0.0.0.0:2380"
+      ETCD_DISABLE_STORE_MEMBER_ID: "true"
 
 volumes:
   cache:

--- a/internal/pkg/api/server/templates/dependencies/locks.go
+++ b/internal/pkg/api/server/templates/dependencies/locks.go
@@ -3,6 +3,7 @@ package dependencies
 import (
 	"context"
 	"errors"
+	"fmt"
 	"time"
 
 	etcd "go.etcd.io/etcd/client/v3"
@@ -11,8 +12,8 @@ import (
 	"github.com/keboola/keboola-as-code/internal/pkg/log"
 )
 
-const LockAcquireTimeout = 1 * time.Second // the lock must be acquired in 1 second, otherwise we continue without the lock
-const LockReleaseTimeout = 5 * time.Second // the lock must be released in 5 second
+const LockAcquireTimeout = 2 * time.Second // the lock must be acquired in 2 seconds, otherwise we continue without the lock
+const LockReleaseTimeout = 2 * time.Second // the lock must be released in 2 seconds
 
 type lockerDeps interface {
 	Logger() log.Logger
@@ -20,47 +21,26 @@ type lockerDeps interface {
 }
 
 type Locker struct {
-	d   lockerDeps
-	ttl int
+	d          lockerDeps
+	ttlSeconds int
 }
 
 type UnlockFn func()
 
-func NewLocker(d lockerDeps, ttl int) *Locker {
-	return &Locker{d: d, ttl: ttl}
+func NewLocker(d lockerDeps, ttlSeconds int) *Locker {
+	return &Locker{d: d, ttlSeconds: ttlSeconds}
 }
 
-func (l *Locker) Lock(requestCtx context.Context, lockName string) (bool, UnlockFn) {
-	// Get client
-	c, err := l.d.EtcdClient(requestCtx)
-	if err != nil {
-		l.d.Logger().Warnf(`cannot acquire etcd lock "%s" (continues without lock): cannot get etcd client: %s`, lockName, err.Error())
-		return true, func() {}
-	}
-
-	// Get concurrency session with TTL
-	session, err := concurrency.NewSession(c, concurrency.WithTTL(l.ttl))
-	if err != nil {
-		l.d.Logger().Warnf(`cannot acquire etcd lock "%s" (continues without lock): cannot obtain session: %s`, err.Error())
-		return true, func() {}
-	}
-
-	// Context with acquire timeout
-	acquireCtx, cancelFn := context.WithTimeout(requestCtx, LockAcquireTimeout)
-	defer cancelFn()
-
+func (l *Locker) TryLock(requestCtx context.Context, lockName string) (bool, UnlockFn) {
 	// Try lock
-	mtx := concurrency.NewMutex(session, lockName)
-	if err := mtx.TryLock(acquireCtx); errors.Is(err, concurrency.ErrLocked) {
+	session, mtx, err := l.tryLock(requestCtx, lockName)
+	if errors.Is(err, concurrency.ErrLocked) {
 		l.d.Logger().Infof(`etcd lock "%s" is used`, lockName)
 		return false, func() {}
 	} else if err != nil {
-		l.d.Logger().Warnf("cannot acquire etcd lock (continues without lock): cannot lock mutex: %s", err.Error())
+		l.d.Logger().Warnf(`cannot acquire etcd lock "%s" (continues without lock): %s`, lockName, err)
 		return true, func() {}
 	}
-
-	// End the refresh for the session lease, so TTL will apply
-	session.Orphan()
 
 	// Locked, must be unlocked by returned unlock function
 	l.d.Logger().Infof(`acquired etcd lock "%s"`, mtx.Key())
@@ -68,11 +48,48 @@ func (l *Locker) Lock(requestCtx context.Context, lockName string) (bool, Unlock
 		releaseCtx, cancelFn := context.WithTimeout(context.Background(), LockReleaseTimeout)
 		defer cancelFn()
 		if err := mtx.Unlock(releaseCtx); err != nil {
-			l.d.Logger().Warnf(`cannot unlock etcd lock "%s": %s`, mtx.Key(), err.Error())
+			l.d.Logger().Warnf(`cannot unlock etcd lock "%s": %s`, lockName, err.Error())
 		}
 		if err := session.Close(); err != nil {
-			l.d.Logger().Warnf(`cannot close etcd session for lock "%s": %s`, mtx.Key(), err.Error())
+			l.d.Logger().Warnf(`cannot close etcd session for lock "%s": %s`, lockName, err.Error())
 		}
 		l.d.Logger().Infof(`released etcd lock "%s"`, lockName)
 	}
+}
+
+func (l *Locker) tryLock(requestCtx context.Context, lockName string) (*concurrency.Session, *concurrency.Mutex, error) {
+	// Get client
+	c, err := l.d.EtcdClient(requestCtx)
+	if err != nil {
+		return nil, nil, fmt.Errorf(`cannot get etcd client: %w`, err)
+	}
+
+	// Acquire timeout
+	acquireCtx, cancelFn := context.WithTimeout(requestCtx, LockAcquireTimeout)
+	defer cancelFn()
+
+	// Creates a new lease
+	lease, err := c.Grant(acquireCtx, int64(l.ttlSeconds))
+	if err != nil {
+		return nil, nil, fmt.Errorf(`cannot grant lease %w`, err)
+	}
+
+	// Get concurrency session with TTL
+	session, err := concurrency.NewSession(c, concurrency.WithContext(requestCtx), concurrency.WithLease(lease.ID))
+	if err != nil {
+		return nil, nil, fmt.Errorf(`cannot obtain session: %w`, err)
+	}
+
+	// Try lock
+	mtx := concurrency.NewMutex(session, lockName)
+	if err := mtx.TryLock(acquireCtx); errors.Is(err, concurrency.ErrLocked) {
+		return nil, nil, err
+	} else if err != nil {
+		return nil, nil, fmt.Errorf(`cannot lock mutex: %w`, err)
+	}
+
+	// End the refresh for the session lease, so TTL will apply
+	session.Orphan()
+
+	return session, mtx, nil
 }

--- a/internal/pkg/api/server/templates/dependencies/locks_test.go
+++ b/internal/pkg/api/server/templates/dependencies/locks_test.go
@@ -41,15 +41,15 @@ func TestLocker_WithoutEtcd(t *testing.T) {
 
 	// Test!
 	// All attempts return true
-	locked1, unlockFn1 := locker.Lock(context.Background(), "projectId=123")
+	locked1, unlockFn1 := locker.TryLock(context.Background(), "projectId=123")
 	defer unlockFn1()
 	assert.True(t, locked1)
 
-	locked2, unlockFn2 := locker.Lock(context.Background(), "projectId=123")
+	locked2, unlockFn2 := locker.TryLock(context.Background(), "projectId=123")
 	defer unlockFn2()
 	assert.True(t, locked2)
 
-	locked3, unlockFn3 := locker.Lock(context.Background(), "projectId=123")
+	locked3, unlockFn3 := locker.TryLock(context.Background(), "projectId=123")
 	defer unlockFn3()
 	assert.True(t, locked3)
 
@@ -72,21 +72,21 @@ func TestLocker_WithEtcd(t *testing.T) {
 
 	// Test!
 	// Project is locked
-	locked1, unlock1Fn := locker.Lock(context.Background(), "projectId=123")
+	locked1, unlock1Fn := locker.TryLock(context.Background(), "projectId=123")
 	defer unlock1Fn()
 	assert.True(t, locked1)
 	// ... so the project cannot be used by other requests
-	locked2, unlock2Fn := locker.Lock(context.Background(), "projectId=123")
+	locked2, unlock2Fn := locker.TryLock(context.Background(), "projectId=123")
 	defer unlock2Fn()
 	assert.False(t, locked2)
 	// ... but another project can be locked
-	locked3, unlock3Fn := locker.Lock(context.Background(), "projectId=789")
+	locked3, unlock3Fn := locker.TryLock(context.Background(), "projectId=789")
 	defer unlock3Fn()
 	assert.True(t, locked3)
 	// Project is unlocked
 	unlock1Fn()
 	// ... so next request can use the  project
-	locked5, unlock5Fn := locker.Lock(context.Background(), "projectId=123")
+	locked5, unlock5Fn := locker.TryLock(context.Background(), "projectId=123")
 	defer unlock5Fn()
 	assert.True(t, locked5)
 	// Unlock both projects
@@ -116,16 +116,16 @@ func TestLocker_WithEtcd_TimeToLiveExpired(t *testing.T) {
 
 	// Test!
 	// Project is locked
-	locked1, unlock1Fn := locker.Lock(context.Background(), "projectId=456")
+	locked1, unlock1Fn := locker.TryLock(context.Background(), "projectId=456")
 	defer unlock1Fn()
 	assert.True(t, locked1)
 	// ... so project cannot be locked by other requests
-	locked2, unlock2Fn := locker.Lock(context.Background(), "projectId=456")
+	locked2, unlock2Fn := locker.TryLock(context.Background(), "projectId=456")
 	defer unlock2Fn()
 	assert.False(t, locked2)
 	// ... but after ttlSeconds, lock is auto-released and project can be locked again
 	time.Sleep(time.Duration(ttlSeconds+1) * time.Second)
-	locked3, unlock3Fn := locker.Lock(context.Background(), "projectId=456")
+	locked3, unlock3Fn := locker.TryLock(context.Background(), "projectId=456")
 	defer unlock3Fn()
 	assert.True(t, locked3)
 	// Unlock

--- a/internal/pkg/api/server/templates/http/middleware.go
+++ b/internal/pkg/api/server/templates/http/middleware.go
@@ -18,6 +18,8 @@ import (
 	"github.com/keboola/keboola-as-code/internal/pkg/idgenerator"
 )
 
+const RequestTimeout = 60 * time.Second
+
 func TraceEndpointsMiddleware() func(endpoint goa.Endpoint) goa.Endpoint {
 	return func(endpoint goa.Endpoint) goa.Endpoint {
 		return func(ctx context.Context, request interface{}) (response interface{}, err error) {
@@ -61,8 +63,8 @@ func ContextMiddleware(serverDeps dependencies.ForServer, h http.Handler) http.H
 			span.SetTag("storage.host", serverDeps.StorageApiHost())
 		}
 
-		// Cancel context after request
-		ctx, cancelFn := context.WithCancel(ctx)
+		// Cancel context after request + set timeout
+		ctx, cancelFn := context.WithTimeout(ctx, RequestTimeout)
 		defer cancelFn()
 
 		// Add dependencies to the context


### PR DESCRIPTION
Part of: https://keboola.atlassian.net/browse/KAC-173

------

Da sa to jednoducho vyskusat aj lokalne:
- otvoris si 2 okna s dokumentaciou
- priblizne naraz spustis `use/upgrade` request
- ten request, ktory si spustil ako druhy skonci s `503`
- kod `503` som vybral podla: https://stackoverflow.com/questions/37116097/http-statuscode-when-waiting-for-lock-release-takes-to-long
- posiela sa `Retry-After` header

![image](https://user-images.githubusercontent.com/19371734/188558477-b026c52b-6342-4dce-9d5e-5c77a6bb1fd5.png)

---- 

Skusal som rozne scenare:
- spustit server BEZ etcd (-> req), spustit etcd (->reg), vypnut etcd (->reg)
- spustit server S etcd (-> req), vypnut etcd (->reg), zapnut etcd (->reg)
