### PR TITLE
API: Connect OpenTelemetry from operations to DataDog

### DIFF
--- a/internal/pkg/api/server/templates/telemetry/telemetry.go
+++ b/internal/pkg/api/server/templates/telemetry/telemetry.go
@@ -1,0 +1,273 @@
+package telemetry
+
+import (
+	"context"
+	"encoding/binary"
+	"net/http"
+	"reflect"
+	"time"
+
+	"github.com/keboola/go-client/pkg/client"
+	"go.opentelemetry.io/otel/attribute"
+	"go.opentelemetry.io/otel/codes"
+	"go.opentelemetry.io/otel/trace"
+	"gopkg.in/DataDog/dd-trace-go.v1/ddtrace/ext"
+	ddtracer "gopkg.in/DataDog/dd-trace-go.v1/ddtrace/tracer"
+
+	"github.com/keboola/keboola-as-code/internal/pkg/env"
+)
+
+type tracer struct{}
+
+type tracerProvider struct {
+	tracer *tracer
+}
+
+type span struct {
+	tracer     *tracer
+	ctx        context.Context
+	ddSpan     ddtracer.Span
+	finishOpts []ddtracer.FinishOption
+}
+
+func NewDataDogTracer() trace.Tracer {
+	return &tracer{}
+}
+
+func (t *tracer) Start(ctx context.Context, spanName string, options ...trace.SpanStartOption) (context.Context, trace.Span) {
+	parentSpan, _ := ddtracer.SpanFromContext(ctx)
+	ddSpan := ddtracer.StartSpan(spanName, mapSpanStartOpts(parentSpan, options)...)
+	return ddtracer.ContextWithSpan(ctx, ddSpan), &span{tracer: t, ctx: ctx, ddSpan: ddSpan}
+}
+
+func (p *tracerProvider) Tracer(_ string, _ ...trace.TracerOption) trace.Tracer {
+	return p.tracer
+}
+
+// End completes the Span. The Span is considered complete and ready to be
+// delivered through the rest of the telemetry pipeline after this method
+// is called. Therefore, updates to the Span are not allowed after this
+// method has been called.
+func (s *span) End(options ...trace.SpanEndOption) {
+	finishOptions := append(s.finishOpts, mapSpanEndOptions(options)...)
+	s.ddSpan.Finish(finishOptions...)
+}
+
+// AddEvent adds an event with the provided name and options.
+func (s *span) AddEvent(name string, options ...trace.EventOption) {
+	// DataDog doesn't support events tracing, use Span with same start/end time
+	startOptions, finishOptions := mapEventOptions(options)
+	startOptions = append(startOptions, ddtracer.ChildOf(s.ddSpan.Context()))
+	eventSpan := ddtracer.StartSpan("event."+name, startOptions...)
+	eventSpan.Finish(finishOptions...)
+}
+
+// IsRecording returns the recording state of the Span. It will return
+// true if the Span is active and events can be recorded.
+func (s *span) IsRecording() bool {
+	return true
+}
+
+// RecordError will record err as an exception span event for this span. An
+// additional call to SetStatus is required if the Status of the Span should
+// be set to Error, as this method does not change the Span status. If this
+// span is not being recorded or err is nil then this method does nothing.
+func (s *span) RecordError(err error, options ...trace.EventOption) {
+	config := trace.NewEventConfig(options...)
+	s.SetAttributes(config.Attributes()...)
+	s.finishOpts = append(s.finishOpts, ddtracer.WithError(err))
+}
+
+// SpanContext returns the SpanContext of the Span. The returned SpanContext
+// is usable even after the End method has been called for the Span.
+func (s *span) SpanContext() trace.SpanContext {
+	// Convert uint64 to byte array
+	traceId := make([]byte, 16)
+	spanId := make([]byte, 8)
+	binary.LittleEndian.PutUint64(traceId, s.ddSpan.Context().TraceID())
+	binary.LittleEndian.PutUint64(spanId, s.ddSpan.Context().SpanID())
+	return trace.NewSpanContext(trace.SpanContextConfig{
+		TraceID:    *(*[16]byte)(traceId),
+		SpanID:     *(*[8]byte)(spanId),
+		TraceFlags: trace.TraceFlags(0),
+		TraceState: trace.TraceState{},
+		Remote:     false,
+	})
+}
+
+// SetStatus sets the status of the Span in the form of a code and a
+// description, overriding previous values set. The description is only
+// included in a status when the code is for an error.
+func (s *span) SetStatus(code codes.Code, description string) {
+	switch code {
+	case codes.Ok:
+		s.ddSpan.SetTag("status", "ok")
+		if description != "" {
+			s.ddSpan.SetTag("status.description", description)
+		}
+	case codes.Error:
+		s.ddSpan.SetTag("status", "error")
+		if description != "" {
+			s.ddSpan.SetTag("status.description", description)
+		}
+	}
+}
+
+// SetName sets the Span name.
+func (s *span) SetName(name string) {
+	s.ddSpan.SetOperationName(name)
+}
+
+// SetAttributes sets kv as attributes of the Span. If a key from kv
+// already exists for an attribute of the Span it will be overwritten with
+// the value contained in kv.
+func (s *span) SetAttributes(kv ...attribute.KeyValue) {
+	for _, pair := range kv {
+		s.ddSpan.SetTag(string(pair.Key), pair.Value)
+	}
+}
+
+// TracerProvider returns a TracerProvider that can be used to generate
+// additional Spans on the same telemetry pipeline as the current Span.
+func (s *span) TracerProvider() trace.TracerProvider {
+	return &tracerProvider{tracer: s.tracer}
+}
+
+func ApiClientTrace() client.TraceFactory {
+	return func() *client.Trace {
+		t := &client.Trace{}
+
+		// Api request
+		var ctx context.Context
+		var apiReqSpan ddtracer.Span
+		t.GotRequest = func(c context.Context, request client.HTTPRequest) context.Context {
+			resultType := reflect.TypeOf(request.ResultDef())
+			resultTypeString := ""
+			if resultType != nil {
+				resultTypeString = resultType.String()
+			}
+			apiReqSpan, ctx = ddtracer.StartSpanFromContext(
+				c,
+				"api.client.request",
+				ddtracer.ResourceName("request"),
+				ddtracer.SpanType("api.client"),
+				ddtracer.Tag("result_type", resultTypeString),
+			)
+			return ctx
+		}
+		t.RequestProcessed = func(result any, err error) {
+			apiReqSpan.Finish(ddtracer.WithError(err))
+		}
+
+		// Retry
+		var retrySpan ddtracer.Span
+		t.HTTPRequestRetry = func(attempt int, delay time.Duration) {
+			retrySpan, _ = ddtracer.StartSpanFromContext(
+				ctx,
+				"api.client.retry.delay",
+				ddtracer.ResourceName("retry"),
+				ddtracer.SpanType("api.client"),
+				ddtracer.Tag("attempt", attempt),
+				ddtracer.Tag("delay_ms", delay.Milliseconds()),
+				ddtracer.Tag("delay_string", delay.String()),
+			)
+		}
+		t.HTTPRequestStart = func(r *http.Request) {
+			if retrySpan != nil {
+				apiReqSpan.Finish()
+				retrySpan = nil
+			}
+		}
+		return t
+	}
+}
+
+func mapSpanStartOpts(parentSpan ddtracer.Span, options []trace.SpanStartOption) (out []ddtracer.StartSpanOption) {
+	config := trace.NewSpanStartConfig(options...)
+
+	// Map SpanKind -> SpanType
+	if spanKind := config.SpanKind(); spanKind != trace.SpanKindUnspecified {
+		var ddSpanType string
+		switch config.SpanKind() {
+		case trace.SpanKindServer:
+			ddSpanType = ext.SpanTypeWeb
+		case trace.SpanKindClient:
+			ddSpanType = ext.SpanTypeHTTP
+		case trace.SpanKindProducer:
+			ddSpanType = ext.SpanTypeMessageProducer
+		case trace.SpanKindConsumer:
+			ddSpanType = ext.SpanTypeMessageConsumer
+		default:
+			ddSpanType = spanKind.String()
+		}
+		out = append(out, ddtracer.SpanType(ddSpanType))
+	}
+
+	// Map Attributes -> Tags
+	for _, pair := range config.Attributes() {
+		out = append(out, ddtracer.Tag(string(pair.Key), pair.Value))
+	}
+
+	// Map NewRoot / parent span
+	if !config.NewRoot() && parentSpan != nil {
+		out = append(out, ddtracer.ChildOf(parentSpan.Context()))
+	}
+
+	// Map Timestamp -> StartTime
+	if !config.Timestamp().IsZero() {
+		out = append(out, ddtracer.StartTime(config.Timestamp()))
+	}
+
+	// config.StackTrace() method doesn't apply to span start
+
+	// config.Links() method is ignored / not supported by DataDog
+
+	return out
+}
+
+func mapSpanEndOptions(options []trace.SpanEndOption) (out []ddtracer.FinishOption) {
+	// In DataDog is stack trace capturing enabled by default
+	options = append([]trace.SpanEndOption{trace.WithStackTrace(true)}, options...)
+	config := trace.NewSpanEndConfig(options...)
+
+	// Map Timestamp -> FinishTime
+	if !config.Timestamp().IsZero() {
+		out = append(out, ddtracer.FinishTime(config.Timestamp()))
+	}
+
+	// Map StackTrace -> NoDebugStack
+	if !config.StackTrace() {
+		out = append(out, ddtracer.NoDebugStack())
+	}
+
+	// config.SpanKind() method doesn't apply to span end
+
+	// config.Attributes() method doesn't apply to span end
+
+	// config.NewRoot() method doesn't apply to span end
+
+	// config.Links() method doesn't apply to span end
+
+	return out
+}
+
+func mapEventOptions(options []trace.EventOption) (startOpts []ddtracer.StartSpanOption, finishOpts []ddtracer.FinishOption) {
+	config := trace.NewEventConfig(options...)
+
+	// Map Attributes -> Tags
+	for _, pair := range config.Attributes() {
+		startOpts = append(startOpts, ddtracer.Tag(string(pair.Key), pair.Value))
+	}
+
+	// Map Timestamp -> StartTime and FinishTime
+	if !config.Timestamp().IsZero() {
+		startOpts = append(startOpts, ddtracer.StartTime(config.Timestamp()))
+		finishOpts = append(finishOpts, ddtracer.FinishTime(config.Timestamp()))
+	}
+
+	return startOpts, finishOpts
+}
+
+func IsDataDogEnabled(envs env.Provider) bool {
+	return envs.Get("DATADOG_ENABLED") != "false"
+}

--- a/internal/pkg/api/server/templates/telemetry/telemetry_test.go
+++ b/internal/pkg/api/server/templates/telemetry/telemetry_test.go
@@ -1,0 +1,168 @@
+// Package connects the OpenTelemetry tracer to the DataDog tracer used in API.
+package telemetry
+
+import (
+	"context"
+	"encoding/binary"
+	"encoding/json"
+	"fmt"
+	"strings"
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/assert"
+	"go.opentelemetry.io/otel/attribute"
+	"go.opentelemetry.io/otel/trace"
+	"gopkg.in/DataDog/dd-trace-go.v1/ddtrace/mocktracer"
+
+	jsonLib "github.com/keboola/keboola-as-code/internal/pkg/json"
+)
+
+type testError struct {
+	msg string
+}
+
+func (v testError) Error() string {
+	return v.msg
+}
+
+// MarshalJSON implementation to show error in test output.
+func (v testError) MarshalJSON() ([]byte, error) {
+	return json.Marshal(v.msg)
+}
+
+func TestOpenTelemetryToDataDogIntegration(t *testing.T) {
+	t.Parallel()
+
+	// Start the mock tracer, it set global variable (DD has no other way)
+	mockedTracer := mocktracer.Start()
+	defer mockedTracer.Stop()
+
+	ctx := context.Background()
+	otelTracker := NewDataDogTracer()
+
+	// Start span1
+	startTime1, err := time.Parse(time.RFC3339, "2000-01-01T10:10:10Z")
+	assert.NoError(t, err)
+	ctxSpan1, span1 := otelTracker.Start(
+		ctx,
+		"my.operation1",
+		trace.WithTimestamp(startTime1),
+		trace.WithSpanKind(trace.SpanKindServer),
+		trace.WithAttributes(
+			attribute.String("resource.name", "my/resource"),
+			attribute.String("foo", "bar"),
+			attribute.Bool("bool", true),
+		),
+	)
+	assert.Len(t, mockedTracer.OpenSpans(), 1)
+	assert.Len(t, mockedTracer.FinishedSpans(), 0)
+
+	// Start span2 - child of span1
+	startTime2, err := time.Parse(time.RFC3339, "2000-01-01T10:10:20Z")
+	assert.NoError(t, err)
+	_, span2 := otelTracker.Start(ctxSpan1, "my.operation1.sub", trace.WithSpanKind(trace.SpanKindClient), trace.WithTimestamp(startTime2))
+	assert.Len(t, mockedTracer.OpenSpans(), 2)
+	assert.Len(t, mockedTracer.FinishedSpans(), 0)
+
+	// Start span3
+	startTime3, err := time.Parse(time.RFC3339, "2000-01-01T10:10:30Z")
+	assert.NoError(t, err)
+	_, span3 := otelTracker.Start(ctx, "my.operation2", trace.WithTimestamp(startTime3))
+	assert.Len(t, mockedTracer.OpenSpans(), 3)
+	assert.Len(t, mockedTracer.FinishedSpans(), 0)
+
+	// Event in span3
+	eventTime, err := time.Parse(time.RFC3339, "2000-01-01T10:10:35Z")
+	assert.NoError(t, err)
+	span3.AddEvent("my.event", trace.WithTimestamp(eventTime))
+	assert.Len(t, mockedTracer.OpenSpans(), 3)
+	assert.Len(t, mockedTracer.FinishedSpans(), 1)
+
+	// End span3 with error, without stacktrace
+	endTime3, err := time.Parse(time.RFC3339, "2000-01-01T10:10:40Z")
+	assert.NoError(t, err)
+	span3.RecordError(&testError{msg: "some span 3 error"})
+	span3.End(trace.WithStackTrace(false), trace.WithTimestamp(endTime3))
+	assert.Len(t, mockedTracer.OpenSpans(), 2)
+	assert.Len(t, mockedTracer.FinishedSpans(), 2)
+
+	// End span2 without error
+	endTime2, err := time.Parse(time.RFC3339, "2000-01-01T10:10:50Z")
+	assert.NoError(t, err)
+	span2.End(trace.WithTimestamp(endTime2))
+	assert.Len(t, mockedTracer.OpenSpans(), 1)
+	assert.Len(t, mockedTracer.FinishedSpans(), 3)
+
+	// End span1 without error
+	endTime1, err := time.Parse(time.RFC3339, "2000-01-01T10:10:55Z")
+	assert.NoError(t, err)
+	span1.RecordError(&testError{msg: "some span 1 error"})
+	span1.End(trace.WithTimestamp(endTime1))
+	assert.Len(t, mockedTracer.OpenSpans(), 0)
+	assert.Len(t, mockedTracer.FinishedSpans(), 4)
+
+	// Check conversion to OpenTelemetry IDs (counter in mocked tracer starts at 123)
+	span1Id := span1.SpanContext().SpanID()
+	span1TraceId := span1.SpanContext().TraceID()
+	assert.Equal(t, uint64(124), binary.LittleEndian.Uint64(span1Id[:]))
+	assert.Equal(t, uint64(124), binary.LittleEndian.Uint64(span1TraceId[:]))
+	span2Id := span2.SpanContext().SpanID()
+	span2TraceId := span2.SpanContext().TraceID()
+	assert.Equal(t, uint64(125), binary.LittleEndian.Uint64(span2Id[:]))
+	assert.Equal(t, uint64(124), binary.LittleEndian.Uint64(span2TraceId[:]))
+	span3Id := span3.SpanContext().SpanID()
+	span3TraceId := span3.SpanContext().TraceID()
+	assert.Equal(t, uint64(126), binary.LittleEndian.Uint64(span3Id[:]))
+	assert.Equal(t, uint64(126), binary.LittleEndian.Uint64(span3TraceId[:]))
+
+	// Convert spans to string
+	var out strings.Builder
+	for _, s := range mockedTracer.FinishedSpans() {
+		out.WriteString(fmt.Sprintf("name: %v\n", s.OperationName()))
+		out.WriteString(fmt.Sprintf("tags: %s\n", jsonLib.MustEncode(s.Tags(), false)))
+		out.WriteString(fmt.Sprintf("start: %s\n", s.StartTime()))
+		out.WriteString(fmt.Sprintf("finish: %s\n", s.FinishTime()))
+		out.WriteString(fmt.Sprintf("spanId: %v\n", s.Context().SpanID()))
+		out.WriteString(fmt.Sprintf("parent: %v\n", s.ParentID()))
+		out.WriteString(fmt.Sprintf("trace: %v\n", s.Context().TraceID()))
+		out.WriteString("-----\n")
+	}
+
+	// Assert all spans
+	expected := `
+name: event.my.event
+tags: {"resource.name":"event.my.event","service.name":null}
+start: 2000-01-01 10:10:35 +0000 UTC
+finish: 2000-01-01 10:10:35 +0000 UTC
+spanId: 127
+parent: 126
+trace: 126
+-----
+name: my.operation2
+tags: {"error":"some span 3 error","error.stack":"\u003cdebug stack disabled\u003e","resource.name":"my.operation2"}
+start: 2000-01-01 10:10:30 +0000 UTC
+finish: 2000-01-01 10:10:40 +0000 UTC
+spanId: 126
+parent: 0
+trace: 126
+-----
+name: my.operation1.sub
+tags: {"resource.name":"my.operation1.sub","service.name":null,"span.type":"http"}
+start: 2000-01-01 10:10:20 +0000 UTC
+finish: 2000-01-01 10:10:50 +0000 UTC
+spanId: 125
+parent: 124
+trace: 124
+-----
+name: my.operation1
+tags: {"bool":{"Type":"BOOL","Value":true},"error":"some span 1 error","foo":{"Type":"STRING","Value":"bar"},"resource.name":{"Type":"STRING","Value":"my/resource"},"span.type":"web"}
+start: 2000-01-01 10:10:10 +0000 UTC
+finish: 2000-01-01 10:10:55 +0000 UTC
+spanId: 124
+parent: 0
+trace: 124
+-----
+`
+	assert.Equal(t, strings.TrimSpace(expected), strings.TrimSpace(out.String()))
+}

--- a/internal/pkg/cli/dependencies/base.go
+++ b/internal/pkg/cli/dependencies/base.go
@@ -28,7 +28,7 @@ type base struct {
 
 func newBaseDeps(commandCtx context.Context, envs env.Provider, logger log.Logger, httpClient client.Client, fs filesystem.Fs, dialogs *dialog.Dialogs, opts *options.Options) *base {
 	return &base{
-		Base:       dependencies.NewBaseDeps(envs, logger, httpClient),
+		Base:       dependencies.NewBaseDeps(envs, nil, logger, httpClient),
 		commandCtx: commandCtx,
 		fs:         fs,
 		fsInfo:     FsInfo{fs: fs},

--- a/internal/pkg/dependencies/base.go
+++ b/internal/pkg/dependencies/base.go
@@ -16,14 +16,19 @@ type base struct {
 	httpClient client.Client
 }
 
-func NewBaseDeps(envs env.Provider, logger log.Logger, httpClient client.Client) Base {
-	return newBaseDeps(envs, logger, httpClient)
+func NewBaseDeps(envs env.Provider, tracer trace.Tracer, logger log.Logger, httpClient client.Client) Base {
+	return newBaseDeps(envs, tracer, logger, httpClient)
 }
 
-func newBaseDeps(envs env.Provider, logger log.Logger, httpClient client.Client) *base {
+func newBaseDeps(envs env.Provider, tracer trace.Tracer, logger log.Logger, httpClient client.Client) *base {
+	if tracer == nil {
+		// Default no operation tracer
+		tracer = trace.NewNoopTracerProvider().Tracer("")
+	}
+
 	return &base{
 		envs:       envs,
-		tracer:     trace.NewNoopTracerProvider().Tracer(""),
+		tracer:     tracer,
 		logger:     logger,
 		httpClient: httpClient,
 	}

--- a/internal/pkg/dependencies/mocked.go
+++ b/internal/pkg/dependencies/mocked.go
@@ -133,7 +133,7 @@ func NewMockedDeps(opts ...MockedOption) Mocked {
 	)
 
 	// Create base, public and project dependencies
-	baseDeps := newBaseDeps(envs, logger, httpClient)
+	baseDeps := newBaseDeps(envs, nil, logger, httpClient)
 	publicDeps, err := newPublicDeps(ctx, baseDeps, values.StorageApiHost)
 	if err != nil {
 		panic(err)

--- a/pkg/lib/operation/template/local/test/operation.go
+++ b/pkg/lib/operation/template/local/test/operation.go
@@ -131,7 +131,7 @@ func runLocalTest(ctx context.Context, test *template.Test, tmpl *template.Templ
 	} else {
 		logger = log.NewNopLogger()
 	}
-	testDeps, err := newTestDependencies(ctx, logger, testPrj.StorageAPIHost(), testPrj.StorageAPIToken().Token)
+	testDeps, err := newTestDependencies(ctx, d.Tracer(), logger, testPrj.StorageAPIHost(), testPrj.StorageAPIToken().Token)
 	if err != nil {
 		return err
 	}
@@ -253,7 +253,7 @@ func runRemoteTest(ctx context.Context, test *template.Test, tmpl *template.Temp
 	} else {
 		logger = log.NewNopLogger()
 	}
-	testDeps, err := newTestDependencies(ctx, logger, testPrj.StorageAPIHost(), testPrj.StorageAPIToken().Token)
+	testDeps, err := newTestDependencies(ctx, d.Tracer(), logger, testPrj.StorageAPIHost(), testPrj.StorageAPIToken().Token)
 	if err != nil {
 		return err
 	}
@@ -422,8 +422,8 @@ type testDependencies struct {
 	dependenciesPkg.Project
 }
 
-func newTestDependencies(ctx context.Context, logger log.Logger, apiHost, apiToken string) (*testDependencies, error) {
-	baseDeps := dependenciesPkg.NewBaseDeps(env.Empty(), logger, client.NewTestClient())
+func newTestDependencies(ctx context.Context, tracer trace.Tracer, logger log.Logger, apiHost, apiToken string) (*testDependencies, error) {
+	baseDeps := dependenciesPkg.NewBaseDeps(env.Empty(), tracer, logger, client.NewTestClient())
 	publicDeps, err := dependenciesPkg.NewPublicDeps(ctx, baseDeps, apiHost)
 	if err != nil {
 		return nil, err


### PR DESCRIPTION
Part of: https://keboola.atlassian.net/browse/KAC-217

Changes:
- Telemetry spans from the [previous PR](https://github.com/keboola/keboola-as-code/pull/801) are now sent to DataDog.