### PR TITLE
Create state machine for file and slice states

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -28,6 +28,7 @@ require (
 	github.com/keboola/go-utils v0.7.0
 	github.com/kylelemons/godebug v1.1.0
 	github.com/lafikl/consistent v0.0.0-20220512074542-bdd3606bfc3e
+	github.com/qmuntal/stateless v1.6.1
 	github.com/relvacode/iso8601 v1.1.0
 	github.com/santhosh-tekuri/jsonschema/v5 v5.1.1
 	github.com/spf13/afero v1.9.3

--- a/go.sum
+++ b/go.sum
@@ -1402,6 +1402,8 @@ github.com/prometheus/procfs v0.7.3/go.mod h1:cz+aTbrPOrUb4q7XlbU9ygM+/jj0fzG6c1
 github.com/prometheus/prometheus v0.35.0/go.mod h1:7HaLx5kEPKJ0GDgbODG0fZgXbQ8K/XjZNJXQmbmgQlY=
 github.com/prometheus/prometheus v0.37.0/go.mod h1:egARUgz+K93zwqsVIAneFlLZefyGOON44WyAp4Xqbbk=
 github.com/prometheus/tsdb v0.7.1/go.mod h1:qhTCs0VvXwvX/y3TZrWD7rabWM+ijKTux40TwIPHuXU=
+github.com/qmuntal/stateless v1.6.1 h1:5K7DNuNKatSJ2kh+7kBoszijflSfx0asABqrIOvoHgQ=
+github.com/qmuntal/stateless v1.6.1/go.mod h1:cWTwXu9ey+FxI0fHvDi1nGCtpYa8N1X2aOmoRg2RUCI=
 github.com/rakyll/embedmd v0.0.0-20171029212350-c8060a0752a2/go.mod h1:7jOTMgqac46PZcF54q6l2hkLEG8op93fZu61KmxWDV4=
 github.com/rcrowley/go-metrics v0.0.0-20181016184325-3113b8401b8a/go.mod h1:bCqnVzQkZxMG4s8nGwiZ5l3QUCyqpo9Y+/ZMZ9VjZe4=
 github.com/relvacode/iso8601 v1.1.0 h1:2nV8sp0eOjpoKQ2vD3xSDygsjAx37NHG2UlZiCkDH4I=

--- a/internal/pkg/service/buffer/file/manager.go
+++ b/internal/pkg/service/buffer/file/manager.go
@@ -54,7 +54,7 @@ func (m *Manager) CreateFilesForReceiver(ctx context.Context, receiver *model.Re
 func (m *Manager) UploadSlicedFileManifest(ctx context.Context, file *model.File, slices []*model.Slice) error {
 	sliceFiles := make([]string, 0)
 	for _, s := range slices {
-		sliceFiles = append(sliceFiles, sliceNumberToFilename(s.SliceNumber))
+		sliceFiles = append(sliceFiles, sliceNumberToFilename(s.Number))
 	}
 	_, err := storageapi.UploadSlicedFileManifest(ctx, file.StorageResource, sliceFiles)
 	return err

--- a/internal/pkg/service/buffer/store/file.go
+++ b/internal/pkg/service/buffer/store/file.go
@@ -2,15 +2,22 @@ package store
 
 import (
 	"context"
+	"time"
 
 	etcd "go.etcd.io/etcd/client/v3"
 
+	"github.com/keboola/keboola-as-code/internal/pkg/service/buffer/store/filestate"
 	"github.com/keboola/keboola-as-code/internal/pkg/service/buffer/store/key"
 	"github.com/keboola/keboola-as-code/internal/pkg/service/buffer/store/model"
 	serviceError "github.com/keboola/keboola-as-code/internal/pkg/service/common/errors"
 	"github.com/keboola/keboola-as-code/internal/pkg/service/common/etcdop/op"
 	"github.com/keboola/keboola-as-code/internal/pkg/telemetry"
+	"github.com/keboola/keboola-as-code/internal/pkg/utils/errors"
 )
+
+type fileTxnFailedError struct {
+	error
+}
 
 func (s *Store) CreateFile(ctx context.Context, file model.File) (err error) {
 	_, span := s.tracer.Start(ctx, "keboola.go.buffer.configstore.CreateFile")
@@ -57,4 +64,59 @@ func (s *Store) getFileOp(_ context.Context, fileKey key.FileKey) op.ForType[*op
 			}
 			return kv, err
 		})
+}
+
+// SetFileState method atomically changes the state of the file.
+// False is returned, if the given file is already in the target state.
+func (s *Store) SetFileState(ctx context.Context, file *model.File, to filestate.State, now time.Time) (bool, error) { //nolint:dupl
+	stm := filestate.NewSTM(file.State, func(ctx context.Context, from, to filestate.State) error {
+		// Update fields
+		clone := *file
+		clone.State = to
+		switch to {
+		case filestate.Closing:
+			clone.ClosingAt = &now
+		case filestate.Closed:
+			clone.ClosedAt = &now
+		case filestate.Importing:
+			clone.ImportingAt = &now
+		case filestate.Imported:
+			clone.ImportedAt = &now
+		case filestate.Failed:
+			clone.FailedAt = &now
+		default:
+			panic(errors.Errorf(`unexpected state "%s"`, to))
+		}
+
+		// Atomically swap keys in the transaction
+		files := s.schema.Files()
+		resp, err := op.MergeToTxn(
+			ctx,
+			files.InState(from).ByKey(file.FileKey).DeleteIfExists(),
+			files.InState(to).ByKey(file.FileKey).PutIfNotExists(clone),
+		).Do(ctx, s.client)
+
+		// Check logical error, transaction failed
+		if err == nil && !resp.Succeeded {
+			file.State = to
+			return fileTxnFailedError{error: errors.Errorf(
+				`transaction "%s" -> "%s" failed: the file "%s" is already in the target state`,
+				from, to, file.FileKey.String(),
+			)}
+		}
+
+		if err == nil {
+			*file = clone
+		}
+
+		return err
+	})
+
+	if err := stm.To(ctx, to); err != nil {
+		if errors.As(err, &fileTxnFailedError{}) {
+			return false, nil
+		}
+		return false, err
+	}
+	return true, nil
 }

--- a/internal/pkg/service/buffer/store/filestate/filestate.go
+++ b/internal/pkg/service/buffer/store/filestate/filestate.go
@@ -1,0 +1,81 @@
+// Package filestate provides transitions between allowed file states.
+package filestate
+
+import (
+	"context"
+
+	"github.com/qmuntal/stateless"
+
+	"github.com/keboola/keboola-as-code/internal/pkg/utils/errors"
+)
+
+// Opened
+// It is the initial state of the file.
+// API nodes can write records to an open slice.
+const Opened State = "opened"
+
+// Closing
+// Import conditions have been met.
+// Waiting for the last slice to be closed and the upload of the file manifest.
+const Closing State = "closing"
+
+// Closed
+// The file is ready for import.
+const Closed State = "closed"
+
+// Importing
+// File import into the table is in progress.
+const Importing State = "importing"
+
+// Imported
+// The file has been successfully imported.
+const Imported State = "imported"
+
+// Failed
+// Import failed, try again later.
+const Failed State = "failed"
+
+type State string
+
+type onEntry func(ctx context.Context, from, to State) error
+
+type STM struct {
+	onEntry onEntry
+	stm     *stateless.StateMachine
+}
+
+func NewSTM(state State, fn onEntry) *STM {
+	v := &STM{onEntry: fn, stm: stateless.NewStateMachine(state)}
+	v.stm.OnUnhandledTrigger(func(_ context.Context, state stateless.State, trigger stateless.Trigger, _ []string) error {
+		return errors.Errorf(`file state transition "%s" -> "%s" is not allowed`, state, trigger)
+	})
+	v.permit(Opened, Closing)
+	v.permit(Closing, Closed)
+	v.permit(Closed, Importing)
+	v.permit(Importing, Failed)
+	v.permit(Failed, Importing)
+	v.permit(Importing, Imported)
+	return v
+}
+
+// To triggers state transition.
+func (v *STM) To(ctx context.Context, to State) error {
+	return v.stm.FireCtx(ctx, to)
+}
+
+// permit registers a new transition.
+func (v *STM) permit(from, to State) {
+	v.stm.
+		Configure(from).
+		Permit(to, to). // first argument, trigger = to, see To method
+		OnExit(func(ctx context.Context, args ...any) error {
+			if stateless.GetTransition(ctx).Destination == to {
+				return v.onEntry(ctx, from, to)
+			}
+			return nil
+		})
+}
+
+func (v State) String() string {
+	return string(v)
+}

--- a/internal/pkg/service/buffer/store/filestate/filestate_test.go
+++ b/internal/pkg/service/buffer/store/filestate/filestate_test.go
@@ -1,0 +1,31 @@
+package filestate_test
+
+import (
+	"context"
+	"fmt"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+
+	. "github.com/keboola/keboola-as-code/internal/pkg/service/buffer/store/filestate"
+)
+
+func TestSTM(t *testing.T) {
+	t.Parallel()
+	ctx := context.Background()
+	var transitions []string
+	stm := NewSTM(Opened, func(ctx context.Context, from, to State) error {
+		transitions = append(transitions, fmt.Sprintf("%s -> %s", from, to))
+		return nil
+	})
+
+	// Valid transition
+	assert.NoError(t, stm.To(ctx, Closing))
+	assert.Equal(t, []string{"opened -> closing"}, transitions)
+
+	// Invalid transition
+	err := stm.To(ctx, Imported)
+	assert.Error(t, err)
+	assert.Equal(t, `file state transition "closing" -> "imported" is not allowed`, err.Error())
+	assert.Equal(t, []string{"opened -> closing"}, transitions)
+}

--- a/internal/pkg/service/buffer/store/model/file.go
+++ b/internal/pkg/service/buffer/store/model/file.go
@@ -5,26 +5,31 @@ import (
 
 	"github.com/keboola/go-client/pkg/storageapi"
 
+	"github.com/keboola/keboola-as-code/internal/pkg/service/buffer/store/filestate"
 	"github.com/keboola/keboola-as-code/internal/pkg/service/buffer/store/key"
 )
 
+// File represent a file with records.
+// A copy of the mapping is stored for retrieval optimization.
+// A change in the mapping causes a new file to be created so the mapping is immutable.
 type File struct {
 	key.FileKey
+	State              filestate.State  `json:"state" validate:"required,oneof=opened closing closed importing imported failed"`
 	Mapping            Mapping          `json:"mapping" validate:"required,dive"`
 	StorageResource    *storageapi.File `json:"storageResource" validate:"required"`
 	ClosingAt          *time.Time       `json:"closingAt,omitempty"`
 	ClosedAt           *time.Time       `json:"closedAt,omitempty"`
-	ManifestUploadedAt *time.Time       `json:"manifestUploadedAt,omitempty"`
+	ImportingAt        *time.Time       `json:"importingAt,omitempty"`
 	ImportedAt         *time.Time       `json:"importedAt,omitempty"`
+	ManifestUploadedAt *time.Time       `json:"manifestUploadedAt,omitempty"`
 	FailedAt           *time.Time       `json:"failedAt,omitempty"`
-	ImportStartedAt    *time.Time       `json:"importStartedAt,omitempty"`
-	ImportFinishedAt   *time.Time       `json:"importFinishedAt,omitempty"`
 	LastError          string           `json:"lastError,omitempty"`
 }
 
 func NewFile(exportKey key.ExportKey, now time.Time, mapping Mapping, resource *storageapi.File) File {
 	return File{
 		FileKey:         key.FileKey{ExportKey: exportKey, FileID: now},
+		State:           filestate.Opened,
 		Mapping:         mapping,
 		StorageResource: resource,
 	}

--- a/internal/pkg/service/buffer/store/model/slice.go
+++ b/internal/pkg/service/buffer/store/model/slice.go
@@ -4,24 +4,26 @@ import (
 	"time"
 
 	"github.com/keboola/keboola-as-code/internal/pkg/service/buffer/store/key"
+	"github.com/keboola/keboola-as-code/internal/pkg/service/buffer/store/slicestate"
 )
 
 type Slice struct {
 	key.SliceKey
-	SliceNumber      int        `json:"sliceNumber" validate:"required"`
-	ClosingAt        *time.Time `json:"closingAt,omitempty"`
-	ClosedAt         *time.Time `json:"closedAt,omitempty"`
-	UploadedAt       *time.Time `json:"uploadedAt,omitempty"`
-	FailedAt         *time.Time `json:"failedAt,omitempty"`
-	UploadStartedAt  *time.Time `json:"uploadStartedAt,omitempty"`
-	UploadFinishedAt *time.Time `json:"uploadFinishedAt,omitempty"`
-	LastError        string     `json:"lastError,omitempty"`
+	State       slicestate.State `json:"state" validate:"required,oneof=opened closing closed uploading uploaded failed"`
+	Number      int              `json:"sliceNumber" validate:"required"`
+	ClosingAt   *time.Time       `json:"closingAt,omitempty"`
+	ClosedAt    *time.Time       `json:"closedAt,omitempty"`
+	UploadingAt *time.Time       `json:"uploadingAt,omitempty"`
+	UploadedAt  *time.Time       `json:"uploadedAt,omitempty"`
+	FailedAt    *time.Time       `json:"failedAt,omitempty"`
+	LastError   string           `json:"lastError,omitempty"`
 }
 
 func NewSlice(fileKey key.FileKey, now time.Time, number int) Slice {
 	return Slice{
-		SliceKey:    key.SliceKey{FileKey: fileKey, SliceID: now},
-		SliceNumber: number,
+		SliceKey: key.SliceKey{FileKey: fileKey, SliceID: now},
+		State:    slicestate.Opened,
+		Number:   number,
 	}
 }
 

--- a/internal/pkg/service/buffer/store/schema/file.go
+++ b/internal/pkg/service/buffer/store/schema/file.go
@@ -4,6 +4,7 @@ import (
 	"strconv"
 	"time"
 
+	"github.com/keboola/keboola-as-code/internal/pkg/service/buffer/store/filestate"
 	storeKey "github.com/keboola/keboola-as-code/internal/pkg/service/buffer/store/key"
 	"github.com/keboola/keboola-as-code/internal/pkg/service/buffer/store/model"
 	. "github.com/keboola/keboola-as-code/internal/pkg/service/common/etcdop"
@@ -32,24 +33,32 @@ func (v *Schema) Files() Files {
 	)}
 }
 
+func (v Files) InState(state filestate.State) FilesInAState {
+	return FilesInAState{files: v.files.Add(string(state))}
+}
+
 func (v Files) Opened() FilesInAState {
-	return FilesInAState{files: v.files.Add("opened")}
+	return v.InState(filestate.Opened)
 }
 
 func (v Files) Closing() FilesInAState {
-	return FilesInAState{files: v.files.Add("closing")}
+	return v.InState(filestate.Closing)
 }
 
 func (v Files) Closed() FilesInAState {
-	return FilesInAState{files: v.files.Add("closed")}
+	return v.InState(filestate.Closed)
+}
+
+func (v Files) Importing() FilesInAState {
+	return v.InState(filestate.Importing)
 }
 
 func (v Files) Imported() FilesInAState {
-	return FilesInAState{files: v.files.Add("imported")}
+	return v.InState(filestate.Imported)
 }
 
 func (v Files) Failed() FilesInAState {
-	return FilesInAState{files: v.files.Add("failed")}
+	return v.InState(filestate.Failed)
 }
 
 func (v FilesInAState) ByKey(k storeKey.FileKey) KeyT[model.File] {

--- a/internal/pkg/service/buffer/store/schema/schema_test.go
+++ b/internal/pkg/service/buffer/store/schema/schema_test.go
@@ -123,6 +123,18 @@ func TestSchema(t *testing.T) {
 			"file/closed/123/my-receiver/my-export/2006-01-02T08:04:05.000Z",
 		},
 		{
+			s.Files().Importing().Prefix(),
+			"file/importing/",
+		},
+		{
+			s.Files().Importing().InExport(exportKey).Prefix(),
+			"file/importing/123/my-receiver/my-export/",
+		},
+		{
+			s.Files().Importing().ByKey(fileKey).Key(),
+			"file/importing/123/my-receiver/my-export/2006-01-02T08:04:05.000Z",
+		},
+		{
 			s.Files().Imported().Prefix(),
 			"file/imported/",
 		},
@@ -177,6 +189,14 @@ func TestSchema(t *testing.T) {
 		{
 			s.Slices().Closed().ByKey(sliceKey).Key(),
 			"slice/closed/123/my-receiver/my-export/2006-01-02T08:04:05.000Z/2006-01-02T09:04:05.000Z",
+		},
+		{
+			s.Slices().Uploading().InFile(fileKey).Prefix(),
+			"slice/uploading/123/my-receiver/my-export/2006-01-02T08:04:05.000Z/",
+		},
+		{
+			s.Slices().Uploading().ByKey(sliceKey).Key(),
+			"slice/uploading/123/my-receiver/my-export/2006-01-02T08:04:05.000Z/2006-01-02T09:04:05.000Z",
 		},
 		{
 			s.Slices().Uploaded().InFile(fileKey).Prefix(),

--- a/internal/pkg/service/buffer/store/schema/slice.go
+++ b/internal/pkg/service/buffer/store/schema/slice.go
@@ -6,6 +6,7 @@ import (
 
 	storeKey "github.com/keboola/keboola-as-code/internal/pkg/service/buffer/store/key"
 	"github.com/keboola/keboola-as-code/internal/pkg/service/buffer/store/model"
+	"github.com/keboola/keboola-as-code/internal/pkg/service/buffer/store/slicestate"
 	. "github.com/keboola/keboola-as-code/internal/pkg/service/common/etcdop"
 	"github.com/keboola/keboola-as-code/internal/pkg/utils/errors"
 )
@@ -32,24 +33,32 @@ func (v *Schema) Slices() Slices {
 	)}
 }
 
+func (v Slices) InState(state slicestate.State) SlicesInAState {
+	return SlicesInAState{slices: v.slices.Add(string(state))}
+}
+
 func (v Slices) Opened() SlicesInAState {
-	return SlicesInAState{slices: v.slices.Add("opened")}
+	return v.InState(slicestate.Opened)
 }
 
 func (v Slices) Closing() SlicesInAState {
-	return SlicesInAState{slices: v.slices.Add("closing")}
+	return v.InState(slicestate.Closing)
 }
 
 func (v Slices) Closed() SlicesInAState {
-	return SlicesInAState{slices: v.slices.Add("closed")}
+	return v.InState(slicestate.Closed)
+}
+
+func (v Slices) Uploading() SlicesInAState {
+	return v.InState(slicestate.Uploading)
 }
 
 func (v Slices) Uploaded() SlicesInAState {
-	return SlicesInAState{slices: v.slices.Add("uploaded")}
+	return v.InState(slicestate.Uploaded)
 }
 
 func (v Slices) Failed() SlicesInAState {
-	return SlicesInAState{slices: v.slices.Add("failed")}
+	return v.InState(slicestate.Failed)
 }
 
 func (v SlicesInAState) ByKey(k storeKey.SliceKey) KeyT[model.Slice] {

--- a/internal/pkg/service/buffer/store/slice_test.go
+++ b/internal/pkg/service/buffer/store/slice_test.go
@@ -2,6 +2,8 @@ package store
 
 import (
 	"context"
+	"fmt"
+	"strings"
 	"testing"
 	"time"
 
@@ -9,6 +11,7 @@ import (
 
 	"github.com/keboola/keboola-as-code/internal/pkg/service/buffer/store/key"
 	"github.com/keboola/keboola-as-code/internal/pkg/service/buffer/store/model"
+	"github.com/keboola/keboola-as-code/internal/pkg/service/buffer/store/slicestate"
 	"github.com/keboola/keboola-as-code/internal/pkg/utils/etcdhelper"
 )
 
@@ -18,6 +21,7 @@ func TestStore_CreateSlice(t *testing.T) {
 	ctx := context.Background()
 	store := newStoreForTest(t)
 	slice := sliceForTest()
+
 	_, err := store.createSliceOp(ctx, slice).Do(ctx, store.client)
 	assert.NoError(t, err)
 
@@ -32,23 +36,11 @@ slice/opened/1000/my-receiver/my-export/2006-01-01T08:04:05.000Z/2006-01-02T08:0
   "exportId": "my-export",
   "fileId": "2006-01-01T15:04:05+07:00",
   "sliceId": "2006-01-02T15:04:05+07:00",
+  "state": "opened",
   "sliceNumber": 1
 }
 >>>>>
 `)
-}
-
-func sliceForTest() model.Slice {
-	time1, _ := time.Parse(time.RFC3339, "2006-01-01T15:04:05+07:00")
-	time2, _ := time.Parse(time.RFC3339, "2006-01-02T15:04:05+07:00")
-	receiverKey := key.ReceiverKey{ProjectID: 1000, ReceiverID: "my-receiver"}
-	exportKey := key.ExportKey{ExportID: "my-export", ReceiverKey: receiverKey}
-	fileKey := key.FileKey{FileID: time1, ExportKey: exportKey}
-	sliceKey := key.SliceKey{SliceID: time2, FileKey: fileKey}
-	return model.Slice{
-		SliceKey:    sliceKey,
-		SliceNumber: 1,
-	}
 }
 
 func TestStore_GetSliceOp(t *testing.T) {
@@ -58,6 +50,7 @@ func TestStore_GetSliceOp(t *testing.T) {
 	store := newStoreForTest(t)
 	slice := sliceForTest()
 	_, err := store.createSliceOp(ctx, slice).Do(ctx, store.client)
+
 	assert.NoError(t, err)
 
 	kv, err := store.getSliceOp(ctx, slice.SliceKey).Do(ctx, store.client)
@@ -75,10 +68,59 @@ slice/opened/1000/my-receiver/my-export/2006-01-01T08:04:05.000Z/2006-01-02T08:0
   "exportId": "my-export",
   "fileId": "2006-01-01T15:04:05+07:00",
   "sliceId": "2006-01-02T15:04:05+07:00",
+  "state": "opened",
   "sliceNumber": 1
 }
 >>>>>
 `)
+}
+
+func TestStore_SetSliceState_Transitions(t *testing.T) {
+	t.Parallel()
+
+	// Test all transitions
+	testCases := []struct{ from, to slicestate.State }{
+		{slicestate.Opened, slicestate.Closing},
+		{slicestate.Closing, slicestate.Closed},
+		{slicestate.Closed, slicestate.Uploading},
+		{slicestate.Uploading, slicestate.Failed},
+		{slicestate.Failed, slicestate.Uploading},
+		{slicestate.Uploading, slicestate.Uploaded},
+	}
+
+	ctx := context.Background()
+	store := newStoreForTest(t)
+	slice := sliceForTest()
+	now, _ := time.Parse(time.RFC3339, "2010-01-01T01:01:01+07:00")
+
+	// Create slice
+	assert.NoError(t, store.CreateSlice(ctx, slice))
+
+	for _, tc := range testCases {
+		// Trigger transition
+		ok, err := store.SetSliceState(ctx, &slice, tc.to, now)
+		desc := fmt.Sprintf("%s -> %s", tc.from, tc.to)
+		assert.NoError(t, err, desc)
+		assert.True(t, ok, desc)
+		assert.Equal(t, tc.to, slice.State, desc)
+		expected := `
+<<<<<
+slice/<STATE>/1000/my-receiver/my-export/2006-01-01T08:04:05.000Z/2006-01-02T08:04:05.000Z
+-----
+%A
+  "state": "<STATE>",%A
+  "<STATE>At": "2010-01-01T01:01:01+07:00"%A
+>>>>>
+`
+		etcdhelper.AssertKVs(t, store.client, strings.ReplaceAll(expected, "<STATE>", tc.to.String()))
+
+		// Test duplicated transition -> nop
+		slice.State = tc.from
+		ok, err = store.SetSliceState(ctx, &slice, tc.to, time.Now())
+		assert.NoError(t, err, desc)
+		assert.False(t, ok, desc)
+		assert.Equal(t, tc.to, slice.State, desc)
+	}
 }
 
 func TestStore_ListUploadedSlices(t *testing.T) {
@@ -87,20 +129,22 @@ func TestStore_ListUploadedSlices(t *testing.T) {
 	ctx := context.Background()
 	store := newStoreForTest(t)
 
-	receiverKey := key.ReceiverKey{ProjectID: 1000, ReceiverID: "github"}
-	exportKey := key.ExportKey{ExportID: "github-issues", ReceiverKey: receiverKey}
+	receiverKey := key.ReceiverKey{ProjectID: 1000, ReceiverID: "my-receiver"}
+	exportKey := key.ExportKey{ExportID: "my-export", ReceiverKey: receiverKey}
 	time1, _ := time.Parse(time.RFC3339, "2006-01-01T15:04:05+07:00")
 	time2, _ := time.Parse(time.RFC3339, "2006-01-02T15:04:05+07:00")
 	time3, _ := time.Parse(time.RFC3339, "2006-01-03T15:04:05+07:00")
 	fileKey := key.FileKey{FileID: time1, ExportKey: exportKey}
 	input := []model.Slice{
 		{
-			SliceKey:    key.SliceKey{SliceID: time2, FileKey: fileKey},
-			SliceNumber: 1,
+			SliceKey: key.SliceKey{SliceID: time2, FileKey: fileKey},
+			State:    slicestate.Uploaded,
+			Number:   1,
 		},
 		{
-			SliceKey:    key.SliceKey{SliceID: time3, FileKey: fileKey},
-			SliceNumber: 2,
+			SliceKey: key.SliceKey{SliceID: time3, FileKey: fileKey},
+			State:    slicestate.Uploaded,
+			Number:   2,
 		},
 	}
 	// Create uploaded slices
@@ -116,29 +160,45 @@ func TestStore_ListUploadedSlices(t *testing.T) {
 	// Check keys
 	etcdhelper.AssertKVs(t, store.client, `
 <<<<<
-slice/uploaded/1000/github/github-issues/2006-01-01T08:04:05.000Z/2006-01-02T08:04:05.000Z
+slice/uploaded/1000/my-receiver/my-export/2006-01-01T08:04:05.000Z/2006-01-02T08:04:05.000Z
 -----
 {
   "projectId": 1000,
-  "receiverId": "github",
-  "exportId": "github-issues",
+  "receiverId": "my-receiver",
+  "exportId": "my-export",
   "fileId": "2006-01-01T15:04:05+07:00",
   "sliceId": "2006-01-02T15:04:05+07:00",
+  "state": "uploaded",
   "sliceNumber": 1
 }
 >>>>>
 
 <<<<<
-slice/uploaded/1000/github/github-issues/2006-01-01T08:04:05.000Z/2006-01-03T08:04:05.000Z
+slice/uploaded/1000/my-receiver/my-export/2006-01-01T08:04:05.000Z/2006-01-03T08:04:05.000Z
 -----
 {
   "projectId": 1000,
-  "receiverId": "github",
-  "exportId": "github-issues",
+  "receiverId": "my-receiver",
+  "exportId": "my-export",
   "fileId": "2006-01-01T15:04:05+07:00",
   "sliceId": "2006-01-03T15:04:05+07:00",
+  "state": "uploaded",
   "sliceNumber": 2
 }
 >>>>>
 `)
+}
+
+func sliceForTest() model.Slice {
+	time1, _ := time.Parse(time.RFC3339, "2006-01-01T15:04:05+07:00")
+	time2, _ := time.Parse(time.RFC3339, "2006-01-02T15:04:05+07:00")
+	receiverKey := key.ReceiverKey{ProjectID: 1000, ReceiverID: "my-receiver"}
+	exportKey := key.ExportKey{ExportID: "my-export", ReceiverKey: receiverKey}
+	fileKey := key.FileKey{FileID: time1, ExportKey: exportKey}
+	sliceKey := key.SliceKey{SliceID: time2, FileKey: fileKey}
+	return model.Slice{
+		SliceKey: sliceKey,
+		State:    slicestate.Opened,
+		Number:   1,
+	}
 }

--- a/internal/pkg/service/buffer/store/slicestate/slicestate.go
+++ b/internal/pkg/service/buffer/store/slicestate/slicestate.go
@@ -1,0 +1,78 @@
+package slicestate
+
+import (
+	"context"
+
+	"github.com/qmuntal/stateless"
+
+	"github.com/keboola/keboola-as-code/internal/pkg/utils/errors"
+)
+
+// Opened
+// It is the initial state of the slice.
+// API nodes can write records to the related etcd prefix.
+const Opened State = "opened"
+
+// Closing
+// Upload conditions have been met.
+// Waiting for the API nodes until they switch to the new slice.
+const Closing State = "closing"
+
+// Closed
+// The slice is ready for upload.
+const Closed State = "closed"
+
+// Uploading
+// Slice upload into the file storage is in progress.
+const Uploading State = "uploading"
+
+// Uploaded
+// The slice has been successfully uploaded.
+const Uploaded State = "uploaded"
+
+// Failed
+// Upload failed, try again later.
+const Failed State = "failed"
+
+type State string
+
+type onEntry func(ctx context.Context, from, to State) error
+
+type STM struct {
+	onEntry onEntry
+	stm     *stateless.StateMachine
+}
+
+func NewSTM(state State, fn onEntry) *STM {
+	v := &STM{onEntry: fn, stm: stateless.NewStateMachine(state)}
+	v.stm.OnUnhandledTrigger(func(_ context.Context, state stateless.State, trigger stateless.Trigger, _ []string) error {
+		return errors.Errorf(`slice state transition "%s" -> "%s" is not allowed`, state, trigger)
+	})
+	v.permit(Opened, Closing)
+	v.permit(Closing, Closed)
+	v.permit(Closed, Uploading)
+	v.permit(Uploading, Failed)
+	v.permit(Failed, Uploading)
+	v.permit(Uploading, Uploaded)
+	return v
+}
+
+func (v *STM) To(ctx context.Context, to State) error {
+	return v.stm.FireCtx(ctx, to)
+}
+
+func (v *STM) permit(from, to State) {
+	v.stm.
+		Configure(from).
+		Permit(to, to). // first argument, trigger = to, see To method
+		OnExit(func(ctx context.Context, args ...any) error {
+			if stateless.GetTransition(ctx).Destination == to {
+				return v.onEntry(ctx, from, to)
+			}
+			return nil
+		})
+}
+
+func (v State) String() string {
+	return string(v)
+}

--- a/internal/pkg/service/buffer/store/slicestate/slicestate_test.go
+++ b/internal/pkg/service/buffer/store/slicestate/slicestate_test.go
@@ -1,0 +1,31 @@
+package slicestate_test
+
+import (
+	"context"
+	"fmt"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+
+	. "github.com/keboola/keboola-as-code/internal/pkg/service/buffer/store/slicestate"
+)
+
+func TestSTM(t *testing.T) {
+	t.Parallel()
+	ctx := context.Background()
+	var transitions []string
+	stm := NewSTM(Opened, func(ctx context.Context, from, to State) error {
+		transitions = append(transitions, fmt.Sprintf("%s -> %s", from, to))
+		return nil
+	})
+
+	// Valid transition
+	assert.NoError(t, stm.To(ctx, Closing))
+	assert.Equal(t, []string{"opened -> closing"}, transitions)
+
+	// Invalid transition
+	err := stm.To(ctx, Uploaded)
+	assert.Error(t, err)
+	assert.Equal(t, `slice state transition "closing" -> "uploaded" is not allowed`, err.Error())
+	assert.Equal(t, []string{"opened -> closing"}, transitions)
+}

--- a/internal/pkg/service/common/etcdop/key.go
+++ b/internal/pkg/service/common/etcdop/key.go
@@ -80,6 +80,21 @@ func (v Key) Delete(opts ...etcd.OpOption) op.BoolOp {
 	)
 }
 
+func (v Key) DeleteIfExists(opts ...etcd.OpOption) op.BoolOp {
+	return op.NewBoolOp(
+		func(_ context.Context) (etcd.Op, error) {
+			return etcd.OpTxn(
+				[]etcd.Cmp{etcd.Compare(etcd.Version(v.Key()), "!=", 0)},
+				[]etcd.Op{etcd.OpDelete(v.Key(), opts...)},
+				[]etcd.Op{},
+			), nil
+		},
+		func(_ context.Context, r etcd.OpResponse) (bool, error) {
+			return r.Txn().Succeeded, nil
+		},
+	)
+}
+
 func (v Key) Put(val string, opts ...etcd.OpOption) op.NoResultOp {
 	return op.NewNoResultOp(
 		func(_ context.Context) (etcd.Op, error) {

--- a/internal/pkg/service/common/etcdop/key_test.go
+++ b/internal/pkg/service/common/etcdop/key_test.go
@@ -89,6 +89,16 @@ func TestKeyOperations(t *testing.T) {
 	assert.NoError(t, err)
 	assert.NotNil(t, kv)
 	assert.Equal(t, []byte("value1"), kv.Value)
+
+	// DeleteIfExists - found
+	ok, err = k.DeleteIfExists().Do(ctx, etcd)
+	assert.NoError(t, err)
+	assert.True(t, ok)
+
+	// DeleteIfNotExists - not found
+	ok, err = k.DeleteIfExists().Do(ctx, etcd)
+	assert.NoError(t, err)
+	assert.False(t, ok)
 }
 
 func TestTypedKeyOperations(t *testing.T) {
@@ -168,6 +178,17 @@ func TestTypedKeyOperations(t *testing.T) {
 	assert.NoError(t, err)
 	assert.NotNil(t, kv)
 	assert.Equal(t, fooType("value1"), kv.Value)
+
+	// ------
+	// DeleteIfExists - found
+	ok, err = k.DeleteIfExists().Do(ctx, etcd)
+	assert.NoError(t, err)
+	assert.True(t, ok)
+
+	// DeleteIfNotExists - not found
+	ok, err = k.DeleteIfExists().Do(ctx, etcd)
+	assert.NoError(t, err)
+	assert.False(t, ok)
 }
 
 func BenchmarkKey_Exists(b *testing.B) {

--- a/internal/pkg/service/common/etcdop/watch_test.go
+++ b/internal/pkg/service/common/etcdop/watch_test.go
@@ -83,6 +83,8 @@ func TestPrefix_Watch(t *testing.T) {
 		}
 		assert.Equal(t, expected, clearEvent(<-ch))
 	}, "DELETE timeout")
+
+	wg.Wait()
 }
 
 func TestPrefix_GetAllAndWatch(t *testing.T) {

--- a/test/api/buffer/exports/create/expected-etcd-kvs.txt
+++ b/test/api/buffer/exports/create/expected-etcd-kvs.txt
@@ -63,6 +63,7 @@
   "receiverId": "my-receiver",
   "exportId": "my-export-1",
   "fileId": "%s",
+  "state": "opened",
   "mapping": {
     "projectId": %%TEST_KBC_PROJECT_ID%%,
     "receiverId": "my-receiver",
@@ -113,6 +114,7 @@
   "exportId": "my-export-1",
   "fileId": "%s",
   "sliceId": "%s",
+  "state": "opened",
   "sliceNumber": 1
 }
 >>>>>

--- a/test/api/buffer/exports/delete/expected-etcd-kvs.txt
+++ b/test/api/buffer/exports/delete/expected-etcd-kvs.txt
@@ -63,6 +63,7 @@
   "receiverId": "my-receiver",
   "exportId": "my-export-1",
   "fileId": "%s",
+  "state": "opened",
   "mapping": {
     "projectId": %%TEST_KBC_PROJECT_ID%%,
     "receiverId": "my-receiver",
@@ -102,6 +103,7 @@
   "receiverId": "my-receiver",
   "exportId": "my-export-2",
   "fileId": "%s",
+  "state": "opened",
   "mapping": {
     "projectId": %%TEST_KBC_PROJECT_ID%%,
     "receiverId": "my-receiver",
@@ -148,6 +150,7 @@
   "exportId": "my-export-1",
   "fileId": "%s",
   "sliceId": "%s",
+  "state": "opened",
   "sliceNumber": 1
 }
 >>>>>
@@ -161,6 +164,7 @@
   "exportId": "my-export-2",
   "fileId": "%s",
   "sliceId": "%s",
+  "state": "opened",
   "sliceNumber": 1
 }
 >>>>>

--- a/test/api/buffer/exports/update/expected-etcd-kvs.txt
+++ b/test/api/buffer/exports/update/expected-etcd-kvs.txt
@@ -147,6 +147,7 @@
   "receiverId": "my-receiver",
   "exportId": "my-export-1",
   "fileId": "%s",
+  "state": "opened",
   "mapping": {
     "projectId": %%TEST_KBC_PROJECT_ID%%,
     "receiverId": "my-receiver",
@@ -193,6 +194,7 @@
   "exportId": "my-export-1",
   "fileId": "%s",
   "sliceId": "%s",
+  "state": "opened",
   "sliceNumber": 1
 }
 >>>>>

--- a/test/api/buffer/receivers/create/expected-etcd-kvs.txt
+++ b/test/api/buffer/receivers/create/expected-etcd-kvs.txt
@@ -107,6 +107,7 @@
   "receiverId": "my-receiver-with-exports",
   "exportId": "my-export-1",
   "fileId": "%s",
+  "state": "opened",
   "mapping": {
     "projectId": %%TEST_KBC_PROJECT_ID%%,
     "receiverId": "my-receiver-with-exports",
@@ -157,6 +158,7 @@
   "exportId": "my-export-1",
   "fileId": "%s",
   "sliceId": "%s",
+  "state": "opened",
   "sliceNumber": 1
 }
 >>>>>

--- a/test/api/buffer/receivers/delete/expected-etcd-kvs.txt
+++ b/test/api/buffer/receivers/delete/expected-etcd-kvs.txt
@@ -60,6 +60,7 @@
   "receiverId": "receiver-b",
   "exportId": "export-1",
   "fileId": "%s",
+  "state": "opened",
   "mapping": {
     "projectId": %%TEST_KBC_PROJECT_ID%%,
     "receiverId": "receiver-b",
@@ -100,6 +101,7 @@
   "receiverId": "receiver-c",
   "exportId": "export-2",
   "fileId": "%s",
+  "state": "opened",
   "mapping": {
     "projectId": %%TEST_KBC_PROJECT_ID%%,
     "receiverId": "receiver-c",
@@ -147,6 +149,7 @@
   "exportId": "export-1",
   "fileId": "%s",
   "sliceId": "%s",
+  "state": "opened",
   "sliceNumber": 1
 }
 >>>>>
@@ -160,6 +163,7 @@
   "exportId": "export-2",
   "fileId": "%s",
   "sliceId": "%s",
+  "state": "opened",
   "sliceNumber": 1
 }
 >>>>>

--- a/test/api/buffer/receivers/update/expected-etcd-kvs.txt
+++ b/test/api/buffer/receivers/update/expected-etcd-kvs.txt
@@ -56,6 +56,7 @@
   "receiverId": "my-receiver",
   "exportId": "my-export-1",
   "fileId": "%s",
+  "state": "opened",
   "mapping": {
     "projectId": %%TEST_KBC_PROJECT_ID%%,
     "receiverId": "my-receiver",
@@ -99,6 +100,7 @@
   "exportId": "my-export-1",
   "fileId": "%s",
   "sliceId": "%s",
+  "state": "opened",
   "sliceNumber": 1
 }
 >>>>>


### PR DESCRIPTION
Part of: https://keboola.atlassian.net/browse/BA-40

Changes:
- Created packages `filestate` and `slicestate` with state machines for file/slice states.
- Together with etcd transactions, this ensures valid and atomic file/slice state changes.