### PR TITLE
Templates API: set soft memory limit to 80%

### DIFF
--- a/provisioning/templates-api/kubernetes/templates/api/deployment.yaml
+++ b/provisioning/templates-api/kubernetes/templates/api/deployment.yaml
@@ -37,8 +37,9 @@ spec:
           ports:
             - containerPort: 8000
           env:
+            # 80% of the resources.limits.memory
             - name: GOMEMLIMIT
-              value: "512MiB"
+              value: "400MiB"
             - name: KBC_STORAGE_API_HOST
               valueFrom:
                 configMapKeyRef:


### PR DESCRIPTION
Changes:
- Set `GOMEMLIMIT` soft memory limit to 80% for the Templates API pod.