### PR TITLE
Fix etcd ErrCompacted

### DIFF
--- a/internal/pkg/service/buffer/api/http/http.go
+++ b/internal/pkg/service/buffer/api/http/http.go
@@ -92,7 +92,7 @@ func HandleHTTPServer(proc *servicectx.Process, d dependencies.ForServer, u *url
 		defer cancel()
 
 		if err := srv.Shutdown(ctx); err != nil {
-			logger.Errorf(`HTTP server shutdown error: %w`, err)
+			logger.Errorf(`HTTP server shutdown error: %s`, err)
 		}
 		logger.Info("HTTP server shutdown finished")
 	})

--- a/internal/pkg/service/buffer/watcher/apinode/revision/syncer.go
+++ b/internal/pkg/service/buffer/watcher/apinode/revision/syncer.go
@@ -28,6 +28,7 @@ import (
 	"github.com/keboola/keboola-as-code/internal/pkg/service/common/etcdclient"
 	"github.com/keboola/keboola-as-code/internal/pkg/service/common/etcdop"
 	"github.com/keboola/keboola-as-code/internal/pkg/service/common/servicectx"
+	"github.com/keboola/keboola-as-code/internal/pkg/utils/errors"
 )
 
 type Syncer struct {
@@ -113,8 +114,8 @@ func NewSyncer(d dependencies, targetKey etcdop.Key, opts ...Option) (*Syncer, e
 			case <-ctx.Done():
 				return
 			case <-syncTicker.C:
-				if err := r.sync(ctx); err != nil {
-					r.logger.Errorf(`sync error: %w`, err)
+				if err := r.sync(ctx); err != nil && !errors.Is(err, context.Canceled) {
+					r.logger.Errorf(`sync error: %s`, err)
 				}
 			}
 		}

--- a/internal/pkg/service/buffer/watcher/apinode/state.go
+++ b/internal/pkg/service/buffer/watcher/apinode/state.go
@@ -7,7 +7,6 @@ import (
 	"time"
 
 	etcd "go.etcd.io/etcd/client/v3"
-	"go.uber.org/atomic"
 
 	"github.com/keboola/keboola-as-code/internal/pkg/log"
 	"github.com/keboola/keboola-as-code/internal/pkg/service/buffer/store/key"
@@ -93,63 +92,84 @@ func (s *state) GetReceiver(receiverKey key.ReceiverKey) (out ReceiverCore, foun
 	return out, true, unlockFn
 }
 
-func (s *state) onError(err error) {
-	s.logger.Error(err)
-}
-
 // The function belongs to the state struct, but generic method cannot be currently defined.
 func watch[T fmt.Stringer](ctx context.Context, wg *sync.WaitGroup, s *state, prefix etcdop.PrefixT[T], rev *revision.Syncer) *stateOf[T] {
 	tree := prefixtree.New[T]()
 
 	initDone := make(chan error)
-	ch := prefix.GetAllAndWatch(ctx, s.client, s.onError, etcd.WithCreatedNotify(), etcd.WithPrevKV())
-
-	// Log only changes, not initial load
-	logsEnabled := atomic.NewBool(false)
+	ch := prefix.GetAllAndWatch(ctx, s.client, etcd.WithCreatedNotify(), etcd.WithPrevKV())
 
 	wg.Add(1)
 	go func() {
 		defer wg.Done()
 
-		// Channel is closed on shutdown, so the context does not have to be checked
-		for events := range ch {
-			if err := events.InitErr; err != nil {
-				initDone <- err
-				close(initDone)
-			} else if events.Created {
-				logsEnabled.Store(true)
-				close(initDone)
-			}
+		// Reset the tree on the restart event.
+		reset := false
 
-			// Modify cache
-			tree.ModifyAtomic(func(t *prefixtree.Tree[T]) {
-				for _, event := range events.Events {
-					k := event.Value.String()
-					switch event.Type {
-					case etcdop.CreateEvent:
-						t.Insert(k, event.Value)
-						if logsEnabled.Load() {
-							s.logger.Infof(`created %s%s`, prefix.Prefix(), k)
-						}
-					case etcdop.UpdateEvent:
-						t.Insert(k, event.Value)
-						if logsEnabled.Load() {
-							s.logger.Infof(`updated %s%s`, prefix.Prefix(), k)
-						}
-					case etcdop.DeleteEvent:
-						t.Delete(k)
-						if logsEnabled.Load() {
-							s.logger.Infof(`deleted %s%s`, prefix.Prefix(), k)
-						}
-					default:
-						panic(errors.Errorf(`unexpected event type "%v"`, event.Type))
+		// Log only changes, not initial load.
+		logsEnabled := false
+
+		// Channel is closed on shutdown, so the context does not have to be checked.
+		for resp := range ch {
+			switch {
+			case resp.InitErr != nil:
+				// Initialization error, stop worker via initDone channel
+				initDone <- resp.InitErr
+				close(initDone)
+			case resp.Err != nil:
+				// An error occurred, it is logged.
+				// If it is a fatal error, then it is followed
+				// by the "Restarted" event handled bellow,
+				// and the operation starts from the beginning.
+				s.logger.Error(resp.Err)
+			case resp.Restarted:
+				// A fatal error (etcd ErrCompacted) occurred.
+				// It is not possible to continue watching, the operation must be restarted.
+				reset = true
+				logsEnabled = false
+				s.logger.Warn(resp.RestartReason)
+			case resp.Created:
+				// The watcher has been successfully created.
+				// This means transition from GetAll to Watch phase.
+				logsEnabled = true
+				close(initDone)
+			default:
+				tree.ModifyAtomic(func(t *prefixtree.Tree[T]) {
+					// Reset the tree after receiving the first batch after the restart.
+					if reset {
+						t.Reset()
+						reset = false
 					}
-				}
-			})
 
-			// ACK revision, so worker nodes knows that the API node is switched to the new slice.
-			if rev != nil {
-				rev.Notify(events.Header.Revision)
+					//  Atomically process all events
+					for _, event := range resp.Events {
+						k := event.Value.String()
+						switch event.Type {
+						case etcdop.CreateEvent:
+							t.Insert(k, event.Value)
+							if logsEnabled {
+								s.logger.Infof(`created %s%s`, prefix.Prefix(), k)
+							}
+						case etcdop.UpdateEvent:
+							t.Insert(k, event.Value)
+							if logsEnabled {
+								s.logger.Infof(`updated %s%s`, prefix.Prefix(), k)
+							}
+						case etcdop.DeleteEvent:
+							t.Delete(k)
+							if logsEnabled {
+								s.logger.Infof(`deleted %s%s`, prefix.Prefix(), k)
+							}
+						default:
+							panic(errors.Errorf(`unexpected event type "%v"`, event.Type))
+						}
+					}
+				})
+
+				// ACK revision, so worker nodes knows that the API node is switched to the new slice.
+				if rev != nil {
+					rev.Notify(resp.Header.Revision)
+				}
 			}
 		}
 	}()

--- a/internal/pkg/service/buffer/watcher/workernode/workernode.go
+++ b/internal/pkg/service/buffer/watcher/workernode/workernode.go
@@ -76,45 +76,41 @@ func (n *Node) WaitForRevision(requiredRev int64) <-chan struct{} {
 // watch for changes in revisions of API nodes.
 func (n *Node) watch(ctx context.Context, wg *sync.WaitGroup) error {
 	pfx := n.schema.Runtime().APINodes().Watchers().SlicesRevision()
-	ch := pfx.GetAllAndWatch(ctx, n.client, n.onError, etcd.WithCreatedNotify())
+	ch := pfx.GetAllAndWatch(ctx, n.client, etcd.WithCreatedNotify())
 	initDone := make(chan error)
 
 	wg.Add(1)
 	go func() {
 		defer wg.Done()
 
+		// Reset the nodes on the restart event.
+		reset := false
+
 		// Channel is closed on shutdown, so the context does not have to be checked
-		for events := range ch {
-			if err := events.InitErr; err != nil {
-				initDone <- err
+		for resp := range ch {
+			switch {
+			case resp.InitErr != nil:
+				// Initialization error, stop worker via initDone channel
+				initDone <- resp.InitErr
 				close(initDone)
-			} else if events.Created {
+			case resp.Err != nil:
+				// An error occurred, it is logged.
+				// If it is a fatal error, then it is followed
+				// by the "Restarted" event handled bellow,
+				// and the operation starts from the beginning.
+				n.logger.Error(resp.Err)
+			case resp.Restarted:
+				// A fatal error (etcd ErrCompacted) occurred.
+				// It is not possible to continue watching, the operation must be restarted.
+				reset = true
+				n.logger.Warn(resp.RestartReason)
+			case resp.Created:
+				// The watcher has been successfully created.
+				// This means transition from GetAll to Watch phase.
 				close(initDone)
-			}
-
-			for _, event := range events.Events {
-				switch event.Type {
-				case etcdop.CreateEvent, etcdop.UpdateEvent:
-					// Cached state of th API node has been updated
-					n.revisionPerAPINode[string(event.Kv.Key)] = cast.ToInt64(string(event.Kv.Value))
-				case etcdop.DeleteEvent:
-					// The API node gone
-					delete(n.revisionPerAPINode, string(event.Kv.Key))
-				default:
-					panic(errors.Errorf(`unexpected event type "%s"`, event.Type.String()))
-				}
-			}
-
-			// Recompute and store minimal revision
-			if rev := minimalRevision(n.revisionPerAPINode); rev != noAPINode {
-				if old := n.minRevision.Swap(rev); old != rev {
-					// Trigger listeners if the minimal version has changed
-					if count := n.listeners.onChange(ctx, n.minRevision); count > 0 {
-						n.logger.Infof(`revision updated to "%v", unblocked "%d" listeners`, rev, count)
-					} else {
-						n.logger.Infof(`revision updated to "%v"`, rev)
-					}
-				}
+			default:
+				n.updateRevisionsFrom(ctx, resp, reset)
+				reset = false
 			}
 		}
 	}()
@@ -123,8 +119,35 @@ func (n *Node) watch(ctx context.Context, wg *sync.WaitGroup) error {
 	return <-initDone
 }
 
-func (n *Node) onError(err error) {
-	n.logger.Error(err)
+func (n *Node) updateRevisionsFrom(ctx context.Context, resp etcdop.WatchResponse, reset bool) {
+	if reset {
+		n.revisionPerAPINode = make(map[string]int64)
+	}
+
+	for _, event := range resp.Events {
+		switch event.Type {
+		case etcdop.CreateEvent, etcdop.UpdateEvent:
+			// Cached state of th API node has been updated
+			n.revisionPerAPINode[string(event.Kv.Key)] = cast.ToInt64(string(event.Kv.Value))
+		case etcdop.DeleteEvent:
+			// The API node gone
+			delete(n.revisionPerAPINode, string(event.Kv.Key))
+		default:
+			panic(errors.Errorf(`unexpected event type "%s"`, event.Type.String()))
+		}
+	}
+
+	// Recompute and store minimal revision
+	if rev := minimalRevision(n.revisionPerAPINode); rev != noAPINode {
+		if old := n.minRevision.Swap(rev); old != rev {
+			// Trigger listeners if the minimal version has changed
+			if count := n.listeners.onChange(ctx, n.minRevision); count > 0 {
+				n.logger.Infof(`revision updated to "%v", unblocked "%d" listeners`, rev, count)
+			} else {
+				n.logger.Infof(`revision updated to "%v"`, rev)
+			}
+		}
+	}
 }
 
 func minimalRevision(revisionPerAPINode map[string]int64) (min int64) {

--- a/internal/pkg/service/buffer/worker/distribution/listener.go
+++ b/internal/pkg/service/buffer/worker/distribution/listener.go
@@ -26,7 +26,7 @@ type Listener struct {
 type listeners struct {
 	config         nodeConfig
 	lock           *sync.Mutex
-	bufferedEvents []Event
+	bufferedEvents Events
 	listeners      map[listenerID]*Listener
 }
 
@@ -102,12 +102,12 @@ func (v *listeners) Reset() {
 
 // Notify listeners about a new event. The event is not processed immediately.
 // All events within the "group interval" are processed at once, see trigger method.
-func (v *listeners) Notify(event Event) {
+func (v *listeners) Notify(events Events) {
 	v.lock.Lock()
 	defer v.lock.Unlock()
 
 	// All events within the "group interval" are processed at once.
-	v.bufferedEvents = append(v.bufferedEvents, event)
+	v.bufferedEvents = append(v.bufferedEvents, events...)
 
 	// Trigger listeners immediately, if there is no grouping interval
 	if v.config.eventsGroupInterval == 0 {

--- a/internal/pkg/service/buffer/worker/task/node.go
+++ b/internal/pkg/service/buffer/worker/task/node.go
@@ -165,6 +165,7 @@ func (n *Node) StartTask(ctx context.Context, exportKey key.ExportKey, lock stri
 				taskEtcdKey.Put(task),
 				lockEtcdKey.DeleteIfExists(),
 			)
+			logger.Infof(`releasing lock "%s"`, task.Lock)
 			if resp, err := finishTaskOp.Do(opCtx, n.client); err != nil {
 				logger.Errorf(`cannot update task and release lock: %s`, err)
 				return
@@ -172,7 +173,6 @@ func (n *Node) StartTask(ctx context.Context, exportKey key.ExportKey, lock stri
 				logger.Errorf(`cannot release task lock "%s", not found`, task.Lock)
 				return
 			}
-			logger.Infof(`lock "%s" released`, task.Lock)
 		}()
 
 		// Do operation

--- a/internal/pkg/service/buffer/worker/task/node_test.go
+++ b/internal/pkg/service/buffer/worker/task/node_test.go
@@ -157,13 +157,13 @@ task/00000123/my-receiver/my-export-1/%s
 [node2][tasks][taskId=%s]INFO  task ignored, the lock "my-lock" is in use
 [node1][tasks][taskId=%s]INFO  some message from the task (1)
 [node1][tasks][taskId=%s]INFO  task succeeded (%s): some result (1)
-[node1][tasks][taskId=%s]INFO  lock "my-lock" released
+[node1][tasks][taskId=%s]INFO  releasing lock "my-lock"
 [node2][tasks][taskId=%s]INFO  new task, key "00000123/my-receiver/my-export-1/%s"
 [node2][tasks][taskId=%s]INFO  acquiring lock "my-lock"
 [node2][tasks][taskId=%s]INFO  lock "my-lock" acquired
 [node2][tasks][taskId=%s]INFO  some message from the task (2)
 [node2][tasks][taskId=%s]INFO  task succeeded (%s): some result (2)
-[node2][tasks][taskId=%s]INFO  lock "my-lock" released
+[node2][tasks][taskId=%s]INFO  releasing lock "my-lock"
 `, logs.String())
 }
 
@@ -301,13 +301,13 @@ task/00000123/my-receiver/my-export-1/%s
 [node2][tasks][taskId=%s]INFO  task ignored, the lock "my-lock" is in use
 [node1][tasks][taskId=%s]INFO  some message from the task (1)
 [node1][tasks][taskId=%s]WARN  task failed (%s): some error (1)
-[node1][tasks][taskId=%s]INFO  lock "my-lock" released
+[node1][tasks][taskId=%s]INFO  releasing lock "my-lock"
 [node2][tasks][taskId=%s]INFO  new task, key "00000123/my-receiver/my-export-1/%s"
 [node2][tasks][taskId=%s]INFO  acquiring lock "my-lock"
 [node2][tasks][taskId=%s]INFO  lock "my-lock" acquired
 [node2][tasks][taskId=%s]INFO  some message from the task (2)
 [node2][tasks][taskId=%s]WARN  task failed (%s): some error (2)
-[node2][tasks][taskId=%s]INFO  lock "my-lock" released
+[node2][tasks][taskId=%s]INFO  releasing lock "my-lock"
 `, logs.String())
 }
 
@@ -388,7 +388,7 @@ task/00000123/my-receiver/my-export-1/%s
 [node1][tasks]INFO  waiting for "1" tasks to be finished
 [node1][tasks][taskId=%s]INFO  some message from the task
 [node1][tasks][taskId=%s]INFO  task succeeded (%s): some result
-[node1][tasks][taskId=%s]INFO  lock "my-lock" released
+[node1][tasks][taskId=%s]INFO  releasing lock "my-lock"
 [node1][tasks]INFO  shutdown done
 [node1][tasks][etcd-session]INFO  closing etcd session
 [node1][tasks][etcd-session]INFO  closed etcd session | %s

--- a/internal/pkg/service/common/etcdop/etcdop.go
+++ b/internal/pkg/service/common/etcdop/etcdop.go
@@ -12,10 +12,23 @@
 // New<Operation>(<operation factory>, <response processor>) function.
 //
 // On Operation.Do(ctx, etcdClient) call :
-//  - The <operation factory> is executed, result is an etcd operation.
-//  - The etcd operation is executed, result is an etcd response.
-//  - The <response processor> is executed, to process the etcd response.
+//   - The <operation factory> is executed, result is an etcd operation.
+//   - The etcd operation is executed, result is an etcd response.
+//   - The <response processor> is executed, to process the etcd response.
 //
 // If an error occurs, it will be returned and the operation will stop.
-
+//
+// # Watch Operations
+//
+// There are following watch operations:
+// - Prefix.Watch - watch for updates.
+// - Prefix.GetAllAndWatch - get all KVs and then watch for updates, restart on a fatal error.
+// - Prefix[T].Watch - watch for updates, values are deserialized to the type T.
+// - Prefix[T].GetAllAndWatch - get all KVs and then watch for updates, restart on a fatal error, values are deserialized to the type T.
+//
+// Watch layers:
+// - Prefix.Watch wraps low-level client.Watch
+// - Prefix.GetAllAndWatch calls wrapWatchWithRestart, Prefix.GetAll and Prefix.Watch
+// - Prefix[T].Watch calls Prefix.Watch and Prefix[T].decodeChannel
+// - Prefix[T].GetAllAndWatch calls Prefix.GetAllAndWatch and Prefix[T].decodeChannel
 package etcdop

--- a/internal/pkg/service/common/etcdop/watch.go
+++ b/internal/pkg/service/common/etcdop/watch.go
@@ -1,11 +1,14 @@
 package etcdop
 
 import (
+	"bytes"
 	"context"
+	"fmt"
 	"sort"
 	"strconv"
 	"time"
 
+	"github.com/cenkalti/backoff/v4"
 	"go.etcd.io/etcd/api/v3/etcdserverpb"
 	"go.etcd.io/etcd/api/v3/mvccpb"
 	etcd "go.etcd.io/etcd/client/v3"
@@ -27,19 +30,32 @@ const (
 	getAllBatchSize = 100
 )
 
-type Event struct {
+type WatchEvent struct {
+	Type   EventType
 	Kv     *op.KeyValue
 	PrevKv *op.KeyValue
-	Type   EventType
 }
 
-type Events struct {
+type WatcherStatus struct {
 	Header *etcdserverpb.ResponseHeader
-	Events []Event
-	// Created is used to indicate the creation of the watcher.
-	Created bool
-	// InitErr signals an error during initialization of the watcher.
+	// InitErr is used to indicate an error during initialization of the watcher, before the first event is received.
 	InitErr error
+	// Err is used to indicate an error.
+	// Fatal error is followed by the "Restarted" event.
+	Err error
+	// Created is used to indicate the creation of the watcher, it is emitted before the first event.
+	Created bool
+	// Restarted is used to indicate re-creation of the watcher, the following events are streamed from the beginning.
+	// It is used in case of a fatal error (etcd ErrCompacted) from which it is not possible to recover.
+	// Restarted is supported only by the GetAllAndWatch methods, for both, untyped and typed prefix.
+	Restarted     bool
+	RestartReason string
+	RestartDelay  time.Duration
+}
+
+type WatchResponse struct {
+	WatcherStatus
+	Events []WatchEvent
 }
 
 func (v EventType) String() string {
@@ -55,161 +71,259 @@ func (v EventType) String() string {
 	}
 }
 
-func (e *Events) Rev() int64 {
+func (e *WatchResponse) Rev() int64 {
 	return e.Header.Revision
 }
 
-func (v Prefix) Watch(ctx context.Context, client etcd.Watcher, handleErr func(error), opts ...etcd.OpOption) <-chan Events {
-	outCh := make(chan Events)
-	go func() {
-		defer close(outCh)
-		v.doWatch(ctx, client, handleErr, outCh, opts...)
-	}()
-	return outCh
+// Watch method wraps low-level etcd watcher and watch for changes in the prefix.
+// See WatchResponse for details.
+func (v Prefix) Watch(ctx context.Context, client etcd.Watcher, opts ...etcd.OpOption) <-chan WatchResponse {
+	return v.watch(ctx, client, opts...)
 }
 
 // GetAllAndWatch loads all keys in the prefix by the iterator and then watch for changes.
-// initDone channel signals end of the load phase and start of the watch phase.
-func (v Prefix) GetAllAndWatch(ctx context.Context, client *etcd.Client, handleErr func(err error), opts ...etcd.OpOption) (out <-chan Events) {
-	outCh := make(chan Events)
+//
+// If a fatal error occurs, the watcher is restarted.
+// The "restarted" event is emitted before the restart.
+// Then, the following events are streamed from the beginning.
+//
+// See WatchResponse for details.
+func (v Prefix) GetAllAndWatch(ctx context.Context, client *etcd.Client, opts ...etcd.OpOption) (out <-chan WatchResponse) {
+	return wrapWatchWithRestart(ctx, func(ctx context.Context) <-chan WatchResponse {
+		outCh := make(chan WatchResponse)
+		go func() {
+			defer close(outCh)
 
+			ctx, cancel := context.WithCancel(ctx)
+			defer cancel()
+
+			// GetAll phase
+			itr := v.GetAll().Do(ctx, client)
+			var events []WatchEvent
+			sendBatch := func() {
+				if len(events) > 0 {
+					resp := WatchResponse{}
+					resp.Header = itr.Header()
+					resp.Events = events
+					events = nil
+					outCh <- resp
+				}
+			}
+
+			// Iterate and send batches of events
+			i := 1
+			err := itr.ForEach(func(kv *op.KeyValue, _ *etcdserverpb.ResponseHeader) error {
+				events = append(events, WatchEvent{Kv: kv, Type: CreateEvent})
+				if i%getAllBatchSize == 0 {
+					sendBatch()
+				}
+				return nil
+			})
+			sendBatch()
+
+			// Process GetAll error
+			if err != nil {
+				resp := WatchResponse{}
+				resp.InitErr = err
+				events = nil
+				outCh <- resp
+
+				// Stop
+				return
+			}
+
+			// Watch phase, continue  where the GetAll operation ended (revision + 1)
+			rawCh := v.watch(ctx, client, append([]etcd.OpOption{etcd.WithRev(itr.Header().Revision + 1)}, opts...)...)
+			for resp := range rawCh {
+				outCh <- resp
+			}
+		}()
+
+		return outCh
+	})
+}
+
+// watch the Prefix, operation can be cancelled by the context or a fatal error (etcd ErrCompacted).
+// Otherwise, watch will retry on other recoverable errors forever until reconnected.
+func (v Prefix) watch(ctx context.Context, client etcd.Watcher, opts ...etcd.OpOption) <-chan WatchResponse {
+	outCh := make(chan WatchResponse)
 	go func() {
 		defer close(outCh)
 
-		// Get all iterator
-		itr := v.GetAll().Do(ctx, client)
-		var events []Event
-		sendBatch := func() {
-			if len(events) > 0 {
-				outCh <- Events{Header: itr.Header(), Events: events}
-			}
-			events = nil
-		}
+		ctx, cancel := context.WithCancel(ctx)
+		defer cancel()
 
-		// Iterate and send batches of events
-		i := 1
-		err := itr.ForEach(func(kv *op.KeyValue, _ *etcdserverpb.ResponseHeader) error {
-			events = append(events, Event{Kv: kv, Type: CreateEvent})
-			if i%getAllBatchSize == 0 {
-				sendBatch()
-			}
-			return nil
-		})
-		sendBatch()
+		// The initialization phase lasts until etcd sends the "created" event.
+		// It is the first event that is sent.
+		// The application logic usually waits for this event when the application starts.
+		// At most one WatchResponse.InitErr will be emitted.
+		init := true
 
-		// Check getAll error
-		if err != nil {
-			outCh <- Events{InitErr: err}
-			return
-		}
+		// The rawCh channel is closed by the context, so the context does not have to be checked here again.
+		rawCh := client.Watch(ctx, v.Prefix(), append([]etcd.OpOption{etcd.WithPrefix(), etcd.WithCreatedNotify()}, opts...)...)
+		for rawResp := range rawCh {
+			resp := WatchResponse{}
+			resp.Header = &rawResp.Header
+			resp.Created = rawResp.Created
 
-		// Continue with Watch where GetAll ended
-		v.doWatch(ctx, client, handleErr, outCh, append(opts, etcd.WithRev(itr.Header().Revision+1))...)
-	}()
+			// Handle error
+			if err := rawResp.Err(); err != nil {
+				if init {
+					// Pass initialization error
+					resp.InitErr = err
+					outCh <- resp
 
-	return outCh
-}
-
-// doWatch is called from the Watch and GetAllAndWatch methods.
-func (v Prefix) doWatch(ctx context.Context, client etcd.Watcher, handleErr func(err error), outCh chan Events, opts ...etcd.OpOption) {
-	opts = append([]etcd.OpOption{etcd.WithPrefix(), etcd.WithCreatedNotify()}, opts...)
-
-	// In case of an error, the watch channel can be closed.
-	// It will be recreated, and it will continue from the last revision.
-	revision := int64(0)
-	for {
-		select {
-		case <-ctx.Done():
-			return
-		default:
-			// If the watch is recreated, continue from the last received revision
-			watchOpts := opts
-			if revision > 0 {
-				watchOpts = append(watchOpts, etcd.WithRev(revision+1))
-			}
-
-			// Wait before recreate attempt
-			if revision > 0 {
-				select {
-				case <-ctx.Done():
+					// Stop watching
 					return
-				case <-time.After(time.Second):
-					// continue
+				} else {
+					// Pass other error
+					resp.Err = err
+					outCh <- resp
+
+					// If the error is fatal, then the rawCh will be closed in the next iteration.
+					// Otherwise, continue.
+					continue
 				}
 			}
 
-			// Process watch events until the rawCh is closed
-			rawCh := client.Watch(ctx, v.Prefix(), watchOpts...)
-			if !processWatchEvents(ctx, &revision, handleErr, rawCh, outCh) {
-				return
-			}
-		}
-	}
-}
-
-func processWatchEvents(ctx context.Context, revision *int64, handleErr func(err error), rawCh etcd.WatchChan, outCh chan<- Events) (retry bool) {
-	created := false
-	for {
-		select {
-		case <-ctx.Done():
-			return false
-		case resp, ok := <-rawCh:
-			if !ok {
-				return true
-			}
-
-			*revision = resp.Header.Revision
-
-			if err := resp.Err(); err != nil {
-				if !created {
-					// Stop on initialization error
-					outCh <- Events{InitErr: err}
-					return true
-				}
-				handleErr(err)
+			// Stop initialization phase after the "created" event
+			if rawResp.Created {
+				init = false
+				outCh <- resp
 				continue
-			}
-
-			if resp.Created {
-				created = true
 			}
 
 			// Sort events from the batch (if multiple keys have been modified in one txn, in one revision)
 			// 1. By type, PUT before DELETE
 			// 2. By key, A->Z
-			sort.SliceStable(resp.Events, func(i, j int) bool {
-				if resp.Events[i].Type != resp.Events[j].Type {
-					return resp.Events[i].Type < resp.Events[j].Type
+			sort.SliceStable(rawResp.Events, func(i, j int) bool {
+				if rawResp.Events[i].Type != rawResp.Events[j].Type {
+					return rawResp.Events[i].Type < rawResp.Events[j].Type
 				}
-				return string(resp.Events[i].Kv.Key) < string(resp.Events[j].Kv.Key)
+				return bytes.Compare(rawResp.Events[i].Kv.Key, rawResp.Events[j].Kv.Key) == -1
 			})
 
-			outEvents := make([]Event, len(resp.Events))
-			for i, rawEvent := range resp.Events {
-				outEvent := Event{Kv: rawEvent.Kv, PrevKv: rawEvent.PrevKv}
+			if len(rawResp.Events) > 0 {
+				resp.Events = make([]WatchEvent, 0, len(rawResp.Events))
+			}
 
-				// Map event type
+			// Map event type
+			for _, rawEvent := range rawResp.Events {
+				var typ EventType
 				switch rawEvent.Type {
 				case mvccpb.PUT:
 					if rawEvent.Kv.CreateRevision == rawEvent.Kv.ModRevision {
-						outEvent.Type = CreateEvent
+						typ = CreateEvent
 					} else {
-						outEvent.Type = UpdateEvent
+						typ = UpdateEvent
 					}
 				case mvccpb.DELETE:
-					outEvent.Type = DeleteEvent
+					typ = DeleteEvent
 				default:
 					panic(errors.Errorf(`unexpected event type "%s"`, rawEvent.Type.String()))
 				}
 
-				outEvents[i] = outEvent
+				resp.Events = append(resp.Events, WatchEvent{
+					Type:   typ,
+					Kv:     rawEvent.Kv,
+					PrevKv: rawEvent.PrevKv,
+				})
 			}
 
-			outCh <- Events{
-				Header:  &resp.Header,
-				Events:  outEvents,
-				Created: resp.Created,
-			}
+			// Pass the response
+			outCh <- resp
 		}
-	}
+	}()
+
+	return outCh
+}
+
+func wrapWatchWithRestart(ctx context.Context, channelFactory func(ctx context.Context) <-chan WatchResponse) <-chan WatchResponse {
+	b := backoff.WithContext(newWatchBackoff(), ctx)
+	outCh := make(chan WatchResponse)
+	go func() {
+		defer close(outCh)
+
+		ctx, cancel := context.WithCancel(ctx)
+		defer cancel()
+
+		// The initialization phase lasts until the first "created" event.
+		// If the watch operation was restarted,
+		// the next initialization error is converted to a common error.
+		init := true
+
+		// The "restarted" event contains RestartReason - last error.
+		var lastErr error
+
+		for {
+			// The rawCh channel is closed by the context, so the context does not have to be checked here again.
+			rawCh := channelFactory(ctx)
+			for resp := range rawCh {
+				// Stop initialization phase after the "created" event
+				if resp.Created {
+					init = false
+				}
+
+				// Update lastErr for "restarted" event
+				if resp.InitErr != nil {
+					lastErr = resp.InitErr
+				} else if resp.Err != nil {
+					lastErr = resp.Err
+				}
+
+				// Handle initialization error
+				if resp.InitErr != nil {
+					if init {
+						// Stop on initialization error
+						outCh <- resp
+						return
+					} else {
+						// Convert initialization error
+						// from an 1+ attempt to a common error and restart watch.
+						resp.Err = resp.InitErr
+						resp.InitErr = nil
+						outCh <- resp
+						break
+					}
+				}
+
+				// Pass the response
+				outCh <- resp
+			}
+
+			// Underlying watcher has stopped, restart
+			delay := b.NextBackOff()
+			if delay == backoff.Stop {
+				return
+			}
+
+			// Wait before restart
+			select {
+			case <-ctx.Done():
+				return
+			case <-time.After(delay):
+				// continue
+			}
+
+			// Emit "restarted" event
+			resp := WatchResponse{}
+			resp.Restarted = true
+			resp.RestartReason = fmt.Sprintf(`restarted after %s, reason: %s`, delay, lastErr)
+			resp.RestartDelay = delay
+			outCh <- resp
+		}
+	}()
+
+	return outCh
+}
+
+func newWatchBackoff() *backoff.ExponentialBackOff {
+	b := backoff.NewExponentialBackOff()
+	b.RandomizationFactor = 0.2
+	b.InitialInterval = 50 * time.Millisecond
+	b.Multiplier = 2
+	b.MaxInterval = 1 * time.Minute
+	b.MaxElapsedTime = 0 // never stop
+	b.Reset()
+	return b
 }

--- a/internal/pkg/service/common/etcdop/watch.go
+++ b/internal/pkg/service/common/etcdop/watch.go
@@ -42,22 +42,6 @@ type Events struct {
 	InitErr error
 }
 
-type EventT[T any] struct {
-	Value  T
-	Kv     *op.KeyValue
-	PrevKv *op.KeyValue
-	Type   EventType
-}
-
-type EventsT[T any] struct {
-	Header *etcdserverpb.ResponseHeader
-	Events []EventT[T]
-	// Created is used to indicate the creation of the watcher.
-	Created bool
-	// InitErr signals an error during initialization of the watcher.
-	InitErr error
-}
-
 func (v EventType) String() string {
 	switch v {
 	case CreateEvent:
@@ -72,10 +56,6 @@ func (v EventType) String() string {
 }
 
 func (e *Events) Rev() int64 {
-	return e.Header.Revision
-}
-
-func (e *EventsT[T]) Rev() int64 {
 	return e.Header.Revision
 }
 
@@ -130,6 +110,7 @@ func (v Prefix) GetAllAndWatch(ctx context.Context, client *etcd.Client, handleE
 	return outCh
 }
 
+// doWatch is called from the Watch and GetAllAndWatch methods.
 func (v Prefix) doWatch(ctx context.Context, client etcd.Watcher, handleErr func(err error), outCh chan Events, opts ...etcd.OpOption) {
 	opts = append([]etcd.OpOption{etcd.WithPrefix(), etcd.WithCreatedNotify()}, opts...)
 
@@ -161,109 +142,6 @@ func (v Prefix) doWatch(ctx context.Context, client etcd.Watcher, handleErr func
 			rawCh := client.Watch(ctx, v.Prefix(), watchOpts...)
 			if !processWatchEvents(ctx, &revision, handleErr, rawCh, outCh) {
 				return
-			}
-		}
-	}
-}
-
-func (v PrefixT[T]) Watch(ctx context.Context, client etcd.Watcher, handleErr func(error), opts ...etcd.OpOption) <-chan EventsT[T] {
-	outCh := make(chan EventsT[T])
-	go func() {
-		defer close(outCh)
-		v.doWatch(ctx, client, handleErr, outCh, opts...)
-	}()
-	return outCh
-}
-
-// GetAllAndWatch loads all keys in the prefix by the iterator and then watch for changes.
-// Values are decoded to the type T.
-// initDone channel signals end of the load phase and start of the watch phase.
-func (v PrefixT[T]) GetAllAndWatch(ctx context.Context, client *etcd.Client, handleErr func(err error), opts ...etcd.OpOption) (out <-chan EventsT[T]) {
-	outCh := make(chan EventsT[T])
-
-	go func() {
-		defer close(outCh)
-
-		// Get all iterator
-		itr := v.GetAll().Do(ctx, client)
-		var events []EventT[T]
-		sendBatch := func() {
-			if len(events) > 0 {
-				outCh <- EventsT[T]{Header: itr.Header(), Events: events}
-			}
-			events = nil
-		}
-
-		// Iterate and send batches of events
-		i := 1
-		err := itr.ForEachKV(func(kv op.KeyValueT[T], _ *etcdserverpb.ResponseHeader) error {
-			events = append(events, EventT[T]{Kv: kv.Kv, Value: kv.Value, Type: CreateEvent})
-			if i%getAllBatchSize == 0 {
-				sendBatch()
-			}
-			return nil
-		})
-		sendBatch()
-
-		// Check getAll error
-		if err != nil {
-			outCh <- EventsT[T]{InitErr: err}
-			return
-		}
-
-		// Continue with Watch where GetAll finished
-		v.doWatch(ctx, client, handleErr, outCh, append(opts, etcd.WithRev(itr.Header().Revision+1))...)
-	}()
-
-	return outCh
-}
-
-func (v PrefixT[T]) doWatch(ctx context.Context, client etcd.Watcher, handleErr func(err error), outCh chan EventsT[T], opts ...etcd.OpOption) {
-	rawCh := v.prefix.Watch(ctx, client, handleErr, opts...)
-	for {
-		select {
-		case <-ctx.Done():
-			return
-		case rawEvents, ok := <-rawCh:
-			if !ok {
-				return
-			}
-
-			outEvents := make([]EventT[T], len(rawEvents.Events))
-			for i, rawEvent := range rawEvents.Events {
-				outEvent := EventT[T]{
-					Kv:     rawEvent.Kv,
-					PrevKv: rawEvent.PrevKv,
-					Type:   rawEvent.Type,
-				}
-
-				if rawEvent.Type == CreateEvent || rawEvent.Type == UpdateEvent {
-					// Always decode create/update value
-					target := new(T)
-					if err := v.serde.Decode(ctx, rawEvent.Kv, target); err != nil {
-						handleErr(err)
-						continue
-					}
-					outEvent.Value = *target
-				} else if rawEvent.Type == DeleteEvent && rawEvent.PrevKv != nil {
-					// Decode previous value on delete, if is present.
-					// etcd.WithPrevKV() option must be used to enable it.
-					target := new(T)
-					if err := v.serde.Decode(ctx, rawEvent.PrevKv, target); err != nil {
-						handleErr(err)
-						continue
-					}
-					outEvent.Value = *target
-				}
-
-				outEvents[i] = outEvent
-			}
-
-			outCh <- EventsT[T]{
-				Header:  rawEvents.Header,
-				Events:  outEvents,
-				Created: rawEvents.Created,
-				InitErr: rawEvents.InitErr,
 			}
 		}
 	}

--- a/internal/pkg/service/common/etcdop/watch_test.go
+++ b/internal/pkg/service/common/etcdop/watch_test.go
@@ -210,6 +210,40 @@ func TestPrefix_GetAllAndWatch(t *testing.T) {
 	}, "DELETE timeout")
 
 	wg.Wait()
+func TestWatchBackoff(t *testing.T) {
+	t.Parallel()
+
+	b := newWatchBackoff()
+	b.RandomizationFactor = 0
+
+	// Get all delays without sleep
+	var delays []time.Duration
+	for i := 0; i < 14; i++ {
+		delay := b.NextBackOff()
+		if delay == backoff.Stop {
+			assert.Fail(t, "unexpected stop")
+			break
+		}
+		delays = append(delays, delay)
+	}
+
+	// Assert
+	assert.Equal(t, []time.Duration{
+		50 * time.Millisecond,
+		100 * time.Millisecond,
+		200 * time.Millisecond,
+		400 * time.Millisecond,
+		800 * time.Millisecond,
+		1600 * time.Millisecond,
+		3200 * time.Millisecond,
+		6400 * time.Millisecond,
+		12800 * time.Millisecond,
+		25600 * time.Millisecond,
+		51200 * time.Millisecond,
+		time.Minute,
+		time.Minute,
+		time.Minute,
+	}, delays)
 }
 
 func clearEvents(events Events) Events {

--- a/internal/pkg/service/common/etcdop/watchtyped.go
+++ b/internal/pkg/service/common/etcdop/watchtyped.go
@@ -1,0 +1,134 @@
+package etcdop
+
+import (
+	"context"
+
+	"go.etcd.io/etcd/api/v3/etcdserverpb"
+	etcd "go.etcd.io/etcd/client/v3"
+
+	"github.com/keboola/keboola-as-code/internal/pkg/service/common/etcdop/op"
+)
+
+type EventT[T any] struct {
+	Value  T
+	Kv     *op.KeyValue
+	PrevKv *op.KeyValue
+	Type   EventType
+}
+
+type EventsT[T any] struct {
+	Header *etcdserverpb.ResponseHeader
+	Events []EventT[T]
+	// Created is used to indicate the creation of the watcher.
+	Created bool
+	// InitErr signals an error during initialization of the watcher.
+	InitErr error
+}
+
+func (e *EventsT[T]) Rev() int64 {
+	return e.Header.Revision
+}
+
+func (v PrefixT[T]) Watch(ctx context.Context, client etcd.Watcher, handleErr func(error), opts ...etcd.OpOption) <-chan EventsT[T] {
+	outCh := make(chan EventsT[T])
+	go func() {
+		defer close(outCh)
+		v.doWatch(ctx, client, handleErr, outCh, opts...)
+	}()
+	return outCh
+}
+
+// GetAllAndWatch loads all keys in the prefix by the iterator and then watch for changes.
+// Values are decoded to the type T.
+// initDone channel signals end of the load phase and start of the watch phase.
+func (v PrefixT[T]) GetAllAndWatch(ctx context.Context, client *etcd.Client, handleErr func(err error), opts ...etcd.OpOption) (out <-chan EventsT[T]) {
+	outCh := make(chan EventsT[T])
+
+	go func() {
+		defer close(outCh)
+
+		// Get all iterator
+		itr := v.GetAll().Do(ctx, client)
+		var events []EventT[T]
+		sendBatch := func() {
+			if len(events) > 0 {
+				outCh <- EventsT[T]{Header: itr.Header(), Events: events}
+			}
+			events = nil
+		}
+
+		// Iterate and send batches of events
+		i := 1
+		err := itr.ForEachKV(func(kv op.KeyValueT[T], _ *etcdserverpb.ResponseHeader) error {
+			events = append(events, EventT[T]{Kv: kv.Kv, Value: kv.Value, Type: CreateEvent})
+			if i%getAllBatchSize == 0 {
+				sendBatch()
+			}
+			return nil
+		})
+		sendBatch()
+
+		// Check getAll error
+		if err != nil {
+			outCh <- EventsT[T]{InitErr: err}
+			return
+		}
+
+		// Continue with Watch where GetAll finished
+		v.doWatch(ctx, client, handleErr, outCh, append(opts, etcd.WithRev(itr.Header().Revision+1))...)
+	}()
+
+	return outCh
+}
+
+// doWatch is called from the Watch and GetAllAndWatch methods.
+func (v PrefixT[T]) doWatch(ctx context.Context, client etcd.Watcher, handleErr func(err error), outCh chan EventsT[T], opts ...etcd.OpOption) {
+	rawCh := v.prefix.Watch(ctx, client, handleErr, opts...)
+	for {
+		select {
+		case <-ctx.Done():
+			return
+		case rawEvents, ok := <-rawCh:
+			if !ok {
+				return
+			}
+
+			outEvents := make([]EventT[T], len(rawEvents.Events))
+			for i, rawEvent := range rawEvents.Events {
+				outEvent := EventT[T]{
+					Kv:     rawEvent.Kv,
+					PrevKv: rawEvent.PrevKv,
+					Type:   rawEvent.Type,
+				}
+
+				if rawEvent.Type == CreateEvent || rawEvent.Type == UpdateEvent {
+					// Always decode create/update value
+					target := new(T)
+					if err := v.serde.Decode(ctx, rawEvent.Kv, target); err != nil {
+						handleErr(err)
+						continue
+					}
+					outEvent.Value = *target
+				} else if rawEvent.Type == DeleteEvent && rawEvent.PrevKv != nil {
+					// Decode previous value on delete, if is present.
+					// etcd.WithPrevKV() option must be used to enable it.
+					target := new(T)
+					if err := v.serde.Decode(ctx, rawEvent.PrevKv, target); err != nil {
+						handleErr(err)
+						continue
+					}
+					outEvent.Value = *target
+				}
+
+				outEvents[i] = outEvent
+			}
+
+			outCh <- EventsT[T]{
+				Header:  rawEvents.Header,
+				Events:  outEvents,
+				Created: rawEvents.Created,
+				InitErr: rawEvents.InitErr,
+			}
+		}
+	}
+}

--- a/internal/pkg/service/common/etcdop/watchtyped.go
+++ b/internal/pkg/service/common/etcdop/watchtyped.go
@@ -25,6 +25,20 @@ func (e *WatchResponseT[T]) Rev() int64 {
 	return e.Header.Revision
 }
 
+// GetAllAndWatch loads all keys in the prefix by the iterator and then watch for changes.
+// Values are decoded to the type T.
+//
+// If a fatal error occurs, the watcher is restarted.
+// The "restarted" event is emitted before the restart.
+// Then, the following events are streamed from the beginning.
+//
+// See WatchResponse for details.
+func (v PrefixT[T]) GetAllAndWatch(ctx context.Context, client *etcd.Client, opts ...etcd.OpOption) (out <-chan WatchResponseT[T]) {
+	return v.decodeChannel(ctx, func(ctx context.Context) <-chan WatchResponse {
+		return v.prefix.GetAllAndWatch(ctx, client, opts...)
+	})
+}
+
 // Watch method wraps low-level etcd watcher.
 // Values are decoded to the type T.
 //
@@ -39,20 +53,6 @@ func (e *WatchResponseT[T]) Rev() int64 {
 func (v PrefixT[T]) Watch(ctx context.Context, client etcd.Watcher, opts ...etcd.OpOption) <-chan WatchResponseT[T] {
 	return v.decodeChannel(ctx, func(ctx context.Context) <-chan WatchResponse {
 		return v.prefix.Watch(ctx, client, opts...)
-	})
-}
-
-// GetAllAndWatch loads all keys in the prefix by the iterator and then watch for changes.
-// Values are decoded to the type T.
-//
-// If a fatal error occurs, the watcher is restarted.
-// The "restarted" event is emitted before the restart.
-// Then, the following events are streamed from the beginning.
-//
-// See WatchResponse for details.
-func (v PrefixT[T]) GetAllAndWatch(ctx context.Context, client *etcd.Client, opts ...etcd.OpOption) (out <-chan WatchResponseT[T]) {
-	return v.decodeChannel(ctx, func(ctx context.Context) <-chan WatchResponse {
-		return v.prefix.GetAllAndWatch(ctx, client, opts...)
 	})
 }
 

--- a/internal/pkg/service/common/prefixtree/prefixtree_test.go
+++ b/internal/pkg/service/common/prefixtree/prefixtree_test.go
@@ -84,4 +84,8 @@ func TestPrefixTree(t *testing.T) {
 	assert.True(t, found)
 	_, found = tree.Get("key/4")
 	assert.True(t, found)
+
+	// Reset
+	tree.Reset()
+	assert.Empty(t, tree.AllFromPrefix(""))
 }

--- a/internal/pkg/service/templates/api/http/http.go
+++ b/internal/pkg/service/templates/api/http/http.go
@@ -92,7 +92,7 @@ func HandleHTTPServer(proc *servicectx.Process, d dependencies.ForServer, u *url
 		defer cancel()
 
 		if err := srv.Shutdown(ctx); err != nil {
-			logger.Errorf(`HTTP server shutdown error: %w`, err)
+			logger.Errorf(`HTTP server shutdown error: %s`, err)
 		}
 		logger.Info("HTTP server shutdown finished")
 	})

--- a/internal/pkg/state/local/save.go
+++ b/internal/pkg/state/local/save.go
@@ -127,7 +127,7 @@ func (w *modelWriter) restoreBackups() {
 	if w.errors.Len() > 0 {
 		for dst, src := range w.backups {
 			if err := w.fs.Move(src, dst); err != nil {
-				w.logger.Debug(errors.Errorf(`cannot restore backup "%s" -> "%s": %w`, src, dst, err))
+				w.logger.Debug(errors.Errorf(`cannot restore backup "%s" -> "%s": %s`, src, dst, err))
 			}
 		}
 	}
@@ -137,7 +137,7 @@ func (w *modelWriter) restoreBackups() {
 func (w *modelWriter) removeBackups() {
 	for _, path := range w.backups {
 		if err := w.fs.Remove(path); err != nil {
-			w.logger.Debug(errors.Errorf(`cannot remove backup "%s": %w`, path, err))
+			w.logger.Debug(errors.Errorf(`cannot remove backup "%s": %s`, path, err))
 		}
 	}
 	w.backups = make(map[string]string)


### PR DESCRIPTION
Changes:
- Refactored `watch` operations in the `etcdop` pkg, fixed problem with `ErrCompacted`.

-----

Mame tu este tento neplanovany PR, problem, ktory bolo potrebne fixnut.

Jedna sa o to, ak pocas etcd watch operacie nastane fatalna chyba (`ErrCompacted`), z ktorej sa neda zotavit pomocou retry.

Watcher sice robi automaticky retries na vsetky chyby, okrem tychto fatalnych (tam sa to neda).

------

Tusil som, ze to moze byt poroblem, ked sa to pise v [dokumentacii](https://github.com/etcd-io/etcd/blob/6315f1cfdc5a16cf7b4610d1af47d67a329f242b/client/v3/watch.go#L70-L73):
```
... returned "WatchChan" will not be closed and block until event is triggered, except when server
returns a non-recoverable error (e.g. ErrCompacted) ...
```

-----

Ale nechal som si to na koniec, kedze sa to dost zlozito simuluje. 
Ale produkcia ma predbehla a vcera to tam [zacalo padat](https://my.papertrailapp.com/groups/37259701/events?q=%22etcdserver%3A+mvcc%3A+required+revision+has+been+compacted%22):
![image](https://user-images.githubusercontent.com/19371734/212301863-e1e53d44-8640-402a-b326-341d75f8aef8.png)

Takze sa to musi fixnut.

------------

**Compaction**
- Etcd si uchovava by default vsetky predchadzajuce stavy/revizie databazy, pomocou `watch` mozes potom prehrat celu historiu eventov, ak chces.
- My to mame nastavene tak, ze nechavame iba poslednych `15min`, a vsetky ostatne eventy sa skomprimuju do jednej revizie (`compact operation`): https://github.com/keboola/keboola-as-code/blob/234b9f3ca93120fa48e29738d15e5d7731d1e265/provisioning/common/etcd/values.yaml#L43-L49

------------

- Problem nastane, ak nastane `compact` pocas toho ako niektory watcher nestihol prijat nejake eventy, napr. sietova chyba, .... alebo sa len este nestihlo vsetko spracovat, ako je ukazane na priklade nizsie.
- Je to vysvetlene napr. tu https://github.com/etcd-io/etcd/issues/8668, neexistuje ziadny spravny sposob, ako by etcd klient mohol spravit retry tak, aby sa nemohlo stat, ze sa niektore eventy stratia `compaction error should not be auto resumed, and it cannot in theory.`

------

**Priklad**

(v kode je pridany podobny test `TestPrefix_GetAllAndWatch_ErrCompacted`)

Situacia je takáto:
```
rev001 PUT key001
rev002 PUT key002
<watcher network error>
rev003 PUT key003
rev004 PUT key004
<auto-compaction>
<watcher reconnected>
?
```

Watcher prijal `key001` a `key002`, nastal sietovy vypadok, pocas ktoreho nastala `auto-compaction`, potom sa podarilo obnovit spojenie.

Pred `compact` operaciou, mame v etcd vsetky revizie:
```
rev001 key001
rev002 key002
rev003 key003
rev004 key004
```

Po `compact` mame vsetko v jednej revizi (zmazane kluce zmiznu uplne, pri zmene sa zachova posledna verzia, ...)
```
rev004 key001
rev004 key002
rev004 key003
rev004 key004
```

- Watcher by teda mal spravne dostat `key003` a `key004`.
- Watcher ma ulozene, ze posledna prijata revizia je `rev002`, ... a teda chce dalsiu reviziu, ktora nasleduje.
- No ked sa pozrieme do etcd ^^^, tak tam mame vsetko ako `rev004` a nevieme rozhodnut co mu mame poslat.
- Jedine mozne riesenie je poslat mu vsekto odznova, ale to si vyzaduje reset aj na aplikacnej urovni.
- Preto `etcd client` vrati chybu `ErrCompacted` a vyriesit si to musi programator v apke.

------

Ja som teda do `GetAllAndWatch` operacie implementovat fix, ... ak nastane `ErrCompacted`, tak do channel sa zapise `Restarted` event  a poslu sa vsetky hodnoty od zaciatku.

Napriklad, ak mame watch na `distribution nodes`, tak sa aj na aplikacnej urovni vsetky zmazu (`reset`) a nastavia sa podla aktualneho stavu v etcd (`getAll`). Dolezite je to spravit atomicky, ... potom si nikto nic nevsimne.

Rovnako je to aj v ostatnych situaciach kde sa pouziva watcher.


--------

Doplnil som aj kratku dokumentaciu/prehlad (asi si to je dobre pred review pozriet):
https://github.com/keboola/keboola-as-code/blob/3bdb87cacea677e557e71e9b96a3495e58ef63d3/internal/pkg/service/common/etcdop/etcdop.go#L21-L33