### PR TITLE
Add CodeQL Analysis to CI

### DIFF
--- a/.github/workflows/codeql-analysis.yml
+++ b/.github/workflows/codeql-analysis.yml
@@ -1,0 +1,74 @@
+# For most projects, this workflow file will not need changing; you simply need
+# to commit it to your repository.
+#
+# You may wish to alter this file to override the set of languages analyzed,
+# or to provide custom queries or build logic.
+#
+# ******** NOTE ********
+# We have attempted to detect the languages in your repository. Please check
+# the `language` matrix defined below to confirm you have the correct set of
+# supported CodeQL languages.
+#
+name: "CodeQL"
+
+on:
+  push:
+    branches: [ "main" ]
+  pull_request:
+    # The branches below must be a subset of the branches above
+    branches: [ "main" ]
+  schedule:
+    - cron: '40 21 * * 1'
+
+jobs:
+  analyze:
+    name: Analyze
+    runs-on: ubuntu-latest
+    permissions:
+      actions: read
+      contents: read
+      security-events: write
+
+    strategy:
+      fail-fast: false
+      matrix:
+        language: [ 'go' ]
+        # CodeQL supports [ 'cpp', 'csharp', 'go', 'java', 'javascript', 'python', 'ruby' ]
+        # Learn more about CodeQL language support at https://aka.ms/codeql-docs/language-support
+
+    steps:
+    - name: Checkout repository
+      uses: actions/checkout@v3
+
+    # Initializes the CodeQL tools for scanning.
+    - name: Initialize CodeQL
+      uses: github/codeql-action/init@v2
+      with:
+        languages: ${{ matrix.language }}
+        # If you wish to specify custom queries, you can do so here or in a config file.
+        # By default, queries listed here will override any specified in a config file.
+        # Prefix the list here with "+" to use these queries and those in the config file.
+        
+        # Details on CodeQL's query packs refer to : https://docs.github.com/en/code-security/code-scanning/automatically-scanning-your-code-for-vulnerabilities-and-errors/configuring-code-scanning#using-queries-in-ql-packs
+        # queries: security-extended,security-and-quality
+
+        
+    # Autobuild attempts to build any compiled languages  (C/C++, C#, or Java).
+    # If this step fails, then you should remove it and run the build manually (see below)
+    - name: Autobuild
+      uses: github/codeql-action/autobuild@v2
+
+    # ℹ️ Command-line programs to run using the OS shell.
+    # 📚 See https://docs.github.com/en/actions/using-workflows/workflow-syntax-for-github-actions#jobsjob_idstepsrun
+
+    #   If the Autobuild fails above, remove it and uncomment the following three lines. 
+    #   modify them (or add more) to build your code if your project, please refer to the EXAMPLE below for guidance.
+
+    # - run: |
+    #   echo "Run, Build Application using script"
+    #   ./location_of_script_within_repo/buildscript.sh
+
+    - name: Perform CodeQL Analysis
+      uses: github/codeql-action/analyze@v2
+      with:
+        category: "/language:${{matrix.language}}"

--- a/internal/pkg/api/server/templates/http/middleware.go
+++ b/internal/pkg/api/server/templates/http/middleware.go
@@ -17,6 +17,7 @@ import (
 
 	"github.com/keboola/keboola-as-code/internal/pkg/api/server/templates/dependencies"
 	"github.com/keboola/keboola-as-code/internal/pkg/idgenerator"
+	"github.com/keboola/keboola-as-code/internal/pkg/log"
 )
 
 const RequestTimeout = 60 * time.Second
@@ -118,7 +119,7 @@ func LogMiddleware(d dependencies.ForServer, h http.Handler) http.Handler {
 		// Log request
 		logger.
 			WithAdditionalPrefix(fmt.Sprintf("[request][requestId=%s]", requestId)).
-			Infof("%s %s %s", r.Method, r.URL.String(), from(r))
+			Infof("%s %s %s", r.Method, log.Sanitize(r.URL.String()), log.Sanitize(from(r)))
 
 		// Capture response
 		rw := httpMiddleware.CaptureResponse(w)

--- a/internal/pkg/log/sanitize.go
+++ b/internal/pkg/log/sanitize.go
@@ -1,0 +1,10 @@
+package log
+
+import (
+	"strings"
+)
+
+func Sanitize(in string) string {
+	out := strings.Replace(in, "\n", `\n`, -1)
+	return strings.Replace(out, "\r", `\n`, -1)
+}


### PR DESCRIPTION
To jsem našel tady v `Security` tabu pod `Code Scanning`, tak zkouším. 🙂 Viz. https://github.com/keboola/keboola-as-code/security/code-scanning?query=is%3Aopen+pr%3A857 

Stěžoval si na vypisování hesla pro workspace na stdout což jsem nechal ignorovat ale ještě jsou tam dvě issues: https://github.com/keboola/keboola-as-code/security/code-scanning/1 a https://github.com/keboola/keboola-as-code/security/code-scanning/2 