### PR TITLE
Use node distribution pkg in worker service

### DIFF
--- a/cmd/buffer-worker/main.go
+++ b/cmd/buffer-worker/main.go
@@ -68,7 +68,10 @@ func start(debug, debugHTTP bool, logger log.Logger, envs *env.Map) error {
 	}
 
 	// Start worker code
-	service.New(d).Start()
+	_, err = service.New(d)
+	if err != nil {
+		return err
+	}
 
 	proc.WaitForShutdown()
 	return nil

--- a/internal/pkg/log/debug.go
+++ b/internal/pkg/log/debug.go
@@ -57,6 +57,7 @@ func NewDebugLoggerWithPrefix(prefix string) DebugLogger {
 		cores = cores.With([]zapcore.Field{{Key: "prefix", String: prefix, Type: zapcore.StringType}})
 	}
 	l.zapLogger = loggerFromZapCore(cores)
+	l.zapLogger.prefix = prefix
 	return l
 }
 

--- a/internal/pkg/service/buffer/dependencies/dependencies.go
+++ b/internal/pkg/service/buffer/dependencies/dependencies.go
@@ -75,7 +75,10 @@ func NewServiceDeps(
 
 	// Create etcd client
 	etcdClient, err := etcdclient.New(
-		proc.Ctx(),
+		// Use separated context.
+		// Graceful shutdown is handled by Process.OnShutdown bellow.
+		// During the shutdown it is necessary to complete some etcd operations.
+		context.Background(),
 		tracer,
 		envs.Get("BUFFER_ETCD_ENDPOINT"),
 		envs.Get("BUFFER_ETCD_NAMESPACE"),

--- a/internal/pkg/service/buffer/worker/distribution/config.go
+++ b/internal/pkg/service/buffer/worker/distribution/config.go
@@ -1,4 +1,4 @@
-package node
+package distribution
 
 import (
 	"time"
@@ -6,26 +6,26 @@ import (
 
 const (
 	DefaultSessionTTL      = 15               // seconds, see WithTTL
-	DefaultInitTimeout     = 60 * time.Second // timeout for PUT operation
-	DefaultShutdownTimeout = 5 * time.Second  // timeout for DELETE operation
+	DefaultStartupTimeout  = 60 * time.Second // timeout for registration, PUT operation
+	DefaultShutdownTimeout = 5 * time.Second  // timeout for un-registration, DELETE operation
 )
 
 type Option func(c *config)
 
 type config struct {
-	initTimeout     time.Duration
+	startupTimeout  time.Duration
 	shutdownTimeout time.Duration
 	ttlSeconds      int
 }
 
 func defaultConfig() config {
-	return config{initTimeout: DefaultInitTimeout, shutdownTimeout: DefaultShutdownTimeout, ttlSeconds: DefaultSessionTTL}
+	return config{startupTimeout: DefaultStartupTimeout, shutdownTimeout: DefaultShutdownTimeout, ttlSeconds: DefaultSessionTTL}
 }
 
 // WithStartupTimeout defines node registration timeout on the node startup.
 func WithStartupTimeout(v time.Duration) Option {
 	return func(c *config) {
-		c.initTimeout = v
+		c.startupTimeout = v
 	}
 }
 

--- a/internal/pkg/service/buffer/worker/distribution/node_test.go
+++ b/internal/pkg/service/buffer/worker/distribution/node_test.go
@@ -1,4 +1,4 @@
-package node_test
+package distribution_test
 
 import (
 	"context"
@@ -14,7 +14,7 @@ import (
 	"github.com/stretchr/testify/assert"
 
 	"github.com/keboola/keboola-as-code/internal/pkg/log"
-	. "github.com/keboola/keboola-as-code/internal/pkg/service/buffer/worker/node"
+	. "github.com/keboola/keboola-as-code/internal/pkg/service/buffer/worker/distribution"
 	"github.com/keboola/keboola-as-code/internal/pkg/service/common/dependencies"
 	"github.com/keboola/keboola-as-code/internal/pkg/service/common/servicectx"
 	"github.com/keboola/keboola-as-code/internal/pkg/utils/errors"
@@ -58,7 +58,7 @@ func TestNodesDiscovery(t *testing.T) {
 			logger := d.DebugLogger()
 			logger.ConnectTo(testhelper.VerboseStdout())
 			process := d.Process()
-			node, err := New(d, WithStartupTimeout(time.Second), WithShutdownTimeout(time.Second))
+			node, err := NewNode(d, WithStartupTimeout(time.Second), WithShutdownTimeout(time.Second))
 			assert.NoError(t, err)
 
 			lock.Lock()
@@ -188,9 +188,10 @@ node3
 	// Logs differs in number of "the node ... gone" messages
 	wildcards.Assert(t, `
 [node1]INFO  process unique id "node1"
-[node1]INFO  created etcd session
+[node1]INFO  creating etcd session
+[node1]INFO  created etcd session | %s
 [node1]INFO  registering the node "node1"
-[node1]INFO  the node "node1" registered
+[node1]INFO  the node "node1" registered | %s
 [node1]INFO  watching for other nodes
 [node1]INFO  found a new node "node%d"
 [node1]INFO  found a new node "node%d"
@@ -198,15 +199,16 @@ node3
 [node1]INFO  exiting (bye bye 1)
 [node1]INFO  cancelled watcher
 [node1]INFO  unregistering the node "node1"
-[node1]INFO  the node "node1" unregistered
+[node1]INFO  the node "node1" unregistered | %s
 [node1]INFO  closed etcd session
 [node1]INFO  exited
 `, loggers[0].AllMessages())
 	wildcards.Assert(t, `
 [node2]INFO  process unique id "node2"
-[node2]INFO  created etcd session
+[node2]INFO  creating etcd session
+[node2]INFO  created etcd session | %s
 [node2]INFO  registering the node "node2"
-[node2]INFO  the node "node2" registered
+[node2]INFO  the node "node2" registered | %s
 [node2]INFO  watching for other nodes
 [node2]INFO  found a new node "node%d"
 [node2]INFO  found a new node "node%d"
@@ -215,15 +217,16 @@ node3
 [node2]INFO  exiting (bye bye 2)
 [node2]INFO  cancelled watcher
 [node2]INFO  unregistering the node "node2"
-[node2]INFO  the node "node2" unregistered
+[node2]INFO  the node "node2" unregistered | %s
 [node2]INFO  closed etcd session
 [node2]INFO  exited
 `, loggers[1].AllMessages())
 	wildcards.Assert(t, `
 [node3]INFO  process unique id "node3"
-[node3]INFO  created etcd session
+[node3]INFO  creating etcd session
+[node3]INFO  created etcd session | %s
 [node3]INFO  registering the node "node3"
-[node3]INFO  the node "node3" registered
+[node3]INFO  the node "node3" registered | %s
 [node3]INFO  watching for other nodes
 [node3]INFO  found a new node "node%d"
 [node3]INFO  found a new node "node%d"
@@ -233,7 +236,7 @@ node3
 [node3]INFO  exiting (bye bye 3)
 [node3]INFO  cancelled watcher
 [node3]INFO  unregistering the node "node3"
-[node3]INFO  the node "node3" unregistered
+[node3]INFO  the node "node3" unregistered | %s
 [node3]INFO  closed etcd session
 [node3]INFO  exited
 `, loggers[2].AllMessages())
@@ -242,7 +245,7 @@ node3
 	assert.Equal(t, 4, nodesCount+1)
 	d4 := createDeps(4)
 	process4 := d4.Process()
-	node4, err := New(d4, WithStartupTimeout(time.Second), WithShutdownTimeout(time.Second))
+	node4, err := NewNode(d4, WithStartupTimeout(time.Second), WithShutdownTimeout(time.Second))
 	assert.NoError(t, err)
 	assert.Eventually(t, func() bool {
 		return reflect.DeepEqual([]string{"node4"}, node4.Nodes())
@@ -264,15 +267,16 @@ node4
 
 	wildcards.Assert(t, `
 [node4]INFO  process unique id "node4"
-[node4]INFO  created etcd session
+[node4]INFO  creating etcd session
+[node4]INFO  created etcd session | %s
 [node4]INFO  registering the node "node4"
-[node4]INFO  the node "node4" registered
+[node4]INFO  the node "node4" registered | %s
 [node4]INFO  watching for other nodes
 [node4]INFO  found a new node "node4"
 [node4]INFO  exiting (bye bye 4)
 [node4]INFO  cancelled watcher
 [node4]INFO  unregistering the node "node4"
-[node4]INFO  the node "node4" unregistered
+[node4]INFO  the node "node4" unregistered | %s
 [node4]INFO  closed etcd session
 [node4]INFO  exited
 `, d4.DebugLogger().AllMessages())

--- a/internal/pkg/service/buffer/worker/distribution/node_test.go
+++ b/internal/pkg/service/buffer/worker/distribution/node_test.go
@@ -188,56 +188,56 @@ node3
 	// Logs differs in number of "the node ... gone" messages
 	wildcards.Assert(t, `
 [node1]INFO  process unique id "node1"
-[node1]INFO  creating etcd session
-[node1]INFO  created etcd session | %s
-[node1]INFO  registering the node "node1"
-[node1]INFO  the node "node1" registered | %s
-[node1]INFO  watching for other nodes
-[node1]INFO  found a new node "node%d"
-[node1]INFO  found a new node "node%d"
-[node1]INFO  found a new node "node%d"
+[node1][distribution]INFO  creating etcd session
+[node1][distribution]INFO  created etcd session | %s
+[node1][distribution]INFO  registering the node "node1"
+[node1][distribution]INFO  the node "node1" registered | %s
+[node1][distribution]INFO  watching for other nodes
+[node1][distribution]INFO  found a new node "node%d"
+[node1][distribution]INFO  found a new node "node%d"
+[node1][distribution]INFO  found a new node "node%d"
 [node1]INFO  exiting (bye bye 1)
-[node1]INFO  cancelled watcher
-[node1]INFO  unregistering the node "node1"
-[node1]INFO  the node "node1" unregistered | %s
-[node1]INFO  closed etcd session
+[node1][distribution]INFO  cancelled watcher
+[node1][distribution]INFO  unregistering the node "node1"
+[node1][distribution]INFO  the node "node1" unregistered | %s
+[node1][distribution]INFO  closed etcd session
 [node1]INFO  exited
 `, loggers[0].AllMessages())
 	wildcards.Assert(t, `
 [node2]INFO  process unique id "node2"
-[node2]INFO  creating etcd session
-[node2]INFO  created etcd session | %s
-[node2]INFO  registering the node "node2"
-[node2]INFO  the node "node2" registered | %s
-[node2]INFO  watching for other nodes
-[node2]INFO  found a new node "node%d"
-[node2]INFO  found a new node "node%d"
-[node2]INFO  found a new node "node%d"
-[node2]INFO  the node "node%d" gone
+[node2][distribution]INFO  creating etcd session
+[node2][distribution]INFO  created etcd session | %s
+[node2][distribution]INFO  registering the node "node2"
+[node2][distribution]INFO  the node "node2" registered | %s
+[node2][distribution]INFO  watching for other nodes
+[node2][distribution]INFO  found a new node "node%d"
+[node2][distribution]INFO  found a new node "node%d"
+[node2][distribution]INFO  found a new node "node%d"
+[node2][distribution]INFO  the node "node%d" gone
 [node2]INFO  exiting (bye bye 2)
-[node2]INFO  cancelled watcher
-[node2]INFO  unregistering the node "node2"
-[node2]INFO  the node "node2" unregistered | %s
-[node2]INFO  closed etcd session
+[node2][distribution]INFO  cancelled watcher
+[node2][distribution]INFO  unregistering the node "node2"
+[node2][distribution]INFO  the node "node2" unregistered | %s
+[node2][distribution]INFO  closed etcd session
 [node2]INFO  exited
 `, loggers[1].AllMessages())
 	wildcards.Assert(t, `
 [node3]INFO  process unique id "node3"
-[node3]INFO  creating etcd session
-[node3]INFO  created etcd session | %s
-[node3]INFO  registering the node "node3"
-[node3]INFO  the node "node3" registered | %s
-[node3]INFO  watching for other nodes
-[node3]INFO  found a new node "node%d"
-[node3]INFO  found a new node "node%d"
-[node3]INFO  found a new node "node%d"
-[node3]INFO  the node "node%d" gone
-[node3]INFO  the node "node%d" gone
+[node3][distribution]INFO  creating etcd session
+[node3][distribution]INFO  created etcd session | %s
+[node3][distribution]INFO  registering the node "node3"
+[node3][distribution]INFO  the node "node3" registered | %s
+[node3][distribution]INFO  watching for other nodes
+[node3][distribution]INFO  found a new node "node%d"
+[node3][distribution]INFO  found a new node "node%d"
+[node3][distribution]INFO  found a new node "node%d"
+[node3][distribution]INFO  the node "node%d" gone
+[node3][distribution]INFO  the node "node%d" gone
 [node3]INFO  exiting (bye bye 3)
-[node3]INFO  cancelled watcher
-[node3]INFO  unregistering the node "node3"
-[node3]INFO  the node "node3" unregistered | %s
-[node3]INFO  closed etcd session
+[node3][distribution]INFO  cancelled watcher
+[node3][distribution]INFO  unregistering the node "node3"
+[node3][distribution]INFO  the node "node3" unregistered | %s
+[node3][distribution]INFO  closed etcd session
 [node3]INFO  exited
 `, loggers[2].AllMessages())
 
@@ -267,17 +267,17 @@ node4
 
 	wildcards.Assert(t, `
 [node4]INFO  process unique id "node4"
-[node4]INFO  creating etcd session
-[node4]INFO  created etcd session | %s
-[node4]INFO  registering the node "node4"
-[node4]INFO  the node "node4" registered | %s
-[node4]INFO  watching for other nodes
-[node4]INFO  found a new node "node4"
+[node4][distribution]INFO  creating etcd session
+[node4][distribution]INFO  created etcd session | %s
+[node4][distribution]INFO  registering the node "node4"
+[node4][distribution]INFO  the node "node4" registered | %s
+[node4][distribution]INFO  watching for other nodes
+[node4][distribution]INFO  found a new node "node4"
 [node4]INFO  exiting (bye bye 4)
-[node4]INFO  cancelled watcher
-[node4]INFO  unregistering the node "node4"
-[node4]INFO  the node "node4" unregistered | %s
-[node4]INFO  closed etcd session
+[node4][distribution]INFO  cancelled watcher
+[node4][distribution]INFO  unregistering the node "node4"
+[node4][distribution]INFO  the node "node4" unregistered | %s
+[node4][distribution]INFO  closed etcd session
 [node4]INFO  exited
 `, d4.DebugLogger().AllMessages())
 }

--- a/internal/pkg/service/buffer/worker/service/service.go
+++ b/internal/pkg/service/buffer/worker/service/service.go
@@ -2,16 +2,18 @@ package service
 
 import (
 	"github.com/keboola/keboola-as-code/internal/pkg/service/buffer/worker/dependencies"
+	"github.com/keboola/keboola-as-code/internal/pkg/service/buffer/worker/distribution"
 )
 
 type Service struct {
 	dependencies.ForWorker
+	dist *distribution.Node
 }
 
-func New(d dependencies.ForWorker) *Service {
-	return &Service{ForWorker: d}
-}
-
-func (s *Service) Start() {
-	s.Logger().Info("starting worker goroutines")
+func New(d dependencies.ForWorker) (*Service, error) {
+	dist, err := distribution.NewNode(d)
+	if err != nil {
+		return nil, err
+	}
+	return &Service{ForWorker: d, dist: dist}, nil
 }

--- a/internal/pkg/service/templates/api/dependencies/dependencies.go
+++ b/internal/pkg/service/templates/api/dependencies/dependencies.go
@@ -239,7 +239,10 @@ func (v *forServer) EtcdClient(ctx context.Context) (*etcd.Client, error) {
 		}
 
 		etcdClient, err := etcdclient.New(
-			v.proc.Ctx(),
+			// Use separated context.
+			// Graceful shutdown is handled by Process.OnShutdown bellow.
+			// During the shutdown it is necessary to complete some etcd operations.
+			context.Background(),
 			v.Tracer(),
 			envs.Get("TEMPLATES_API_ETCD_ENDPOINT"),
 			envs.Get("TEMPLATES_API_ETCD_NAMESPACE"),
@@ -257,9 +260,9 @@ func (v *forServer) EtcdClient(ctx context.Context) (*etcd.Client, error) {
 		// Close client when shutting down the server
 		v.proc.OnShutdown(func() {
 			if err := etcdClient.Close(); err != nil {
-				v.logger.Warnf("cannot close connection etcd: %s", err)
+				v.logger.Warnf("cannot close etcd connection: %s", err)
 			} else {
-				v.logger.Info("closed connection to etcd")
+				v.logger.Info("closed etcd connection")
 			}
 		})
 


### PR DESCRIPTION
Part of: https://keboola.atlassian.net/browse/BA-40

Changes:
- Worker binary is using `distribution.Node` instance.

-----

V tomto PR pridavam posledne veci potrebne k tomu aby sme vedeli distribuovat tasky medzi `workers`.
V predchadzajucich krokoch sa spravil `pkg` `Node`, ale este sa nepouzival vo worker binarke.

Teraz to ide uz E2E:
```
make build-buffer-worker
./target/buffer/worker
```

Pomocou `docker exec` sa da spustit viacero `workers` oproti jednej `etcd` db.
A pekne vidno ako sa pripajaju a odpajaju.
Pri testovani som narazil este na par veci, ktore fixujem v tomto PR.

![image](https://user-images.githubusercontent.com/19371734/206878382-4cf074a9-07dd-4ece-9cda-23d0090779c7.png)
