### PR TITLE
distribution: Add support for listeners

### DIFF
--- a/internal/pkg/service/buffer/worker/distribution/config.go
+++ b/internal/pkg/service/buffer/worker/distribution/config.go
@@ -5,21 +5,31 @@ import (
 )
 
 const (
-	DefaultSessionTTL      = 15               // seconds, see WithTTL
-	DefaultStartupTimeout  = 60 * time.Second // timeout for registration, PUT operation
-	DefaultShutdownTimeout = 5 * time.Second  // timeout for un-registration, DELETE operation
+	DefaultSessionTTL           = 15               // seconds, see WithTTL
+	DefaultStartupTimeout       = 60 * time.Second // timeout for registration, PUT operation
+	DefaultShutdownTimeout      = 5 * time.Second  // timeout for un-registration, DELETE operation
+	DefaultSelfDiscoveryTimeout = 30 * time.Second // timeout, how long the Node should wait to discover itself back by the etcd watcher.
+	DefaultEventsGroupInterval  = 5 * time.Second  // all changes in the interval are grouped together, so that updates do not occur too often
 )
 
 type Option func(c *config)
 
 type config struct {
-	startupTimeout  time.Duration
-	shutdownTimeout time.Duration
-	ttlSeconds      int
+	startupTimeout       time.Duration
+	shutdownTimeout      time.Duration
+	selfDiscoveryTimeout time.Duration
+	eventsGroupInterval  time.Duration
+	ttlSeconds           int
 }
 
 func defaultConfig() config {
-	return config{startupTimeout: DefaultStartupTimeout, shutdownTimeout: DefaultShutdownTimeout, ttlSeconds: DefaultSessionTTL}
+	return config{
+		startupTimeout:       DefaultStartupTimeout,
+		shutdownTimeout:      DefaultShutdownTimeout,
+		selfDiscoveryTimeout: DefaultSelfDiscoveryTimeout,
+		eventsGroupInterval:  DefaultEventsGroupInterval,
+		ttlSeconds:           DefaultSessionTTL,
+	}
 }
 
 // WithStartupTimeout defines node registration timeout on the node startup.
@@ -33,6 +43,21 @@ func WithStartupTimeout(v time.Duration) Option {
 func WithShutdownTimeout(v time.Duration) Option {
 	return func(c *config) {
 		c.shutdownTimeout = v
+	}
+}
+
+// WithSelfDiscoveryTimeout defines how long the Node should wait to discover itself back by the etcd watcher.
+func WithSelfDiscoveryTimeout(v time.Duration) Option {
+	return func(c *config) {
+		c.selfDiscoveryTimeout = v
+	}
+}
+
+// WithEventsGroupInterval defines events grouping interval.
+// All changes in the interval are grouped together, so that updates do not occur too often.
+func WithEventsGroupInterval(v time.Duration) Option {
+	return func(c *config) {
+		c.eventsGroupInterval = v
 	}
 }
 

--- a/internal/pkg/service/buffer/worker/distribution/event.go
+++ b/internal/pkg/service/buffer/worker/distribution/event.go
@@ -1,0 +1,16 @@
+package distribution
+
+const (
+	EventTypeAdd EventType = iota
+	EventTypeRemove
+)
+
+type EventType int
+
+type Events []Event
+
+type Event struct {
+	Type    EventType
+	NodeID  string
+	Message string
+}

--- a/internal/pkg/service/buffer/worker/distribution/listener.go
+++ b/internal/pkg/service/buffer/worker/distribution/listener.go
@@ -1,0 +1,144 @@
+package distribution
+
+import (
+	"context"
+	"sync"
+
+	"github.com/benbjohnson/clock"
+	gonanoid "github.com/matoous/go-nanoid/v2"
+
+	"github.com/keboola/keboola-as-code/internal/pkg/log"
+	"github.com/keboola/keboola-as-code/internal/pkg/service/common/servicectx"
+)
+
+// Listener contains channel C with distribution change Events.
+type Listener struct {
+	ctx    context.Context
+	cancel context.CancelFunc
+	wg     *sync.WaitGroup
+	all    *listeners
+	id     listenerID
+	C      chan Events
+}
+
+type listeners struct {
+	lock           *sync.Mutex
+	bufferedEvents []Event
+	listeners      map[listenerID]*Listener
+}
+
+type listenerID string
+
+func newListeners(proc *servicectx.Process, clock clock.Clock, logger log.Logger, config config) *listeners {
+	logger = logger.AddPrefix("[listeners]")
+	v := &listeners{
+		lock:      &sync.Mutex{},
+		listeners: make(map[listenerID]*Listener),
+	}
+
+	// Graceful shutdown
+	ctx, cancel := context.WithCancel(context.Background())
+	wg := &sync.WaitGroup{}
+	proc.OnShutdown(func() {
+		logger.Info("received shutdown request")
+		cancel()
+		wg.Wait()
+		logger.Info("shutdown done")
+	})
+
+	wg.Add(1)
+	go func() {
+		defer wg.Done()
+
+		// Listeners are not triggered immediately on change,
+		// but all events within the groupInterval are processed at once.
+		triggerTicker := clock.Ticker(config.eventsGroupInterval)
+		defer triggerTicker.Stop()
+
+		for {
+			select {
+			case <-ctx.Done():
+				// Handle shutdown
+				logger.Info("waiting for listeners")
+				v.lock.Lock()
+				// Process remaining events
+				v.trigger()
+				// Stop all listeners
+				for _, l := range v.listeners {
+					l.wg.Wait()
+					l.cancel()
+					close(l.C)
+				}
+				v.listeners = nil
+				v.lock.Unlock()
+				return
+			case <-triggerTicker.C:
+				// Trigger listeners at most once per "group interval"
+				v.lock.Lock()
+				v.trigger()
+				v.lock.Unlock()
+			}
+		}
+	}()
+
+	return v
+}
+
+// Notify listeners about a new event. The event is not processed immediately.
+// All events within the "group interval" are processed at once, see trigger method.
+func (v *listeners) Notify(event Event) {
+	v.lock.Lock()
+	v.bufferedEvents = append(v.bufferedEvents, event)
+	v.lock.Unlock()
+}
+
+// add a new listener, it contains channel C with streamed distribution change Events.
+func (v *listeners) add() *Listener {
+	ctx, cancel := context.WithCancel(context.Background())
+	out := &Listener{
+		ctx:    ctx,
+		cancel: cancel,
+		wg:     &sync.WaitGroup{},
+		all:    v,
+		id:     listenerID(gonanoid.Must(10)),
+		C:      make(chan Events),
+	}
+	v.lock.Lock()
+	v.listeners[out.id] = out
+	v.lock.Unlock()
+	return out
+}
+
+func (v *listeners) trigger() {
+	for _, l := range v.listeners {
+		l.trigger(v.bufferedEvents)
+	}
+	v.bufferedEvents = nil
+}
+
+func (l *Listener) Stop() {
+	l.all.lock.Lock()
+	defer l.all.lock.Unlock()
+
+	l.cancel()
+	l.wg.Wait()
+	close(l.C)
+	delete(l.all.listeners, l.id)
+}
+
+func (l *Listener) trigger(events Events) {
+	if len(events) == 0 {
+		return
+	}
+
+	l.wg.Add(1)
+	go func() {
+		defer l.wg.Done()
+		select {
+		case <-l.ctx.Done():
+			// stop goroutine on stop/shutdown
+		case l.C <- events:
+			// propagate events, wait for other side
+		}
+	}()
+}

--- a/internal/pkg/service/buffer/worker/distribution/listener_test.go
+++ b/internal/pkg/service/buffer/worker/distribution/listener_test.go
@@ -1,0 +1,82 @@
+package distribution_test
+
+import (
+	"context"
+	"testing"
+
+	"github.com/benbjohnson/clock"
+	"github.com/keboola/go-utils/pkg/wildcards"
+	gonanoid "github.com/matoous/go-nanoid/v2"
+
+	"github.com/keboola/keboola-as-code/internal/pkg/log"
+	. "github.com/keboola/keboola-as-code/internal/pkg/service/buffer/worker/distribution"
+	"github.com/keboola/keboola-as-code/internal/pkg/service/common/dependencies"
+	"github.com/keboola/keboola-as-code/internal/pkg/utils/errors"
+	"github.com/keboola/keboola-as-code/internal/pkg/utils/etcdhelper"
+)
+
+func TestOnChangeListener(t *testing.T) {
+	t.Parallel()
+
+	clk := clock.NewMock()
+	ctx, cancel := context.WithCancel(context.Background())
+	defer cancel()
+
+	var node1 *Node
+	var d1, d2, d3, d4 dependencies.Mocked
+
+	etcdNamespace := "unit-" + t.Name() + "-" + gonanoid.Must(8)
+	client := etcdhelper.ClientForTestWithNamespace(t, etcdNamespace)
+
+	// Create node with a listener
+	node1, d1 = createNode(t, ctx, clk, etcdNamespace, "node1")
+	listenerLogger := log.NewDebugLogger()
+	listener := node1.OnChangeListener()
+	go func() {
+		for {
+			select {
+			case <-ctx.Done():
+				return
+			case events := <-listener.C:
+				for _, event := range events {
+					listenerLogger.Infof(`[listener] distribution changed: %s`, event.Message)
+				}
+			}
+		}
+	}()
+
+	// Add node 2,3, stop node 2
+	etcdhelper.ExpectModification(t, client, func() {
+		_, d2 = createNode(t, ctx, clk, etcdNamespace, "node2")
+		clk.Add(eventsGroupInterval)
+
+		_, d3 = createNode(t, ctx, clk, etcdNamespace, "node3")
+		clk.Add(eventsGroupInterval)
+
+		d2.Process().Shutdown(errors.New("test"))
+		d2.Process().WaitForShutdown()
+		clk.Add(eventsGroupInterval)
+	})
+
+	// Stop listener
+	listener.Stop()
+
+	// Add node 4 (listener is stopped, no log msg expected)
+	_, d4 = createNode(t, ctx, clk, etcdNamespace, "node4")
+
+	// Stop all nodes (listener is stopped, no log msg expected)
+	d1.Process().Shutdown(errors.New("test"))
+	d1.Process().WaitForShutdown()
+	d3.Process().Shutdown(errors.New("test"))
+	d3.Process().WaitForShutdown()
+	d4.Process().Shutdown(errors.New("test"))
+	d4.Process().WaitForShutdown()
+
+	// Check logs
+	wildcards.Assert(t, `
+INFO  [listener] distribution changed: found a new node "node1"
+INFO  [listener] distribution changed: found a new node "node2"
+INFO  [listener] distribution changed: found a new node "node3"
+INFO  [listener] distribution changed: the node "node2" gone
+`, listenerLogger.AllMessages())
+}

--- a/internal/pkg/service/buffer/worker/distribution/node.go
+++ b/internal/pkg/service/buffer/worker/distribution/node.go
@@ -43,8 +43,9 @@ type Node struct {
 	schema  *schema.Schema
 	client  *etcd.Client
 	session *concurrency.Session
+	nodeID  string
 
-	nodeID string
+	config config
 	nodes  *consistent.Consistent
 }
 
@@ -73,6 +74,7 @@ func NewNode(d dependencies, opts ...Option) (*Node, error) {
 		client: d.EtcdClient(),
 		nodeID: d.Process().UniqueID(),
 		nodes:  consistent.New(),
+		config: c,
 	}
 
 	// Create etcd session

--- a/internal/pkg/service/buffer/worker/distribution/node.go
+++ b/internal/pkg/service/buffer/worker/distribution/node.go
@@ -1,14 +1,18 @@
-// Package distribution provides distribution of various keys/tasks between worker nodes, it consists of:
+// Package distribution provides distribution of various keys/tasks between worker nodes.
+//
+// The package consists of:
 // - Registration of a worker node in the cluster as an etcd key (with lease).
 // - Discovering of other worker nodes in the cluster by the etcd Watch API.
 // - Local decision and assignment of a key/task to a specific worker node (by a consistent hash/HashRing approach).
 //
-// Key benefits:
-//   - The node only watch of other node's registration/un-registration, which doesn't happen often.
-//   - Based on this, the node can quickly and locally determine owner node for a key/task.
-//   - It aims to reduce the risk of collision and minimizes load.
+// # Key benefits
 //
-// Atomicity:
+// - The node only watch of other node's registration/un-registration, which doesn't happen often.
+// - Based on this, the node can quickly and locally determine owner node for a key/task.
+// - It aims to reduce the risk of collision and minimizes load.
+//
+// # Atomicity
+//
 // - During watch propagation or lease timeout, individual nodes can have a different list of the active nodes.
 // - This could lead to the situation, when 2+ nodes have ownership of a task at the same time.
 // - Therefore, the task itself must be also protected by a transaction (version number validation).
@@ -16,10 +20,15 @@
 // Read more:
 // - https://etcd.io/docs/v3.5/learning/why/#notes-on-the-usage-of-lock-and-lease
 // - "Actually, the lease mechanism itself doesn't guarantee mutual exclusion...."
+//
+// # Listeners
+//
+// Use Node.OnChangeListener method to create a listener for nodes distribution change events.
 package distribution
 
 import (
 	"context"
+	"fmt"
 	"sort"
 	"sync"
 	"time"
@@ -45,8 +54,9 @@ type Node struct {
 	session *concurrency.Session
 	nodeID  string
 
-	config config
-	nodes  *consistent.Consistent
+	config    config
+	nodes     *consistent.Consistent
+	listeners *listeners
 }
 
 type dependencies interface {
@@ -100,12 +110,20 @@ func NewNode(d dependencies, opts ...Option) (*Node, error) {
 		n.logger.Info("shutdown done")
 	})
 
+	// Create listeners handler
+	n.listeners = newListeners(proc, n.clock, n.logger, n.config)
+
 	// Watch for nodes
 	if err := n.watch(ctx, wg); err != nil {
 		return nil, err
 	}
 
 	return n, nil
+}
+
+// OnChangeListener returns a new listener, it contains channel C with streamed distribution change Events.
+func (n *Node) OnChangeListener() *Listener {
+	return n.listeners.add()
 }
 
 // Nodes method returns IDs of all known nodes.
@@ -151,21 +169,32 @@ func (n *Node) MustCheckIsOwner(key string) bool {
 	return is
 }
 
-func (n *Node) onWatchEvent(events etcdop.Events) {
-	for _, event := range events.Events {
-		switch event.Type {
-		case etcdop.CreateEvent, etcdop.UpdateEvent:
-			nodeID := string(event.Kv.Value)
-			n.nodes.Add(nodeID)
-			n.logger.Infof(`found a new node "%s"`, nodeID)
-		case etcdop.DeleteEvent:
-			nodeID := string(event.PrevKv.Value)
-			n.nodes.Remove(nodeID)
-			n.logger.Infof(`the node "%s" gone`, nodeID)
-		default:
-			panic(errors.Errorf(`unexpected event type "%s"`, event.Type.String()))
+func (n *Node) onWatchEvent(rawEvent etcdop.Event) {
+	var event Event
+	switch rawEvent.Type {
+	case etcdop.CreateEvent, etcdop.UpdateEvent:
+		nodeID := string(rawEvent.Kv.Value)
+		event = Event{
+			Type:    EventTypeAdd,
+			NodeID:  nodeID,
+			Message: fmt.Sprintf(`found a new node "%s"`, nodeID),
 		}
+		n.nodes.Add(nodeID)
+		n.logger.Infof(event.Message)
+	case etcdop.DeleteEvent:
+		nodeID := string(rawEvent.PrevKv.Value)
+		event = Event{
+			Type:    EventTypeRemove,
+			NodeID:  nodeID,
+			Message: fmt.Sprintf(`the node "%s" gone`, nodeID),
+		}
+		n.nodes.Remove(nodeID)
+		n.logger.Infof(event.Message)
+	default:
+		panic(errors.Errorf(`unexpected event type "%s"`, rawEvent.Type.String()))
 	}
+
+	n.listeners.Notify(event)
 }
 
 func (n *Node) onWatchErr(err error) {

--- a/internal/pkg/service/buffer/worker/distribution/node.go
+++ b/internal/pkg/service/buffer/worker/distribution/node.go
@@ -216,15 +216,11 @@ func (n *Node) watch(ctx context.Context, wg *sync.WaitGroup) error {
 	go func() {
 		defer wg.Done()
 		n.logger.Info("watching for other nodes")
-		for {
-			select {
-			case <-ctx.Done():
-				return
-			case events, ok := <-ch:
-				if !ok {
-					return
-				}
-				n.onWatchEvent(events)
+
+		// Channel is closed on shutdown, so the context does not have to be checked
+		for events := range ch {
+			for _, event := range events.Events {
+				n.onWatchEvent(event)
 			}
 		}
 	}()

--- a/internal/pkg/service/buffer/worker/distribution/node_test.go
+++ b/internal/pkg/service/buffer/worker/distribution/node_test.go
@@ -23,6 +23,8 @@ import (
 	"github.com/keboola/keboola-as-code/internal/pkg/utils/testhelper"
 )
 
+const eventsGroupInterval = 10 * time.Millisecond // only for tests
+
 func TestNodesDiscovery(t *testing.T) {
 	t.Parallel()
 	ctx, cancel := context.WithCancel(context.Background())

--- a/internal/pkg/service/buffer/worker/distribution/node_test.go
+++ b/internal/pkg/service/buffer/worker/distribution/node_test.go
@@ -187,6 +187,9 @@ node3
 [node1][distribution]INFO  found a new node "node%d"
 [node1][distribution]INFO  found a new node "node%d"
 [node1]INFO  exiting (bye bye 1)
+[node1][distribution][listeners]INFO  received shutdown request
+[node1][distribution][listeners]INFO  waiting for listeners
+[node1][distribution][listeners]INFO  shutdown done
 [node1][distribution]INFO  received shutdown request
 [node1][distribution]INFO  unregistering the node "node1"
 [node1][distribution]INFO  the node "node1" unregistered | %s
@@ -207,6 +210,9 @@ node3
 [node2][distribution]INFO  found a new node "node%d"
 [node2][distribution]INFO  the node "node%d" gone
 [node2]INFO  exiting (bye bye 2)
+[node2][distribution][listeners]INFO  received shutdown request
+[node2][distribution][listeners]INFO  waiting for listeners
+[node2][distribution][listeners]INFO  shutdown done
 [node2][distribution]INFO  received shutdown request
 [node2][distribution]INFO  unregistering the node "node2"
 [node2][distribution]INFO  the node "node2" unregistered | %s
@@ -228,6 +234,9 @@ node3
 [node3][distribution]INFO  the node "node%d" gone
 [node3][distribution]INFO  the node "node%d" gone
 [node3]INFO  exiting (bye bye 3)
+[node3][distribution][listeners]INFO  received shutdown request
+[node3][distribution][listeners]INFO  waiting for listeners
+[node3][distribution][listeners]INFO  shutdown done
 [node3][distribution]INFO  received shutdown request
 [node3][distribution]INFO  unregistering the node "node3"
 [node3][distribution]INFO  the node "node3" unregistered | %s
@@ -267,6 +276,9 @@ node4
 [node4][distribution]INFO  watching for other nodes
 [node4][distribution]INFO  found a new node "node4"
 [node4]INFO  exiting (bye bye 4)
+[node4][distribution][listeners]INFO  received shutdown request
+[node4][distribution][listeners]INFO  waiting for listeners
+[node4][distribution][listeners]INFO  shutdown done
 [node4][distribution]INFO  received shutdown request
 [node4][distribution]INFO  unregistering the node "node4"
 [node4][distribution]INFO  the node "node4" unregistered | %s

--- a/internal/pkg/service/buffer/worker/distribution/node_test.go
+++ b/internal/pkg/service/buffer/worker/distribution/node_test.go
@@ -8,6 +8,7 @@ import (
 	"testing"
 	"time"
 
+	"github.com/benbjohnson/clock"
 	"github.com/keboola/go-utils/pkg/wildcards"
 	"github.com/lafikl/consistent"
 	gonanoid "github.com/matoous/go-nanoid/v2"
@@ -27,6 +28,7 @@ func TestNodesDiscovery(t *testing.T) {
 	ctx, cancel := context.WithCancel(context.Background())
 	defer cancel()
 
+	clk := clock.New() // use real clock
 	etcdNamespace := "unit-" + t.Name() + "-" + gonanoid.Must(8)
 	client := etcdhelper.ClientForTestWithNamespace(t, etcdNamespace)
 
@@ -37,16 +39,6 @@ func TestNodesDiscovery(t *testing.T) {
 	loggers := make(map[int]log.DebugLogger)
 	processes := make(map[int]*servicectx.Process)
 
-	createDeps := func(nodeNumber int) dependencies.Mocked {
-		return dependencies.NewMockedDeps(
-			t,
-			dependencies.WithUniqueID(fmt.Sprintf("node%d", nodeNumber)),
-			dependencies.WithLoggerPrefix(fmt.Sprintf("[node%d]", nodeNumber)),
-			dependencies.WithCtx(ctx),
-			dependencies.WithEtcdNamespace(etcdNamespace),
-		)
-	}
-
 	// Create nodes
 	wg := &sync.WaitGroup{}
 	for i := 0; i < nodesCount; i++ {
@@ -54,17 +46,13 @@ func TestNodesDiscovery(t *testing.T) {
 		wg.Add(1)
 		go func() {
 			defer wg.Done()
-			d := createDeps(i + 1)
-			logger := d.DebugLogger()
-			logger.ConnectTo(testhelper.VerboseStdout())
-			process := d.Process()
-			node, err := NewNode(d, WithStartupTimeout(time.Second), WithShutdownTimeout(time.Second))
-			assert.NoError(t, err)
+
+			node, d := createNode(t, ctx, clk, etcdNamespace, fmt.Sprintf("node%d", i+1))
 
 			lock.Lock()
-			processes[i] = process
 			nodes[i] = node
-			loggers[i] = logger
+			processes[i] = d.Process()
+			loggers[i] = d.DebugLogger()
 			lock.Unlock()
 		}()
 	}
@@ -249,11 +237,8 @@ node3
 
 	// All node are off, start a new node
 	assert.Equal(t, 4, nodesCount+1)
-	d4 := createDeps(4)
-	d4.DebugLogger().ConnectTo(testhelper.VerboseStdout())
+	node4, d4 := createNode(t, ctx, clk, etcdNamespace, "node4")
 	process4 := d4.Process()
-	node4, err := NewNode(d4, WithStartupTimeout(time.Second), WithShutdownTimeout(time.Second))
-	assert.NoError(t, err)
 	assert.Eventually(t, func() bool {
 		return reflect.DeepEqual([]string{"node4"}, node4.Nodes())
 	}, time.Second, 10*time.Millisecond)
@@ -338,4 +323,42 @@ func TestConsistentHashLib(t *testing.T) {
 		"node3": 30,
 		"node5": 23,
 	}, keysPerNode)
+}
+
+func createNode(t *testing.T, ctx context.Context, clk clock.Clock, etcdNamespace, nodeName string) (*Node, dependencies.Mocked) {
+	t.Helper()
+
+	// Create dependencies
+	d := createDeps(t, ctx, clk, etcdNamespace, nodeName)
+
+	// Disable waiting for self-discovery in tests with mocked clocks
+	selfDiscoveryTimeout := time.Second
+	if _, ok := clk.(*clock.Mock); ok {
+		selfDiscoveryTimeout = 0
+	}
+
+	// Create node
+	node, err := NewNode(
+		d,
+		WithStartupTimeout(time.Second),
+		WithShutdownTimeout(time.Second),
+		WithSelfDiscoveryTimeout(selfDiscoveryTimeout),
+		WithEventsGroupInterval(eventsGroupInterval),
+	)
+	assert.NoError(t, err)
+	return node, d
+}
+
+func createDeps(t *testing.T, ctx context.Context, clk clock.Clock, etcdNamespace, nodeName string) dependencies.Mocked {
+	t.Helper()
+	d := dependencies.NewMockedDeps(
+		t,
+		dependencies.WithClock(clk),
+		dependencies.WithUniqueID(nodeName),
+		dependencies.WithLoggerPrefix(fmt.Sprintf("[%s]", nodeName)),
+		dependencies.WithCtx(ctx),
+		dependencies.WithEtcdNamespace(etcdNamespace),
+	)
+	d.DebugLogger().ConnectTo(testhelper.VerboseStdout())
+	return d
 }

--- a/internal/pkg/service/buffer/worker/distribution/self.go
+++ b/internal/pkg/service/buffer/worker/distribution/self.go
@@ -1,0 +1,45 @@
+package distribution
+
+import (
+	"context"
+	"sync"
+
+	"github.com/keboola/keboola-as-code/internal/pkg/utils/errors"
+)
+
+func (n *Node) waitForSelfDiscovery(ctx context.Context, wg *sync.WaitGroup) <-chan error {
+	errCh := make(chan error)
+
+	// Waiting for self-discovery can be disabled in tests
+	if n.config.selfDiscoveryTimeout == 0 {
+		close(errCh)
+		return errCh
+	}
+
+	wg.Add(1)
+	go func() {
+		defer wg.Done()
+		defer close(errCh)
+
+		l := n.OnChangeListener()
+		defer l.Stop()
+
+		for {
+			select {
+			case <-ctx.Done():
+				return
+			case <-n.clock.After(n.config.selfDiscoveryTimeout):
+				errCh <- errors.New("self-discovery timeout")
+				return
+			case events := <-l.C:
+				for _, event := range events {
+					if event.Type == EventTypeAdd && event.NodeID == n.nodeID {
+						return
+					}
+				}
+			}
+		}
+	}()
+
+	return errCh
+}


### PR DESCRIPTION
Part of: https://keboola.atlassian.net/browse/BA-40

Changes:
- Implemented custom listeners for `distribution.Node`.
- Other parts of the service will be able to respond to the changes in tasks distribution.