### PR TITLE
servicectx pkg: process unique ID and graceful shutdown

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -27,7 +27,6 @@ require (
 	github.com/keboola/go-client v0.18.0
 	github.com/keboola/go-utils v0.7.0
 	github.com/kylelemons/godebug v1.1.0
-	github.com/pkg/errors v0.9.1
 	github.com/relvacode/iso8601 v1.1.0
 	github.com/santhosh-tekuri/jsonschema/v5 v5.1.1
 	github.com/spf13/afero v1.9.3
@@ -167,6 +166,7 @@ require (
 	github.com/modern-go/reflect2 v1.0.2 // indirect
 	github.com/pelletier/go-toml/v2 v2.0.5 // indirect
 	github.com/pkg/browser v0.0.0-20210115035449-ce105d075bb4 // indirect
+	github.com/pkg/errors v0.9.1 // indirect
 	github.com/pmezard/go-difflib v1.0.0 // indirect
 	github.com/rivo/uniseg v0.4.2 // indirect
 	go.etcd.io/etcd/client/pkg/v3 v3.5.6 // indirect

--- a/internal/pkg/service/buffer/api/http/http.go
+++ b/internal/pkg/service/buffer/api/http/http.go
@@ -17,6 +17,7 @@ import (
 	"github.com/keboola/keboola-as-code/internal/pkg/service/buffer/api/openapi"
 	"github.com/keboola/keboola-as-code/internal/pkg/service/common/httpserver"
 	"github.com/keboola/keboola-as-code/internal/pkg/service/common/muxer"
+	"github.com/keboola/keboola-as-code/internal/pkg/service/common/servicectx"
 	swaggerui "github.com/keboola/keboola-as-code/third_party"
 )
 
@@ -27,7 +28,7 @@ const (
 
 // HandleHTTPServer starts configures and starts a HTTP server on the given
 // URL. It shuts down the server if any error is received in the error channel.
-func HandleHTTPServer(ctx context.Context, d dependencies.ForServer, u *url.URL, endpoints *buffer.Endpoints, errCh chan error, debug bool) {
+func HandleHTTPServer(proc *servicectx.Process, d dependencies.ForServer, u *url.URL, endpoints *buffer.Endpoints, debug bool) {
 	logger := d.Logger()
 
 	// Trace endpoint start, finish and error
@@ -77,17 +78,14 @@ func HandleHTTPServer(ctx context.Context, d dependencies.ForServer, u *url.URL,
 		logger.Infof("HTTP %q mounted on %s %s", m.Method, m.Verb, m.Pattern)
 	}
 
-	wg := d.ServerWaitGroup()
-	wg.Add(1)
-	go func() {
-		defer wg.Done()
-
+	proc.Add(func(ctx context.Context, errCh chan<- error) {
 		// Start HTTP server in a separate goroutine.
 		go func() {
 			logger.Infof("HTTP server listening on %q", u.Host)
 			errCh <- srv.ListenAndServe()
 		}()
 
+		// Wait for termination
 		<-ctx.Done()
 		logger.Infof("shutting down HTTP server at %q", u.Host)
 
@@ -96,5 +94,5 @@ func HandleHTTPServer(ctx context.Context, d dependencies.ForServer, u *url.URL,
 		defer cancel()
 
 		_ = srv.Shutdown(ctx)
-	}()
+	})
 }

--- a/internal/pkg/service/buffer/worker/dependencies/dependencies.go
+++ b/internal/pkg/service/buffer/worker/dependencies/dependencies.go
@@ -23,13 +23,11 @@ import (
 // The container exists during the entire run of the Worker.
 type ForWorker interface {
 	serviceDependencies.ForService
-	Process() *servicectx.Process
 }
 
 // forWorker implements ForWorker interface.
 type forWorker struct {
 	serviceDependencies.ForService
-	proc *servicectx.Process
 }
 
 func NewWorkerDeps(ctx context.Context, proc *servicectx.Process, envs env.Provider, logger log.Logger, debug, dumpHTTP bool) (v ForWorker, err error) {
@@ -54,12 +52,7 @@ func NewWorkerDeps(ctx context.Context, proc *servicectx.Process, envs env.Provi
 	// Create server dependencies
 	d := &forWorker{
 		ForService: serviceDeps,
-		proc:       proc,
 	}
 
 	return d, nil
-}
-
-func (v *forWorker) Process() *servicectx.Process {
-	return v.proc
 }

--- a/internal/pkg/service/common/dependencies/dependencies.go
+++ b/internal/pkg/service/common/dependencies/dependencies.go
@@ -52,7 +52,6 @@ import (
 	"context"
 	"net"
 	"net/http"
-	"sync"
 
 	"github.com/jarcoal/httpmock"
 	"github.com/keboola/go-client/pkg/client"
@@ -68,6 +67,7 @@ import (
 	projectPkg "github.com/keboola/keboola-as-code/internal/pkg/project"
 	bufferStore "github.com/keboola/keboola-as-code/internal/pkg/service/buffer/store"
 	"github.com/keboola/keboola-as-code/internal/pkg/service/cli/options"
+	"github.com/keboola/keboola-as-code/internal/pkg/service/common/servicectx"
 	"github.com/keboola/keboola-as-code/internal/pkg/state"
 )
 
@@ -120,8 +120,8 @@ type Mocked interface {
 	MockedProject(fs filesystem.Fs) *projectPkg.Project
 	MockedHTTPTransport() *httpmock.MockTransport
 
-	ServerCtx() context.Context
-	ServerWaitGroup() *sync.WaitGroup
+	Process() *servicectx.Process
+
 	RequestCtx() context.Context
 	RequestID() string
 	RequestHeader() http.Header

--- a/internal/pkg/service/common/servicectx/servicectx.go
+++ b/internal/pkg/service/common/servicectx/servicectx.go
@@ -95,7 +95,7 @@ func New(ctx context.Context, cancel context.CancelFunc, logger log.Logger, opts
 		proc.terminating = true
 		proc.lock.Unlock()
 
-		// Iterate callbacks in reverse order, LIFO
+		// Iterate callbacks in reverse order, LIFO, see the OnShutdown method
 		for i := len(proc.onShutdown) - 1; i >= 0; i-- {
 			proc.onShutdown[i]()
 		}
@@ -167,10 +167,10 @@ func (v *Process) Add(operation func(ctx context.Context, errCh chan<- error)) {
 
 // OnShutdown registers a callback that is invoked when the process is terminating.
 // Graceful shutdown waits until the callback has finished.
-// Callback are invoked sequentially in LIFO order.
+// Callbacks are invoked sequentially, in LIFO order, see the New function.
 func (v *Process) OnShutdown(fn OnShutdownFn) {
 	v.lock.Lock()
-	if v.terminating == true {
+	if v.terminating {
 		v.logger.Errorf(`cannot register OnShutdown callback: the process is terminating`)
 	}
 	v.onShutdown = append(v.onShutdown, fn)

--- a/internal/pkg/service/common/servicectx/servicectx.go
+++ b/internal/pkg/service/common/servicectx/servicectx.go
@@ -1,0 +1,155 @@
+// Package servicectx provides unique ID for a service process and support for the graceful shutdown.
+package servicectx
+
+import (
+	"context"
+	"fmt"
+	"os"
+	"os/signal"
+	"sync"
+	"syscall"
+	"testing"
+
+	"github.com/keboola/keboola-as-code/internal/pkg/idgenerator"
+	"github.com/keboola/keboola-as-code/internal/pkg/log"
+	"github.com/keboola/keboola-as-code/internal/pkg/utils/errors"
+)
+
+type Process struct {
+	ctx      context.Context
+	cancel   context.CancelFunc
+	logger   log.Logger
+	wg       *sync.WaitGroup
+	errCh    chan error
+	uniqueID string
+}
+
+type Option func(c *config)
+
+type config struct {
+	uniqueID string
+}
+
+// WithUniqueID sets unique ID of the service process.
+// By default, it is generated from the hostname and PID.
+func WithUniqueID(v string) Option {
+	return func(c *config) {
+		c.uniqueID = v
+	}
+}
+
+func New(ctx context.Context, cancel context.CancelFunc, logger log.Logger, opts ...Option) (*Process, error) {
+	// Apply options
+	c := config{}
+	for _, o := range opts {
+		o(&c)
+	}
+
+	// Generate uniqueID if not set
+	if c.uniqueID == "" {
+		// Get hostname
+		hostname, err := os.Hostname()
+		if err != nil {
+			return nil, err
+		}
+
+		// Get PID
+		pid := os.Getpid()
+
+		// Compose unique ID
+		c.uniqueID = fmt.Sprintf(`%s-%05d`, hostname, pid)
+	}
+
+	// Create channel used by both the signal handler and service goroutines
+	// to notify the main goroutine when to stop the server.
+	errCh := make(chan error)
+
+	// Setup interrupt handler,
+	// so SIGINT and SIGTERM signals cause the services to stop gracefully.
+	go func() {
+		c := make(chan os.Signal, 1)
+		signal.Notify(c, syscall.SIGINT, syscall.SIGTERM)
+		errCh <- errors.Errorf("%s", <-c)
+	}()
+
+	proc := &Process{
+		ctx:      ctx,
+		cancel:   cancel,
+		logger:   logger,
+		wg:       &sync.WaitGroup{},
+		errCh:    errCh,
+		uniqueID: c.uniqueID,
+	}
+
+	logger.Infof(`process unique id "%s"`, proc.UniqueID())
+	return proc, nil
+}
+
+func NewForTest(t *testing.T) *Process {
+	t.Helper()
+
+	ctx, cancel := context.WithCancel(context.Background())
+	proc, err := New(ctx, cancel, log.NewNopLogger(), WithUniqueID("test_"+t.Name()+"_"+idgenerator.Random(5)))
+	if err != nil {
+		t.Fatal(err)
+		return nil
+	}
+
+	t.Cleanup(func() {
+		proc.Shutdown(errors.New("test cleanup"))
+		proc.WaitForShutdown()
+	})
+
+	return proc
+}
+
+// Ctx returns context of the Process.
+func (v *Process) Ctx() context.Context {
+	return v.ctx
+}
+
+// Shutdown triggers termination of the Process.
+func (v *Process) Shutdown(err error) {
+	go func() {
+		v.errCh <- err
+	}()
+}
+
+func (v *Process) WaitForShutdown() {
+	// Wait for signal.
+	v.logger.Infof("exiting (%v)", <-v.errCh)
+
+	// Send cancellation signal to the goroutines.
+	v.cancel()
+
+	// Wait for all operations
+	v.wg.Wait()
+
+	v.logger.Info("exited")
+}
+
+// UniqueID returns unique process ID, it consists of hostname and PID.
+func (v *Process) UniqueID() string {
+	return v.uniqueID
+}
+
+// Add an operation.
+// The Process is graceful terminated when all operations are completed.
+// The ctx parameter can be used to wait for the service termination.
+// The errCh parameter can be used to stop the service with an error.
+func (v *Process) Add(operation func(ctx context.Context, errCh chan<- error)) {
+	v.wg.Add(1)
+	go func() {
+		defer v.wg.Done()
+		operation(v.ctx, v.errCh)
+	}()
+}
+
+// OnShutdown registers an operation that is invoked when the server is terminating.
+// Graceful shutdown waits until the operation has finished.
+func (v *Process) OnShutdown(operation func()) {
+	v.Add(func(ctx context.Context, errCh chan<- error) {
+		<-v.ctx.Done()
+		operation()
+	})
+}

--- a/internal/pkg/service/common/servicectx/servicectx_test.go
+++ b/internal/pkg/service/common/servicectx/servicectx_test.go
@@ -1,0 +1,93 @@
+package servicectx
+
+import (
+	"context"
+	"strings"
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/assert"
+
+	"github.com/keboola/keboola-as-code/internal/pkg/log"
+	"github.com/keboola/keboola-as-code/internal/pkg/utils/errors"
+)
+
+func TestProcess_Add(t *testing.T) {
+	t.Parallel()
+
+	ctx, cancel := context.WithCancel(context.Background())
+	logger := log.NewDebugLogger()
+	proc, err := New(ctx, cancel, logger, WithUniqueID("<id>"))
+	assert.NoError(t, err)
+
+	// Do some work
+	proc.Add(func(ctx context.Context, errCh chan<- error) {
+		<-ctx.Done()
+		time.Sleep(100 * time.Millisecond)
+		logger.Info("end1")
+	})
+	proc.Add(func(ctx context.Context, errCh chan<- error) {
+		<-ctx.Done()
+		time.Sleep(200 * time.Millisecond)
+		logger.Info("end2")
+	})
+	proc.Add(func(ctx context.Context, errCh chan<- error) {
+		<-ctx.Done()
+		time.Sleep(300 * time.Millisecond)
+		logger.Info("end3")
+	})
+	proc.Add(func(ctx context.Context, errCh chan<- error) {
+		errCh <- errors.New("operation failed")
+	})
+	proc.WaitForShutdown()
+
+	// Check logs
+	expected := `
+INFO  process unique id "<id>"
+INFO  exiting (operation failed)
+INFO  end1
+INFO  end2
+INFO  end3
+INFO  exited
+`
+	assert.Equal(t, strings.TrimLeft(expected, "\n"), logger.AllMessages())
+}
+
+func TestProcess_Shutdown(t *testing.T) {
+	t.Parallel()
+
+	ctx, cancel := context.WithCancel(context.Background())
+	logger := log.NewDebugLogger()
+	proc, err := New(ctx, cancel, logger, WithUniqueID("<id>"))
+	assert.NoError(t, err)
+
+	// Do some work
+	proc.Add(func(ctx context.Context, errCh chan<- error) {
+		<-ctx.Done()
+		time.Sleep(100 * time.Millisecond)
+		logger.Info("end1")
+	})
+	proc.Add(func(ctx context.Context, errCh chan<- error) {
+		<-ctx.Done()
+		time.Sleep(200 * time.Millisecond)
+		logger.Info("end2")
+	})
+	proc.Add(func(ctx context.Context, errCh chan<- error) {
+		<-ctx.Done()
+		time.Sleep(300 * time.Millisecond)
+		logger.Info("end3")
+	})
+	proc.Shutdown(errors.New("some error"))
+	proc.WaitForShutdown()
+
+	// Check logs
+	expected := `
+INFO  process unique id "<id>"
+INFO  exiting (some error)
+INFO  end1
+INFO  end2
+INFO  end3
+INFO  exited
+`
+	assert.Equal(t, strings.TrimLeft(expected, "\n"), logger.AllMessages())
+}

--- a/internal/pkg/service/templates/api/dependencies/dependencies_test.go
+++ b/internal/pkg/service/templates/api/dependencies/dependencies_test.go
@@ -42,7 +42,7 @@ func TestForPublicRequest_Components_Cached(t *testing.T) {
 
 	// Create mocked dependencies for server with "components1"
 	mockedDeps := dependencies.NewMockedDeps(t, dependencies.WithMockedComponents(components1))
-	serverDeps := &forServer{Base: mockedDeps, Public: mockedDeps, serverCtx: context.Background(), logger: log.NewNopLogger()}
+	serverDeps := &forServer{Base: mockedDeps, Public: mockedDeps, logger: log.NewNopLogger()}
 
 	// Request 1 gets "components1"
 	req1Deps := NewDepsForPublicRequest(serverDeps, context.Background(), "req1")
@@ -83,10 +83,10 @@ func TestForProjectRequest_TemplateRepository_Cached(t *testing.T) {
 
 	// Create mocked dependencies for server
 	ctx := context.Background()
-	mockedDeps := dependencies.NewMockedDeps(t, dependencies.WithMockedTokenResponse(3))
-	manager, err := repositoryManager.New(ctx, nil, mockedDeps)
+	mockedDeps := dependencies.NewMockedDeps(t, dependencies.WithMultipleTokenVerification(true))
+	manager, err := repositoryManager.New(ctx, mockedDeps, nil)
 	assert.NoError(t, err)
-	serverDeps := &forServer{Base: mockedDeps, Public: mockedDeps, serverCtx: ctx, logger: log.NewNopLogger(), repositoryManager: manager}
+	serverDeps := &forServer{Base: mockedDeps, Public: mockedDeps, logger: log.NewNopLogger(), repositoryManager: manager}
 	requestDepsFactory := func(ctx context.Context) (ForProjectRequest, error) {
 		requestId := gonanoid.Must(8)
 		return NewDepsForProjectRequest(NewDepsForPublicRequest(serverDeps, ctx, requestId), ctx, mockedDeps.StorageAPITokenID())
@@ -208,10 +208,10 @@ func TestForProjectRequest_Template_Cached(t *testing.T) {
 
 	// Create mocked dependencies for server
 	ctx := context.Background()
-	mockedDeps := dependencies.NewMockedDeps(t, dependencies.WithMockedTokenResponse(4))
-	manager, err := repositoryManager.New(ctx, nil, mockedDeps)
+	mockedDeps := dependencies.NewMockedDeps(t, dependencies.WithMultipleTokenVerification(true))
+	manager, err := repositoryManager.New(ctx, mockedDeps, nil)
 	assert.NoError(t, err)
-	serverDeps := &forServer{Base: mockedDeps, Public: mockedDeps, serverCtx: ctx, logger: log.NewNopLogger(), repositoryManager: manager}
+	serverDeps := &forServer{Base: mockedDeps, Public: mockedDeps, logger: log.NewNopLogger(), repositoryManager: manager}
 	requestDepsFactory := func(ctx context.Context) (ForProjectRequest, error) {
 		requestId := gonanoid.Must(8)
 		return NewDepsForProjectRequest(NewDepsForPublicRequest(serverDeps, ctx, requestId), ctx, mockedDeps.StorageAPITokenID())

--- a/internal/pkg/service/templates/api/service/service.go
+++ b/internal/pkg/service/templates/api/service/service.go
@@ -35,11 +35,11 @@ const ProjectLockedRetryAfter = 5 * time.Second
 type service struct{}
 
 func New(d dependencies.ForServer) (Service, error) {
-	if err := StartComponentsCron(d.ServerCtx(), d); err != nil {
+	if err := StartComponentsCron(d.Process().Ctx(), d); err != nil {
 		return nil, err
 	}
 
-	if err := StartRepositoriesPullCron(d.ServerCtx(), d); err != nil {
+	if err := StartRepositoriesPullCron(d.Process().Ctx(), d); err != nil {
 		return nil, err
 	}
 

--- a/internal/pkg/template/repository/manager/manager_test.go
+++ b/internal/pkg/template/repository/manager/manager_test.go
@@ -38,9 +38,8 @@ func TestNew(t *testing.T) {
 	// Create manager
 	ctx := context.Background()
 	d := dependencies.NewMockedDeps(t)
-	m, err := manager.New(ctx, nil, d)
+	m, err := manager.New(ctx, d, nil)
 	assert.NoError(t, err)
-	defer m.Free()
 
 	repo, unlockFn, err := m.Repository(ctx, ref)
 	assert.NoError(t, err)
@@ -69,9 +68,8 @@ func TestRepository(t *testing.T) {
 	// Create manager
 	ctx := context.Background()
 	d := dependencies.NewMockedDeps(t)
-	m, err := manager.New(ctx, nil, d)
+	m, err := manager.New(ctx, d, nil)
 	assert.NoError(t, err)
-	defer m.Free()
 
 	v, unlockFn1, err := m.Repository(ctx, repo)
 	assert.NotNil(t, v)
@@ -113,10 +111,10 @@ func TestDefaultRepositories(t *testing.T) {
 	}
 
 	// Create manager
+	ctx := context.Background()
 	d := dependencies.NewMockedDeps(t)
-	m, err := manager.New(context.Background(), defaultRepositories, d)
+	m, err := manager.New(ctx, d, defaultRepositories)
 	assert.NoError(t, err)
-	defer m.Free()
 
 	// Get list of default repositories
 	assert.Equal(t, defaultRepositories, m.DefaultRepositories())


### PR DESCRIPTION
Part of: https://keboola.atlassian.net/browse/BA-39

### Changes

#### `servicectx.Process.UniqueID`

Used to obtain a unique ID for service process (API/Worker) 
for elections (division of work) using the etcd Election API.


#### `servicectx.Process.Add/Shutdown/OnShutdown/WaitForShutdown`

Abstraction for the graceful shutdown for API or Worker.


-------------------------

##### Before

https://github.com/keboola/keboola-as-code/blob/ba86539708c7ec1456f4ad65142effd5d36e77a0/internal/pkg/service/common/etcdclient/etcdclient.go#L224-L238

##### After

https://github.com/keboola/keboola-as-code/blob/9c311176be57d84694ba909641d5283b65d229ca/internal/pkg/service/buffer/dependencies/dependencies.go#L90-L97


-------------------------

##### Before

https://github.com/keboola/keboola-as-code/blob/ba86539708c7ec1456f4ad65142effd5d36e77a0/internal/pkg/service/buffer/api/http/http.go#L76-L99

##### After

https://github.com/keboola/keboola-as-code/blob/9c311176be57d84694ba909641d5283b65d229ca/internal/pkg/service/buffer/api/http/http.go#L77-L97

-------------------------

##### Before

https://github.com/keboola/keboola-as-code/blob/ba86539708c7ec1456f4ad65142effd5d36e77a0/cmd/buffer-api/main.go#L74-L107

##### After

https://github.com/keboola/keboola-as-code/blob/9c311176be57d84694ba909641d5283b65d229ca/cmd/buffer-api/main.go#L76-L87
