### PR TITLE
Check dbt project before CLI dialogs

### DIFF
--- a/internal/pkg/cli/cmd/dbt/generate/env.go
+++ b/internal/pkg/cli/cmd/dbt/generate/env.go
@@ -15,6 +15,12 @@ func EnvCommand(p dependencies.Provider) *cobra.Command {
 		Short: helpmsg.Read(`dbt/generate/env/short`),
 		Long:  helpmsg.Read(`dbt/generate/env/long`),
 		RunE: func(cmd *cobra.Command, args []string) error {
+			// Check that we are in dbt directory
+			if _, _, err := p.LocalDbtProject(cmd.Context()); err != nil {
+				return err
+			}
+
+			// Get dependencies
 			d, err := p.DependenciesForRemoteCommand()
 			if err != nil {
 				return err

--- a/internal/pkg/cli/cmd/dbt/generate/profile.go
+++ b/internal/pkg/cli/cmd/dbt/generate/profile.go
@@ -14,6 +14,12 @@ func ProfileCommand(p dependencies.Provider) *cobra.Command {
 		Short: helpmsg.Read(`dbt/generate/profile/short`),
 		Long:  helpmsg.Read(`dbt/generate/profile/long`),
 		RunE: func(cmd *cobra.Command, args []string) error {
+			// Check that we are in dbt directory
+			if _, _, err := p.LocalDbtProject(cmd.Context()); err != nil {
+				return err
+			}
+
+			// Get dependencies
 			d, err := p.DependenciesForLocalCommand()
 			if err != nil {
 				return err

--- a/internal/pkg/cli/cmd/dbt/generate/sources.go
+++ b/internal/pkg/cli/cmd/dbt/generate/sources.go
@@ -14,6 +14,12 @@ func SourcesCommand(p dependencies.Provider) *cobra.Command {
 		Short: helpmsg.Read(`dbt/generate/sources/short`),
 		Long:  helpmsg.Read(`dbt/generate/sources/long`),
 		RunE: func(cmd *cobra.Command, args []string) error {
+			// Check that we are in dbt directory
+			if _, _, err := p.LocalDbtProject(cmd.Context()); err != nil {
+				return err
+			}
+
+			// Get dependencies
 			d, err := p.DependenciesForRemoteCommand()
 			if err != nil {
 				return err

--- a/internal/pkg/cli/cmd/dbt/init.go
+++ b/internal/pkg/cli/cmd/dbt/init.go
@@ -14,6 +14,12 @@ func InitCommand(p dependencies.Provider) *cobra.Command {
 		Short: helpmsg.Read(`dbt/init/short`),
 		Long:  helpmsg.Read(`dbt/init/long`),
 		RunE: func(cmd *cobra.Command, args []string) error {
+			// Check that we are in dbt directory
+			if _, _, err := p.LocalDbtProject(cmd.Context()); err != nil {
+				return err
+			}
+
+			// Get dependencies
 			d, err := p.DependenciesForRemoteCommand()
 			if err != nil {
 				return err

--- a/internal/pkg/cli/dependencies/base.go
+++ b/internal/pkg/cli/dependencies/base.go
@@ -9,6 +9,7 @@ import (
 	"github.com/keboola/keboola-as-code/internal/pkg/build"
 	"github.com/keboola/keboola-as-code/internal/pkg/cli/dialog"
 	"github.com/keboola/keboola-as-code/internal/pkg/cli/options"
+	"github.com/keboola/keboola-as-code/internal/pkg/dbt"
 	"github.com/keboola/keboola-as-code/internal/pkg/dependencies"
 	"github.com/keboola/keboola-as-code/internal/pkg/env"
 	"github.com/keboola/keboola-as-code/internal/pkg/filesystem"
@@ -18,12 +19,18 @@ import (
 // base dependencies container implements Base interface.
 type base struct {
 	dependencies.Base
-	commandCtx context.Context
-	fs         filesystem.Fs
-	fsInfo     FsInfo
-	dialogs    *dialog.Dialogs
-	options    *options.Options
-	emptyDir   dependencies.Lazy[filesystem.Fs]
+	commandCtx      context.Context
+	fs              filesystem.Fs
+	fsInfo          FsInfo
+	dialogs         *dialog.Dialogs
+	options         *options.Options
+	emptyDir        dependencies.Lazy[filesystem.Fs]
+	localDbtProject dependencies.Lazy[dbtProjectValue]
+}
+
+type dbtProjectValue struct {
+	found bool
+	value *dbt.Project
 }
 
 func newBaseDeps(commandCtx context.Context, envs env.Provider, logger log.Logger, httpClient client.Client, fs filesystem.Fs, dialogs *dialog.Dialogs, opts *options.Options) *base {
@@ -64,6 +71,22 @@ func (v *base) EmptyDir() (filesystem.Fs, error) {
 		}
 		return v.fs, nil
 	})
+}
+
+func (v *base) LocalDbtProject(ctx context.Context) (*dbt.Project, bool, error) {
+	value, err := v.localDbtProject.InitAndGet(func() (dbtProjectValue, error) {
+		// Get directory
+		fs, _, err := v.FsInfo().DbtProjectDir()
+		if err != nil {
+			return dbtProjectValue{found: false, value: nil}, err
+		}
+
+		// Load project
+		prj, err := dbt.LoadProject(ctx, fs)
+		return dbtProjectValue{found: true, value: prj}, err
+	})
+
+	return value.value, value.found, err
 }
 
 func cliHttpClient(logger log.Logger, dumpHttp bool) client.Client {

--- a/internal/pkg/cli/dependencies/dependencies.go
+++ b/internal/pkg/cli/dependencies/dependencies.go
@@ -78,4 +78,6 @@ type Provider interface {
 	LocalProject(ignoreErrors bool) (*projectPkg.Project, ForRemoteCommand, error)
 	// LocalRepository method can be used by a CLI command that must be run in the local repository directory.
 	LocalRepository() (*repository.Repository, ForLocalCommand, error)
+	// LocalDbtProject method can be used by a CLI command that must be run in the dbt project directory.
+	LocalDbtProject(ctx context.Context) (*dbt.Project, bool, error)
 }

--- a/internal/pkg/cli/dependencies/dependencies.go
+++ b/internal/pkg/cli/dependencies/dependencies.go
@@ -46,6 +46,7 @@ type Base interface {
 	Dialogs() *dialog.Dialogs
 	Options() *options.Options
 	EmptyDir() (filesystem.Fs, error)
+	LocalDbtProject(ctx context.Context) (*dbt.Project, bool, error)
 }
 
 // ForLocalCommand interface provides dependencies for commands that do not modify the remote project.
@@ -57,7 +58,6 @@ type ForLocalCommand interface {
 	LocalProject(ignoreErrors bool) (*projectPkg.Project, bool, error)
 	LocalTemplate(ctx context.Context) (*template.Template, bool, error)
 	LocalTemplateRepository(ctx context.Context) (*repository.Repository, bool, error)
-	LocalDbtProject(ctx context.Context) (*dbt.Project, bool, error)
 }
 
 // ForRemoteCommand interface provides dependencies for commands that modify remote project.

--- a/internal/pkg/cli/dependencies/local.go
+++ b/internal/pkg/cli/dependencies/local.go
@@ -5,7 +5,6 @@ import (
 	"fmt"
 	"path/filepath"
 
-	"github.com/keboola/keboola-as-code/internal/pkg/dbt"
 	"github.com/keboola/keboola-as-code/internal/pkg/dependencies"
 	"github.com/keboola/keboola-as-code/internal/pkg/filesystem"
 	"github.com/keboola/keboola-as-code/internal/pkg/model"
@@ -26,7 +25,6 @@ type local struct {
 	localProject            dependencies.Lazy[localProjectValue]
 	localTemplate           dependencies.Lazy[localTemplateValue]
 	localTemplateRepository dependencies.Lazy[localRepositoryValue]
-	localDbtProject         dependencies.Lazy[localDbtProjectValue]
 }
 
 type localProjectValue struct {
@@ -42,11 +40,6 @@ type localRepositoryValue struct {
 type localTemplateValue struct {
 	found bool
 	value *template.Template
-}
-
-type localDbtProjectValue struct {
-	found bool
-	value *dbt.Project
 }
 
 func newPublicDeps(baseDeps Base) (*local, error) {
@@ -159,22 +152,6 @@ func (v *local) LocalTemplate(ctx context.Context) (*template.Template, bool, er
 		}
 
 		return localTemplateValue{found: true, value: tmpl}, nil
-	})
-
-	return value.value, value.found, err
-}
-
-func (v *local) LocalDbtProject(ctx context.Context) (*dbt.Project, bool, error) {
-	value, err := v.localDbtProject.InitAndGet(func() (localDbtProjectValue, error) {
-		// Get directory
-		fs, _, err := v.FsInfo().DbtProjectDir()
-		if err != nil {
-			return localDbtProjectValue{found: false, value: nil}, err
-		}
-
-		// Load project
-		prj, err := dbt.LoadProject(ctx, fs)
-		return localDbtProjectValue{found: true, value: prj}, err
 	})
 
 	return value.value, value.found, err

--- a/internal/pkg/cli/dependencies/provider.go
+++ b/internal/pkg/cli/dependencies/provider.go
@@ -5,6 +5,7 @@ import (
 
 	"github.com/keboola/keboola-as-code/internal/pkg/cli/dialog"
 	"github.com/keboola/keboola-as-code/internal/pkg/cli/options"
+	"github.com/keboola/keboola-as-code/internal/pkg/dbt"
 	"github.com/keboola/keboola-as-code/internal/pkg/dependencies"
 	"github.com/keboola/keboola-as-code/internal/pkg/env"
 	"github.com/keboola/keboola-as-code/internal/pkg/filesystem"
@@ -108,4 +109,8 @@ func (v *provider) LocalRepository() (*repository.Repository, ForLocalCommand, e
 		return nil, nil, err
 	}
 	return repo, d, nil
+}
+
+func (v *provider) LocalDbtProject(ctx context.Context) (*dbt.Project, bool, error) {
+	return v.BaseDependencies().LocalDbtProject(ctx)
 }

--- a/pkg/lib/operation/dbt/generate/env/operation.go
+++ b/pkg/lib/operation/dbt/generate/env/operation.go
@@ -9,7 +9,6 @@ import (
 	"go.opentelemetry.io/otel/trace"
 
 	"github.com/keboola/keboola-as-code/internal/pkg/dbt"
-	"github.com/keboola/keboola-as-code/internal/pkg/filesystem"
 	"github.com/keboola/keboola-as-code/internal/pkg/log"
 	"github.com/keboola/keboola-as-code/internal/pkg/telemetry"
 )
@@ -20,7 +19,6 @@ type GenerateEnvOptions struct {
 }
 
 type dependencies interface {
-	Fs() filesystem.Fs
 	Logger() log.Logger
 	SandboxesApiClient() client.Sender
 	Tracer() trace.Tracer

--- a/pkg/lib/operation/dbt/generate/profile/operation.go
+++ b/pkg/lib/operation/dbt/generate/profile/operation.go
@@ -15,7 +15,6 @@ import (
 )
 
 type dependencies interface {
-	Fs() filesystem.Fs
 	Logger() log.Logger
 	Tracer() trace.Tracer
 	LocalDbtProject(ctx context.Context) (*dbt.Project, bool, error)
@@ -32,6 +31,7 @@ func Run(ctx context.Context, targetName string, d dependencies) (err error) {
 	if err != nil {
 		return err
 	}
+	fs := project.Fs()
 
 	targetUpper := strings.ToUpper(targetName)
 	profileDetails := map[string]interface{}{
@@ -51,8 +51,8 @@ func Run(ctx context.Context, targetName string, d dependencies) (err error) {
 	profilesFile := make(map[string]interface{})
 	profilesFile["send_anonymous_usage_stats"] = false
 
-	if d.Fs().Exists(profilePath) {
-		file, err := d.Fs().ReadFile(filesystem.NewFileDef(profilePath))
+	if fs.Exists(profilePath) {
+		file, err := fs.ReadFile(filesystem.NewFileDef(profilePath))
 		if err != nil {
 			return err
 		}
@@ -67,7 +67,7 @@ func Run(ctx context.Context, targetName string, d dependencies) (err error) {
 	if err != nil {
 		return err
 	}
-	err = d.Fs().WriteFile(filesystem.NewRawFile(profilePath, string(yamlEnc)))
+	err = fs.WriteFile(filesystem.NewRawFile(profilePath, string(yamlEnc)))
 	if err != nil {
 		return err
 	}

--- a/pkg/lib/operation/dbt/init/operation.go
+++ b/pkg/lib/operation/dbt/init/operation.go
@@ -11,7 +11,6 @@ import (
 	"go.opentelemetry.io/otel/trace"
 
 	"github.com/keboola/keboola-as-code/internal/pkg/dbt"
-	"github.com/keboola/keboola-as-code/internal/pkg/filesystem"
 	"github.com/keboola/keboola-as-code/internal/pkg/log"
 	"github.com/keboola/keboola-as-code/internal/pkg/telemetry"
 	"github.com/keboola/keboola-as-code/pkg/lib/operation/dbt/generate/env"
@@ -25,7 +24,6 @@ type DbtInitOptions struct {
 }
 
 type dependencies interface {
-	Fs() filesystem.Fs
 	JobsQueueApiClient() client.Sender
 	Logger() log.Logger
 	Tracer() trace.Tracer


### PR DESCRIPTION
Part of: https://keboola.atlassian.net/browse/KAC-241

Vsimol som si bug: chybu, ze nie sme v dbt projekte (v adresary projektu) vypiseme az po tom, co sa spytame na `target name` a ostatne veci, co je trochu naopak. 

V tomto PR som to opravil, ... najprv sa skontroluje dbt projekt:
https://github.com/keboola/keboola-as-code/blob/fc5bec4eabf973acc11e5e2b445429e8ef612323/internal/pkg/cli/cmd/dbt/generate/profile.go#L17-L22

Rovnako to robime aj inde:
https://github.com/keboola/keboola-as-code/blob/fc5bec4eabf973acc11e5e2b445429e8ef612323/internal/pkg/cli/cmd/local/encrypt.go#L19-L25
