### PR TITLE
Bump aferocopy to stable v2.0.1

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -4,8 +4,6 @@ go 1.19
 
 replace github.com/google/go-jsonnet v0.18.0 => github.com/keboola/go-jsonnet v0.18.1-0.20220810085752-aee7595aa305
 
-replace go.nhat.io/aferocopy/v2 v2.0.0 => github.com/keboola/aferocopy/v2 v2.0.0-20220906135934-de489c8021dc
-
 require (
 	github.com/ActiveState/vt10x v1.3.1
 	github.com/AlecAivazis/survey/v2 v2.2.12
@@ -38,7 +36,7 @@ require (
 	github.com/stretchr/testify v1.8.0
 	github.com/umisama/go-regexpcache v0.0.0-20150417035358-2444a542492f
 	go.etcd.io/etcd/client/v3 v3.5.0
-	go.nhat.io/aferocopy/v2 v2.0.0
+	go.nhat.io/aferocopy/v2 v2.0.1
 	go.uber.org/zap v1.23.0
 	goa.design/goa/v3 v3.8.5
 	goa.design/plugins/v3 v3.8.5

--- a/go.sum
+++ b/go.sum
@@ -372,8 +372,6 @@ github.com/julienschmidt/httprouter v1.2.0/go.mod h1:SYymIcj16QtmaHHD7aYtjjsJG7V
 github.com/julienschmidt/httprouter v1.3.0/go.mod h1:JR6WtHb+2LUe8TCKY3cZOxFyyO8IZAc4RVcycCCAKdM=
 github.com/kballard/go-shellquote v0.0.0-20180428030007-95032a82bc51 h1:Z9n2FFNUXsshfwJMBgNA0RU6/i7WVaAegv3PtuIHPMs=
 github.com/kballard/go-shellquote v0.0.0-20180428030007-95032a82bc51/go.mod h1:CzGEWj7cYgsdH8dAjBGEr58BoE7ScuLd+fwFZ44+/x8=
-github.com/keboola/aferocopy/v2 v2.0.0-20220906135934-de489c8021dc h1:2pSw61bp48hBkOiR9CYiQ5zgtnE1Tcw7HaejiPiRKyM=
-github.com/keboola/aferocopy/v2 v2.0.0-20220906135934-de489c8021dc/go.mod h1:Nyd1b35gqLm279GSd7OOVS3qBGcRAIaJ/rsZCGENtD0=
 github.com/keboola/go-client v0.4.0 h1:Dv0VNcrRK/EGjIY2SokzFP8d/ehUl5GXOzPCS0CO6JE=
 github.com/keboola/go-client v0.4.0/go.mod h1:YPQenBSf8SQhXu8/KvpX/rcPgI7nE6p4iiI7sY5hL6U=
 github.com/keboola/go-jsonnet v0.18.1-0.20220810085752-aee7595aa305 h1:hS/jX0HQzeGZWjMBSAs/IqrJTrTB5/BlYu7UcjFW9NU=
@@ -577,6 +575,8 @@ go.etcd.io/etcd/client/pkg/v3 v3.5.1/go.mod h1:IJHfcCEKxYu1Os13ZdwCwIUTUVGYTSAM3
 go.etcd.io/etcd/client/v2 v2.305.1/go.mod h1:pMEacxZW7o8pg4CrFE7pquyCJJzZvkvdD2RibOCCCGs=
 go.etcd.io/etcd/client/v3 v3.5.0 h1:62Eh0XOro+rDwkrypAGDfgmNh5Joq+z+W9HZdlXMzek=
 go.etcd.io/etcd/client/v3 v3.5.0/go.mod h1:AIKXXVX/DQXtfTEqBryiLTUXwON+GuvO6Z7lLS/oTh0=
+go.nhat.io/aferocopy/v2 v2.0.1 h1:z+AXOocir6zZsBbd1WXj0yny0cn3G0xqVJftD//tSSw=
+go.nhat.io/aferocopy/v2 v2.0.1/go.mod h1:cUjw3cg2oAx1YqGp2VJl248LsNW/x4PDVHESfxfdHww=
 go.nhat.io/aferomock v0.4.0 h1:gs3nJzIqAezglUuaPfautAmZwulwRWLcfSSzdK4YCC0=
 go.opencensus.io v0.21.0/go.mod h1:mSImk1erAIZhrmZN+AvHh14ztQfjbGwt4TtuofqLduU=
 go.opencensus.io v0.22.0/go.mod h1:+kGneAE2xo2IficOXnaByMWTGM9T73dGwxeWcUqIpI8=


### PR DESCRIPTION
Changes:
- `aferocopy` package now track official (fixed) version.