### PR TITLE
Add oneOf types for input.default field

### DIFF
--- a/api/templates/design.go
+++ b/api/templates/design.go
@@ -927,7 +927,7 @@ var Input = Type("input", func() {
 		Meta(oneof.Meta, json.MustEncodeString([]*openapi.Schema{
 			{Type: openapi.String},
 			{Type: openapi.Integer},
-			{Type: "double"},
+			{Type: openapi.Number},
 			{Type: openapi.Boolean},
 			{Type: openapi.Array, Items: &openapi.Schema{Type: openapi.String}},
 			{Type: openapi.Object},

--- a/api/templates/design.go
+++ b/api/templates/design.go
@@ -6,13 +6,17 @@ import (
 	. "goa.design/goa/v3/dsl"
 	"goa.design/goa/v3/eval"
 	"goa.design/goa/v3/expr"
+	"goa.design/goa/v3/http/codegen/openapi"
 	cors "goa.design/plugins/v3/cors/dsl"
 
 	_ "github.com/keboola/keboola-as-code/internal/pkg/api/server/templates/extension/anytype"
 	_ "github.com/keboola/keboola-as-code/internal/pkg/api/server/templates/extension/dependencies"
 	_ "github.com/keboola/keboola-as-code/internal/pkg/api/server/templates/extension/genericerror"
+	"github.com/keboola/keboola-as-code/internal/pkg/api/server/templates/extension/oneof"
+	_ "github.com/keboola/keboola-as-code/internal/pkg/api/server/templates/extension/oneof"
 	_ "github.com/keboola/keboola-as-code/internal/pkg/api/server/templates/extension/operationid"
 	. "github.com/keboola/keboola-as-code/internal/pkg/api/server/templates/extension/token"
+	"github.com/keboola/keboola-as-code/internal/pkg/json"
 )
 
 // API definition ------------------------------------------------------------------------------------------------------
@@ -920,6 +924,14 @@ var Input = Type("input", func() {
 		Example("input")
 	})
 	Attribute("default", Any, "Default value, match defined type.", func() {
+		Meta(oneof.Meta, json.MustEncodeString([]*openapi.Schema{
+			{Type: openapi.String},
+			{Type: openapi.Integer},
+			{Type: "double"},
+			{Type: openapi.Boolean},
+			{Type: openapi.Array, Items: &openapi.Schema{Type: openapi.String}},
+			{Type: openapi.Object},
+		}, false))
 		Example("foo bar")
 	})
 	Attribute("options", ArrayOf(InputOption), "Input options for type = select OR multiselect.", func() {

--- a/internal/pkg/api/server/templates/extension/dependencies/dependencies.go
+++ b/internal/pkg/api/server/templates/extension/dependencies/dependencies.go
@@ -16,7 +16,7 @@ func init() {
 	codegen.RegisterPluginFirst("api-dependencies", "gen", nil, generate)
 }
 
-func generate(_ string, roots []eval.Root, files []*codegen.File) ([]*codegen.File, error) {
+func generate(_ string, _ []eval.Root, files []*codegen.File) ([]*codegen.File, error) {
 	for _, f := range files {
 		// nolint: forbidigo
 		switch filepath.Base(f.Path) {

--- a/internal/pkg/api/server/templates/extension/oneof/oneof.go
+++ b/internal/pkg/api/server/templates/extension/oneof/oneof.go
@@ -1,0 +1,74 @@
+// Package oneof contains extension to modify OpenApi specification and add oneOf definition to a schema.
+// The Goa library supports OneOf, but array type is not supported there, so OpenApi specification must be modified in this way.
+// It is workaround for error: "union type ... has array elements, not supported by gRCP attribute".
+//
+// Example usage:
+// 	Attribute("foo", Any, func() {
+//		Meta(oneof.Meta, json.MustEncodeString([]*openapi.Schema{
+//			{Type: openapi.String},
+//			{Type: openapi.Array, Items: &openapi.Schema{Type: openapi.String}},
+//			{Type: openapi.Object},
+//		}, false))
+//	})
+package oneof
+
+import (
+	"reflect"
+
+	"github.com/keboola/go-utils/pkg/deepcopy"
+	"goa.design/goa/v3/codegen"
+	"goa.design/goa/v3/eval"
+	"goa.design/goa/v3/http/codegen/openapi"
+	openapiv2 "goa.design/goa/v3/http/codegen/openapi/v2"
+	openapiv3 "goa.design/goa/v3/http/codegen/openapi/v3"
+)
+
+const Meta = "openapi:extension:" + oneOfExtensionName
+const oneOfExtensionName = "x-one-of"
+const oneOfFieldName = "oneOf"
+
+// nolint: gochecknoinits
+func init() {
+	codegen.RegisterPluginLast("one-of", "gen", nil, generate)
+}
+
+func generate(_ string, roots []eval.Root, files []*codegen.File) ([]*codegen.File, error) {
+	for _, f := range files {
+		// Modify OpenApi2 files
+		for _, s := range f.Section("openapi") {
+			if source, ok := s.Data.(*openapiv2.V2); ok {
+				s.Data = modifyOpenApiV2(source)
+			}
+		}
+		// Modify OpenApi3 files
+		for _, s := range f.Section("openapi_v3") {
+			if source, ok := s.Data.(*openapiv3.OpenAPI); ok {
+				s.Data = modifyOpenApiV3(source)
+			}
+		}
+	}
+	return files, nil
+}
+
+func modifyOpenApiV2(data *openapiv2.V2) *openapiv2.V2 {
+	return deepcopy.CopyTranslate(data, translate).(*openapiv2.V2)
+}
+
+func modifyOpenApiV3(data *openapiv3.OpenAPI) *openapiv3.OpenAPI {
+	return deepcopy.CopyTranslate(data, translate).(*openapiv3.OpenAPI)
+}
+
+func translate(_, clone reflect.Value, _ deepcopy.Path) {
+	if !clone.IsValid() {
+		return
+	}
+
+	// The Goa library allows you to add custom fields only with the prefix "x-...",
+	// so "x-one-of" field is converted to "oneOf".
+	if v, ok := clone.Interface().(*openapi.Schema); ok && v != nil && v.Extensions != nil {
+		if value, found := v.Extensions[oneOfExtensionName]; found {
+			delete(v.Extensions, oneOfExtensionName)
+			v.Extensions[oneOfFieldName] = value
+		}
+	}
+}

--- a/test/api/api_test.go
+++ b/test/api/api_test.go
@@ -360,13 +360,17 @@ func RunRequests(
 
 	// Optionally check API server stdout/stderr
 	expectedStdoutPath := "expected-server-stdout"
+	expectedStderrPath := "expected-server-stderr"
+	if testDirFs.IsFile(expectedStdoutPath) || testDirFs.IsFile(expectedStderrPath) {
+		// Wait a while the server logs everything for previous requests.
+		time.Sleep(100 * time.Millisecond)
+	}
 	if testDirFs.IsFile(expectedStdoutPath) {
 		file, err := testDirFs.ReadFile(filesystem.NewFileDef(expectedStdoutPath))
 		assert.NoError(t, err)
 		expected := testhelper.ReplaceEnvsString(file.Content, envProvider)
 		wildcards.Assert(t, expected, stdout.String(), "Unexpected STDOUT.")
 	}
-	expectedStderrPath := "expected-server-stderr"
 	if testDirFs.IsFile(expectedStderrPath) {
 		file, err := testDirFs.ReadFile(filesystem.NewFileDef(expectedStderrPath))
 		assert.NoError(t, err)


### PR DESCRIPTION
Jira: https://keboola.atlassian.net/browse/KAC-124

Changes:
- Templates API: instead of the `any` type in the OpenAPI specification,  the `input.default` field  has listed concrete types that it can return.

---- 

**Problem:**
- UI nam nahlasilo, ze im robi problem field `input.default` v OpenAPI.
- Generuju z toho klienta, a ked tam nie je specifikovany typ (`any`), tak im IDE hlasi `warnings`.
- Zial, `Goa` kniznica v `OneOf` nepodporuje array typ, preto sme museli pridat vlastne `extensions` a upravit iba vystupnu OpenAPI specifikaciu.
- Po funkcnej stranke nie je ziadna zmena, tyka sa to iba OpenAPI.

----

`make run-templates-api`

**Pred:**
![image](https://user-images.githubusercontent.com/19371734/190602807-423473c5-2fe9-4235-9bcf-df2b39fdd108.png)


**Po:**
![image](https://user-images.githubusercontent.com/19371734/190602856-4c9badc1-bdcd-4b05-a77e-8423d6a523b3.png)

`http://localhost:8000/v1/documentation/openapi3.yaml`:
![image](https://user-images.githubusercontent.com/19371734/190603191-c838b29b-3b8e-4fc2-8c0c-a6cac7b1352b.png)
