### PR TITLE
Make shared code row scripts optional

### DIFF
--- a/internal/pkg/model/sharedcode.go
+++ b/internal/pkg/model/sharedcode.go
@@ -14,7 +14,7 @@ type SharedCodeConfig struct {
 
 type SharedCodeRow struct {
 	Target  storageapi.ComponentID `validate:"required"`
-	Scripts Scripts                `validate:"required"`
+	Scripts Scripts
 }
 
 // LinkScript is reference to shared code used in transformation.


### PR DESCRIPTION
Jako hotfix bych teda ty scripts udělal optional. 🙂