### PR TITLE
Cat install log if msiexec fails + add timeout

### DIFF
--- a/.github/workflows/release-cli.yml
+++ b/.github/workflows/release-cli.yml
@@ -531,10 +531,22 @@ jobs:
           curl "${BASE_URL}/msi/${MSI_FILE}" --output install.msi
 
       - name: Install on Windows from MSI
-        shell: bash
+        timeout-minutes: 2
+        continue-on-error: true
         run: |
-          msiexec /i install.msi /quiet /qn /l*vx install_log.txt
-          [ ! -d "C:\Program Files\Keboola CLI" ] && exit 1
+          msiexec /i install.msi /quiet /qn /le install_log.txt
+
+      - name: Get the Install log
+        run: |
+          if (Test-Path "install_log.txt") {
+            Get-Content -Path install_log.txt
+          }
+
+      - name: Check the CLI was installed
+        run: |
+          if (!(Test-Path "C:\Program Files\Keboola CLI")) {
+            Exit 1
+          }
 
       - name: Install on Windows using Scoop
         run: |
@@ -543,4 +555,3 @@ jobs:
           scoop install keboola/keboola-cli
           kbc --version
           If (-Not (kbc --version | Select-String -Quiet "Version:    $($env:VERSION)")) { throw "kbc command not installed properly" }
-

--- a/.github/workflows/test-lint.yml
+++ b/.github/workflows/test-lint.yml
@@ -31,4 +31,3 @@ jobs:
       - name: Run code linters
         run: make lint
         shell: bash
-


### PR DESCRIPTION
(Pokus o fix timeoutující instalace MSI v CI)

Mno, přidal jsem timeout na tu instalaci a zbytek je trochu výstřel naslepo. 🙂 Proč to timeoutuje pořád netuším, ale raději bych to pouštěl v Power Shellu stejně jak jsem to zkoušel na notebooku. A trochu doufám, že to třeba i vyřeší ten timeout. 😅 

Potom jsem přidal vypsání install logu pokud instalace vyfailuje. V `msiexec` jsem změnil parametry logování, `/le` loguje jen chyby. Ty předchozí parametry logovaly všechno možný a spíš byl problém v tom najít něco smysluplnýho než že by to pomáhalo debugování.