### PR TITLE
Show credentials on workspace create

### DIFF
--- a/internal/pkg/cli/dependencies/dependencies_test.go
+++ b/internal/pkg/cli/dependencies/dependencies_test.go
@@ -47,6 +47,7 @@ func TestDifferentProjectIdInManifestAndToken(t *testing.T) {
 					{ID: "encryption", URL: "https://encryption.mocked.transport.http"},
 					{ID: "scheduler", URL: "https://scheduler.mocked.transport.http"},
 					{ID: "queue", URL: "https://queue.mocked.transport.http"},
+					{ID: "sandboxes", URL: "https://sandboxes.mocked.transport.http"},
 				},
 			},
 			Components: testapi.MockedComponents(),

--- a/internal/pkg/dependencies/dependencies.go
+++ b/internal/pkg/dependencies/dependencies.go
@@ -95,6 +95,7 @@ type Project interface {
 	StorageApiClient() client.Sender
 	SchedulerApiClient() client.Sender
 	JobsQueueApiClient() client.Sender
+	SandboxesApiClient() client.Sender
 	EventSender() event.Sender
 	ObjectIDGeneratorFactory() func(ctx context.Context) *storageapi.TicketProvider
 }

--- a/internal/pkg/dependencies/mocked.go
+++ b/internal/pkg/dependencies/mocked.go
@@ -95,6 +95,7 @@ func NewMockedDeps(opts ...MockedOption) Mocked {
 			{ID: "encryption", URL: "https://encryption.mocked.transport.http"},
 			{ID: "scheduler", URL: "https://scheduler.mocked.transport.http"},
 			{ID: "queue", URL: "https://queue.mocked.transport.http"},
+			{ID: "sandboxes", URL: "https://sandboxes.mocked.transport.http"},
 		},
 		Features:       storageapi.Features{"FeatureA", "FeatureB"},
 		Components:     testapi.MockedComponents(),

--- a/internal/pkg/dependencies/project.go
+++ b/internal/pkg/dependencies/project.go
@@ -6,6 +6,7 @@ import (
 
 	"github.com/keboola/go-client/pkg/client"
 	"github.com/keboola/go-client/pkg/jobsqueueapi"
+	"github.com/keboola/go-client/pkg/sandboxesapi"
 	"github.com/keboola/go-client/pkg/schedulerapi"
 	"github.com/keboola/go-client/pkg/storageapi"
 
@@ -22,6 +23,7 @@ type project struct {
 	storageApiClient   client.Client
 	schedulerApiClient client.Client
 	jobsQueueAPIClient client.Client
+	sandboxesApiClient client.Client
 	eventSender        event.Sender
 }
 
@@ -61,6 +63,12 @@ func newProjectDeps(base Base, public Public, token storageapi.Token) (*project,
 		v.jobsQueueAPIClient = jobsqueueapi.ClientWithHostAndToken(v.base.HttpClient(), queueHost.String(), v.token.Token)
 	}
 
+	if sandboxesHost, found := v.public.StackServices().URLByID("sandboxes"); !found {
+		return nil, fmt.Errorf("sandboxes host not found")
+	} else {
+		v.sandboxesApiClient = sandboxesapi.ClientWithHostAndToken(v.base.HttpClient(), sandboxesHost.String(), v.token.Token)
+	}
+
 	// Setup event sender
 	v.eventSender = event.NewSender(v.base.Logger(), v.StorageApiClient(), v.ProjectID())
 
@@ -93,6 +101,10 @@ func (v project) SchedulerApiClient() client.Sender {
 
 func (v project) JobsQueueApiClient() client.Sender {
 	return v.jobsQueueAPIClient
+}
+
+func (v project) SandboxesApiClient() client.Sender {
+	return v.sandboxesApiClient
 }
 
 func (v project) EventSender() event.Sender {

--- a/test/cli/workspace/create/expected-stdout
+++ b/test/cli/workspace/create/expected-stdout
@@ -1,2 +1,9 @@
 Creating new workspace, please wait.
 Created new workspace "foo".
+Credentials:
+  Host: %s
+  User: %s
+  Password: %s
+  Database: %s
+  Schema: %s
+  Warehouse: %s


### PR DESCRIPTION
https://keboola.atlassian.net/browse/KAC-245

Changes:
- Add `SandboxesApiClient` to remote dependencies
- Log credentials in `remote workspace create`