### PR TITLE
Support Snowflake Writer componentId placeholder in repository.json

### DIFF
--- a/internal/pkg/template/repository/manifest/manifest.go
+++ b/internal/pkg/template/repository/manifest/manifest.go
@@ -9,6 +9,13 @@ import (
 	"github.com/keboola/keboola-as-code/internal/pkg/utils/strhelper"
 )
 
+// SnowflakeWriterComponentIdPlaceholder can be used in "repository.json"
+// to define Snowflake Writer used in the stack.
+// In Jsonnet files is used function "SnowflakeWriterComponentId",
+// but repository definition is Json, not Jsonnet.
+// Placeholder is replaced when generating API response.
+const SnowflakeWriterComponentIdPlaceholder = "<keboola.wr-snowflake>"
+
 type TemplateNotFoundError struct {
 	error
 }

--- a/test/api/projects/instance-get/004-get-ok/expected-response.json
+++ b/test/api/projects/instance-get/004-get-ok/expected-response.json
@@ -1,6 +1,9 @@
 {
   "versionDetail": {
-    "components": [],
+    "components": [
+      "foo.bar",
+      "keboola.wr-%s"
+    ],
     "longDescription": "A long **description**.\n",
     "readme": "### My Template\n\nFull workflow to ...\n\n",
     "version": "1.2.3",

--- a/test/api/projects/instance-get/repository/.keboola/repository.json
+++ b/test/api/projects/instance-get/repository/.keboola/repository.json
@@ -15,7 +15,11 @@
           "version": "1.2.3",
           "description": "",
           "stable": false,
-          "path": "v1"
+          "path": "v1",
+          "components": [
+            "<keboola.wr-snowflake>",
+            "foo.bar"
+          ]
         }
       ]
     }

--- a/test/api/projects/instances-list/repository/.keboola/repository.json
+++ b/test/api/projects/instances-list/repository/.keboola/repository.json
@@ -15,7 +15,11 @@
           "version": "1.2.3",
           "description": "",
           "stable": false,
-          "path": "v1"
+          "path": "v1",
+          "components": [
+            "<keboola.wr-snowflake>",
+            "foo.bar"
+          ]
         }
       ]
     }

--- a/test/api/repositories/template-detail/repository/.keboola/repository.json
+++ b/test/api/repositories/template-detail/repository/.keboola/repository.json
@@ -15,10 +15,10 @@
           "version": "1.2.3",
           "description": "",
           "stable": false,
+          "path": "v1",
           "components": [
             "keboola.ex-aws-s3"
-          ],
-          "path": "v1"
+          ]
         }
       ]
     }

--- a/test/api/repositories/template-list/002-list-ok/expected-response.json
+++ b/test/api/repositories/template-list/002-list-ok/expected-response.json
@@ -12,7 +12,10 @@
     {
       "id": "my-template-id",
       "name": "My Template",
-      "components": [],
+      "components": [
+        "foo.bar",
+        "keboola.wr-%s"
+      ],
       "author": {
         "name": "Example Author",
         "url": "https://example.com"

--- a/test/api/repositories/template-list/repository/.keboola/repository.json
+++ b/test/api/repositories/template-list/repository/.keboola/repository.json
@@ -15,7 +15,10 @@
           "version": "1.2.3",
           "description": "",
           "stable": false,
-          "path": "v1"
+          "path": "v1","components": [
+            "<keboola.wr-snowflake>",
+            "foo.bar"
+          ]
         }
       ]
     }

--- a/test/api/repositories/template-version/004-version-ok/expected-response.json
+++ b/test/api/repositories/template-version/004-version-ok/expected-response.json
@@ -13,7 +13,8 @@
     "name": "My Template",
     "components": [
       "keboola.ex-aws-s3",
-      "keboola.ex-facebook"
+      "keboola.ex-facebook",
+      "keboola.wr-%s"
     ],
     "author": {
       "name": "Example Author",
@@ -31,7 +32,8 @@
   },
   "components": [
     "keboola.ex-aws-s3",
-    "keboola.ex-facebook"
+    "keboola.ex-facebook",
+    "keboola.wr-%s"
   ],
   "longDescription": "A long **description**.\n",
   "readme": "### My Template\n\nFull workflow to ...\n\n",

--- a/test/api/repositories/template-version/repository/.keboola/repository.json
+++ b/test/api/repositories/template-version/repository/.keboola/repository.json
@@ -17,6 +17,7 @@
           "stable": false,
           "path": "v1",
           "components": [
+            "<keboola.wr-snowflake>",
             "keboola.ex-aws-s3",
             "keboola.ex-facebook"
           ]


### PR DESCRIPTION
Part of: https://keboola.atlassian.net/browse/KAC-222

Changes:
- Added support for `<keboola.wr-snowflake>` placeholder in `repository.json`, in `version.components` list.

----

V predchadzajucom PR https://github.com/keboola/keboola-as-code/pull/827 som pridal
`SnowflakeWriterComponentId()` funkciu do Jsonnet.

Pri upravovani sablon som si vsimol, ze `componentId` moze byz aj v `repository.json` (zoznam podporovanych komponent), a preto tu musim pridat placeholder, kedze je to Json a nie Jsonnet.