### PR TITLE
Simplify MergeToTxn function

### DIFF
--- a/internal/pkg/service/buffer/store/file.go
+++ b/internal/pkg/service/buffer/store/file.go
@@ -90,7 +90,7 @@ func (s *Store) SetFileState(ctx context.Context, now time.Time, file *model.Fil
 	return true, nil
 }
 
-func (s *Store) setFileStateOp(ctx context.Context, now time.Time, file *model.File, to filestate.State) (*op.TxnOp, error) {
+func (s *Store) setFileStateOp(ctx context.Context, now time.Time, file *model.File, to filestate.State) (*op.TxnOpDef, error) {
 	from := file.State
 	clone := *file
 	stm := filestate.NewSTM(file.State, func(ctx context.Context, from, to filestate.State) error {
@@ -125,7 +125,7 @@ func (s *Store) setFileStateOp(ctx context.Context, now time.Time, file *model.F
 
 	// Create transaction
 	txn := op.
-		MergeToTxn(ctx, ops...).
+		MergeToTxn(ops...).
 		WithProcessor(func(_ context.Context, _ *etcd.TxnResponse, result op.TxnResult, err error) error {
 			if err == nil {
 				*file = clone

--- a/internal/pkg/service/buffer/store/receiver.go
+++ b/internal/pkg/service/buffer/store/receiver.go
@@ -33,7 +33,7 @@ func (s *Store) CreateReceiver(ctx context.Context, receiver model.Receiver) (er
 	for _, export := range receiver.Exports {
 		ops = append(ops, s.createExportOp(ctx, export))
 	}
-	_, err = op.MergeToTxn(ctx, ops...).Do(ctx, s.client)
+	_, err = op.MergeToTxn(ops...).Do(ctx, s.client)
 	return err
 }
 
@@ -98,7 +98,7 @@ func (s *Store) UpdateReceiver(ctx context.Context, k key.ReceiverKey, fn func(m
 
 	receiver, err = fn(receiver)
 
-	_, err = op.MergeToTxn(ctx, s.updateReceiverBaseOp(ctx, receiver.ReceiverBase)).Do(ctx, s.client)
+	_, err = op.MergeToTxn(s.updateReceiverBaseOp(ctx, receiver.ReceiverBase)).Do(ctx, s.client)
 
 	return err
 }
@@ -151,7 +151,6 @@ func (s *Store) DeleteReceiver(ctx context.Context, receiverKey key.ReceiverKey)
 	defer telemetry.EndSpan(span, &err)
 
 	_, err = op.MergeToTxn(
-		ctx,
 		s.deleteReceiverBaseOp(ctx, receiverKey),
 		s.deleteReceiverExportsOp(ctx, receiverKey),
 		s.deleteReceiverMappingsOp(ctx, receiverKey),

--- a/internal/pkg/service/buffer/store/slice.go
+++ b/internal/pkg/service/buffer/store/slice.go
@@ -119,7 +119,7 @@ func (s *Store) SetSliceState(ctx context.Context, slice *model.Slice, to slices
 	return true, nil
 }
 
-func (s *Store) setSliceStateOp(ctx context.Context, now time.Time, slice *model.Slice, to slicestate.State) (*op.TxnOp, error) { //nolint:dupl
+func (s *Store) setSliceStateOp(ctx context.Context, now time.Time, slice *model.Slice, to slicestate.State) (*op.TxnOpDef, error) { //nolint:dupl
 	from := slice.State
 	clone := *slice
 	stm := slicestate.NewSTM(slice.State, func(ctx context.Context, from, to slicestate.State) error {
@@ -149,7 +149,6 @@ func (s *Store) setSliceStateOp(ctx context.Context, now time.Time, slice *model
 	// Atomically swap keys in the transaction
 	txn := op.
 		MergeToTxn(
-			ctx,
 			s.schema.Slices().InState(from).ByKey(slice.SliceKey).DeleteIfExists(),
 			s.schema.Slices().InState(to).ByKey(slice.SliceKey).PutIfNotExists(clone),
 		).

--- a/internal/pkg/service/buffer/store/token.go
+++ b/internal/pkg/service/buffer/store/token.go
@@ -34,7 +34,7 @@ func (s *Store) UpdateTokens(ctx context.Context, tokens []model.Token) (err err
 		ops = append(ops, s.updateTokenOp(ctx, token))
 	}
 
-	_, err = op.MergeToTxn(ctx, ops...).Do(ctx, s.client)
+	_, err = op.MergeToTxn(ops...).Do(ctx, s.client)
 
 	return err
 }

--- a/internal/pkg/service/buffer/worker/task/node.go
+++ b/internal/pkg/service/buffer/worker/task/node.go
@@ -111,7 +111,6 @@ func (n *Node) StartTask(ctx context.Context, exportKey key.ExportKey, lock stri
 	// Atomicity: If the lock key already exists, the then the transaction fails and task is ignored.
 	// Resistance to outages: If the Worker node fails, the lock is released automatically by the lease, after the session TTL seconds.
 	createTaskOp := op.MergeToTxn(
-		ctx,
 		taskEtcdKey.Put(task),
 		lockEtcdKey.PutIfNotExists(task.WorkerNode, etcd.WithLease(n.session.Lease())),
 	)
@@ -163,7 +162,6 @@ func (n *Node) StartTask(ctx context.Context, exportKey key.ExportKey, lock stri
 
 			// Update task and release lock in etcd
 			finishTaskOp := op.MergeToTxn(
-				opCtx,
 				taskEtcdKey.Put(task),
 				lockEtcdKey.DeleteIfExists(),
 			)

--- a/internal/pkg/service/common/etcdop/op/join.go
+++ b/internal/pkg/service/common/etcdop/op/join.go
@@ -8,15 +8,15 @@ import (
 
 type JoinTo[R any] struct {
 	result *R
-	txn    *TxnOp
+	txn    *TxnOpDef
 }
 
 // Join is a wrapper over a transaction mapped to a result R.
 // For usage see tests.
-func Join[R any](ctx context.Context, result *R, ops ...Op) JoinTo[R] {
+func Join[R any](result *R, ops ...Op) JoinTo[R] {
 	return JoinTo[R]{
 		result: result,
-		txn:    MergeToTxn(ctx, ops...),
+		txn:    MergeToTxn(ops...),
 	}
 }
 

--- a/internal/pkg/service/common/etcdop/op/join_test.go
+++ b/internal/pkg/service/common/etcdop/op/join_test.go
@@ -30,7 +30,6 @@ func TestJoin(t *testing.T) {
 	// Use Join
 	result := fooResult{}
 	joinTxn := Join(
-		ctx,
 		&result,
 		key1.Get().WithOnResult(func(kv *KeyValue) {
 			result.field1 = string(kv.Value)

--- a/internal/pkg/service/common/etcdop/op/txn_test.go
+++ b/internal/pkg/service/common/etcdop/op/txn_test.go
@@ -160,7 +160,7 @@ func TestMergeToTxn_ToRaw_Complex(t *testing.T) {
 	t.Parallel()
 
 	ctx := context.Background()
-	txn1 := MergeToTxn(ctx, opsForTest(false)...)
+	txn1 := MergeToTxn(opsForTest(false)...).Txn(ctx)
 
 	// Add another IF
 	txn1.If(etcd.Compare(etcd.Version("missingKey"), "=", 0))
@@ -210,7 +210,6 @@ func TestMergeToTxn_ToRaw_Nested_Txn(t *testing.T) {
 
 	// Merge 3 operations
 	txn := MergeToTxn(
-		ctx,
 		NewTxnOp().
 			If(etcd.Compare(etcd.Version("shouldBeMissing1"), "=", 0)).
 			Then(
@@ -413,11 +412,9 @@ func TestMergeToTxn_Processors(t *testing.T) {
 		}
 	}
 	txn := MergeToTxn(
-		ctx,
 		pfx.Key("key1").PutIfNotExists("value").WithProcessor(createProcessor("key1")),
 		pfx.Key("key2").PutIfNotExists("value").WithProcessor(createProcessor("key2")),
 		MergeToTxn(
-			ctx,
 			pfx.Key("key3").PutIfNotExists("value").WithProcessor(createProcessor("key3")),
 			pfx.Key("key4").PutIfNotExists("value").WithProcessor(createProcessor("key4")),
 		),


### PR DESCRIPTION
Part of: https://keboola.atlassian.net/browse/BA-40

Changes:
- Simplified `MergeToTxn` function, `ctx` is not required.