### PR TITLE
Better API E2E tests

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -25,7 +25,7 @@ require (
 	github.com/joho/godotenv v1.4.0
 	github.com/jpillora/longestcommon v0.0.0-20161227235612-adb9d91ee629
 	github.com/keboola/go-client v0.16.0
-	github.com/keboola/go-utils v0.6.2
+	github.com/keboola/go-utils v0.6.3-0.20221206111321-11dbd6a3faa6
 	github.com/kylelemons/godebug v1.1.0
 	github.com/pkg/errors v0.9.1
 	github.com/relvacode/iso8601 v1.1.0

--- a/go.mod
+++ b/go.mod
@@ -25,7 +25,7 @@ require (
 	github.com/joho/godotenv v1.4.0
 	github.com/jpillora/longestcommon v0.0.0-20161227235612-adb9d91ee629
 	github.com/keboola/go-client v0.16.0
-	github.com/keboola/go-utils v0.6.3-0.20221206111321-11dbd6a3faa6
+	github.com/keboola/go-utils v0.7.0
 	github.com/kylelemons/godebug v1.1.0
 	github.com/pkg/errors v0.9.1
 	github.com/relvacode/iso8601 v1.1.0

--- a/go.sum
+++ b/go.sum
@@ -1066,8 +1066,8 @@ github.com/keboola/go-client v0.16.0 h1:rOvx0y5QeU8zz0YJ+P8ugHJUXhjHZSxLZXHJ7O1y
 github.com/keboola/go-client v0.16.0/go.mod h1:N3K8v6NM0wuV+u/+dPS/wcbTmDLrRXQcyRInYZRSgPE=
 github.com/keboola/go-jsonnet v0.18.1-0.20220810085752-aee7595aa305 h1:hS/jX0HQzeGZWjMBSAs/IqrJTrTB5/BlYu7UcjFW9NU=
 github.com/keboola/go-jsonnet v0.18.1-0.20220810085752-aee7595aa305/go.mod h1:2YGGjrWbRtdL5/lAp1anatj8zA+y/fKT0lLWvTqk+/Q=
-github.com/keboola/go-utils v0.6.3-0.20221206111321-11dbd6a3faa6 h1:veXGkCRiaG9YxM0F53mj1vSqlS9bv2AhgV+0+oAEOtU=
-github.com/keboola/go-utils v0.6.3-0.20221206111321-11dbd6a3faa6/go.mod h1:5wkrBfGBpJ/COCkBO0JPckD0e9sdT1PQo09Phx+kqrw=
+github.com/keboola/go-utils v0.7.0 h1:wuxVuPf9p9huq6PNdGrF8bs1oC50bnBQD6aNLpqq4c0=
+github.com/keboola/go-utils v0.7.0/go.mod h1:5wkrBfGBpJ/COCkBO0JPckD0e9sdT1PQo09Phx+kqrw=
 github.com/kisielk/errcheck v1.1.0/go.mod h1:EZBBE59ingxPouuu3KfxchcWSUPOHkagtvWXihfKN4Q=
 github.com/kisielk/errcheck v1.2.0/go.mod h1:/BMXB+zMLi60iA8Vv6Ksmxu/1UDYcXs4uQLJ+jE2L00=
 github.com/kisielk/errcheck v1.5.0/go.mod h1:pFxgyoBC7bSaBwPgfKdkLd5X25qrDl4LWUI2bnpBCr8=

--- a/go.sum
+++ b/go.sum
@@ -1066,8 +1066,8 @@ github.com/keboola/go-client v0.16.0 h1:rOvx0y5QeU8zz0YJ+P8ugHJUXhjHZSxLZXHJ7O1y
 github.com/keboola/go-client v0.16.0/go.mod h1:N3K8v6NM0wuV+u/+dPS/wcbTmDLrRXQcyRInYZRSgPE=
 github.com/keboola/go-jsonnet v0.18.1-0.20220810085752-aee7595aa305 h1:hS/jX0HQzeGZWjMBSAs/IqrJTrTB5/BlYu7UcjFW9NU=
 github.com/keboola/go-jsonnet v0.18.1-0.20220810085752-aee7595aa305/go.mod h1:2YGGjrWbRtdL5/lAp1anatj8zA+y/fKT0lLWvTqk+/Q=
-github.com/keboola/go-utils v0.6.2 h1:drCyJA1+0xslOe/G53G4zd/M9Bgp7fLIkrj3AkUOanY=
-github.com/keboola/go-utils v0.6.2/go.mod h1:5wkrBfGBpJ/COCkBO0JPckD0e9sdT1PQo09Phx+kqrw=
+github.com/keboola/go-utils v0.6.3-0.20221206111321-11dbd6a3faa6 h1:veXGkCRiaG9YxM0F53mj1vSqlS9bv2AhgV+0+oAEOtU=
+github.com/keboola/go-utils v0.6.3-0.20221206111321-11dbd6a3faa6/go.mod h1:5wkrBfGBpJ/COCkBO0JPckD0e9sdT1PQo09Phx+kqrw=
 github.com/kisielk/errcheck v1.1.0/go.mod h1:EZBBE59ingxPouuu3KfxchcWSUPOHkagtvWXihfKN4Q=
 github.com/kisielk/errcheck v1.2.0/go.mod h1:/BMXB+zMLi60iA8Vv6Ksmxu/1UDYcXs4uQLJ+jE2L00=
 github.com/kisielk/errcheck v1.5.0/go.mod h1:pFxgyoBC7bSaBwPgfKdkLd5X25qrDl4LWUI2bnpBCr8=

--- a/test/api/buffer/api_test.go
+++ b/test/api/buffer/api_test.go
@@ -452,17 +452,23 @@ func RunRequests(
 		expectedCodeFile, err := testDirFs.ReadFile(filesystem.NewFileDef(filesystem.Join(requestDir, "expected-http-code")))
 		assert.NoError(t, err)
 		expectedCode := cast.ToInt(strings.TrimSpace(expectedCodeFile.Content))
-		assert.Equal(
+		ok1 := assert.Equal(
 			t,
 			expectedCode,
 			resp.StatusCode(),
-			"Unexpected status code for request %s.\nRESPONSE:\n%s\n\n",
+			"Unexpected status code for request \"%s\".\nRESPONSE:\n%s\n\n",
 			requestDir,
 			resp.String(),
 		)
 
 		// Assert response body
-		wildcards.Assert(t, expectedRespBody, respBody, fmt.Sprintf("Unexpected response for request %s.", requestDir))
+		ok2 := wildcards.Assert(t, expectedRespBody, respBody, fmt.Sprintf("Unexpected response for request %s.", requestDir))
+
+		// If the request failed, skip other requests
+		if !ok1 || !ok2 {
+			t.Errorf(`request "%s" failed, skipping the other requests`, requestDir)
+			break
+		}
 	}
 }
 

--- a/test/api/buffer/api_test.go
+++ b/test/api/buffer/api_test.go
@@ -126,7 +126,7 @@ func RunE2ETest(t *testing.T, testDir, workingDir string, binary string) {
 		err = etcdhelper.PutAllFromSnapshot(context.Background(), etcdClient, etcdStateFileContentStr)
 		assert.NoError(t, err)
 	}
-	
+
 	// Assert
 	RunRequests(t, envProvider, testDirFs, apiUrl)
 

--- a/test/api/templates/api_test.go
+++ b/test/api/templates/api_test.go
@@ -338,7 +338,7 @@ func RunRequests(
 		return nil
 	})
 
-	// rRquest folders should be named e.g. 001-request1, 002-request2
+	// Request folders should be named e.g. 001-request1, 002-request2
 	dirs, err := testDirFs.Glob("[0-9][0-9][0-9]-*")
 	assert.NoError(t, err)
 	for _, requestDir := range dirs {
@@ -388,17 +388,23 @@ func RunRequests(
 		expectedCodeFile, err := testDirFs.ReadFile(filesystem.NewFileDef(filesystem.Join(requestDir, "expected-http-code")))
 		assert.NoError(t, err)
 		expectedCode := cast.ToInt(strings.TrimSpace(expectedCodeFile.Content))
-		assert.Equal(
+		ok1 := assert.Equal(
 			t,
 			expectedCode,
 			resp.StatusCode(),
-			"Unexpected status code for request %s.\nRESPONSE:\n%s\n\n",
+			"Unexpected status code for request \"%s\".\nRESPONSE:\n%s\n\n",
 			requestDir,
 			resp.String(),
 		)
 
 		// Assert response body
-		wildcards.Assert(t, expectedRespBody, respBody, fmt.Sprintf("Unexpected response for request %s.", requestDir))
+		ok2 := wildcards.Assert(t, expectedRespBody, respBody, fmt.Sprintf("Unexpected response for request %s.", requestDir))
+
+		// If the request failed, skip other requests
+		if !ok1 || !ok2 {
+			t.Errorf(`request "%s" failed, skipping the other requests`, requestDir)
+			break
+		}
 	}
 }
 

--- a/test/api/templates/api_test.go
+++ b/test/api/templates/api_test.go
@@ -7,6 +7,8 @@ import (
 	"fmt"
 	"io"
 	"net"
+	"net/http"
+	"net/http/httputil"
 	"os"
 	"os/exec"
 	"path/filepath"
@@ -33,6 +35,10 @@ import (
 	"github.com/keboola/keboola-as-code/internal/pkg/utils/testproject"
 	"github.com/keboola/keboola-as-code/internal/pkg/validator"
 )
+
+const dumpDirCtxKey = ctxKey("dumpDir")
+
+type ctxKey string
 
 // TestTemplatesApiE2E runs one functional test per each subdirectory.
 func TestTemplatesApiE2E(t *testing.T) {
@@ -113,7 +119,7 @@ func RunE2ETest(t *testing.T, testDir, workingDir string, binary string) {
 	apiUrl, stdout, stderr := RunApiServer(t, binary, project.StorageAPIHost(), repositories)
 
 	// Assert
-	RunRequests(t, envProvider, testDirFs, apiUrl)
+	RunRequests(t, envProvider, testDirFs, workingDirFs, apiUrl)
 
 	// Optionally check project state
 	expectedStatePath := "expected-state.json"
@@ -315,18 +321,29 @@ func RunRequests(
 	t *testing.T,
 	envProvider testhelper.EnvProvider,
 	testDirFs filesystem.Fs,
+	workingDirFs filesystem.Fs,
 	apiUrl string,
 ) {
 	t.Helper()
 	client := resty.New()
 	client.SetBaseURL(apiUrl)
 
+	// Dump raw HTTP request
+	client.SetPreRequestHook(func(client *resty.Client, request *http.Request) error {
+		if dumpDir, ok := request.Context().Value(dumpDirCtxKey).(string); ok {
+			reqDump, err := httputil.DumpRequest(request, true)
+			assert.NoError(t, err)
+			assert.NoError(t, workingDirFs.WriteFile(filesystem.NewRawFile(filesystem.Join(dumpDir, "request.txt"), string(reqDump))))
+		}
+		return nil
+	})
+
 	// rRquest folders should be named e.g. 001-request1, 002-request2
 	dirs, err := testDirFs.Glob("[0-9][0-9][0-9]-*")
 	assert.NoError(t, err)
-	for _, dir := range dirs {
+	for _, requestDir := range dirs {
 		// Read the request file
-		requestFile, err := testDirFs.ReadFile(filesystem.NewFileDef(filesystem.Join(dir, "request.json")))
+		requestFile, err := testDirFs.ReadFile(filesystem.NewFileDef(filesystem.Join(requestDir, "request.json")))
 		assert.NoError(t, err)
 		requestFileStr := testhelper.MustReplaceEnvsString(requestFile.Content, envProvider)
 
@@ -342,23 +359,19 @@ func RunRequests(
 			r.SetBody(request.Body)
 		}
 		r.SetHeader("X-StorageApi-Token", envProvider.MustGet("TEST_KBC_STORAGE_API_TOKEN"))
-		var resp *resty.Response
-		switch request.Method {
-		case "DELETE":
-			resp, err = r.Delete(request.Path)
-		case "GET":
-			resp, err = r.Get(request.Path)
-		case "PATCH":
-			resp, err = r.Patch(request.Path)
-		case "POST":
-			resp, err = r.Post(request.Path)
-		case "PUT":
-			resp, err = r.Put(request.Path)
-		}
+
+		// Send request
+		r.SetContext(context.WithValue(r.Context(), dumpDirCtxKey, requestDir))
+		resp, err := r.Execute(request.Method, request.Path)
 		assert.NoError(t, err)
 
+		// Dump raw HTTP response
+		respDump, err := httputil.DumpResponse(resp.RawResponse, false)
+		assert.NoError(t, err)
+		assert.NoError(t, workingDirFs.WriteFile(filesystem.NewRawFile(filesystem.Join(requestDir, "response.txt"), string(respDump)+string(resp.Body()))))
+
 		// Compare response body
-		expectedRespFile, err := testDirFs.ReadFile(filesystem.NewFileDef(filesystem.Join(dir, "expected-response.json")))
+		expectedRespFile, err := testDirFs.ReadFile(filesystem.NewFileDef(filesystem.Join(requestDir, "expected-response.json")))
 		assert.NoError(t, err)
 		expectedRespBody := testhelper.MustReplaceEnvsString(expectedRespFile.Content, envProvider)
 
@@ -372,7 +385,7 @@ func RunRequests(
 		assert.NoError(t, err)
 
 		// Compare response status code
-		expectedCodeFile, err := testDirFs.ReadFile(filesystem.NewFileDef(filesystem.Join(dir, "expected-http-code")))
+		expectedCodeFile, err := testDirFs.ReadFile(filesystem.NewFileDef(filesystem.Join(requestDir, "expected-http-code")))
 		assert.NoError(t, err)
 		expectedCode := cast.ToInt(strings.TrimSpace(expectedCodeFile.Content))
 		assert.Equal(
@@ -380,12 +393,12 @@ func RunRequests(
 			expectedCode,
 			resp.StatusCode(),
 			"Unexpected status code for request %s.\nRESPONSE:\n%s\n\n",
-			dir,
+			requestDir,
 			resp.String(),
 		)
 
 		// Assert response body
-		wildcards.Assert(t, expectedRespBody, respBody, fmt.Sprintf("Unexpected response for request %s.", dir))
+		wildcards.Assert(t, expectedRespBody, respBody, fmt.Sprintf("Unexpected response for request %s.", requestDir))
 	}
 }
 


### PR DESCRIPTION
### Changes

####  Raw HTTP request/response is dumped to the `.out` directory.

![image](https://user-images.githubusercontent.com/19371734/205903441-3067db22-6e79-4a75-91b3-d0d23b10731b.png)

![image](https://user-images.githubusercontent.com/19371734/205903471-523f2cc4-3bf7-41b5-9876-25c43843c6b7.png)

#### Other requests are skipped if a request failed

![image](https://user-images.githubusercontent.com/19371734/205903536-c3860068-ec1a-448e-b457-01ba35fde073.png)

![image](https://user-images.githubusercontent.com/19371734/205903555-111d78b5-fe8a-43a0-bb2e-8b9155db1f1a.png)


------------

Fixol som, co sa da rychlo vyriesit, na ostatne je task:
https://keboola.atlassian.net/browse/BA-89