### PR TITLE
Move repository pull to separated operation

### DIFF
--- a/internal/pkg/api/server/templates/dependencies/dependencies_test.go
+++ b/internal/pkg/api/server/templates/dependencies/dependencies_test.go
@@ -100,7 +100,7 @@ func TestForProjectRequest_TemplateRepository_Cached(t *testing.T) {
 	assert.False(t, repo1.Fs().Exists("template2"))
 
 	// Update repository -> no change
-	err = <-repositoryManager.Pull()
+	err = <-repositoryManager.Pull(context.Background())
 	assert.NoError(t, err)
 	wildcards.Assert(t, `%Arepository "%s" update finished, no change found%A`, mockedDeps.DebugLogger().InfoMessages())
 	mockedDeps.DebugLogger().Truncate()
@@ -123,7 +123,7 @@ func TestForProjectRequest_TemplateRepository_Cached(t *testing.T) {
 	runGitCommand(t, tmpDir, "reset", "--hard", "b1")
 
 	// Update repository -> change occurred
-	err = <-repositoryManager.Pull()
+	err = <-repositoryManager.Pull(context.Background())
 	assert.NoError(t, err)
 	wildcards.Assert(t, `%Arepository "%s" updated from c6c1f0be98fa8fd49be15022a47dcdca22f0dc41 to db2c26cc2f75b730f034378031d43df445dd6bec%A`, mockedDeps.DebugLogger().InfoMessages())
 	mockedDeps.DebugLogger().Truncate()
@@ -175,7 +175,7 @@ func TestForProjectRequest_TemplateRepository_Cached(t *testing.T) {
 	runGitCommand(t, tmpDir, "reset", "--hard", "HEAD~2")
 
 	// Update repository -> change occurred
-	err = <-repositoryManager.Pull()
+	err = <-repositoryManager.Pull(context.Background())
 	assert.NoError(t, err)
 	wildcards.Assert(t, `%Arepository "%s" updated from db2c26cc2f75b730f034378031d43df445dd6bec to f4bf236227116803d28fa2f931f28059a5ab588f%A`, mockedDeps.DebugLogger().InfoMessages())
 	mockedDeps.DebugLogger().Truncate()

--- a/internal/pkg/api/server/templates/service/cron.go
+++ b/internal/pkg/api/server/templates/service/cron.go
@@ -27,13 +27,13 @@ func StartRepositoriesPullCron(ctx context.Context, d dependencies.ForServer) er
 		// Start ticker
 		d.Logger().Infof("repository pull cron started at %s, interval=%s", time.Now().Format("15:04:05"), interval)
 		ticker := time.NewTicker(interval)
-		manager.Pull()
+		manager.Pull(ctx)
 		for {
 			select {
 			case <-ctx.Done():
 				return
 			case <-ticker.C:
-				manager.Pull()
+				manager.Pull(ctx)
 			}
 		}
 	}()

--- a/internal/pkg/template/repository/manager.go
+++ b/internal/pkg/template/repository/manager.go
@@ -138,9 +138,9 @@ func (m *Manager) Pull(ctx context.Context) <-chan error {
 
 			// Done
 			if result.Changed {
-				m.logger.Infof(`repository "%s" update finished, no change found | %s`, repo, time.Since(startTime))
-			} else {
 				m.logger.Infof(`repository "%s" updated from %s to %s | %s`, repo, result.OldHash, result.NewHash, time.Since(startTime))
+			} else {
+				m.logger.Infof(`repository "%s" update finished, no change found | %s`, repo, time.Since(startTime))
 			}
 		}()
 	}

--- a/internal/pkg/template/repository/manager.go
+++ b/internal/pkg/template/repository/manager.go
@@ -12,6 +12,7 @@ import (
 	"github.com/keboola/keboola-as-code/internal/pkg/model"
 	"github.com/keboola/keboola-as-code/internal/pkg/utils"
 	checkoutOp "github.com/keboola/keboola-as-code/pkg/lib/operation/repository/checkout"
+	pullOp "github.com/keboola/keboola-as-code/pkg/lib/operation/repository/pull"
 )
 
 const PullTimeout = 30 * time.Second
@@ -112,7 +113,7 @@ func (m *Manager) Repository(ctx context.Context, repoDef model.TemplateReposito
 	return m.repositories[repoDef.Hash()], nil
 }
 
-func (m *Manager) Pull() <-chan error {
+func (m *Manager) Pull(ctx context.Context) <-chan error {
 	errorCh := make(chan error, 1)
 	errors := utils.NewMultiError()
 
@@ -123,11 +124,23 @@ func (m *Manager) Pull() <-chan error {
 		wg.Add(1)
 		go func() {
 			defer wg.Done()
-			ctx, cancel := context.WithTimeout(m.ctx, PullTimeout)
-			defer cancel()
-			if err := pullRepo(ctx, m.logger, repo); err != nil {
+
+			// Log start
+			startTime := time.Now()
+			m.logger.Infof(`repository "%s" update started`, repo)
+
+			// Pull
+			result, err := pullOp.Run(ctx, repo, m.deps)
+			if err != nil {
 				errors.Append(err)
 				m.logger.Errorf(`error while updating repository "%s": %w`, repo, err)
+			}
+
+			// Done
+			if result.Changed {
+				m.logger.Infof(`repository "%s" update finished, no change found | %s`, repo, time.Since(startTime))
+			} else {
+				m.logger.Infof(`repository "%s" updated from %s to %s | %s`, repo, result.OldHash, result.NewHash, time.Since(startTime))
 			}
 		}()
 	}
@@ -154,31 +167,4 @@ func (m *Manager) Free() {
 
 	wg.Wait()
 	m.logger.Infof("repository manager cleaned up")
-}
-
-func pullRepo(ctx context.Context, logger log.Logger, repo *git.Repository) error {
-	startTime := time.Now()
-	logger.Infof(`repository "%s" update started`, repo)
-
-	oldHash, err := repo.CommitHash(ctx)
-	if err != nil {
-		return err
-	}
-
-	if err := repo.Pull(ctx); err != nil {
-		return err
-	}
-
-	newHash, err := repo.CommitHash(ctx)
-	if err != nil {
-		return err
-	}
-
-	if oldHash == newHash {
-		logger.Infof(`repository "%s" update finished, no change found | %s`, repo, time.Since(startTime))
-	} else {
-		logger.Infof(`repository "%s" updated from %s to %s | %s`, repo, oldHash, newHash, time.Since(startTime))
-	}
-
-	return nil
 }

--- a/pkg/lib/operation/repository/pull/operation.go
+++ b/pkg/lib/operation/repository/pull/operation.go
@@ -1,0 +1,47 @@
+package pull
+
+import (
+	"context"
+	"time"
+
+	"github.com/keboola/keboola-as-code/internal/pkg/git"
+	"github.com/keboola/keboola-as-code/internal/pkg/log"
+)
+
+const PullTimeout = 30 * time.Second
+
+type dependencies interface {
+	Logger() log.Logger
+}
+
+type Result struct {
+	OldHash string
+	NewHash string
+	Changed bool
+}
+
+func Run(ctx context.Context, repo *git.Repository, d dependencies) (*Result, error) {
+	// Context with timeout
+	ctx, cancel := context.WithTimeout(ctx, PullTimeout)
+	defer cancel()
+
+	// Get old hash
+	oldHash, err := repo.CommitHash(ctx)
+	if err != nil {
+		return nil, err
+	}
+
+	// Pull
+	if err := repo.Pull(ctx); err != nil {
+		return nil, err
+	}
+
+	// Get new hash
+	newHash, err := repo.CommitHash(ctx)
+	if err != nil {
+		return nil, err
+	}
+
+	// Done
+	return &Result{OldHash: oldHash, NewHash: newHash, Changed: oldHash != newHash}, nil
+}

--- a/provisioning/kubernetes/templates/templates-api.yaml
+++ b/provisioning/kubernetes/templates/templates-api.yaml
@@ -44,7 +44,7 @@ spec:
                   key: storageApiHost
             - name: ETCD_ENDPOINT
               value: templates-api-etcd-headless.templates-api.svc.cluster.local:2379
-            - name: ETCD_USER
+            - name: ETCD_USERNAME
               value: root
             - name: ETCD_PASSWORD
               valueFrom:


### PR DESCRIPTION
Changed:
- Created `repository/pull` operation, so in the next step we can add telemetry.