### PR TITLE
Fix shutdown of the API server

### DIFF
--- a/internal/pkg/template/repository/manager/manager_test.go
+++ b/internal/pkg/template/repository/manager/manager_test.go
@@ -31,10 +31,13 @@ func TestNew(t *testing.T) {
 		Ref:  "main",
 	}
 
+	// Create manager
 	ctx := context.Background()
 	d := dependencies.NewMockedDeps()
 	m, err := manager.New(ctx, nil, d)
 	assert.NoError(t, err)
+	defer m.Free()
+
 	repo, unlockFn, err := m.Repository(ctx, ref)
 	assert.NoError(t, err)
 	defer unlockFn()
@@ -56,10 +59,12 @@ func TestRepository(t *testing.T) {
 		Ref:  "main",
 	}
 
+	// Create manager
 	ctx := context.Background()
 	d := dependencies.NewMockedDeps()
 	m, err := manager.New(ctx, nil, d)
 	assert.NoError(t, err)
+	defer m.Free()
 
 	v, unlockFn1, err := m.Repository(ctx, repo)
 	assert.NotNil(t, v)
@@ -101,6 +106,7 @@ func TestDefaultRepositories(t *testing.T) {
 	d := dependencies.NewMockedDeps()
 	m, err := manager.New(context.Background(), defaultRepositories, d)
 	assert.NoError(t, err)
+	defer m.Free()
 
 	// Get list of default repositories
 	assert.Equal(t, defaultRepositories, m.DefaultRepositories())

--- a/internal/pkg/template/repository/manager/repository.go
+++ b/internal/pkg/template/repository/manager/repository.go
@@ -226,6 +226,7 @@ func (r *CachedRepository) free() <-chan struct{} {
 		defer r.freeLock.Unlock()
 		r.unlockFn()
 		r.d.Logger().Infof(`cleaned repository cache "%s"`, r.String())
+		close(done)
 	}()
 	return done
 }


### PR DESCRIPTION
Part of: https://keboola.atlassian.net/browse/KAC-218

-----
Pred:
![image](https://user-images.githubusercontent.com/19371734/190154131-972d67ec-1aaa-4d12-98b5-48ea0da2655e.png)


Po:
![image](https://user-images.githubusercontent.com/19371734/190153817-9c9ea261-8666-4893-9578-07c05313a737.png)

