### PR TITLE
cli-dist - create role for release

### DIFF
--- a/.github/workflows/push.yml
+++ b/.github/workflows/push.yml
@@ -249,7 +249,7 @@ jobs:
       - name: Configure AWS Credentials to KAC Assets Account
         uses: aws-actions/configure-aws-credentials@v1-node16
         with:
-          role-to-assume: arn:aws:iam::455460941449:role/kbc-github-actions-admin-role
+          role-to-assume: arn:aws:iam::455460941449:role/cli-dist-release
           aws-region: eu-central-1
       - name: Release
         run: make release
@@ -356,7 +356,7 @@ jobs:
       - name: Configure AWS Credentials to KAC Assets Account
         uses: aws-actions/configure-aws-credentials@v1-node16
         with:
-          role-to-assume: arn:aws:iam::455460941449:role/kbc-github-actions-admin-role
+          role-to-assume: arn:aws:iam::455460941449:role/cli-dist-release
           aws-region: eu-central-1
       - name: Upload MSI to KAC Assets S3
         env:
@@ -429,7 +429,7 @@ jobs:
       - name: Configure AWS Credentials to KAC Assets AWS
         uses: aws-actions/configure-aws-credentials@v1-node16
         with:
-          role-to-assume: arn:aws:iam::455460941449:role/kbc-github-actions-admin-role
+          role-to-assume: arn:aws:iam::455460941449:role/cli-dist-release
           aws-region: eu-central-1
       - name: Mount KAC Assets S3 Bucket
         uses: ./.github/actions/mount-s3

--- a/provisioning/cli-dist/release_role.tf
+++ b/provisioning/cli-dist/release_role.tf
@@ -1,0 +1,65 @@
+# IAM role which allows production release workflow push artifacts to cli-dist S3 bucket
+
+data "aws_iam_policy_document" "cli_dist_release_assume_policy_doc" {
+  version = "2012-10-17"
+  statement {
+    sid = "AllowAssumeRoleFromGithub"
+    actions = [
+      "sts:AssumeRoleWithWebIdentity"
+    ]
+    effect = "Allow"
+    principals {
+      identifiers = [
+        var.github_oidc_provider_arn
+      ]
+      type = "Federated"
+    }
+    condition {
+      test     = "StringLike"
+      variable = "token.actions.githubusercontent.com:sub"
+      values = [
+        "repo:keboola/keboola-as-code:ref:refs/tags/*",
+      ]
+    }
+    condition {
+      test     = "StringEquals"
+      variable = "token.actions.githubusercontent.com:aud"
+      values = [
+        "sts.amazonaws.com"
+      ]
+    }
+  }
+}
+
+data "aws_iam_policy_document" "cli_dist_release_resources_policy_doc" {
+  version = "2012-10-17"
+  statement {
+    effect = "Allow"
+    actions = [
+      "s3:*"
+    ]
+    resources = [
+      "${aws_s3_bucket.cli_dist_bucket.arn}/*"
+    ]
+  }
+  statement {
+    effect = "Allow"
+    actions = [
+      "s3:ListBucket"
+    ]
+    resources = [
+      aws_s3_bucket.cli_dist_bucket.arn
+    ]
+  }
+}
+
+resource "aws_iam_role_policy" "cli_dist_release_resources_policy" {
+  name_prefix   = "cli-dist-release-bucket-full-access"
+  role   = aws_iam_role.cli_dist_release_role.id
+  policy = data.aws_iam_policy_document.cli_dist_release_resources_policy_doc.json
+}
+
+resource "aws_iam_role" "cli_dist_release_role" {
+  name               = "cli-dist-release"
+  assume_role_policy = data.aws_iam_policy_document.cli_dist_release_assume_policy_doc.json
+}


### PR DESCRIPTION
Fixes: https://keboola.atlassian.net/browse/SRE-4105

- Připravuje novou IAM roli pro github actions která má práva pouze pro push artefaktů do dist S3 bucketu, tuto roli použuje release workflow

Nasazení:
 - Merge - triggeruje `CLI Dist Provisioning` a to vytvoří novou release roli v produkčním accountu
 - Release - Uploadne artefakty do S3 už pomocí nové role