### PR TITLE
Fix log-file E2E test

### DIFF
--- a/internal/pkg/cli/cmd/cmd.go
+++ b/internal/pkg/cli/cmd/cmd.go
@@ -158,6 +158,8 @@ func NewRootCommand(stdin io.Reader, stdout io.Writer, stderr io.Writer, prompt 
 		if err := versionCheck.Run(cmd.Context(), p.BaseDependencies()); err != nil {
 			// Ignore error, send to logs
 			root.logger.Debugf(`Version check: %s.`, err.Error())
+		} else {
+			root.logger.Debugf(`Version check: successful.`, err.Error())
 		}
 
 		return nil

--- a/test/cli/environment/log-file/env
+++ b/test/cli/environment/log-file/env
@@ -1,0 +1,1 @@
+KBC_VERSION_CHECK=false


### PR DESCRIPTION
Spadol CLI release: https://github.com/keboola/keboola-as-code/actions/runs/3157376355
![image](https://user-images.githubusercontent.com/19371734/193236650-ffb7eb41-e918-4873-b314-9c1efda46af1.png)


Na tom, ze E2E CLI test `environment/log-file` tu ocakava `version check` hlasku:
https://github.com/keboola/keboola-as-code/blob/c864a220f295db2c747f431c165c6061d8c92c1b/test/cli/environment/log-file/out/log-file.txt#L18

Ta hlaska je tam vzdy v `dev` builde, pretoze sa zam zaloguju tieto "chyby":
https://github.com/keboola/keboola-as-code/blob/c864a220f295db2c747f431c165c6061d8c92c1b/internal/pkg/version/check_remote.go#L35
https://github.com/keboola/keboola-as-code/blob/c864a220f295db2c747f431c165c6061d8c92c1b/internal/pkg/version/check_remote.go#L38-L46

Upravil som to tak, aby sa zalogovala hlaska aj v pripade uspechu + dana ENV sa dostane do testu.