### PR TITLE
Use UTCTime for all datetimes in the model

### DIFF
--- a/internal/pkg/service/buffer/store/file.go
+++ b/internal/pkg/service/buffer/store/file.go
@@ -95,18 +95,19 @@ func (s *Store) setFileStateOp(ctx context.Context, now time.Time, file *model.F
 	clone := *file
 	stm := filestate.NewSTM(file.State, func(ctx context.Context, from, to filestate.State) error {
 		// Update fields
+		nowUTC := model.UTCTime(now)
 		clone.State = to
 		switch to {
 		case filestate.Closing:
-			clone.ClosingAt = &now
+			clone.ClosingAt = &nowUTC
 		case filestate.Closed:
-			clone.ClosedAt = &now
+			clone.ClosedAt = &nowUTC
 		case filestate.Importing:
-			clone.ImportingAt = &now
+			clone.ImportingAt = &nowUTC
 		case filestate.Imported:
-			clone.ImportedAt = &now
+			clone.ImportedAt = &nowUTC
 		case filestate.Failed:
-			clone.FailedAt = &now
+			clone.FailedAt = &nowUTC
 		default:
 			panic(errors.Errorf(`unexpected state "%s"`, to))
 		}

--- a/internal/pkg/service/buffer/store/file_test.go
+++ b/internal/pkg/service/buffer/store/file_test.go
@@ -154,7 +154,7 @@ file/<STATE>/00001000/my-receiver/my-export/2006-01-01T08:04:05.000Z
 -----
 %A
   "state": "<STATE>",%A
-  "<STATE>At": "2010-01-01T01:01:01+07:00"%A
+  "<STATE>At": "2009-12-31T18:01:01.000Z"%A
 >>>>>
 `
 		etcdhelper.AssertKVs(t, store.client, strings.ReplaceAll(expected, "<STATE>", tc.to.String()))

--- a/internal/pkg/service/buffer/store/model/conditions.go
+++ b/internal/pkg/service/buffer/store/model/conditions.go
@@ -30,14 +30,17 @@ func (c ImportConditions) ShouldImport(s CurrentImportState) (bool, string) {
 	}
 
 	if s.Count >= c.Count {
-		return true, fmt.Sprintf("import count limit met, received: %d rows, limit: %d rows", s.Count, c.Count)
+		return true, fmt.Sprintf("import count threshold met, received: %d rows, threshold: %d rows", s.Count, c.Count)
 	}
 	if s.Size >= c.Size {
-		return true, fmt.Sprintf("import size limit met, received: %s, limit: %s", s.Size.String(), c.Size.String())
+		return true, fmt.Sprintf("import size threshold met, received: %s, threshold: %s", s.Size.String(), c.Size.String())
 	}
-	sinceLastImport := s.Now.Sub(s.LastImportAt).Truncate(time.Second)
+
+	now := time.Time(s.Now)
+	lastImportAt := time.Time(s.LastImportAt)
+	sinceLastImport := now.Sub(lastImportAt).Truncate(time.Second)
 	if sinceLastImport >= c.Time {
-		return true, fmt.Sprintf("import time limit met, last import at: %s, passed: %s limit: %s", s.LastImportAt.Format(time.Stamp), sinceLastImport.String(), c.Time.String())
+		return true, fmt.Sprintf("import time threshold met, last import at: %s, passed: %s threshold: %s", lastImportAt.Format(TimeFormat), sinceLastImport.String(), c.Time.String())
 	}
 	return false, "conditions not met"
 }

--- a/internal/pkg/service/buffer/store/model/conditions_test.go
+++ b/internal/pkg/service/buffer/store/model/conditions_test.go
@@ -13,6 +13,11 @@ import (
 func TestImportConditions_ShouldImport_Defaults(t *testing.T) {
 	t.Parallel()
 
+	now, _ := time.Parse(time.RFC3339, "2010-01-01T01:01:01Z")
+	nowUTC := model.UTCTime(now)
+	before01MinUTC := model.UTCTime(now.Add(-1 * time.Minute))
+	before20MinUTC := model.UTCTime(now.Add(-20 * time.Minute))
+
 	// Defaults
 	ic := model.ImportConditions{
 		Count: 0,
@@ -23,8 +28,8 @@ func TestImportConditions_ShouldImport_Defaults(t *testing.T) {
 	res, desc := ic.ShouldImport(model.CurrentImportState{
 		Count:        50,
 		Size:         1 * datasize.KB,
-		Now:          time.Now(),
-		LastImportAt: time.Now().Add(-1 * time.Minute),
+		Now:          nowUTC,
+		LastImportAt: before01MinUTC,
 	})
 	assert.False(t, res)
 	assert.Equal(t, "conditions not met", desc)
@@ -33,36 +38,40 @@ func TestImportConditions_ShouldImport_Defaults(t *testing.T) {
 	res, desc = ic.ShouldImport(model.CurrentImportState{
 		Count:        2000,
 		Size:         1 * datasize.MB,
-		Now:          time.Now(),
-		LastImportAt: time.Now().Add(-1 * time.Minute),
+		Now:          nowUTC,
+		LastImportAt: before01MinUTC,
 	})
 	assert.True(t, res)
-	assert.Equal(t, "import count limit met, received: 2000 rows, limit: 1000 rows", desc)
+	assert.Equal(t, "import count threshold met, received: 2000 rows, threshold: 1000 rows", desc)
 
 	// Default size met
 	res, desc = ic.ShouldImport(model.CurrentImportState{
 		Count:        100,
 		Size:         5 * datasize.MB,
-		Now:          time.Now(),
-		LastImportAt: time.Now().Add(-1 * time.Minute),
+		Now:          nowUTC,
+		LastImportAt: before01MinUTC,
 	})
 	assert.True(t, res)
-	assert.Equal(t, "import size limit met, received: 5MB, limit: 1MB", desc)
+	assert.Equal(t, "import size threshold met, received: 5MB, threshold: 1MB", desc)
 
 	// Default time met
 	res, desc = ic.ShouldImport(model.CurrentImportState{
 		Count:        100,
 		Size:         1 * datasize.KB,
-		Now:          time.Now(),
-		LastImportAt: time.Now().Add(-10 * time.Minute),
+		Now:          nowUTC,
+		LastImportAt: before20MinUTC,
 	})
 	assert.True(t, res)
-	assert.Contains(t, desc, "import time limit met, last import at")
-	assert.Contains(t, desc, "limit: 5m0s")
+	assert.Equal(t, "import time threshold met, last import at: 2010-01-01T00:41:01.000Z, passed: 20m0s threshold: 5m0s", desc)
 }
 
 func TestImportConditions_ShouldImport_Custom(t *testing.T) {
 	t.Parallel()
+
+	now, _ := time.Parse(time.RFC3339, "2010-01-01T01:01:01Z")
+	nowUTC := model.UTCTime(now)
+	before01MinUTC := model.UTCTime(now.Add(-1 * time.Minute))
+	before20MinUTC := model.UTCTime(now.Add(-20 * time.Minute))
 
 	// Defaults
 	ic := model.ImportConditions{
@@ -74,8 +83,8 @@ func TestImportConditions_ShouldImport_Custom(t *testing.T) {
 	res, desc := ic.ShouldImport(model.CurrentImportState{
 		Count:        50,
 		Size:         1 * datasize.MB,
-		Now:          time.Now(),
-		LastImportAt: time.Now().Add(-1 * time.Minute),
+		Now:          nowUTC,
+		LastImportAt: before01MinUTC,
 	})
 	assert.False(t, res)
 	assert.Equal(t, "conditions not met", desc)
@@ -84,30 +93,29 @@ func TestImportConditions_ShouldImport_Custom(t *testing.T) {
 	res, desc = ic.ShouldImport(model.CurrentImportState{
 		Count:        200,
 		Size:         1 * datasize.MB,
-		Now:          time.Now(),
-		LastImportAt: time.Now().Add(-1 * time.Minute),
+		Now:          nowUTC,
+		LastImportAt: before01MinUTC,
 	})
 	assert.True(t, res)
-	assert.Equal(t, "import count limit met, received: 200 rows, limit: 100 rows", desc)
+	assert.Equal(t, "import count threshold met, received: 200 rows, threshold: 100 rows", desc)
 
 	// Size met
 	res, desc = ic.ShouldImport(model.CurrentImportState{
 		Count:        50,
 		Size:         10 * datasize.MB,
-		Now:          time.Now(),
-		LastImportAt: time.Now().Add(-1 * time.Minute),
+		Now:          nowUTC,
+		LastImportAt: before01MinUTC,
 	})
 	assert.True(t, res)
-	assert.Equal(t, "import size limit met, received: 10MB, limit: 5MB", desc)
+	assert.Equal(t, "import size threshold met, received: 10MB, threshold: 5MB", desc)
 
 	// Time met
 	res, desc = ic.ShouldImport(model.CurrentImportState{
 		Count:        50,
 		Size:         1 * datasize.MB,
-		Now:          time.Now(),
-		LastImportAt: time.Now().Add(-20 * time.Minute),
+		Now:          nowUTC,
+		LastImportAt: before20MinUTC,
 	})
 	assert.True(t, res)
-	assert.Contains(t, desc, "import time limit met, last import at")
-	assert.Contains(t, desc, "limit: 10m0s")
+	assert.Equal(t, "import time threshold met, last import at: 2010-01-01T00:41:01.000Z, passed: 20m0s threshold: 10m0s", desc)
 }

--- a/internal/pkg/service/buffer/store/model/file.go
+++ b/internal/pkg/service/buffer/store/model/file.go
@@ -17,12 +17,12 @@ type File struct {
 	State              filestate.State  `json:"state" validate:"required,oneof=opened closing closed importing imported failed"`
 	Mapping            Mapping          `json:"mapping" validate:"required,dive"`
 	StorageResource    *storageapi.File `json:"storageResource" validate:"required"`
-	ClosingAt          *time.Time       `json:"closingAt,omitempty"`
-	ClosedAt           *time.Time       `json:"closedAt,omitempty"`
-	ImportingAt        *time.Time       `json:"importingAt,omitempty"`
-	ImportedAt         *time.Time       `json:"importedAt,omitempty"`
-	ManifestUploadedAt *time.Time       `json:"manifestUploadedAt,omitempty"`
-	FailedAt           *time.Time       `json:"failedAt,omitempty"`
+	ClosingAt          *UTCTime         `json:"closingAt,omitempty"`
+	ClosedAt           *UTCTime         `json:"closedAt,omitempty"`
+	ImportingAt        *UTCTime         `json:"importingAt,omitempty"`
+	ImportedAt         *UTCTime         `json:"importedAt,omitempty"`
+	ManifestUploadedAt *UTCTime         `json:"manifestUploadedAt,omitempty"`
+	FailedAt           *UTCTime         `json:"failedAt,omitempty"`
 	LastError          string           `json:"lastError,omitempty"`
 }
 

--- a/internal/pkg/service/buffer/store/model/slice.go
+++ b/internal/pkg/service/buffer/store/model/slice.go
@@ -15,10 +15,10 @@ type Slice struct {
 	State       slicestate.State `json:"state" validate:"required,oneof=opened closing closed uploading uploaded failed"`
 	Mapping     Mapping          `json:"mapping" validate:"required,dive"`
 	Number      int              `json:"sliceNumber" validate:"required"`
-	ClosingAt   *time.Time       `json:"closingAt,omitempty"`
-	UploadingAt *time.Time       `json:"uploadingAt,omitempty"`
-	UploadedAt  *time.Time       `json:"uploadedAt,omitempty"`
-	FailedAt    *time.Time       `json:"failedAt,omitempty"`
+	ClosingAt   *UTCTime         `json:"closingAt,omitempty"`
+	UploadingAt *UTCTime         `json:"uploadingAt,omitempty"`
+	UploadedAt  *UTCTime         `json:"uploadedAt,omitempty"`
+	FailedAt    *UTCTime         `json:"failedAt,omitempty"`
 	LastError   string           `json:"lastError,omitempty"`
 }
 

--- a/internal/pkg/service/buffer/store/model/state.go
+++ b/internal/pkg/service/buffer/store/model/state.go
@@ -9,8 +9,8 @@ import (
 type CurrentImportState struct {
 	Count        int
 	Size         datasize.ByteSize
-	Now          time.Time
-	LastImportAt time.Time
+	Now          UTCTime
+	LastImportAt UTCTime
 }
 
 func DefaultConditions() ImportConditions {

--- a/internal/pkg/service/buffer/store/model/time.go
+++ b/internal/pkg/service/buffer/store/model/time.go
@@ -1,0 +1,9 @@
+package model
+
+import (
+	"github.com/keboola/keboola-as-code/internal/pkg/service/buffer/store/key"
+)
+
+const TimeFormat = key.TimeFormat
+
+type UTCTime = key.UTCTime

--- a/internal/pkg/service/buffer/store/slice_test.go
+++ b/internal/pkg/service/buffer/store/slice_test.go
@@ -120,14 +120,13 @@ func TestStore_SetSliceState_Transitions(t *testing.T) {
 	ctx := context.Background()
 	store := newStoreForTest(t)
 	slice := sliceForTest()
-	now, _ := time.Parse(time.RFC3339, "2010-01-01T01:01:01+07:00")
 
 	// Create slice
 	assert.NoError(t, store.CreateSlice(ctx, slice))
 
 	for _, tc := range testCases {
 		// Trigger transition
-		ok, err := store.SetSliceState(ctx, &slice, tc.to, now)
+		ok, err := store.SetSliceState(ctx, &slice, tc.to)
 		desc := fmt.Sprintf("%s -> %s", tc.from, tc.to)
 		assert.NoError(t, err, desc)
 		assert.True(t, ok, desc)
@@ -138,14 +137,14 @@ slice/<STATE>/00001000/my-receiver/my-export/2006-01-01T08:04:05.000Z/2006-01-02
 -----
 %A
   "state": "<STATE>",%A
-  "<STATE>At": "2010-01-01T01:01:01+07:00"%A
+  "<STATE>At": "2009-12-31T18:01:01.000Z"%A
 >>>>>
 `
 		etcdhelper.AssertKVs(t, store.client, strings.ReplaceAll(expected, "<STATE>", tc.to.String()))
 
 		// Test duplicated transition -> nop
 		slice.State = tc.from
-		ok, err = store.SetSliceState(ctx, &slice, tc.to, time.Now())
+		ok, err = store.SetSliceState(ctx, &slice, tc.to)
 		assert.NoError(t, err, desc)
 		assert.False(t, ok, desc)
 		assert.Equal(t, tc.to, slice.State, desc)


### PR DESCRIPTION
Part of: https://keboola.atlassian.net/browse/BA-40

Changes:
- All times are now stored in the same UTCTime format.