### PR TITLE
CI: stop on unbound variable

### DIFF
--- a/.github/workflows/push.yml
+++ b/.github/workflows/push.yml
@@ -549,6 +549,9 @@ jobs:
           DEB_KEY_PUBLIC: ${{ secrets.DEB_KEY_PUBLIC }}
           RPM_KEY_PUBLIC: ${{ secrets.RPM_KEY_PUBLIC }}
           APK_KEY_PUBLIC: ${{ secrets.APK_KEY_PUBLIC }}
+          DEB_KEY_PRIVATE: ${{ secrets.DEB_KEY_PRIVATE }}
+          RPM_KEY_PRIVATE: ${{ secrets.RPM_KEY_PRIVATE }}
+          APK_KEY_PRIVATE: ${{ secrets.APK_KEY_PRIVATE }}
       - name: Clean aws credentials file
         run: rm -rf ${HOME}/.aws
       - name: Configure AWS Credentials to KAC Assets AWS
@@ -568,6 +571,9 @@ jobs:
           DEB_KEY_PUBLIC: ${{ secrets.DEB_KEY_PUBLIC }}
           RPM_KEY_PUBLIC: ${{ secrets.RPM_KEY_PUBLIC }}
           APK_KEY_PUBLIC: ${{ secrets.APK_KEY_PUBLIC }}
+          DEB_KEY_PRIVATE: ${{ secrets.DEB_KEY_PRIVATE }}
+          RPM_KEY_PRIVATE: ${{ secrets.RPM_KEY_PRIVATE }}
+          APK_KEY_PRIVATE: ${{ secrets.APK_KEY_PRIVATE }}
       - name: Download Scoop manifest
         uses: actions/download-artifact@v3
         with:

--- a/build/package/linux/index.sh
+++ b/build/package/linux/index.sh
@@ -28,21 +28,21 @@ function retry {
 }
 
 function indexDeb {
-  docker-compose run --rm -u "$(id -u):$(id -g)" deb
+  docker-compose run --rm -T -u "$(id -u):$(id -g)" deb
   echo "OK. DEB packages indexed."
   echo
   echo
 }
 
 function indexRpm {
-  docker-compose run --rm -u "$(id -u):$(id -g)" rpm
+  docker-compose run --rm -T -u "$(id -u):$(id -g)" rpm
   echo "OK. RPM packages indexed."
   echo
   echo
 }
 
 function indexApk {
-  docker-compose run --rm -u "$(id -u):$(id -g)" apk
+  docker-compose run --rm -T -u "$(id -u):$(id -g)" apk
   echo "OK. APK packages indexed."
   echo
   echo


### PR DESCRIPTION
V scriptoch mame `set -o nounset` (alebo `set -u` kratsie)

https://www.gnu.org/software/bash/manual/html_node/The-Set-Builtin.html
![image](https://user-images.githubusercontent.com/19371734/196351413-39245909-ea8a-43ba-b977-e51b9389299b.png)

----------------

`docker-compose run` by defaul alokuje pseudo-tty, pseudo interaktivny terminal.

`docker-compose run --help`
![image](https://user-images.githubusercontent.com/19371734/196351655-3be50ec1-d59f-40db-bd37-912934d94cc6.png)

-----

To sposobi, ze ak sa najde nedefinovana premenna, tak ani s `set -o nounset` script neskonci s chybou - pretoze terminal je interaktivny.

----

`docker run` to ma "spravne" (lepsie), by default je terminal neinteraktivny, neviem preco to ma `docker-compose run` opacne :man_shrugging: 

`docker run --help`:
![image](https://user-images.githubusercontent.com/19371734/196352340-488a303f-75db-4bd5-8471-82e5e9cfbcf0.png)

