### PR TITLE
dbt commands: ask for host/token if it not set

### DIFF
--- a/internal/pkg/cli/cmd/dbt/generate/env.go
+++ b/internal/pkg/cli/cmd/dbt/generate/env.go
@@ -20,6 +20,12 @@ func EnvCommand(p dependencies.Provider) *cobra.Command {
 				return err
 			}
 
+			// Ask for host and token if needed
+			baseDeps := p.BaseDependencies()
+			if err := baseDeps.Dialogs().AskHostAndToken(baseDeps); err != nil {
+				return err
+			}
+
 			// Get dependencies
 			d, err := p.DependenciesForRemoteCommand()
 			if err != nil {

--- a/internal/pkg/cli/cmd/dbt/generate/sources.go
+++ b/internal/pkg/cli/cmd/dbt/generate/sources.go
@@ -19,6 +19,12 @@ func SourcesCommand(p dependencies.Provider) *cobra.Command {
 				return err
 			}
 
+			// Ask for host and token if needed
+			baseDeps := p.BaseDependencies()
+			if err := baseDeps.Dialogs().AskHostAndToken(baseDeps); err != nil {
+				return err
+			}
+
 			// Get dependencies
 			d, err := p.DependenciesForRemoteCommand()
 			if err != nil {

--- a/internal/pkg/cli/cmd/dbt/init.go
+++ b/internal/pkg/cli/cmd/dbt/init.go
@@ -19,6 +19,12 @@ func InitCommand(p dependencies.Provider) *cobra.Command {
 				return err
 			}
 
+			// Ask for host and token if needed
+			baseDeps := p.BaseDependencies()
+			if err := baseDeps.Dialogs().AskHostAndToken(baseDeps); err != nil {
+				return err
+			}
+
 			// Get dependencies
 			d, err := p.DependenciesForRemoteCommand()
 			if err != nil {

--- a/internal/pkg/cli/cmd/remote/workspace/delete.go
+++ b/internal/pkg/cli/cmd/remote/workspace/delete.go
@@ -15,6 +15,12 @@ func DeleteCommand(p dependencies.Provider) *cobra.Command {
 		Short: helpmsg.Read(`remote/workspace/delete/short`),
 		Long:  helpmsg.Read(`remote/workspace/delete/long`),
 		RunE: func(cmd *cobra.Command, args []string) error {
+			// Ask for host and token if needed
+			baseDeps := p.BaseDependencies()
+			if err := baseDeps.Dialogs().AskHostAndToken(baseDeps); err != nil {
+				return err
+			}
+
 			return fmt.Errorf("not implemented")
 		},
 	}

--- a/internal/pkg/cli/cmd/remote/workspace/list.go
+++ b/internal/pkg/cli/cmd/remote/workspace/list.go
@@ -15,6 +15,12 @@ func ListCommand(p dependencies.Provider) *cobra.Command {
 		Short: helpmsg.Read(`remote/workspace/list/short`),
 		Long:  helpmsg.Read(`remote/workspace/list/long`),
 		RunE: func(cmd *cobra.Command, args []string) error {
+			// Ask for host and token if needed
+			baseDeps := p.BaseDependencies()
+			if err := baseDeps.Dialogs().AskHostAndToken(baseDeps); err != nil {
+				return err
+			}
+
 			return fmt.Errorf("not implemented")
 		},
 	}


### PR DESCRIPTION
Changes:
- `kbc dbt init` and `kbc dbt generate sources/env` asks for Storage API token and host if they are not set by ENV or flag.

-------------

Prikaz `kbc dbt init`, aj dalsie prikazy, by mal byt jednoduche na pouzivanie ... teraz musi uzivatel zadat token cez ENV alebo flag ... upravil som to, aby sa zobrazil dialog ak hodnota nie je nastavena.