### PR TITLE
Show kbc dbt * commands

### DIFF
--- a/internal/pkg/cli/cmd/cmd.go
+++ b/internal/pkg/cli/cmd/cmd.go
@@ -170,12 +170,8 @@ func NewRootCommand(stdin io.Reader, stdout io.Writer, stderr io.Writer, prompt 
 		ci.Commands(p),
 		local.Commands(p, envs),
 		remote.Commands(p, envs),
+		dbt.Commands(p),
 	)
-
-	// Dbt commands are not finished yet.
-	if envs.Get(`KBC_DBT_PRIVATE_BETA`) == `true` {
-		root.AddCommand(dbt.Commands(p))
-	}
 
 	// Templates are private beta, can be enabled by ENV
 	if envs.Get(`KBC_TEMPLATES_PRIVATE_BETA`) == `true` {


### PR DESCRIPTION
Show `kbc dbt *` commands before release.
Commands `kbc workspace *` are still hidden.