### PR TITLE
Move repository checkout to separated operation

### DIFF
--- a/internal/pkg/api/server/templates/dependencies/dependencies_test.go
+++ b/internal/pkg/api/server/templates/dependencies/dependencies_test.go
@@ -11,7 +11,6 @@ import (
 	"os"
 	"os/exec"
 	"path/filepath"
-	"sync"
 	"testing"
 	"time"
 
@@ -84,7 +83,7 @@ func TestForProjectRequest_TemplateRepository_Cached(t *testing.T) {
 	ctx := context.Background()
 	nopApiLogger := log.NewApiLogger(stdLog.New(io.Discard, "", 0), "", false)
 	mockedDeps := dependencies.NewMockedDeps(dependencies.WithMockedTokenResponse(3))
-	repositoryManager, err := repository.NewManager(ctx, &sync.WaitGroup{}, mockedDeps.Logger(), nil)
+	repositoryManager, err := repository.NewManager(ctx, nil, mockedDeps)
 	assert.NoError(t, err)
 	serverDeps := &forServer{Base: mockedDeps, Public: mockedDeps, serverCtx: ctx, logger: nopApiLogger, repositoryManager: repositoryManager}
 

--- a/internal/pkg/dependencies/dependencies.go
+++ b/internal/pkg/dependencies/dependencies.go
@@ -49,6 +49,7 @@ package dependencies
 
 import (
 	"context"
+	"sync"
 
 	"github.com/jarcoal/httpmock"
 	"github.com/keboola/go-client/pkg/client"
@@ -106,6 +107,7 @@ type Mocked interface {
 	Base
 	Public
 	Project
+	ServerWaitGroup() *sync.WaitGroup
 	SetFromTestProject(project *testproject.Project)
 	EnvsMutable() *env.Map
 	Options() *options.Options

--- a/internal/pkg/dependencies/mocked.go
+++ b/internal/pkg/dependencies/mocked.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"fmt"
 	"net/http"
+	"sync"
 
 	"github.com/jarcoal/httpmock"
 	"github.com/keboola/go-client/pkg/client"
@@ -30,6 +31,7 @@ type mocked struct {
 	*project
 	envs                *env.Map
 	options             *options.Options
+	serverWg            *sync.WaitGroup
 	debugLogger         log.DebugLogger
 	mockedHttpTransport *httpmock.MockTransport
 }
@@ -150,6 +152,7 @@ func NewMockedDeps(opts ...MockedOption) Mocked {
 		project:             projectDeps,
 		envs:                envs,
 		options:             options.New(),
+		serverWg:            &sync.WaitGroup{},
 		debugLogger:         logger,
 		mockedHttpTransport: mockedHttpTransport,
 	}
@@ -176,6 +179,10 @@ func (v *mocked) Options() *options.Options {
 
 func (v *mocked) DebugLogger() log.DebugLogger {
 	return v.debugLogger
+}
+
+func (v *mocked) ServerWaitGroup() *sync.WaitGroup {
+	return v.serverWg
 }
 
 func (v *mocked) MockedHttpTransport() *httpmock.MockTransport {

--- a/internal/pkg/template/repository/manager_test.go
+++ b/internal/pkg/template/repository/manager_test.go
@@ -6,13 +6,12 @@ import (
 	"fmt"
 	"os"
 	"path/filepath"
-	"sync"
 	"testing"
 
 	"github.com/stretchr/testify/assert"
 
+	"github.com/keboola/keboola-as-code/internal/pkg/dependencies"
 	"github.com/keboola/keboola-as-code/internal/pkg/filesystem/aferofs"
-	"github.com/keboola/keboola-as-code/internal/pkg/log"
 	"github.com/keboola/keboola-as-code/internal/pkg/model"
 	"github.com/keboola/keboola-as-code/internal/pkg/template/repository"
 )
@@ -31,9 +30,11 @@ func TestNewManager(t *testing.T) {
 		Ref:  "main",
 	}
 
-	m, err := repository.NewManager(context.Background(), &sync.WaitGroup{}, log.NewDebugLogger(), nil)
+	ctx := context.Background()
+	d := dependencies.NewMockedDeps()
+	m, err := repository.NewManager(ctx, nil, d)
 	assert.NoError(t, err)
-	defaultRepo, err := m.Repository(repo)
+	defaultRepo, err := m.Repository(ctx, repo)
 	assert.NoError(t, err)
 
 	fs, unlockFS := defaultRepo.Fs()
@@ -56,12 +57,14 @@ func TestManager_Repository(t *testing.T) {
 		Ref:  "main",
 	}
 
-	m, err := repository.NewManager(context.Background(), &sync.WaitGroup{}, log.NewDebugLogger(), nil)
+	ctx := context.Background()
+	d := dependencies.NewMockedDeps()
+	m, err := repository.NewManager(ctx, nil, d)
 	assert.NoError(t, err)
-	v, err := m.Repository(repo)
+	v, err := m.Repository(ctx, repo)
 	assert.NotNil(t, v)
 	assert.NoError(t, err)
-	v, err = m.Repository(repo)
+	v, err = m.Repository(ctx, repo)
 	assert.NotNil(t, v)
 	assert.NoError(t, err)
 }
@@ -91,7 +94,8 @@ func TestNewManager_DefaultRepositories(t *testing.T) {
 	}
 
 	// Create manager
-	m, err := repository.NewManager(context.Background(), &sync.WaitGroup{}, log.NewDebugLogger(), defaultRepositories)
+	d := dependencies.NewMockedDeps()
+	m, err := repository.NewManager(context.Background(), defaultRepositories, d)
 	assert.NoError(t, err)
 
 	// Get list of default repositories

--- a/pkg/lib/operation/repository/checkout/operation.go
+++ b/pkg/lib/operation/repository/checkout/operation.go
@@ -1,0 +1,32 @@
+package checkout
+
+import (
+	"context"
+	"fmt"
+	"time"
+
+	"github.com/keboola/keboola-as-code/internal/pkg/git"
+	"github.com/keboola/keboola-as-code/internal/pkg/log"
+	"github.com/keboola/keboola-as-code/internal/pkg/model"
+)
+
+const Timeout = 30 * time.Second
+
+type dependencies interface {
+	Logger() log.Logger
+}
+
+func Run(ctx context.Context, repoDef model.TemplateRepository, d dependencies) (*git.Repository, error) {
+	// Create context with timeout
+	ctx, cancel := context.WithTimeout(ctx, Timeout)
+	defer cancel()
+
+	// Checkout
+	repo, err := git.Checkout(ctx, repoDef.Url, repoDef.Ref, false, d.Logger())
+	if err != nil {
+		return nil, fmt.Errorf(`cannot checkout out repository "%s": %w`, repoDef, err)
+	}
+
+	// Done
+	return repo, nil
+}


### PR DESCRIPTION
Changed:
- Created `repository/checkout` operation, so in the next step we can add telemetry.