### PR TITLE
Store Watcher

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -11,6 +11,7 @@ require (
 	github.com/MichaelMure/go-term-markdown v0.1.4
 	github.com/Netflix/go-expect v0.0.0-20220104043353-73e0943537d2
 	github.com/acarl005/stripansi v0.0.0-20180116102854-5a71ef0e047d
+	github.com/armon/go-radix v1.0.0
 	github.com/benbjohnson/clock v1.3.0
 	github.com/c2h5oh/datasize v0.0.0-20220606134207-859f65c6625b
 	github.com/cenkalti/backoff/v4 v4.2.0

--- a/go.sum
+++ b/go.sum
@@ -235,6 +235,7 @@ github.com/armon/consul-api v0.0.0-20180202201655-eb2c6b5be1b6/go.mod h1:grANhF5
 github.com/armon/go-metrics v0.0.0-20180917152333-f0300d1749da/go.mod h1:Q73ZrmVTwzkszR9V5SSuryQ31EELlFMUz1kKyl939pY=
 github.com/armon/go-metrics v0.3.3/go.mod h1:4O98XIr/9W0sxpJ8UaYkvjk10Iff7SnFrb4QAOwNTFc=
 github.com/armon/go-radix v0.0.0-20180808171621-7fddfc383310/go.mod h1:ufUuZ+zHj4x4TnLV4JWEpy2hxWSpsRywHrMgIH9cCH8=
+github.com/armon/go-radix v1.0.0 h1:F4z6KzEeeQIMeLFa97iZU6vupzoecKdU5TX24SNppXI=
 github.com/armon/go-radix v1.0.0/go.mod h1:ufUuZ+zHj4x4TnLV4JWEpy2hxWSpsRywHrMgIH9cCH8=
 github.com/armon/go-socks5 v0.0.0-20160902184237-e75332964ef5/go.mod h1:wHh0iHkYZB8zMSxRWpUBQtwG5a7fFgvEO+odwuTv2gs=
 github.com/aryann/difflib v0.0.0-20170710044230-e206f873d14a/go.mod h1:DAHtR1m6lCRdSC2Tm3DSWRPvIPr6xNKyeHdqDQSQT+A=

--- a/internal/pkg/encoding/json/schema/generate.go
+++ b/internal/pkg/encoding/json/schema/generate.go
@@ -109,9 +109,7 @@ func getDefaultValueFor(schema *jsonschema.Schema, level int) interface{} {
 			return `3e4666bf-d5e5-4aa7-b8ce-cefe41c7568a`
 		}
 		return ``
-	case `number`:
-		fallthrough
-	case `integer`:
+	case `number`, `integer`:
 		return 0
 	case `boolean`:
 		return false

--- a/internal/pkg/model/transformation.go
+++ b/internal/pkg/model/transformation.go
@@ -126,11 +126,7 @@ func (v Scripts) String(componentID storageapi.ComponentID) string {
 	}
 
 	switch componentID.String() {
-	case `keboola.snowflake-transformation`:
-		fallthrough
-	case `keboola.synapse-transformation`:
-		fallthrough
-	case `keboola.oracle-transformation`:
+	case `keboola.snowflake-transformation`, `keboola.synapse-transformation`, `keboola.oracle-transformation`:
 		return sql.Join(items) + "\n"
 	default:
 		return strings.Join(items, "\n") + "\n"
@@ -175,11 +171,7 @@ func ScriptsFromStr(content string, componentID storageapi.ComponentID) Scripts 
 	content = NormalizeScript(content)
 	var items []string
 	switch componentID.String() {
-	case `keboola.snowflake-transformation`:
-		fallthrough
-	case `keboola.synapse-transformation`:
-		fallthrough
-	case `keboola.oracle-transformation`:
+	case `keboola.snowflake-transformation`, `keboola.synapse-transformation`, `keboola.oracle-transformation`:
 		items = sql.Split(content)
 	default:
 		items = []string{content}

--- a/internal/pkg/service/buffer/api/service/service.go
+++ b/internal/pkg/service/buffer/api/service/service.go
@@ -8,6 +8,7 @@ import (
 	"github.com/keboola/keboola-as-code/internal/pkg/service/buffer/api/gen/buffer"
 	"github.com/keboola/keboola-as-code/internal/pkg/service/buffer/api/service/mapper"
 	"github.com/keboola/keboola-as-code/internal/pkg/service/buffer/statistics"
+	"github.com/keboola/keboola-as-code/internal/pkg/service/buffer/store/watcher"
 )
 
 type service struct {
@@ -16,6 +17,7 @@ type service struct {
 	logger log.Logger
 	stats  *statistics.APINode
 	mapper *mapper.Mapper
+	state  *watcher.State
 }
 
 func New(d dependencies.ForServer) buffer.Service {
@@ -25,6 +27,7 @@ func New(d dependencies.ForServer) buffer.Service {
 		logger: d.Logger(),
 		stats:  statistics.NewAPINode(d),
 		mapper: mapper.NewMapper(d),
+		state:  watcher.NewState(d),
 	}
 }
 

--- a/internal/pkg/service/buffer/statistics/apinode.go
+++ b/internal/pkg/service/buffer/statistics/apinode.go
@@ -65,9 +65,7 @@ func NewAPINode(d dependencies) *APINode {
 		for {
 			select {
 			case <-ctx.Done():
-				m.logger.Info("the server is shutting down, starting sync")
 				<-m.handleSync(context.Background())
-				m.logger.Info("all done")
 				close(done)
 				return
 			case event := <-m.ch:
@@ -81,8 +79,10 @@ func NewAPINode(d dependencies) *APINode {
 	// The context is cancelled on shutdown, after the HTTP server.
 	// OnShutdown applies LIFO order, the HTTP server is started last and terminated first.
 	d.Process().OnShutdown(func() {
+		m.logger.Info("received shutdown request")
 		cancel()
 		<-done
+		m.logger.Info("shutdown done")
 	})
 
 	return m

--- a/internal/pkg/service/buffer/statistics/apinode_test.go
+++ b/internal/pkg/service/buffer/statistics/apinode_test.go
@@ -148,10 +148,10 @@ INFO  process unique id "%s"
 [stats]DEBUG  syncing 1 records
 [stats]DEBUG  sync done
 INFO  exiting (test shutdown)
-[stats]INFO  the server is shutting down, starting sync
+[stats]INFO  received shutdown request
 [stats]DEBUG  syncing 1 records
 [stats]DEBUG  sync done
-[stats]INFO  all done
+[stats]INFO  shutdown done
 INFO  exited
 `
 	wildcards.Assert(t, strings.TrimSpace(expected), d.DebugLogger().AllMessages())

--- a/internal/pkg/service/buffer/store/export.go
+++ b/internal/pkg/service/buffer/store/export.go
@@ -23,7 +23,7 @@ import (
 // - CountLimitReachedError
 // - ResourceAlreadyExistsError.
 func (s *Store) CreateExport(ctx context.Context, export model.Export) (err error) {
-	_, span := s.tracer.Start(ctx, "keboola.go.buffer.configstore.CreateExport")
+	_, span := s.tracer.Start(ctx, "keboola.go.buffer.store.CreateExport")
 	defer telemetry.EndSpan(span, &err)
 
 	count, err := s.schema.Configs().Exports().InReceiver(export.ReceiverKey).Count().Do(ctx, s.client)
@@ -62,7 +62,7 @@ func (s *Store) createExportBaseOp(_ context.Context, export model.ExportBase) o
 }
 
 func (s *Store) UpdateExport(ctx context.Context, k key.ExportKey, fn func(model.Export) (model.Export, error)) (err error) {
-	_, span := s.tracer.Start(ctx, "keboola.go.buffer.configstore.UpdateExport")
+	_, span := s.tracer.Start(ctx, "keboola.go.buffer.store.UpdateExport")
 	defer telemetry.EndSpan(span, &err)
 
 	export, err := s.GetExport(ctx, k)
@@ -136,7 +136,7 @@ func (s *Store) updateExportBaseOp(_ context.Context, export model.ExportBase) o
 // Logic errors:
 // - ResourceNotFoundError.
 func (s *Store) GetExport(ctx context.Context, exportKey key.ExportKey) (r model.Export, err error) {
-	_, span := s.tracer.Start(ctx, "keboola.go.buffer.configstore.GetExport")
+	_, span := s.tracer.Start(ctx, "keboola.go.buffer.store.GetExport")
 	defer telemetry.EndSpan(span, &err)
 	return s.getExportOp(ctx, exportKey).Do(ctx, s.client)
 }
@@ -177,7 +177,7 @@ func (s *Store) getExportBaseOp(_ context.Context, exportKey key.ExportKey) op.F
 
 // ListExports from the store.
 func (s *Store) ListExports(ctx context.Context, receiverKey key.ReceiverKey, ops ...iterator.Option) (exports []model.Export, err error) {
-	_, span := s.tracer.Start(ctx, "keboola.go.buffer.configstore.ListExports")
+	_, span := s.tracer.Start(ctx, "keboola.go.buffer.store.ListExports")
 	defer telemetry.EndSpan(span, &err)
 
 	// Load sub-objects in parallel, stop at the first error
@@ -248,7 +248,7 @@ func (s *Store) exportBaseIterator(_ context.Context, receiverKey key.ReceiverKe
 // Logic errors:
 // - ResourceNotFoundError.
 func (s *Store) DeleteExport(ctx context.Context, exportKey key.ExportKey) (err error) {
-	_, span := s.tracer.Start(ctx, "keboola.go.buffer.configstore.DeleteReceiver")
+	_, span := s.tracer.Start(ctx, "keboola.go.buffer.store.DeleteReceiver")
 	defer telemetry.EndSpan(span, &err)
 
 	_, err = op.MergeToTxn(

--- a/internal/pkg/service/buffer/store/export.go
+++ b/internal/pkg/service/buffer/store/export.go
@@ -186,7 +186,7 @@ func (s *Store) ListExports(ctx context.Context, receiverKey key.ReceiverKey, op
 
 	i := 0
 	err = s.
-		exportBaseIterator(ctx, receiverKey).Do(ctx, s.client).
+		exportBaseIterator(ctx, receiverKey, ops...).Do(ctx, s.client).
 		ForEachValue(func(exportBase model.ExportBase, header *iterator.Header) error {
 			export := &model.Export{ExportBase: exportBase}
 			exportsMap[exportBase.ExportKey] = export

--- a/internal/pkg/service/buffer/store/file.go
+++ b/internal/pkg/service/buffer/store/file.go
@@ -32,7 +32,7 @@ func (s *Store) createFileOp(ctx context.Context, file model.File) *op.TxnOp {
 }
 
 func (s *Store) GetFile(ctx context.Context, fileKey key.FileKey) (out model.File, err error) {
-	_, span := s.tracer.Start(ctx, "keboola.go.buffer.configstore.GetFile")
+	_, span := s.tracer.Start(ctx, "keboola.go.buffer.store.GetFile")
 	defer telemetry.EndSpan(span, &err)
 
 	file, err := s.getFileOp(ctx, fileKey).Do(ctx, s.client)

--- a/internal/pkg/service/buffer/store/key/key.go
+++ b/internal/pkg/service/buffer/store/key/key.go
@@ -64,7 +64,7 @@ func NewRecordKey(sliceKey SliceKey, now time.Time) RecordKey {
 	return RecordKey{SliceKey: sliceKey, ReceivedAt: ReceivedAt(now)}
 }
 
-func (v *ReceiverKey) String() string {
+func (v ReceiverKey) String() string {
 	return fmt.Sprintf("project:%d/receiver:%s", v.ProjectID, v.ReceiverID)
 }
 

--- a/internal/pkg/service/buffer/store/mapping.go
+++ b/internal/pkg/service/buffer/store/mapping.go
@@ -18,7 +18,7 @@ import (
 // Logic errors:
 // - CountLimitReachedError.
 func (s *Store) CreateMapping(ctx context.Context, mapping model.Mapping) (err error) {
-	_, span := s.tracer.Start(ctx, "keboola.go.buffer.configstore.CreateMapping")
+	_, span := s.tracer.Start(ctx, "keboola.go.buffer.store.CreateMapping")
 	defer telemetry.EndSpan(span, &err)
 
 	if mapping.RevisionID != 0 {
@@ -89,7 +89,7 @@ func (s *Store) updateMappingOp(_ context.Context, mapping model.Mapping) op.NoR
 
 // GetLatestMapping fetches the current mapping from the store.
 func (s *Store) GetLatestMapping(ctx context.Context, exportKey key.ExportKey) (r model.Mapping, err error) {
-	_, span := s.tracer.Start(ctx, "keboola.go.buffer.configstore.GetLatestMapping")
+	_, span := s.tracer.Start(ctx, "keboola.go.buffer.store.GetLatestMapping")
 	defer telemetry.EndSpan(span, &err)
 
 	kv, err := s.getLatestMappingOp(ctx, exportKey).Do(ctx, s.client)
@@ -118,7 +118,7 @@ func (s *Store) getLatestMappingOp(_ context.Context, exportKey key.ExportKey, o
 // Logic errors:
 // - ResourceNotFoundError.
 func (s *Store) GetMapping(ctx context.Context, mappingKey key.MappingKey) (r model.Mapping, err error) {
-	_, span := s.tracer.Start(ctx, "keboola.go.buffer.configstore.GetMapping")
+	_, span := s.tracer.Start(ctx, "keboola.go.buffer.store.GetMapping")
 	defer telemetry.EndSpan(span, &err)
 
 	kv, err := s.getMappingOp(ctx, mappingKey).Do(ctx, s.client)

--- a/internal/pkg/service/buffer/store/receiver.go
+++ b/internal/pkg/service/buffer/store/receiver.go
@@ -18,7 +18,7 @@ import (
 // - CountLimitReachedError
 // - ResourceAlreadyExistsError.
 func (s *Store) CreateReceiver(ctx context.Context, receiver model.Receiver) (err error) {
-	_, span := s.tracer.Start(ctx, "keboola.go.buffer.configstore.CreateReceiver")
+	_, span := s.tracer.Start(ctx, "keboola.go.buffer.store.CreateReceiver")
 	defer telemetry.EndSpan(span, &err)
 
 	receivers := s.schema.Configs().Receivers().InProject(receiver.ProjectID)
@@ -55,7 +55,7 @@ func (s *Store) createReceiverBaseOp(_ context.Context, receiver model.ReceiverB
 // Logic errors:
 // - ResourceNotFoundError.
 func (s *Store) GetReceiver(ctx context.Context, receiverKey key.ReceiverKey) (r model.Receiver, err error) {
-	_, span := s.tracer.Start(ctx, "keboola.go.buffer.configstore.GetReceiver")
+	_, span := s.tracer.Start(ctx, "keboola.go.buffer.store.GetReceiver")
 	defer telemetry.EndSpan(span, &err)
 
 	receiverBase, err := s.getReceiverBaseOp(ctx, receiverKey).Do(ctx, s.client)
@@ -88,7 +88,7 @@ func (s *Store) getReceiverBaseOp(_ context.Context, receiverKey key.ReceiverKey
 }
 
 func (s *Store) UpdateReceiver(ctx context.Context, k key.ReceiverKey, fn func(model.Receiver) (model.Receiver, error)) (err error) {
-	_, span := s.tracer.Start(ctx, "keboola.go.buffer.configstore.UpdateReceiver")
+	_, span := s.tracer.Start(ctx, "keboola.go.buffer.store.UpdateReceiver")
 	defer telemetry.EndSpan(span, &err)
 
 	receiver, err := s.GetReceiver(ctx, k)
@@ -115,7 +115,7 @@ func (s *Store) updateReceiverBaseOp(_ context.Context, receiver model.ReceiverB
 // Logic errors:
 // - ResourceNotFoundError.
 func (s *Store) ListReceivers(ctx context.Context, projectID key.ProjectID) (receivers []model.Receiver, err error) {
-	_, span := s.tracer.Start(ctx, "keboola.go.buffer.configstore.ListReceivers")
+	_, span := s.tracer.Start(ctx, "keboola.go.buffer.store.ListReceivers")
 	defer telemetry.EndSpan(span, &err)
 
 	err = s.
@@ -147,7 +147,7 @@ func (s *Store) receiversIterator(_ context.Context, projectID key.ProjectID) it
 // Logic errors:
 // - ResourceNotFoundError.
 func (s *Store) DeleteReceiver(ctx context.Context, receiverKey key.ReceiverKey) (err error) {
-	_, span := s.tracer.Start(ctx, "keboola.go.buffer.configstore.DeleteReceiver")
+	_, span := s.tracer.Start(ctx, "keboola.go.buffer.store.DeleteReceiver")
 	defer telemetry.EndSpan(span, &err)
 
 	_, err = op.MergeToTxn(

--- a/internal/pkg/service/buffer/store/slice.go
+++ b/internal/pkg/service/buffer/store/slice.go
@@ -17,7 +17,7 @@ import (
 )
 
 func (s *Store) CreateSlice(ctx context.Context, slice model.Slice) (err error) {
-	_, span := s.tracer.Start(ctx, "keboola.go.buffer.configstore.CreateSlice")
+	_, span := s.tracer.Start(ctx, "keboola.go.buffer.store.CreateSlice")
 	defer telemetry.EndSpan(span, &err)
 
 	_, err = s.createSliceOp(ctx, slice).Do(ctx, s.client)
@@ -39,7 +39,7 @@ func (s *Store) createSliceOp(_ context.Context, slice model.Slice) op.BoolOp {
 }
 
 func (s *Store) GetSlice(ctx context.Context, sliceKey key.SliceKey) (r model.Slice, err error) {
-	_, span := s.tracer.Start(ctx, "keboola.go.buffer.configstore.GetSlice")
+	_, span := s.tracer.Start(ctx, "keboola.go.buffer.store.GetSlice")
 	defer telemetry.EndSpan(span, &err)
 
 	slice, err := s.getSliceOp(ctx, sliceKey).Do(ctx, s.client)
@@ -50,7 +50,7 @@ func (s *Store) GetSlice(ctx context.Context, sliceKey key.SliceKey) (r model.Sl
 }
 
 func (s *Store) GetLatestSlice(ctx context.Context, fileKey key.FileKey) (r model.Slice, err error) {
-	_, span := s.tracer.Start(ctx, "keboola.go.buffer.configstore.GetLatestSlice")
+	_, span := s.tracer.Start(ctx, "keboola.go.buffer.store.GetLatestSlice")
 	defer telemetry.EndSpan(span, &err)
 
 	slice, err := s.getLatestSliceOp(ctx, fileKey).Do(ctx, s.client)
@@ -89,7 +89,7 @@ func (s *Store) getLatestSliceOp(_ context.Context, fileKey key.FileKey) op.ForT
 }
 
 func (s *Store) ListUploadedSlices(ctx context.Context, fileKey key.FileKey) (r []model.Slice, err error) {
-	_, span := s.tracer.Start(ctx, "keboola.go.buffer.configstore.GetAllUploadedSlices")
+	_, span := s.tracer.Start(ctx, "keboola.go.buffer.store.GetAllUploadedSlices")
 	defer telemetry.EndSpan(span, &err)
 
 	slices, err := s.listUploadedSlicesOp(ctx, fileKey).Do(ctx, s.client).All()

--- a/internal/pkg/service/buffer/store/stats.go
+++ b/internal/pkg/service/buffer/store/stats.go
@@ -9,7 +9,7 @@ import (
 )
 
 func (s *Store) UpdateSliceStats(ctx context.Context, nodeID string, stats []model.SliceStats) (err error) {
-	_, span := s.tracer.Start(ctx, "keboola.go.buffer.configstore.UpdateStats")
+	_, span := s.tracer.Start(ctx, "keboola.go.buffer.store.UpdateStats")
 	defer telemetry.EndSpan(span, &err)
 
 	var ops []op.Op

--- a/internal/pkg/service/buffer/store/token.go
+++ b/internal/pkg/service/buffer/store/token.go
@@ -14,7 +14,7 @@ import (
 )
 
 func (s *Store) ListTokens(ctx context.Context, receiverKey key.ReceiverKey) (out []model.Token, err error) {
-	_, span := s.tracer.Start(ctx, "keboola.go.buffer.configstore.ListTokens")
+	_, span := s.tracer.Start(ctx, "keboola.go.buffer.store.ListTokens")
 	defer telemetry.EndSpan(span, &err)
 
 	tokens, err := s.getReceiverTokensOp(ctx, receiverKey).Do(ctx, s.client).All()
@@ -26,7 +26,7 @@ func (s *Store) ListTokens(ctx context.Context, receiverKey key.ReceiverKey) (ou
 }
 
 func (s *Store) UpdateTokens(ctx context.Context, tokens []model.Token) (err error) {
-	_, span := s.tracer.Start(ctx, "keboola.go.buffer.configstore.UpdateTokens")
+	_, span := s.tracer.Start(ctx, "keboola.go.buffer.store.UpdateTokens")
 	defer telemetry.EndSpan(span, &err)
 
 	ops := make([]op.Op, 0, len(tokens))

--- a/internal/pkg/service/buffer/store/watcher/state.go
+++ b/internal/pkg/service/buffer/store/watcher/state.go
@@ -1,0 +1,177 @@
+package watcher
+
+import (
+	"context"
+	"fmt"
+	"sync"
+
+	"github.com/benbjohnson/clock"
+	etcd "go.etcd.io/etcd/client/v3"
+
+	"github.com/keboola/keboola-as-code/internal/pkg/log"
+	"github.com/keboola/keboola-as-code/internal/pkg/service/buffer/store/key"
+	"github.com/keboola/keboola-as-code/internal/pkg/service/buffer/store/model"
+	"github.com/keboola/keboola-as-code/internal/pkg/service/buffer/store/schema"
+	"github.com/keboola/keboola-as-code/internal/pkg/service/common/etcdop"
+	"github.com/keboola/keboola-as-code/internal/pkg/service/common/prefixtree"
+	"github.com/keboola/keboola-as-code/internal/pkg/service/common/servicectx"
+	"github.com/keboola/keboola-as-code/internal/pkg/utils/errors"
+)
+
+type State struct {
+	ctx    context.Context
+	wg     *sync.WaitGroup
+	logger log.Logger
+	client *etcd.Client
+
+	lock        *sync.RWMutex
+	receivers   *objectsState[model.ReceiverBase]
+	exports     *objectsState[model.ExportBase]
+	mappings    *objectsState[model.Mapping]
+	openedFiles *objectsState[model.File]
+	tokens      *objectsState[model.Token]
+}
+
+type objectsState[T any] struct {
+	*prefixtree.Tree[T]
+	initDone <-chan struct{}
+}
+
+type dependencies interface {
+	Clock() clock.Clock
+	Logger() log.Logger
+	Process() *servicectx.Process
+	Schema() *schema.Schema
+	EtcdClient() *etcd.Client
+}
+
+func NewState(d dependencies) *State {
+	ctx, cancel := context.WithCancel(context.Background())
+	s := &State{
+		ctx:    ctx,
+		wg:     &sync.WaitGroup{},
+		logger: d.Logger().AddPrefix("[watcher]"),
+		client: d.EtcdClient(),
+		lock:   &sync.RWMutex{},
+	}
+
+	d.Process().OnShutdown(func() {
+		s.logger.Info("received shutdown request")
+		cancel()
+		s.wg.Wait()
+		s.logger.Info("shutdown done")
+	})
+
+	sm := d.Schema()
+	s.receivers = watch(s, sm.Configs().Receivers().PrefixT())
+	s.exports = watch(s, sm.Configs().Exports().PrefixT())
+	s.mappings = watch(s, sm.Configs().Mappings().PrefixT())
+	s.openedFiles = watch(s, sm.Files().Opened().PrefixT())
+	s.tokens = watch(s, sm.Secrets().Tokens().PrefixT())
+
+	// Wait for initial load
+	startTime := d.Clock().Now()
+	<-s.receivers.initDone
+	<-s.exports.initDone
+	<-s.mappings.initDone
+	<-s.openedFiles.initDone
+	<-s.tokens.initDone
+	s.logger.Infof(`initialized | %s`, d.Clock().Since(startTime))
+	return s
+}
+
+func (s *State) Receiver(k key.ReceiverKey) (out model.Receiver, found bool) {
+	s.lock.RLock()
+	defer s.lock.RUnlock()
+
+	out.ReceiverBase, found = s.receivers.Get(k.String())
+	if !found {
+		return out, false
+	}
+
+	// Add exports
+	for _, base := range s.exports.AllFromPrefix(k.String()) {
+		if export, found := s.exportDetails(base); found {
+			out.Exports = append(out.Exports, export)
+		} else {
+			return out, false
+		}
+	}
+
+	return out, true
+}
+
+func (s *State) exportDetails(base model.ExportBase) (out model.Export, found bool) {
+	out.ExportBase = base
+
+	out.Mapping, found = s.mappings.LastFromPrefix(base.ExportKey.String())
+	if !found {
+		return out, false
+	}
+
+	out.Token, found = s.tokens.LastFromPrefix(base.ExportKey.String())
+	if !found {
+		return out, false
+	}
+
+	out.OpenedFile, found = s.openedFiles.LastFromPrefix(base.ExportKey.String())
+	if !found {
+		return out, false
+	}
+
+	return out, true
+}
+
+func (s *State) onError(err error) {
+	s.logger.Error(err)
+}
+
+func watch[T fmt.Stringer](s *State, prefix etcdop.PrefixT[T]) *objectsState[T] {
+	watchFactory := func() (out <-chan etcdop.EventT[T], initDone <-chan struct{}) {
+		return prefix.GetAllAndWatch(s.ctx, s.client, s.onError, etcd.WithCreatedNotify(), etcd.WithPrevKV())
+	}
+
+	tree := prefixtree.NewWithLock[T](s.lock)
+	ch, initDone := watchFactory()
+	s.wg.Add(1)
+	go func() {
+		defer s.wg.Done()
+
+		// Log only changes, not initial load
+		logsEnabled := false
+
+		for {
+			select {
+			case <-s.ctx.Done():
+				return
+			case <-initDone:
+				logsEnabled = true
+			case event, ok := <-ch:
+				if !ok {
+					return
+				}
+
+				switch event.Type {
+				case etcdop.CreateEvent, etcdop.UpdateEvent:
+					k := event.Value.String()
+					tree.Insert(k, event.Value)
+					if logsEnabled {
+						s.logger.Infof(`updated %s%s`, prefix.Prefix(), k)
+					}
+				case etcdop.DeleteEvent:
+					if event.PrevKv == nil {
+						panic("etcd.WithPrevKV() option must be used")
+					}
+					k := event.Value.String()
+					tree.Delete(k)
+					if logsEnabled {
+						s.logger.Infof(`deleted %s%s`, prefix.Prefix(), k)
+					}
+				default:
+					panic(errors.Errorf(`unexpected event type "%v"`, event.Type))
+				}
+			}
+		}
+	}()
+	return &objectsState[T]{tree, initDone}
+}

--- a/internal/pkg/service/buffer/worker/distribution/node.go
+++ b/internal/pkg/service/buffer/worker/distribution/node.go
@@ -132,9 +132,7 @@ func (n *Node) MustCheckIsOwner(key string) bool {
 
 func (n *Node) onWatchEvent(event etcdop.Event) {
 	switch event.Type {
-	case etcdop.CreateEvent:
-		fallthrough
-	case etcdop.UpdateEvent:
+	case etcdop.CreateEvent, etcdop.UpdateEvent:
 		nodeID := string(event.Kv.Value)
 		n.nodes.Add(nodeID)
 		n.logger.Infof(`found a new node "%s"`, nodeID)

--- a/internal/pkg/service/buffer/worker/distribution/node_test.go
+++ b/internal/pkg/service/buffer/worker/distribution/node_test.go
@@ -197,9 +197,10 @@ node3
 [node1][distribution]INFO  found a new node "node%d"
 [node1][distribution]INFO  found a new node "node%d"
 [node1]INFO  exiting (bye bye 1)
-[node1][distribution]INFO  cancelled watcher
+[node1][distribution]INFO  received shutdown request
 [node1][distribution]INFO  unregistering the node "node1"
 [node1][distribution]INFO  the node "node1" unregistered | %s
+[node1][distribution]INFO  shutdown done
 [node1][distribution]INFO  closed etcd session
 [node1]INFO  exited
 `, loggers[0].AllMessages())
@@ -215,9 +216,10 @@ node3
 [node2][distribution]INFO  found a new node "node%d"
 [node2][distribution]INFO  the node "node%d" gone
 [node2]INFO  exiting (bye bye 2)
-[node2][distribution]INFO  cancelled watcher
+[node2][distribution]INFO  received shutdown request
 [node2][distribution]INFO  unregistering the node "node2"
 [node2][distribution]INFO  the node "node2" unregistered | %s
+[node2][distribution]INFO  shutdown done
 [node2][distribution]INFO  closed etcd session
 [node2]INFO  exited
 `, loggers[1].AllMessages())
@@ -234,9 +236,10 @@ node3
 [node3][distribution]INFO  the node "node%d" gone
 [node3][distribution]INFO  the node "node%d" gone
 [node3]INFO  exiting (bye bye 3)
-[node3][distribution]INFO  cancelled watcher
+[node3][distribution]INFO  received shutdown request
 [node3][distribution]INFO  unregistering the node "node3"
 [node3][distribution]INFO  the node "node3" unregistered | %s
+[node3][distribution]INFO  shutdown done
 [node3][distribution]INFO  closed etcd session
 [node3]INFO  exited
 `, loggers[2].AllMessages())
@@ -274,9 +277,10 @@ node4
 [node4][distribution]INFO  watching for other nodes
 [node4][distribution]INFO  found a new node "node4"
 [node4]INFO  exiting (bye bye 4)
-[node4][distribution]INFO  cancelled watcher
+[node4][distribution]INFO  received shutdown request
 [node4][distribution]INFO  unregistering the node "node4"
 [node4][distribution]INFO  the node "node4" unregistered | %s
+[node4][distribution]INFO  shutdown done
 [node4][distribution]INFO  closed etcd session
 [node4]INFO  exited
 `, d4.DebugLogger().AllMessages())

--- a/internal/pkg/service/common/etcdop/prefix.go
+++ b/internal/pkg/service/common/etcdop/prefix.go
@@ -39,6 +39,10 @@ func (v PrefixT[T]) Prefix() string {
 	return v.prefix.Prefix()
 }
 
+func (v PrefixT[T]) PrefixT() PrefixT[T] {
+	return v
+}
+
 func (v PrefixT[T]) Add(str string) PrefixT[T] {
 	return PrefixT[T]{prefix: v.prefix.Add(str), serde: v.serde}
 }

--- a/internal/pkg/service/common/prefixtree/prefixtree.go
+++ b/internal/pkg/service/common/prefixtree/prefixtree.go
@@ -1,0 +1,83 @@
+// Package prefixtree wraps go-radix library, adds lock and generic type support.
+package prefixtree
+
+import (
+	"sync"
+
+	"github.com/armon/go-radix"
+)
+
+type Tree[T any] struct {
+	lock *sync.RWMutex
+	tree *radix.Tree
+}
+
+func New[T any]() *Tree[T] {
+	return NewWithLock[T](&sync.RWMutex{})
+}
+
+func NewWithLock[T any](lock *sync.RWMutex) *Tree[T] {
+	return &Tree[T]{
+		lock: lock,
+		tree: radix.New(),
+	}
+}
+
+func (t *Tree[T]) Insert(key string, value T) {
+	t.lock.Lock()
+	defer t.lock.Unlock()
+	t.tree.Insert(key, value)
+}
+
+func (t *Tree[T]) Delete(key string) bool {
+	t.lock.Lock()
+	defer t.lock.Unlock()
+	_, ok := t.tree.Delete(key)
+	return ok
+}
+
+func (t *Tree[T]) Get(key string) (T, bool) {
+	t.lock.RLock()
+	defer t.lock.RUnlock()
+	val, found := t.tree.Get(key)
+	if !found {
+		var empty T
+		return empty, false
+	}
+	return val.(T), true
+}
+
+func (t *Tree[T]) WalkPrefix(key string, fn func(key string, value T) (stop bool)) {
+	t.lock.RLock()
+	defer t.lock.RUnlock()
+	t.tree.WalkPrefix(key, func(key string, value interface{}) bool {
+		return fn(key, value.(T))
+	})
+}
+
+func (t *Tree[T]) AllFromPrefix(key string) []T {
+	var out []T
+	t.WalkPrefix(key, func(_ string, value T) bool {
+		out = append(out, value)
+		return false
+	})
+	return out
+}
+
+func (t *Tree[T]) FirstFromPrefix(key string) (value T, found bool) {
+	t.WalkPrefix(key, func(_ string, v T) bool {
+		value = v
+		found = true
+		return true
+	})
+	return
+}
+
+func (t *Tree[T]) LastFromPrefix(key string) (value T, found bool) {
+	t.WalkPrefix(key, func(_ string, v T) bool {
+		value = v
+		found = true
+		return false
+	})
+	return
+}

--- a/internal/pkg/service/common/prefixtree/prefixtree_test.go
+++ b/internal/pkg/service/common/prefixtree/prefixtree_test.go
@@ -1,0 +1,71 @@
+package prefixtree_test
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+
+	. "github.com/keboola/keboola-as-code/internal/pkg/service/common/prefixtree"
+)
+
+type value struct {
+	field string
+}
+
+func TestPrefixTree(t *testing.T) {
+	t.Parallel()
+	tree := New[value]()
+
+	// Get - not found
+	_, found := tree.Get("key/1")
+	assert.False(t, found)
+
+	// AllFromPrefix - no value
+	assert.Len(t, tree.AllFromPrefix("key"), 0)
+	_, found = tree.FirstFromPrefix("key")
+	assert.False(t, found)
+	_, found = tree.LastFromPrefix("key")
+	assert.False(t, found)
+
+	// -----
+	tree.Insert("key/1", value{field: "value1"})
+	tree.Insert("key/2", value{field: "value2"})
+
+	// Get - found
+	v, found := tree.Get("key/1")
+	assert.True(t, found)
+	assert.Equal(t, value{field: "value1"}, v)
+	v, found = tree.Get("key/2")
+	assert.True(t, found)
+	assert.Equal(t, value{field: "value2"}, v)
+
+	// AllFromPrefix - 2 items
+	assert.Len(t, tree.AllFromPrefix("key"), 2)
+	v, found = tree.FirstFromPrefix("key")
+	assert.True(t, found)
+	assert.Equal(t, value{field: "value1"}, v)
+	v, found = tree.LastFromPrefix("key")
+	assert.True(t, found)
+	assert.Equal(t, value{field: "value2"}, v)
+
+	// -----
+	tree.Delete("key/2")
+
+	// Get - found
+	v, found = tree.Get("key/1")
+	assert.True(t, found)
+	assert.Equal(t, value{field: "value1"}, v)
+
+	// Get - not found
+	_, found = tree.Get("key/2")
+	assert.False(t, found)
+
+	// AllFromPrefix - 1 item
+	assert.Len(t, tree.AllFromPrefix("key"), 1)
+	v, found = tree.FirstFromPrefix("key")
+	assert.True(t, found)
+	assert.Equal(t, value{field: "value1"}, v)
+	v, found = tree.LastFromPrefix("key")
+	assert.True(t, found)
+	assert.Equal(t, value{field: "value1"}, v)
+}

--- a/test/api/buffer/api_test.go
+++ b/test/api/buffer/api_test.go
@@ -443,9 +443,11 @@ func RunRequests(
 		assert.NoError(t, err)
 
 		// Dump raw HTTP response
-		respDump, err := httputil.DumpResponse(resp.RawResponse, false)
-		assert.NoError(t, err)
-		assert.NoError(t, workingDirFs.WriteFile(filesystem.NewRawFile(filesystem.Join(requestDir, "response.txt"), string(respDump)+string(resp.Body()))))
+		if err == nil {
+			respDump, err := httputil.DumpResponse(resp.RawResponse, false)
+			assert.NoError(t, err)
+			assert.NoError(t, workingDirFs.WriteFile(filesystem.NewRawFile(filesystem.Join(requestDir, "response.txt"), string(respDump)+string(resp.Body()))))
+		}
 
 		// Compare response body
 		expectedRespFile, err := testDirFs.ReadFile(filesystem.NewFileDef(filesystem.Join(requestDir, "expected-response.json")))

--- a/test/api/buffer/api_test.go
+++ b/test/api/buffer/api_test.go
@@ -15,6 +15,7 @@ import (
 	"runtime"
 	"strings"
 	"sync"
+	"syscall"
 	"testing"
 	"time"
 
@@ -114,7 +115,7 @@ func RunE2ETest(t *testing.T, testDir, workingDir string, binary string) {
 	testhelper.MustReplaceEnvsDir(workingDirFs, `/`, envProvider)
 
 	// Run API server
-	apiUrl, apiEnvs, stdout, stderr := RunApiServer(t, binary, project.StorageAPIHost())
+	apiUrl, apiEnvs, cmd, cmdWaitCh, stdout, stderr := RunApiServer(t, binary, project.StorageAPIHost())
 
 	// Connect to the etcd
 	etcdClient := etcdhelper.ClientForTestFrom(
@@ -135,8 +136,17 @@ func RunE2ETest(t *testing.T, testDir, workingDir string, binary string) {
 		assert.NoError(t, err)
 	}
 
-	// Assert
+	// Request
 	requestsOk := RunRequests(t, envProvider, testDirFs, workingDirFs, apiUrl, etcdClient)
+
+	// Shutdown API server
+	_ = cmd.Process.Signal(syscall.SIGTERM)
+	select {
+	case <-time.After(10 * time.Second):
+		t.Fatalf("timeout while waiting for server shutdown")
+	case <-cmdWaitCh:
+		// continue
+	}
 
 	// Optionally check project state
 	expectedStatePath := "expected-state.json"
@@ -291,7 +301,7 @@ func waitForAPI(cmdErrCh <-chan error, apiUrl string) error {
 }
 
 // RunApiServer runs the compiled api binary on the background.
-func RunApiServer(t *testing.T, binary string, storageApiHost string) (apiUrl string, p env.Provider, stdout, stderr *cmdOut) {
+func RunApiServer(t *testing.T, binary string, storageApiHost string) (apiUrl string, p env.Provider, cmd *exec.Cmd, cmdWait <-chan error, stdout, stderr *cmdOut) {
 	t.Helper()
 
 	// Get a free port
@@ -323,7 +333,7 @@ func RunApiServer(t *testing.T, binary string, storageApiHost string) (apiUrl st
 	// Start API server
 	stdout = newCmdOut()
 	stderr = newCmdOut()
-	cmd := exec.Command(binary, args...)
+	cmd = exec.Command(binary, args...)
 	cmd.Env = envs.ToSlice()
 	cmd.Stdout = io.MultiWriter(stdout, testhelper.VerboseStdout())
 	cmd.Stderr = io.MultiWriter(stderr, testhelper.VerboseStderr())
@@ -331,16 +341,14 @@ func RunApiServer(t *testing.T, binary string, storageApiHost string) (apiUrl st
 		t.Fatalf("Server failed to start: %s", err)
 	}
 
-	cmdErrCh := make(chan error, 1)
+	cmdWaitCh := make(chan error, 1)
 	go func() {
-		cmdErrCh <- cmd.Wait()
+		cmdWaitCh <- cmd.Wait()
 	}()
 
 	t.Cleanup(func() {
 		// kill api server
-		if err := cmd.Process.Kill(); err != nil {
-			assert.NoError(t, err)
-		}
+		_ = cmd.Process.Kill()
 
 		// delete etcd namespace
 		ctx := context.Background()
@@ -356,7 +364,7 @@ func RunApiServer(t *testing.T, binary string, storageApiHost string) (apiUrl st
 	})
 
 	// Wait for API server
-	if err = waitForAPI(cmdErrCh, apiUrl); err != nil {
+	if err = waitForAPI(cmdWaitCh, apiUrl); err != nil {
 		t.Fatalf(
 			"Unexpected error while waiting for API: %s\n\nServer STDERR:%s\n\nServer STDOUT:%s\n",
 			err,
@@ -365,7 +373,7 @@ func RunApiServer(t *testing.T, binary string, storageApiHost string) (apiUrl st
 		)
 	}
 
-	return apiUrl, envs, stdout, stderr
+	return apiUrl, envs, cmd, cmdWaitCh, stdout, stderr
 }
 
 type ApiRequest struct {

--- a/test/api/buffer/import/import/expected-etcd-kvs.txt
+++ b/test/api/buffer/import/import/expected-etcd-kvs.txt
@@ -120,13 +120,13 @@
 >>>>>
 
 <<<<<
-/record/%%TEST_KBC_PROJECT_ID%%/receiver-1/export-1/%s/%s
+/record/%%TEST_KBC_PROJECT_ID%%/receiver-1/export-1/%sZ/%sZ_%c%c%c%c%c
 -----
 <<~~id~~>>,"{""col1"":""val1"",""col2"":""val2""}","{""Accept"":""application/json"",""Accept-Encoding"":""gzip"",""Content-Length"":""29"",""Content-Type"":""application/json"",""User-Agent"":""%s""}",%s,%s,"""val1:val2"""
 >>>>>
 
 <<<<<
-/record/%%TEST_KBC_PROJECT_ID%%/receiver-1/export-1/%s/%s
+/record/%%TEST_KBC_PROJECT_ID%%/receiver-1/export-1/%sZ/%sZ_%c%c%c%c%c
 -----
 <<~~id~~>>,"{""col1"":""val3"",""col2"":""val4""}","{""Accept-Encoding"":""gzip"",""Content-Length"":""19"",""Content-Type"":""application/x-www-form-urlencoded"",""User-Agent"":""%s""}",%s,%s,"""val3:val4"""
 >>>>>
@@ -164,7 +164,7 @@
 >>>>>
 
 <<<<<
-/slice/opened/%%TEST_KBC_PROJECT_ID%%/receiver-1/export-1/%s
+/slice/opened/%%TEST_KBC_PROJECT_ID%%/receiver-1/export-1/%sZ/%sZ
 -----
 {
   "projectId": %%TEST_KBC_PROJECT_ID%%,
@@ -174,5 +174,35 @@
   "sliceId": "%s",
   "state": "opened",
   "sliceNumber": 1
+}
+>>>>>
+
+<<<<<
+/stats/received/%%TEST_KBC_PROJECT_ID%%/receiver-1/export-1/%sZ/%sZ/%s
+-----
+{
+  "projectId": %%TEST_KBC_PROJECT_ID%%,
+  "receiverId": "receiver-1",
+  "exportId": "export-1",
+  "fileId": "%s",
+  "sliceId": "%s",
+  "count": 1,
+  "size": %d,
+  "lastReceivedAt": "%s"
+}
+>>>>>
+
+<<<<<
+/stats/received/%%TEST_KBC_PROJECT_ID%%/receiver-1/export-1/%sZ/%sZ/%s
+-----
+{
+  "projectId": %%TEST_KBC_PROJECT_ID%%,
+  "receiverId": "receiver-1",
+  "exportId": "export-1",
+  "fileId": "%s",
+  "sliceId": "%s",
+  "count": 1,
+  "size": %d,
+  "lastReceivedAt": "%s"
 }
 >>>>>

--- a/test/api/templates/api_test.go
+++ b/test/api/templates/api_test.go
@@ -366,9 +366,11 @@ func RunRequests(
 		assert.NoError(t, err)
 
 		// Dump raw HTTP response
-		respDump, err := httputil.DumpResponse(resp.RawResponse, false)
-		assert.NoError(t, err)
-		assert.NoError(t, workingDirFs.WriteFile(filesystem.NewRawFile(filesystem.Join(requestDir, "response.txt"), string(respDump)+string(resp.Body()))))
+		if err == nil {
+			respDump, err := httputil.DumpResponse(resp.RawResponse, false)
+			assert.NoError(t, err)
+			assert.NoError(t, workingDirFs.WriteFile(filesystem.NewRawFile(filesystem.Join(requestDir, "response.txt"), string(respDump)+string(resp.Body()))))
+		}
 
 		// Compare response body
 		expectedRespFile, err := testDirFs.ReadFile(filesystem.NewFileDef(filesystem.Join(requestDir, "expected-response.json")))

--- a/test/api/templates/api_test.go
+++ b/test/api/templates/api_test.go
@@ -15,6 +15,7 @@ import (
 	"runtime"
 	"strings"
 	"sync"
+	"syscall"
 	"testing"
 	"time"
 
@@ -116,10 +117,19 @@ func RunE2ETest(t *testing.T, testDir, workingDir string, binary string) {
 	}
 
 	// Run API server
-	apiUrl, stdout, stderr := RunApiServer(t, binary, project.StorageAPIHost(), repositories)
+	apiUrl, cmd, cmdWaitCh, stdout, stderr := RunApiServer(t, binary, project.StorageAPIHost(), repositories)
 
-	// Assert
+	// Request
 	requestsOk := RunRequests(t, envProvider, testDirFs, workingDirFs, apiUrl)
+
+	// Shutdown API server
+	_ = cmd.Process.Signal(syscall.SIGTERM)
+	select {
+	case <-time.After(10 * time.Second):
+		t.Fatalf("timeout while waiting for server shutdown")
+	case <-cmdWaitCh:
+		// continue
+	}
 
 	// Optionally check project state
 	expectedStatePath := "expected-state.json"
@@ -250,7 +260,7 @@ func waitForAPI(cmdErrCh <-chan error, apiUrl string) error {
 }
 
 // RunApiServer runs the compiled api binary on the background.
-func RunApiServer(t *testing.T, binary string, storageApiHost string, repositories string) (apiUrl string, stdout, stderr *cmdOut) {
+func RunApiServer(t *testing.T, binary string, storageApiHost string, repositories string) (apiUrl string, cmd *exec.Cmd, cmdWait <-chan error, stdout, stderr *cmdOut) {
 	t.Helper()
 
 	// Get a free port
@@ -277,7 +287,7 @@ func RunApiServer(t *testing.T, binary string, storageApiHost string, repositori
 	// Start API server
 	stdout = newCmdOut()
 	stderr = newCmdOut()
-	cmd := exec.Command(binary, args...)
+	cmd = exec.Command(binary, args...)
 	cmd.Env = envs.ToSlice()
 	cmd.Stdout = io.MultiWriter(stdout, testhelper.VerboseStdout())
 	cmd.Stderr = io.MultiWriter(stderr, testhelper.VerboseStderr())
@@ -285,20 +295,19 @@ func RunApiServer(t *testing.T, binary string, storageApiHost string, repositori
 		t.Fatalf("Server failed to start: %s", err)
 	}
 
-	cmdErrCh := make(chan error, 1)
+	cmdWaitCh := make(chan error, 1)
 	go func() {
-		cmdErrCh <- cmd.Wait()
+		cmdWaitCh <- cmd.Wait()
+		close(cmdWaitCh)
 	}()
 
 	// Kill API server after test
 	t.Cleanup(func() {
-		if err := cmd.Process.Kill(); err != nil {
-			assert.NoError(t, err)
-		}
+		_ = cmd.Process.Kill()
 	})
 
 	// Wait for API server
-	if err = waitForAPI(cmdErrCh, apiUrl); err != nil {
+	if err = waitForAPI(cmdWaitCh, apiUrl); err != nil {
 		t.Fatalf(
 			"Unexpected error while waiting for API: %s\n\nServer STDERR:%s\n\nServer STDOUT:%s\n",
 			err,
@@ -307,7 +316,7 @@ func RunApiServer(t *testing.T, binary string, storageApiHost string, repositori
 		)
 	}
 
-	return apiUrl, stdout, stderr
+	return apiUrl, cmd, cmdWaitCh, stdout, stderr
 }
 
 type ApiRequest struct {


### PR DESCRIPTION
Part of: https://keboola.atlassian.net/browse/BA-14

Changes:
- Optimized import endpoint
- data is cached in the memory (by etcd watch API)
- data is not loaded from the etcd on each import request.

------

`stderr` E2E testu `import/import`:
![image](https://user-images.githubusercontent.com/19371734/208991968-b7ad83e5-3651-4f87-8a18-d6d5ef1b58a3.png)

- :green_circle: logs zmien prijatych cez etcd watch
- :large_blue_circle: `404` request, overit secret vieme bez toho, aby sme nieco museli tahat z etcd
- :purple_circle: import request, z `2ms` zabera najviac vykonanie `Jsonnet` sablony

------

Samotna implementacia je tu, zvysok su nejake pripravy a opravy:
https://github.com/keboola/keboola-as-code/blob/d50134ce2a2c1f7f286290f83a652bbdc26a675a/internal/pkg/service/buffer/store/watcher/state.go