### PR TITLE
Update Winget fork repository for release

### DIFF
--- a/.github/workflows/push.yml
+++ b/.github/workflows/push.yml
@@ -47,7 +47,7 @@ env:
   APK_KEY_PUBLIC: ${{ secrets.APK_KEY_PUBLIC }}
 
   # WinGet packages
-  WINGET_PACKAGES_REPO_FORK: "JakubMatejka/winget-pkgs"
+  WINGET_PACKAGES_REPO_FORK: "keboola/winget-pkgs"
 
   # macOS notarization
   APPLE_ACCOUNT_USERNAME: "apple@keboola.com"


### PR DESCRIPTION
https://keboola.atlassian.net/browse/KAC-256

Vytvořil jsem uživatele `devel+kac@keboola.com` a vytvořil mu tři PAT tokeny pro Homebrew, Scoop a WinGet (asi by mohl být jeden, stejně má přístup do všech repo toho uživatele, ale tak pro jistotu.) Nastavil jsem jim expiraci na rok. (Přidám reminder do Slacku.) Secrety v GH jsem updatoval.