### PR TITLE
Remove slice "closed" state, "closing" -> "uploading"

### DIFF
--- a/internal/pkg/service/buffer/store/model/slice.go
+++ b/internal/pkg/service/buffer/store/model/slice.go
@@ -16,7 +16,6 @@ type Slice struct {
 	Mapping     Mapping          `json:"mapping" validate:"required,dive"`
 	Number      int              `json:"sliceNumber" validate:"required"`
 	ClosingAt   *time.Time       `json:"closingAt,omitempty"`
-	ClosedAt    *time.Time       `json:"closedAt,omitempty"`
 	UploadingAt *time.Time       `json:"uploadingAt,omitempty"`
 	UploadedAt  *time.Time       `json:"uploadedAt,omitempty"`
 	FailedAt    *time.Time       `json:"failedAt,omitempty"`

--- a/internal/pkg/service/buffer/store/schema/slice.go
+++ b/internal/pkg/service/buffer/store/schema/slice.go
@@ -45,10 +45,6 @@ func (v Slices) Closing() SlicesInAState {
 	return v.InState(slicestate.Closing)
 }
 
-func (v Slices) Closed() SlicesInAState {
-	return v.InState(slicestate.Closed)
-}
-
 func (v Slices) Uploading() SlicesInAState {
 	return v.InState(slicestate.Uploading)
 }

--- a/internal/pkg/service/buffer/store/slice.go
+++ b/internal/pkg/service/buffer/store/slice.go
@@ -128,8 +128,6 @@ func (s *Store) setSliceStateOp(ctx context.Context, now time.Time, slice *model
 		switch to {
 		case slicestate.Closing:
 			clone.ClosingAt = &now
-		case slicestate.Closed:
-			clone.ClosedAt = &now
 		case slicestate.Uploading:
 			clone.UploadingAt = &now
 		case slicestate.Uploaded:

--- a/internal/pkg/service/buffer/store/slice_test.go
+++ b/internal/pkg/service/buffer/store/slice_test.go
@@ -111,8 +111,7 @@ func TestStore_SetSliceState_Transitions(t *testing.T) {
 	// Test all transitions
 	testCases := []struct{ from, to slicestate.State }{
 		{slicestate.Opened, slicestate.Closing},
-		{slicestate.Closing, slicestate.Closed},
-		{slicestate.Closed, slicestate.Uploading},
+		{slicestate.Closing, slicestate.Uploading},
 		{slicestate.Uploading, slicestate.Failed},
 		{slicestate.Failed, slicestate.Uploading},
 		{slicestate.Uploading, slicestate.Uploaded},

--- a/internal/pkg/service/buffer/store/slicestate/slicestate.go
+++ b/internal/pkg/service/buffer/store/slicestate/slicestate.go
@@ -18,12 +18,9 @@ const Opened State = "opened"
 // Waiting for the API nodes until they switch to the new slice.
 const Closing State = "closing"
 
-// Closed
-// The slice is ready for upload.
-const Closed State = "closed"
-
 // Uploading
-// Slice upload into the file storage is in progress.
+// The slice is ready for upload.
+// Some worker is/will be uploading it.
 const Uploading State = "uploading"
 
 // Uploaded
@@ -49,8 +46,7 @@ func NewSTM(state State, fn onEntry) *STM {
 		return errors.Errorf(`slice state transition "%s" -> "%s" is not allowed`, state, trigger)
 	})
 	v.permit(Opened, Closing)
-	v.permit(Closing, Closed)
-	v.permit(Closed, Uploading)
+	v.permit(Closing, Uploading)
 	v.permit(Uploading, Failed)
 	v.permit(Failed, Uploading)
 	v.permit(Uploading, Uploaded)


### PR DESCRIPTION
Part of: https://keboola.atlassian.net/browse/BA-40

Changes:
- Removed unused slice `closed` state.