### PR TITLE
Fix description check for markdown fields

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -35,6 +35,7 @@ require (
 	github.com/spf13/viper v1.10.0
 	github.com/stretchr/testify v1.8.0
 	github.com/umisama/go-regexpcache v0.0.0-20150417035358-2444a542492f
+	github.com/writeas/go-strip-markdown v2.0.1+incompatible
 	go.etcd.io/etcd/client/v3 v3.5.0
 	go.nhat.io/aferocopy/v2 v2.0.1
 	go.opentelemetry.io/otel v1.9.0

--- a/go.sum
+++ b/go.sum
@@ -559,6 +559,8 @@ github.com/tinylib/msgp v1.1.2/go.mod h1:+d+yLhGm8mzTaHzB+wgMYrodPfmZrzkirds8fDW
 github.com/tv42/httpunix v0.0.0-20150427012821-b75d8614f926/go.mod h1:9ESjWnEqriFuLhtthL60Sar/7RFoluCcXsuvEwTV5KM=
 github.com/umisama/go-regexpcache v0.0.0-20150417035358-2444a542492f h1:haUDHoDEHXYsmhhJ9DwOcJBGtgRSCT6d5J1EcqxMFuU=
 github.com/umisama/go-regexpcache v0.0.0-20150417035358-2444a542492f/go.mod h1:YTm0hcnGJEKJOLVM4x0PvO8p43r7DANkXRNiONPfWIM=
+github.com/writeas/go-strip-markdown v2.0.1+incompatible h1:IIqxTM5Jr7RzhigcL6FkrCNfXkvbR+Nbu1ls48pXYcw=
+github.com/writeas/go-strip-markdown v2.0.1+incompatible/go.mod h1:Rsyu10ZhbEK9pXdk8V6MVnZmTzRG0alMNLMwa0J01fE=
 github.com/yuin/goldmark v1.1.25/go.mod h1:3hX8gzYuyVAZsxl0MRgGTJEmQBFcNTphYh9decYSb74=
 github.com/yuin/goldmark v1.1.27/go.mod h1:3hX8gzYuyVAZsxl0MRgGTJEmQBFcNTphYh9decYSb74=
 github.com/yuin/goldmark v1.1.32/go.mod h1:3hX8gzYuyVAZsxl0MRgGTJEmQBFcNTphYh9decYSb74=

--- a/internal/pkg/template/input/step.go
+++ b/internal/pkg/template/input/step.go
@@ -221,7 +221,7 @@ type Step struct {
 	Name              string `json:"name" validate:"required,min=1,max=25"`
 	Description       string `json:"description" validate:"min=1,max=60"`
 	DialogName        string `json:"dialogName,omitempty" validate:"omitempty,max=25"`
-	DialogDescription string `json:"dialogDescription,omitempty" validate:"omitempty,max=200"`
+	DialogDescription string `json:"dialogDescription,omitempty" validate:"omitempty,mdmax=200"`
 	Inputs            Inputs `json:"inputs" validate:"omitempty,dive"`
 }
 

--- a/internal/pkg/utils/strhelper/strhelper.go
+++ b/internal/pkg/utils/strhelper/strhelper.go
@@ -8,6 +8,7 @@ import (
 
 	"github.com/jpillora/longestcommon"
 	"github.com/umisama/go-regexpcache"
+	stripmd "github.com/writeas/go-strip-markdown"
 	"golang.org/x/text/runes"
 	"golang.org/x/text/transform"
 	"golang.org/x/text/unicode/norm"
@@ -126,4 +127,8 @@ func FirstN(str string, n int) string {
 		n = len(str)
 	}
 	return str[0:n]
+}
+
+func StripMarkdown(str string) string {
+	return stripmd.Strip(str)
 }

--- a/internal/pkg/utils/strhelper/strhelper_test.go
+++ b/internal/pkg/utils/strhelper/strhelper_test.go
@@ -168,3 +168,10 @@ func TestFirstN(t *testing.T) {
 	assert.Equal(t, "abcde", FirstN("abcde", 5))
 	assert.Equal(t, "abcde", FirstN("abcde", 6))
 }
+
+func TestStripMarkdown(t *testing.T) {
+	t.Parallel()
+	assert.Equal(t, "unchanged\ntest", StripMarkdown("unchanged\ntest"))
+	assert.Equal(t, "heading", StripMarkdown("### heading"))
+	assert.Equal(t, "link", StripMarkdown("[link](https://google.com/?a=b&c=d#anchor)"))
+}

--- a/internal/pkg/validator/validator.go
+++ b/internal/pkg/validator/validator.go
@@ -173,7 +173,7 @@ func (v *wrapper) registerCustomRules() {
 				paramStr := fl.Param()
 				param, err := strconv.Atoi(paramStr)
 				if err != nil {
-					panic(fmt.Sprintf("failed to convert mdmax param `%v` to an int", paramStr))
+					panic(fmt.Sprintf("failed to convert mdmax param \"%v\" to an int", paramStr))
 				}
 				value = strhelper.StripMarkdown(value)
 				return len(value) <= param

--- a/internal/pkg/validator/validator.go
+++ b/internal/pkg/validator/validator.go
@@ -11,6 +11,7 @@ import (
 	"context"
 	"fmt"
 	"reflect"
+	"strconv"
 	"strings"
 
 	"github.com/go-playground/locales/en"
@@ -20,6 +21,7 @@ import (
 	"github.com/umisama/go-regexpcache"
 
 	"github.com/keboola/keboola-as-code/internal/pkg/utils"
+	"github.com/keboola/keboola-as-code/internal/pkg/utils/strhelper"
 )
 
 const (
@@ -163,6 +165,22 @@ func (v *wrapper) registerCustomRules() {
 				return false
 			},
 			ErrorMsg: "{0} does not contain an allowed icon",
+		},
+		Rule{
+			Tag: "mdmax",
+			FuncCtx: func(ctx context.Context, fl validator.FieldLevel) bool {
+				value := fl.Field().String()
+				paramStr := fl.Param()
+				param, err := strconv.Atoi(paramStr)
+				if err != nil {
+					panic(fmt.Sprintf("failed to convert mdmax param `%v` to an int", paramStr))
+				}
+				value = strhelper.StripMarkdown(value)
+				return len(value) <= param
+			},
+			ErrorMsgFunc: func(fe validator.FieldError) string {
+				return fmt.Sprintf("%s exceeded maximum length of %s", fe.Tag(), fe.Param())
+			},
 		},
 	)
 }

--- a/internal/pkg/validator/validator_test.go
+++ b/internal/pkg/validator/validator_test.go
@@ -176,3 +176,24 @@ func TestValidatorTemplateIcon(t *testing.T) {
 		}
 	}
 }
+
+func TestValidatorMarkdownLength(t *testing.T) {
+	t.Parallel()
+
+	cases := []struct{ value, error string }{
+		{"test", ""},
+		{"### test test", ""},
+		{"[test](https://google.com/)", ""},
+		{"this is more than 10 characters", "some_field exceeded maximum length of 10"},
+		{"[this is also more than 10 characters](https://google.com/)", "some_field exceeded maximum length of 10"},
+	}
+
+	for i, c := range cases {
+		err := ValidateCtx(context.Background(), c.value, `mdmax=10`, `some_field`)
+		if c.error == "" {
+			assert.NoError(t, err, fmt.Sprintf("case: %d", i+1))
+		} else {
+			assert.Error(t, err, c.error, fmt.Sprintf("case: %d", i+1))
+		}
+	}
+}


### PR DESCRIPTION
https://keboola.atlassian.net/browse/KAC-198

Changes:

- Add `StripMarkdown` helper to `utils/strhelper` which uses `go-strip-markdown`
  - `go-strip-markdown` removes markdown syntax using a series of regular expressions. It turned out to be significantly less work than creating a custom `gomarkdown` renderer, and seems to work well.
- Add validation rule `mdmax`
  - Parametrized similarly to builtin validator `max`
  - Measures length after passing field value through `StripMarkdown`
- Use `mdmax` instead of `max` for `Step.DialogDescription`
