### PR TITLE
statistics: Add BodySize, FileSize, FileGZipSize fields, merge stats on slice close

### DIFF
--- a/internal/pkg/service/buffer/api/dependencies/dependencies.go
+++ b/internal/pkg/service/buffer/api/dependencies/dependencies.go
@@ -184,7 +184,7 @@ func NewDepsForProjectRequest(publicDeps ForPublicRequest, ctx context.Context, 
 	}
 	d.tokenManager = token.NewManager(d)
 	d.tableManager = table.NewManager(d)
-	d.fileManager = file.NewManager(d)
+	d.fileManager = file.NewManager(d.Clock(), d.StorageAPIClient())
 	return d, nil
 }
 

--- a/internal/pkg/service/buffer/api/receive/importer.go
+++ b/internal/pkg/service/buffer/api/receive/importer.go
@@ -71,7 +71,7 @@ func (r *Importer) CreateRecord(ctx context.Context, d requestDeps, receiverKey 
 		}
 	}
 
-	body, err := ReadBody(bodyReader)
+	body, bodySize, err := ReadBody(bodyReader)
 	if err != nil {
 		return errors.Errorf(`cannot read request body: %w`, err)
 	}
@@ -103,7 +103,7 @@ func (r *Importer) CreateRecord(ctx context.Context, d requestDeps, receiverKey 
 		}
 
 		// Update statistics
-		r.stats.Notify(slice.SliceKey, uint64(len(csvRow)))
+		r.stats.Notify(slice.SliceKey, uint64(len(csvRow)), uint64(bodySize))
 	}
 
 	if errs.Len() > 1 {

--- a/internal/pkg/service/buffer/api/receive/readbody_test.go
+++ b/internal/pkg/service/buffer/api/receive/readbody_test.go
@@ -16,6 +16,6 @@ func TestReadBody_TooLarge(t *testing.T) {
 
 	size := int(datasize.MB + 1)
 	assert.Equal(t, 1024*1024+1, size)
-	_, err := ReadBody(io.NopCloser(strings.NewReader(idgenerator.Random(size))))
+	_, _, err := ReadBody(io.NopCloser(strings.NewReader(idgenerator.Random(size))))
 	assert.EqualError(t, err, "payload too large, the maximum size is 1MB")
 }

--- a/internal/pkg/service/buffer/statistics/apinode_test.go
+++ b/internal/pkg/service/buffer/statistics/apinode_test.go
@@ -35,7 +35,7 @@ func TestStatsManager(t *testing.T) {
 	etcdhelper.AssertKVs(t, client, "")
 
 	// notify -> wait 1 second -> sync
-	node.Notify(sliceKey, 1000)
+	node.Notify(sliceKey, 1000, 1100)
 	etcdhelper.ExpectModification(t, client, func() {
 		clk.Add(SyncInterval)
 	})
@@ -49,9 +49,10 @@ stats/received/00000123/my-receiver/my-export/1970-01-01T00:00:00.000Z/1970-01-0
   "exportId": "my-export",
   "fileId": "1970-01-01T00:00:00.000Z",
   "sliceId": "1970-01-01T00:00:00.000Z",
-  "count": 1,
-  "size": 1000,
-  "lastRecordAt": "1970-01-01T01:00:01.000Z"
+  "lastRecordAt": "1970-01-01T01:00:01.000Z",
+  "recordsCount": 1,
+  "recordsSize": 1000,
+  "bodySize": 1100
 }
 >>>>>
 `)
@@ -68,15 +69,16 @@ stats/received/00000123/my-receiver/my-export/1970-01-01T00:00:00.000Z/1970-01-0
   "exportId": "my-export",
   "fileId": "1970-01-01T00:00:00.000Z",
   "sliceId": "1970-01-01T00:00:00.000Z",
-  "count": 1,
-  "size": 1000,
-  "lastRecordAt": "1970-01-01T01:00:01.000Z"
+  "lastRecordAt": "1970-01-01T01:00:01.000Z",
+  "recordsCount": 1,
+  "recordsSize": 1000,
+  "bodySize": 1100
 }
 >>>>>
 `)
 
 	// notify -> wait 1 second -> sync
-	node.Notify(sliceKey, 2000)
+	node.Notify(sliceKey, 2000, 2200)
 	etcdhelper.ExpectModification(t, client, func() {
 		clk.Add(SyncInterval)
 	})
@@ -90,9 +92,10 @@ stats/received/00000123/my-receiver/my-export/1970-01-01T00:00:00.000Z/1970-01-0
   "exportId": "my-export",
   "fileId": "1970-01-01T00:00:00.000Z",
   "sliceId": "1970-01-01T00:00:00.000Z",
-  "count": 2,
-  "size": 3000,
-  "lastRecordAt": "1970-01-01T01:00:03.000Z"
+  "lastRecordAt": "1970-01-01T01:00:03.000Z",
+  "recordsCount": 2,
+  "recordsSize": 3000,
+  "bodySize": 3300
 }
 >>>>>
 `)
@@ -109,15 +112,16 @@ stats/received/00000123/my-receiver/my-export/1970-01-01T00:00:00.000Z/1970-01-0
   "exportId": "my-export",
   "fileId": "1970-01-01T00:00:00.000Z",
   "sliceId": "1970-01-01T00:00:00.000Z",
-  "count": 2,
-  "size": 3000,
-  "lastRecordAt": "1970-01-01T01:00:03.000Z"
+  "lastRecordAt": "1970-01-01T01:00:03.000Z",
+  "recordsCount": 2,
+  "recordsSize": 3000,
+  "bodySize": 3300
 }
 >>>>>
 `)
 
 	// notify before shutdown
-	node.Notify(sliceKey, 3000)
+	node.Notify(sliceKey, 3000, 3300)
 	etcdhelper.ExpectModification(t, client, func() {
 		d.Process().Shutdown(errors.New("test shutdown"))
 		d.Process().WaitForShutdown()
@@ -134,9 +138,10 @@ stats/received/00000123/my-receiver/my-export/1970-01-01T00:00:00.000Z/1970-01-0
   "exportId": "my-export",
   "fileId": "1970-01-01T00:00:00.000Z",
   "sliceId": "1970-01-01T00:00:00.000Z",
-  "count": 3,
-  "size": 6000,
-  "lastRecordAt": "1970-01-01T01:00:05.000Z"
+  "lastRecordAt": "1970-01-01T01:00:05.000Z",
+  "recordsCount": 3,
+  "recordsSize": 6000,
+  "bodySize": 6600
 }
 >>>>>
 `)

--- a/internal/pkg/service/buffer/storage/file/manager.go
+++ b/internal/pkg/service/buffer/storage/file/manager.go
@@ -14,20 +14,17 @@ import (
 	"github.com/keboola/keboola-as-code/internal/pkg/utils/errors"
 )
 
-const DateFormat = "20060102150405"
+const (
+	DateFormat = "20060102150405"
+)
 
 type Manager struct {
 	clock  clock.Clock
 	client client.Sender
 }
 
-type dependencies interface {
-	Clock() clock.Clock
-	StorageAPIClient() client.Sender
-}
-
-func NewManager(d dependencies) *Manager {
-	return &Manager{clock: d.Clock(), client: d.StorageAPIClient()}
+func NewManager(clk clock.Clock, client client.Sender) *Manager {
+	return &Manager{clock: clk, client: client}
 }
 
 func (m *Manager) CreateFiles(ctx context.Context, rb rollback.Builder, receiver *model.Receiver) error {

--- a/internal/pkg/service/buffer/storage/file/manager_test.go
+++ b/internal/pkg/service/buffer/storage/file/manager_test.go
@@ -29,7 +29,7 @@ func TestManager_CreateFile(t *testing.T) {
 	ctx := context.Background()
 	p := testproject.GetTestProjectForTest(t)
 	d := bufferDependencies.NewMockedDeps(t, dependencies.WithClock(clk), dependencies.WithTestProject(p))
-	m := NewManager(d)
+	m := NewManager(d.Clock(), d.StorageAPIClient())
 	rb := rollback.New(d.Logger())
 	client := p.StorageAPIClient()
 

--- a/internal/pkg/service/buffer/store/file.go
+++ b/internal/pkg/service/buffer/store/file.go
@@ -71,7 +71,10 @@ func (s *Store) getFileOp(_ context.Context, fileKey key.FileKey) op.ForType[*op
 
 // SetFileState method atomically changes the state of the file.
 // False is returned, if the given file is already in the target state.
-func (s *Store) SetFileState(ctx context.Context, now time.Time, file *model.File, to filestate.State) (bool, error) { //nolint:dupl
+func (s *Store) SetFileState(ctx context.Context, now time.Time, file *model.File, to filestate.State) (ok bool, err error) { //nolint:dupl
+	_, span := s.tracer.Start(ctx, "keboola.go.buffer.store.SetFileState")
+	defer telemetry.EndSpan(span, &err)
+
 	txn, err := s.setFileStateOp(ctx, now, file, to)
 	if err != nil {
 		return false, err

--- a/internal/pkg/service/buffer/store/filestate/filestate.go
+++ b/internal/pkg/service/buffer/store/filestate/filestate.go
@@ -20,7 +20,7 @@ const Opened State = "opened"
 const Closing State = "closing"
 
 // Closed
-// The file is ready for import.
+// The file is ready for import, the manifest has been uploaded.
 const Closed State = "closed"
 
 // Importing

--- a/internal/pkg/service/buffer/store/model/slice.go
+++ b/internal/pkg/service/buffer/store/model/slice.go
@@ -20,6 +20,8 @@ type Slice struct {
 	UploadedAt  *UTCTime         `json:"uploadedAt,omitempty"`
 	FailedAt    *UTCTime         `json:"failedAt,omitempty"`
 	LastError   string           `json:"lastError,omitempty"`
+	// Statistics are set by the "slice close" operation, the value is nil, if there is no record.
+	Statistics *Stats `json:"statistics,omitempty"`
 }
 
 func NewSlice(fileKey key.FileKey, now time.Time, mapping Mapping, number int) Slice {

--- a/internal/pkg/service/buffer/store/model/slice.go
+++ b/internal/pkg/service/buffer/store/model/slice.go
@@ -13,6 +13,7 @@ import (
 type Slice struct {
 	key.SliceKey
 	State       slicestate.State `json:"state" validate:"required,oneof=opened closing closed uploading uploaded failed"`
+	IsEmpty     bool             `json:"isEmpty,omitempty"`
 	Mapping     Mapping          `json:"mapping" validate:"required,dive"`
 	Number      int              `json:"sliceNumber" validate:"required"`
 	ClosingAt   *UTCTime         `json:"closingAt,omitempty"`

--- a/internal/pkg/service/buffer/store/model/stats.go
+++ b/internal/pkg/service/buffer/store/model/stats.go
@@ -11,31 +11,23 @@ type StatsProvider interface {
 
 // Stats struct is common for received/uploaded/imported statistics.
 type Stats struct {
-	Count uint64 `json:"count" validate:"required"`
-	Size  uint64 `json:"size" validate:"required"`
 	// LastRecordAt contains the timestamp of the last received/uploaded/imported record, according to the type of statistics.
-	LastRecordAt key.UTCTime `json:"lastRecordAt" validate:"required"`
+	LastRecordAt UTCTime `json:"lastRecordAt" validate:"required"`
+	// RecordsCount is count of received/uploaded/imported records.
+	RecordsCount uint64 `json:"recordsCount" validate:"required"`
+	// RecordsSize is total size of CSV rows.
+	RecordsSize uint64 `json:"recordsSize"`
+	// BodySize is total size of all processed request bodies.
+	BodySize uint64 `json:"bodySize"`
+	// FileSize total file size before compression.
+	FileSize uint64 `json:"fileSize,omitempty"`
+	// FileSize total file size after compression.
+	FileGZipSize uint64 `json:"fileGZipSize,omitempty"`
 }
 
 type SliceStats struct {
 	key.SliceKey
 	Stats
-}
-
-func NewSliceStats(
-	sliceKey key.SliceKey,
-	count uint64,
-	size uint64,
-	lastReceivedAt key.ReceivedAt,
-) SliceStats {
-	return SliceStats{
-		SliceKey: sliceKey,
-		Stats: Stats{
-			Count:        count,
-			Size:         size,
-			LastRecordAt: key.UTCTime(lastReceivedAt),
-		},
-	}
 }
 
 func (s Stats) GetStats() Stats {

--- a/internal/pkg/service/buffer/store/receiver.go
+++ b/internal/pkg/service/buffer/store/receiver.go
@@ -185,7 +185,20 @@ func (s *Store) DeleteReceiver(ctx context.Context, receiverKey key.ReceiverKey)
 		s.deleteReceiverExportsOp(ctx, receiverKey),
 		s.deleteReceiverMappingsOp(ctx, receiverKey),
 		s.deleteReceiverTokensOp(ctx, receiverKey),
-		s.deleteReceiverStatsOp(ctx, receiverKey),
+		s.schema.ReceivedStats().InReceiver(receiverKey).DeleteAll(),
+		s.schema.Files().Opened().InReceiver(receiverKey).DeleteAll(),
+		s.schema.Files().Closed().InReceiver(receiverKey).DeleteAll(),
+		s.schema.Files().Closing().InReceiver(receiverKey).DeleteAll(),
+		s.schema.Files().Importing().InReceiver(receiverKey).DeleteAll(),
+		s.schema.Files().Imported().InReceiver(receiverKey).DeleteAll(),
+		s.schema.Files().Failed().InReceiver(receiverKey).DeleteAll(),
+		s.schema.Slices().Opened().InReceiver(receiverKey).DeleteAll(),
+		s.schema.Slices().Closing().InReceiver(receiverKey).DeleteAll(),
+		s.schema.Slices().Uploading().InReceiver(receiverKey).DeleteAll(),
+		s.schema.Slices().Uploaded().InReceiver(receiverKey).DeleteAll(),
+		s.schema.Slices().Failed().InReceiver(receiverKey).DeleteAll(),
+		s.schema.Records().InReceiver(receiverKey).DeleteAll(),
+		s.schema.Tasks().InReceiver(receiverKey).DeleteAll(),
 	).Do(ctx, s.client)
 	return err
 }

--- a/internal/pkg/service/buffer/store/record.go
+++ b/internal/pkg/service/buffer/store/record.go
@@ -32,3 +32,9 @@ func (s *Store) CreateRecord(ctx context.Context, recordKey key.RecordKey, csvRo
 
 	return s.schema.Records().ByKey(recordKey).Put(csvRow).Do(ctx, s.client)
 }
+
+func (s *Store) CountRecords(ctx context.Context, k key.SliceKey) (count int64, err error) {
+	_, span := s.tracer.Start(ctx, "keboola.go.buffer.store.RecordsCount")
+	defer telemetry.EndSpan(span, &err)
+	return s.schema.Records().InSlice(k).Count().Do(ctx, s.client)
+}

--- a/internal/pkg/service/buffer/store/record.go
+++ b/internal/pkg/service/buffer/store/record.go
@@ -8,6 +8,7 @@ import (
 	"github.com/keboola/keboola-as-code/internal/pkg/idgenerator"
 	"github.com/keboola/keboola-as-code/internal/pkg/service/buffer/store/key"
 	serviceError "github.com/keboola/keboola-as-code/internal/pkg/service/common/errors"
+	"github.com/keboola/keboola-as-code/internal/pkg/service/common/etcdop/op"
 	"github.com/keboola/keboola-as-code/internal/pkg/telemetry"
 	"github.com/keboola/keboola-as-code/internal/pkg/utils/errors"
 )
@@ -36,5 +37,12 @@ func (s *Store) CreateRecord(ctx context.Context, recordKey key.RecordKey, csvRo
 func (s *Store) CountRecords(ctx context.Context, k key.SliceKey) (count int64, err error) {
 	_, span := s.tracer.Start(ctx, "keboola.go.buffer.store.RecordsCount")
 	defer telemetry.EndSpan(span, &err)
-	return s.schema.Records().InSlice(k).Count().Do(ctx, s.client)
+	err = s.countRecordsOp(k, &count).DoOrErr(ctx, s.client)
+	return count, err
+}
+
+func (s *Store) countRecordsOp(k key.SliceKey, out *int64) op.Op {
+	return s.schema.Records().InSlice(k).Count().WithOnResult(func(v int64) {
+		*out = v
+	})
 }

--- a/internal/pkg/service/buffer/store/record_test.go
+++ b/internal/pkg/service/buffer/store/record_test.go
@@ -17,25 +17,51 @@ func TestStore_CreateRecord(t *testing.T) {
 	ctx := context.Background()
 	store := newStoreForTest(t)
 
-	time1, err := time.Parse(time.RFC3339, `2006-01-01T15:04:05+07:00`)
-	assert.NoError(t, err)
-	time2, err := time.Parse(time.RFC3339, `2006-01-02T15:04:05+07:00`)
-	assert.NoError(t, err)
-	receiverKey := key.ReceiverKey{ProjectID: 1000, ReceiverID: "my-receiver"}
-	exportKey := key.ExportKey{ReceiverKey: receiverKey, ExportID: "my-export"}
-	fileKey := key.FileKey{ExportKey: exportKey, FileID: key.FileID(time1)}
-	sliceKey := key.SliceKey{FileKey: fileKey, SliceID: key.SliceID(time2)}
-
-	record := key.NewRecordKey(sliceKey, time2)
-	err = store.CreateRecord(ctx, record, `one,two,"th""ree"`)
-	assert.NoError(t, err)
+	recordKey := recordKeyForTest("2006-01-02T15:04:10+07:00")
+	assert.NoError(t, store.CreateRecord(ctx, recordKey, `one,two,"th""ree"`))
 
 	// Check keys
 	etcdhelper.AssertKVs(t, store.client, `
 <<<<<
-record/00001000/my-receiver/my-export/2006-01-02T08:04:05.000Z/2006-01-02T08:04:05.000Z_%c%c%c%c%c
+record/00001000/my-receiver/my-export/2006-01-01T08:04:05.000Z/2006-01-02T08:04:10.000Z_%c%c%c%c%c
 -----
 one,two,"th""ree"
 >>>>>
 `)
+}
+
+func TestStore_CountRecords(t *testing.T) {
+	t.Parallel()
+
+	ctx := context.Background()
+	store := newStoreForTest(t)
+
+	recordKey1 := recordKeyForTest("2006-01-02T15:04:10+07:00")
+	recordKey2 := recordKeyForTest("2006-01-02T15:04:20+07:00")
+	recordKey3 := recordKeyForTest("2006-01-02T15:04:30+07:00")
+
+	count, err := store.CountRecords(ctx, recordKey1.SliceKey)
+	assert.Equal(t, int64(0), count)
+	assert.NoError(t, err)
+
+	assert.NoError(t, store.CreateRecord(ctx, recordKey1, `...`))
+	count, err = store.CountRecords(ctx, recordKey1.SliceKey)
+	assert.Equal(t, int64(1), count)
+	assert.NoError(t, err)
+
+	assert.NoError(t, store.CreateRecord(ctx, recordKey2, `...`))
+	assert.NoError(t, store.CreateRecord(ctx, recordKey3, `...`))
+	count, err = store.CountRecords(ctx, recordKey1.SliceKey)
+	assert.Equal(t, int64(3), count)
+	assert.NoError(t, err)
+}
+
+func recordKeyForTest(now string) key.RecordKey {
+	sliceFileTime, _ := time.Parse(time.RFC3339, "2006-01-01T15:04:05+07:00")
+	recordTime, _ := time.Parse(time.RFC3339, now)
+	receiverKey := key.ReceiverKey{ProjectID: 1000, ReceiverID: "my-receiver"}
+	exportKey := key.ExportKey{ReceiverKey: receiverKey, ExportID: "my-export"}
+	fileKey := key.FileKey{ExportKey: exportKey, FileID: key.FileID(sliceFileTime)}
+	sliceKey := key.SliceKey{FileKey: fileKey, SliceID: key.SliceID(sliceFileTime)}
+	return key.NewRecordKey(sliceKey, recordTime)
 }

--- a/internal/pkg/service/buffer/store/schema/file.go
+++ b/internal/pkg/service/buffer/store/schema/file.go
@@ -14,6 +14,10 @@ type Files struct {
 	files
 }
 
+type FilesInReceiver struct {
+	files
+}
+
 type FilesInAState struct {
 	files
 }
@@ -59,6 +63,10 @@ func (v Files) Failed() FilesInAState {
 
 func (v FilesInAState) ByKey(k storeKey.FileKey) KeyT[model.File] {
 	return v.Key(k.String())
+}
+
+func (v FilesInAState) InReceiver(k storeKey.ReceiverKey) FilesInReceiver {
+	return FilesInReceiver{files: v.files.Add(k.String())}
 }
 
 func (v FilesInAState) InExport(k storeKey.ExportKey) FilesInExport {

--- a/internal/pkg/service/buffer/store/schema/record.go
+++ b/internal/pkg/service/buffer/store/schema/record.go
@@ -35,6 +35,12 @@ func (v *Schema) Records() RecordsRoot {
 	return RecordsRoot{records: NewPrefix("record")}
 }
 
+func (v RecordsRoot) InReceiver(k storeKey.ReceiverKey) RecordsInReceiver {
+	return RecordsInReceiver{
+		records: v.records.Add(k.String()),
+	}
+}
+
 func (v RecordsRoot) InSlice(k storeKey.SliceKey) RecordsInSlice {
 	return RecordsInSlice{
 		records: v.records.Add(k.ExportKey.String()).Add(k.SliceID.String()),

--- a/internal/pkg/service/buffer/store/schema/record.go
+++ b/internal/pkg/service/buffer/store/schema/record.go
@@ -35,6 +35,12 @@ func (v *Schema) Records() RecordsRoot {
 	return RecordsRoot{records: NewPrefix("record")}
 }
 
+func (v RecordsRoot) InSlice(k storeKey.SliceKey) RecordsInSlice {
+	return RecordsInSlice{
+		records: v.records.Add(k.ExportKey.String()).Add(k.SliceID.String()),
+	}
+}
+
 func (v RecordsRoot) ByKey(k storeKey.RecordKey) Key {
-	return v.records.Key(k.String())
+	return v.InSlice(k.SliceKey).Key(k.ID())
 }

--- a/internal/pkg/service/buffer/store/schema/runtime_counter.go
+++ b/internal/pkg/service/buffer/store/schema/runtime_counter.go
@@ -1,0 +1,34 @@
+package schema
+
+import (
+	storeKey "github.com/keboola/keboola-as-code/internal/pkg/service/buffer/store/key"
+	. "github.com/keboola/keboola-as-code/internal/pkg/service/common/etcdop"
+)
+
+type Counters struct {
+	prefix
+}
+
+type RecordIDCounter struct {
+	prefix
+}
+
+type RecordIDCounterInReceiver struct {
+	prefix
+}
+
+func (v RuntimeRoot) Counter() Counters {
+	return Counters{prefix: v.prefix.Add("counter")}
+}
+
+func (v Counters) RecordID() RecordIDCounter {
+	return RecordIDCounter{prefix: v.prefix.Add("record/id")}
+}
+
+func (v RecordIDCounter) InReceiver(k storeKey.ReceiverKey) RecordIDCounterInReceiver {
+	return RecordIDCounterInReceiver{prefix: v.prefix.Add(k.String())}
+}
+
+func (v RecordIDCounter) ByKey(k storeKey.ExportKey) Key {
+	return v.Key(k.String())
+}

--- a/internal/pkg/service/buffer/store/schema/schema_test.go
+++ b/internal/pkg/service/buffer/store/schema/schema_test.go
@@ -213,6 +213,10 @@ func TestSchema(t *testing.T) {
 			"record/",
 		},
 		{
+			s.Records().InSlice(sliceKey).Prefix(),
+			"record/00000123/my-receiver/my-export/2006-01-02T09:04:05.000Z/",
+		},
+		{
 			s.Records().ByKey(recordKey).Key(),
 			"record/00000123/my-receiver/my-export/2006-01-02T09:04:05.000Z/2006-01-02T10:04:05.000Z_abcdef",
 		},

--- a/internal/pkg/service/buffer/store/schema/schema_test.go
+++ b/internal/pkg/service/buffer/store/schema/schema_test.go
@@ -8,8 +8,10 @@ import (
 
 	"github.com/stretchr/testify/assert"
 
+	"github.com/keboola/keboola-as-code/internal/pkg/service/buffer/store/filestate"
 	"github.com/keboola/keboola-as-code/internal/pkg/service/buffer/store/key"
 	"github.com/keboola/keboola-as-code/internal/pkg/service/buffer/store/schema"
+	"github.com/keboola/keboola-as-code/internal/pkg/service/buffer/store/slicestate"
 )
 
 type keyTestCase struct{ actual, expected string }
@@ -89,11 +91,11 @@ func TestSchema(t *testing.T) {
 			"file/",
 		},
 		{
-			s.Files().Opened().Prefix(),
-			"file/opened/",
+			s.Files().InState(filestate.Opened).InReceiver(receiverKey).Prefix(),
+			"file/opened/00000123/my-receiver/",
 		},
 		{
-			s.Files().Opened().InExport(exportKey).Prefix(),
+			s.Files().InState(filestate.Opened).InExport(exportKey).Prefix(),
 			"file/opened/00000123/my-receiver/my-export/",
 		},
 		{
@@ -101,64 +103,44 @@ func TestSchema(t *testing.T) {
 			"file/opened/00000123/my-receiver/my-export/2006-01-02T08:04:05.000Z",
 		},
 		{
+			s.Files().Opened().Prefix(),
+			"file/opened/",
+		},
+		{
 			s.Files().Closing().Prefix(),
 			"file/closing/",
-		},
-		{
-			s.Files().Closing().InExport(exportKey).Prefix(),
-			"file/closing/00000123/my-receiver/my-export/",
-		},
-		{
-			s.Files().Closing().ByKey(fileKey).Key(),
-			"file/closing/00000123/my-receiver/my-export/2006-01-02T08:04:05.000Z",
 		},
 		{
 			s.Files().Closed().Prefix(),
 			"file/closed/",
 		},
 		{
-			s.Files().Closed().InExport(exportKey).Prefix(),
-			"file/closed/00000123/my-receiver/my-export/",
-		},
-		{
-			s.Files().Closed().ByKey(fileKey).Key(),
-			"file/closed/00000123/my-receiver/my-export/2006-01-02T08:04:05.000Z",
-		},
-		{
-			s.Files().Importing().Prefix(),
-			"file/importing/",
-		},
-		{
-			s.Files().Importing().InExport(exportKey).Prefix(),
-			"file/importing/00000123/my-receiver/my-export/",
-		},
-		{
-			s.Files().Importing().ByKey(fileKey).Key(),
-			"file/importing/00000123/my-receiver/my-export/2006-01-02T08:04:05.000Z",
-		},
-		{
 			s.Files().Imported().Prefix(),
 			"file/imported/",
-		},
-		{
-			s.Files().Imported().InExport(exportKey).Prefix(),
-			"file/imported/00000123/my-receiver/my-export/",
-		},
-		{
-			s.Files().Imported().ByKey(fileKey).Key(),
-			"file/imported/00000123/my-receiver/my-export/2006-01-02T08:04:05.000Z",
 		},
 		{
 			s.Files().Failed().Prefix(),
 			"file/failed/",
 		},
 		{
-			s.Files().Failed().InExport(exportKey).Prefix(),
-			"file/failed/00000123/my-receiver/my-export/",
+			s.Slices().InState(slicestate.Opened).Prefix(),
+			"slice/opened/",
 		},
 		{
-			s.Files().Failed().ByKey(fileKey).Key(),
-			"file/failed/00000123/my-receiver/my-export/2006-01-02T08:04:05.000Z",
+			s.Slices().InState(slicestate.Opened).InReceiver(receiverKey).Prefix(),
+			"slice/opened/00000123/my-receiver/",
+		},
+		{
+			s.Slices().InState(slicestate.Opened).InExport(exportKey).Prefix(),
+			"slice/opened/00000123/my-receiver/my-export/",
+		},
+		{
+			s.Slices().InState(slicestate.Opened).InFile(fileKey).Prefix(),
+			"slice/opened/00000123/my-receiver/my-export/2006-01-02T08:04:05.000Z/",
+		},
+		{
+			s.Slices().InState(slicestate.Opened).ByKey(sliceKey).Key(),
+			"slice/opened/00000123/my-receiver/my-export/2006-01-02T08:04:05.000Z/2006-01-02T09:04:05.000Z",
 		},
 		{
 			s.Slices().Prefix(),
@@ -169,48 +151,28 @@ func TestSchema(t *testing.T) {
 			"slice/opened/",
 		},
 		{
-			s.Slices().Opened().InFile(fileKey).Prefix(),
-			"slice/opened/00000123/my-receiver/my-export/2006-01-02T08:04:05.000Z/",
+			s.Slices().Closing().Prefix(),
+			"slice/closing/",
 		},
 		{
-			s.Slices().Opened().ByKey(sliceKey).Key(),
-			"slice/opened/00000123/my-receiver/my-export/2006-01-02T08:04:05.000Z/2006-01-02T09:04:05.000Z",
+			s.Slices().Uploading().Prefix(),
+			"slice/uploading/",
 		},
 		{
-			s.Slices().Closing().InFile(fileKey).Prefix(),
-			"slice/closing/00000123/my-receiver/my-export/2006-01-02T08:04:05.000Z/",
+			s.Slices().Uploaded().Prefix(),
+			"slice/uploaded/",
 		},
 		{
-			s.Slices().Closing().ByKey(sliceKey).Key(),
-			"slice/closing/00000123/my-receiver/my-export/2006-01-02T08:04:05.000Z/2006-01-02T09:04:05.000Z",
-		},
-		{
-			s.Slices().Uploading().InFile(fileKey).Prefix(),
-			"slice/uploading/00000123/my-receiver/my-export/2006-01-02T08:04:05.000Z/",
-		},
-		{
-			s.Slices().Uploading().ByKey(sliceKey).Key(),
-			"slice/uploading/00000123/my-receiver/my-export/2006-01-02T08:04:05.000Z/2006-01-02T09:04:05.000Z",
-		},
-		{
-			s.Slices().Uploaded().InFile(fileKey).Prefix(),
-			"slice/uploaded/00000123/my-receiver/my-export/2006-01-02T08:04:05.000Z/",
-		},
-		{
-			s.Slices().Uploaded().ByKey(sliceKey).Key(),
-			"slice/uploaded/00000123/my-receiver/my-export/2006-01-02T08:04:05.000Z/2006-01-02T09:04:05.000Z",
-		},
-		{
-			s.Slices().Failed().InFile(fileKey).Prefix(),
-			"slice/failed/00000123/my-receiver/my-export/2006-01-02T08:04:05.000Z/",
-		},
-		{
-			s.Slices().Failed().ByKey(sliceKey).Key(),
-			"slice/failed/00000123/my-receiver/my-export/2006-01-02T08:04:05.000Z/2006-01-02T09:04:05.000Z",
+			s.Slices().Failed().Prefix(),
+			"slice/failed/",
 		},
 		{
 			s.Records().Prefix(),
 			"record/",
+		},
+		{
+			s.Records().InReceiver(receiverKey).Prefix(),
+			"record/00000123/my-receiver/",
 		},
 		{
 			s.Records().InSlice(sliceKey).Prefix(),
@@ -277,19 +239,35 @@ func TestSchema(t *testing.T) {
 			"runtime/lock/task/00000123/my-receiver/my-export/my-lock",
 		},
 		{
+			s.Runtime().Counter().Prefix(),
+			"runtime/counter/",
+		},
+		{
+			s.Runtime().Counter().RecordID().Prefix(),
+			"runtime/counter/record/id/",
+		},
+		{
+			s.Runtime().Counter().RecordID().InReceiver(exportKey.ReceiverKey).Prefix(),
+			"runtime/counter/record/id/00000123/my-receiver/",
+		},
+		{
+			s.Runtime().Counter().RecordID().ByKey(exportKey).Key(),
+			"runtime/counter/record/id/00000123/my-receiver/my-export",
+		},
+		{
 			s.Tasks().Prefix(),
 			"task/",
 		},
 		{
-			s.Tasks().ByProject(projectID).Prefix(),
+			s.Tasks().InProject(projectID).Prefix(),
 			"task/00000123/",
 		},
 		{
-			s.Tasks().ByReceiver(receiverKey).Prefix(),
+			s.Tasks().InReceiver(receiverKey).Prefix(),
 			"task/00000123/my-receiver/",
 		},
 		{
-			s.Tasks().ByExport(exportKey).Prefix(),
+			s.Tasks().InExport(exportKey).Prefix(),
 			"task/00000123/my-receiver/my-export/",
 		},
 		{

--- a/internal/pkg/service/buffer/store/schema/slice.go
+++ b/internal/pkg/service/buffer/store/schema/slice.go
@@ -18,6 +18,10 @@ type SlicesInAState struct {
 	slices
 }
 
+type SlicesInReceiver struct {
+	slices
+}
+
 type SlicesInExport struct {
 	slices
 }
@@ -59,6 +63,10 @@ func (v Slices) Failed() SlicesInAState {
 
 func (v SlicesInAState) ByKey(k storeKey.SliceKey) KeyT[model.Slice] {
 	return v.Key(k.String())
+}
+
+func (v SlicesInAState) InReceiver(k storeKey.ReceiverKey) SlicesInReceiver {
+	return SlicesInReceiver{slices: v.slices.Add(k.String())}
 }
 
 func (v SlicesInAState) InExport(k storeKey.ExportKey) SlicesInExport {

--- a/internal/pkg/service/buffer/store/schema/task.go
+++ b/internal/pkg/service/buffer/store/schema/task.go
@@ -28,15 +28,15 @@ func (v *Schema) Tasks() TasksRoot {
 	return TasksRoot{tasks: NewTypedPrefix[model.Task]("task", v.serde)}
 }
 
-func (v TasksRoot) ByProject(projectID key.ProjectID) TasksByProject {
+func (v TasksRoot) InProject(projectID key.ProjectID) TasksByProject {
 	return TasksByProject{tasks: v.tasks.Add(projectID.String())}
 }
 
-func (v TasksRoot) ByReceiver(k key.ReceiverKey) TasksByReceiver {
+func (v TasksRoot) InReceiver(k key.ReceiverKey) TasksByReceiver {
 	return TasksByReceiver{tasks: v.tasks.Add(k.String())}
 }
 
-func (v TasksRoot) ByExport(k key.ExportKey) TasksByReceiver {
+func (v TasksRoot) InExport(k key.ExportKey) TasksByReceiver {
 	return TasksByReceiver{tasks: v.tasks.Add(k.String())}
 }
 

--- a/internal/pkg/service/buffer/store/slice.go
+++ b/internal/pkg/service/buffer/store/slice.go
@@ -122,6 +122,8 @@ func (s *Store) CloseSlice(ctx context.Context, slice *model.Slice) (err error) 
 			if recordsCount > 0 {
 				slice.Statistics = &stats
 				slice.Statistics.RecordsCount = uint64(recordsCount)
+			} else {
+				slice.IsEmpty = true
 			}
 
 			// Delete all "per node" statistics

--- a/internal/pkg/service/buffer/store/slice.go
+++ b/internal/pkg/service/buffer/store/slice.go
@@ -100,7 +100,10 @@ func (s *Store) listUploadedSlicesOp(_ context.Context, fileKey key.FileKey) ite
 
 // SetSliceState method atomically changes the state of the file.
 // False is returned, if the given file is already in the target state.
-func (s *Store) SetSliceState(ctx context.Context, slice *model.Slice, to slicestate.State) (bool, error) { //nolint:dupl
+func (s *Store) SetSliceState(ctx context.Context, slice *model.Slice, to slicestate.State) (ok bool, err error) { //nolint:dupl
+	_, span := s.tracer.Start(ctx, "keboola.go.buffer.store.SetSliceState")
+	defer telemetry.EndSpan(span, &err)
+
 	txn, err := s.setSliceStateOp(ctx, s.clock.Now(), slice, to)
 	if err != nil {
 		return false, err

--- a/internal/pkg/service/buffer/store/slice.go
+++ b/internal/pkg/service/buffer/store/slice.go
@@ -98,6 +98,16 @@ func (s *Store) listUploadedSlicesOp(_ context.Context, fileKey key.FileKey) ite
 		GetAll()
 }
 
+func (s *Store) MarkSliceClosed(ctx context.Context, slice *model.Slice) (err error) {
+	ok, err := s.SetSliceState(ctx, slice, slicestate.Uploading)
+	if err != nil {
+		return err
+	}
+	if !ok {
+		return errors.Errorf(`slice "%s" is already in the "uploading" state`, slice.SliceKey)
+	}
+	return nil
+}
 // SetSliceState method atomically changes the state of the file.
 // False is returned, if the given file is already in the target state.
 func (s *Store) SetSliceState(ctx context.Context, slice *model.Slice, to slicestate.State) (ok bool, err error) { //nolint:dupl

--- a/internal/pkg/service/buffer/store/slice.go
+++ b/internal/pkg/service/buffer/store/slice.go
@@ -108,6 +108,7 @@ func (s *Store) MarkSliceClosed(ctx context.Context, slice *model.Slice) (err er
 	}
 	return nil
 }
+
 // SetSliceState method atomically changes the state of the file.
 // False is returned, if the given file is already in the target state.
 func (s *Store) SetSliceState(ctx context.Context, slice *model.Slice, to slicestate.State) (ok bool, err error) { //nolint:dupl

--- a/internal/pkg/service/buffer/store/stats.go
+++ b/internal/pkg/service/buffer/store/stats.go
@@ -1,18 +1,31 @@
 package store
 
 import (
+	"context"
+
 	"github.com/keboola/keboola-as-code/internal/pkg/service/buffer/store/model"
 	"github.com/keboola/keboola-as-code/internal/pkg/service/common/etcdop/iterator"
+	"github.com/keboola/keboola-as-code/internal/pkg/telemetry"
 )
+
+func GetStatsFrom[T model.StatsProvider](ctx context.Context, s *Store, prefix iterator.DefinitionT[T]) (out model.Stats, err error) {
+	_, span := s.tracer.Start(ctx, "keboola.go.buffer.store.GetStats")
+	defer telemetry.EndSpan(span, &err)
+	err = sumStatsOp(prefix, &out).DoOrErr(ctx, s.client)
+	return out, err
+}
 
 // sumStatsOp sums all stats from the iterator.
 func sumStatsOp[T model.StatsProvider](prefix iterator.DefinitionT[T], out *model.Stats) *iterator.ForEachOpT[T] {
 	return prefix.ForEachOp(func(item T, _ *iterator.Header) error {
-		partialStats := item.GetStats()
-		out.Count += partialStats.Count
-		out.Size += partialStats.Size
-		if partialStats.LastRecordAt.After(out.LastRecordAt) {
-			out.LastRecordAt = partialStats.LastRecordAt
+		partial := item.GetStats()
+		out.RecordsCount += partial.RecordsCount
+		out.RecordsSize += partial.RecordsSize
+		out.BodySize += partial.BodySize
+		out.FileSize += partial.FileSize
+		out.FileGZipSize += partial.FileGZipSize
+		if partial.LastRecordAt.After(out.LastRecordAt) {
+			out.LastRecordAt = partial.LastRecordAt
 		}
 		return nil
 	})

--- a/internal/pkg/service/buffer/store/stats_received.go
+++ b/internal/pkg/service/buffer/store/stats_received.go
@@ -6,39 +6,12 @@ import (
 
 	"github.com/keboola/keboola-as-code/internal/pkg/service/buffer/store/key"
 	"github.com/keboola/keboola-as-code/internal/pkg/service/buffer/store/model"
-	"github.com/keboola/keboola-as-code/internal/pkg/service/common/etcdop/iterator"
 	"github.com/keboola/keboola-as-code/internal/pkg/service/common/etcdop/op"
 	"github.com/keboola/keboola-as-code/internal/pkg/telemetry"
 	"github.com/keboola/keboola-as-code/internal/pkg/utils/errors"
 )
 
 const maxStatsPerTxn = 50
-
-func (s *Store) GetReceivedStatsByFile(ctx context.Context, fileKey key.FileKey) (stats model.Stats, err error) {
-	_, span := s.tracer.Start(ctx, "keboola.go.buffer.store.GetReceivedStatsByFile")
-	defer telemetry.EndSpan(span, &err)
-
-	out := model.Stats{}
-	err = s.getReceivedStatsByFileOp(fileKey, &out).DoOrErr(ctx, s.client)
-	return out, err
-}
-
-func (s *Store) getReceivedStatsByFileOp(fileKey key.FileKey, out *model.Stats) *iterator.ForEachOpT[model.SliceStats] {
-	return sumStatsOp(s.schema.ReceivedStats().InFile(fileKey).GetAll(), out)
-}
-
-func (s *Store) GetReceivedStatsBySlice(ctx context.Context, sliceKey key.SliceKey) (stats model.Stats, err error) {
-	_, span := s.tracer.Start(ctx, "keboola.go.buffer.store.GetReceivedStatsBySlice")
-	defer telemetry.EndSpan(span, &err)
-
-	out := model.Stats{}
-	err = s.getReceivedStatsBySliceOp(sliceKey, &out).DoOrErr(ctx, s.client)
-	return out, err
-}
-
-func (s *Store) getReceivedStatsBySliceOp(sliceKey key.SliceKey, out *model.Stats) *iterator.ForEachOpT[model.SliceStats] {
-	return sumStatsOp(s.schema.ReceivedStats().InSlice(sliceKey).GetAll(), out)
-}
 
 func (s *Store) UpdateSliceReceivedStats(ctx context.Context, nodeID string, stats []model.SliceStats) (err error) {
 	_, span := s.tracer.Start(ctx, "keboola.go.buffer.store.UpdateSliceReceivedStats")

--- a/internal/pkg/service/buffer/store/stats_received.go
+++ b/internal/pkg/service/buffer/store/stats_received.go
@@ -4,7 +4,6 @@ import (
 	"context"
 	"sync"
 
-	"github.com/keboola/keboola-as-code/internal/pkg/service/buffer/store/key"
 	"github.com/keboola/keboola-as-code/internal/pkg/service/buffer/store/model"
 	"github.com/keboola/keboola-as-code/internal/pkg/service/common/etcdop/op"
 	"github.com/keboola/keboola-as-code/internal/pkg/telemetry"
@@ -56,11 +55,4 @@ func (s *Store) updateStatsOp(_ context.Context, nodeID string, stats model.Slic
 		InSlice(stats.SliceKey).
 		ByNodeID(nodeID).
 		Put(stats)
-}
-
-func (s *Store) deleteReceiverStatsOp(_ context.Context, receiverKey key.ReceiverKey) op.CountOp {
-	return s.schema.
-		ReceivedStats().
-		InReceiver(receiverKey).
-		DeleteAll()
 }

--- a/internal/pkg/service/buffer/store/stats_received_test.go
+++ b/internal/pkg/service/buffer/store/stats_received_test.go
@@ -10,13 +10,16 @@ import (
 
 	"github.com/keboola/keboola-as-code/internal/pkg/service/buffer/store/key"
 	"github.com/keboola/keboola-as-code/internal/pkg/service/buffer/store/model"
+	"github.com/keboola/keboola-as-code/internal/pkg/service/buffer/store/schema"
 	"github.com/keboola/keboola-as-code/internal/pkg/utils/etcdhelper"
+	"github.com/keboola/keboola-as-code/internal/pkg/validator"
 )
 
 func TestStore_GetReceivedStatsByFile(t *testing.T) {
 	t.Parallel()
 
 	ctx := context.Background()
+	sm := schema.New(validator.New().Validate)
 	store := newStoreForTest(t)
 
 	time1 := time.Time{}.UTC().Add(time.Minute)
@@ -38,10 +41,10 @@ func TestStore_GetReceivedStatsByFile(t *testing.T) {
 	}}))
 
 	// No stats
-	stats, err := store.GetReceivedStatsByFile(ctx, fileF1Key)
+	stats, err := GetStatsFrom(ctx, store, sm.ReceivedStats().InFile(fileF1Key).GetAll())
 	assert.NoError(t, err)
 	assert.Empty(t, stats)
-	stats, err = store.GetReceivedStatsByFile(ctx, fileF2Key)
+	stats, err = GetStatsFrom(ctx, store, sm.ReceivedStats().InFile(fileF2Key).GetAll())
 	assert.NoError(t, err)
 	assert.Empty(t, stats)
 
@@ -49,88 +52,88 @@ func TestStore_GetReceivedStatsByFile(t *testing.T) {
 	assert.NoError(t, store.UpdateSliceReceivedStats(ctx, "node1", []model.SliceStats{
 		{
 			SliceKey: sliceF1S1Key,
-			Stats:    model.Stats{Count: 10, Size: 100, LastRecordAt: key.UTCTime(time1.Add(1 * time.Hour))},
+			Stats:    model.Stats{RecordsCount: 10, RecordsSize: 100, BodySize: 1000, LastRecordAt: key.UTCTime(time1.Add(1 * time.Hour))},
 		},
 		{
 			SliceKey: sliceF1S2Key,
-			Stats:    model.Stats{Count: 1, Size: 10, LastRecordAt: key.UTCTime(time1.Add(1 * time.Hour))},
+			Stats:    model.Stats{RecordsCount: 1, RecordsSize: 10, BodySize: 100, LastRecordAt: key.UTCTime(time1.Add(1 * time.Hour))},
 		},
 		{
 			SliceKey: sliceF2S1Key,
-			Stats:    model.Stats{Count: 2, Size: 20, LastRecordAt: key.UTCTime(time2.Add(1 * time.Hour))},
+			Stats:    model.Stats{RecordsCount: 2, RecordsSize: 20, BodySize: 200, LastRecordAt: key.UTCTime(time2.Add(1 * time.Hour))},
 		},
 	}))
 	// node1[sliceF1S1Key] + node1[sliceF1S2Key]
-	assertFileStats(t, store, fileF1Key, 10+1, 100+10, time1.Add(1*time.Hour))
+	assertFileStats(t, store, fileF1Key, 10+1, 100+10, 1000+100, time1.Add(1*time.Hour))
 	// node1[sliceF2S1Key]
-	assertFileStats(t, store, fileF2Key, 2, 20, time2.Add(1*time.Hour))
+	assertFileStats(t, store, fileF2Key, 2, 20, 200, time2.Add(1*time.Hour))
 
 	// Update - node 1
 	assert.NoError(t, store.UpdateSliceReceivedStats(ctx, "node1", []model.SliceStats{
 		{
 			SliceKey: sliceF1S1Key,
-			Stats:    model.Stats{Count: 30, Size: 300, LastRecordAt: key.UTCTime(time1.Add(2 * time.Hour))},
+			Stats:    model.Stats{RecordsCount: 30, RecordsSize: 300, BodySize: 3000, LastRecordAt: key.UTCTime(time1.Add(2 * time.Hour))},
 		},
 		{
 			SliceKey: sliceF1S2Key,
-			Stats:    model.Stats{Count: 4, Size: 40, LastRecordAt: key.UTCTime(time1.Add(2 * time.Hour))},
+			Stats:    model.Stats{RecordsCount: 4, RecordsSize: 40, BodySize: 400, LastRecordAt: key.UTCTime(time1.Add(2 * time.Hour))},
 		},
 		{
 			SliceKey: sliceF2S1Key,
-			Stats:    model.Stats{Count: 5, Size: 50, LastRecordAt: key.UTCTime(time2.Add(2 * time.Hour))},
+			Stats:    model.Stats{RecordsCount: 5, RecordsSize: 50, BodySize: 500, LastRecordAt: key.UTCTime(time2.Add(2 * time.Hour))},
 		},
 	}))
 	// node1[sliceF1S1Key] + node1[sliceF1S2Key]
-	assertFileStats(t, store, fileF1Key, 30+4, 300+40, time1.Add(2*time.Hour))
+	assertFileStats(t, store, fileF1Key, 30+4, 300+40, 3000+400, time1.Add(2*time.Hour))
 	// node1[sliceF2S1Key]
-	assertFileStats(t, store, fileF2Key, 5, 50, time2.Add(2*time.Hour))
+	assertFileStats(t, store, fileF2Key, 5, 50, 500, time2.Add(2*time.Hour))
 
 	// First sync - node 2
 	assert.NoError(t, store.UpdateSliceReceivedStats(ctx, "node2", []model.SliceStats{
 		{
 			SliceKey: sliceF1S1Key,
-			Stats:    model.Stats{Count: 60, Size: 600, LastRecordAt: key.UTCTime(time1.Add(3 * time.Hour))},
+			Stats:    model.Stats{RecordsCount: 60, RecordsSize: 600, BodySize: 6000, LastRecordAt: key.UTCTime(time1.Add(3 * time.Hour))},
 		},
 		{
 			SliceKey: sliceF1S2Key,
-			Stats:    model.Stats{Count: 7, Size: 70, LastRecordAt: key.UTCTime(time1.Add(3 * time.Hour))},
+			Stats:    model.Stats{RecordsCount: 7, RecordsSize: 70, BodySize: 700, LastRecordAt: key.UTCTime(time1.Add(3 * time.Hour))},
 		},
 		{
 			SliceKey: sliceF2S1Key,
-			Stats:    model.Stats{Count: 8, Size: 80, LastRecordAt: key.UTCTime(time2.Add(3 * time.Hour))},
+			Stats:    model.Stats{RecordsCount: 8, RecordsSize: 80, BodySize: 800, LastRecordAt: key.UTCTime(time2.Add(3 * time.Hour))},
 		},
 	}))
 	// node1[sliceF1S1Key] + node1[sliceF1S2Key] + node2[sliceF1S1Key] + node2[sliceF1S2Key]
-	assertFileStats(t, store, fileF1Key, 30+4+60+7, 300+40+600+70, time1.Add(3*time.Hour))
+	assertFileStats(t, store, fileF1Key, 30+4+60+7, 300+40+600+70, 3000+400+6000+700, time1.Add(3*time.Hour))
 	// node1[sliceF2S1Key] + node2[sliceF2S1Key]
-	assertFileStats(t, store, fileF2Key, 5+8, 50+80, time2.Add(3*time.Hour))
+	assertFileStats(t, store, fileF2Key, 5+8, 50+80, 500+800, time2.Add(3*time.Hour))
 
 	// Update - node 2
 	assert.NoError(t, store.UpdateSliceReceivedStats(ctx, "node2", []model.SliceStats{
 		{
 			SliceKey: sliceF1S1Key,
-			Stats:    model.Stats{Count: 10, Size: 100, LastRecordAt: key.UTCTime(time1.Add(4 * time.Hour))},
+			Stats:    model.Stats{RecordsCount: 10, RecordsSize: 100, BodySize: 1000, LastRecordAt: key.UTCTime(time1.Add(4 * time.Hour))},
 		},
 		{
 			SliceKey: sliceF1S2Key,
-			Stats:    model.Stats{Count: 2, Size: 20, LastRecordAt: key.UTCTime(time1.Add(4 * time.Hour))},
+			Stats:    model.Stats{RecordsCount: 2, RecordsSize: 20, BodySize: 200, LastRecordAt: key.UTCTime(time1.Add(4 * time.Hour))},
 		},
 		{
 			SliceKey: sliceF2S1Key,
-			Stats:    model.Stats{Count: 3, Size: 30, LastRecordAt: key.UTCTime(time2.Add(4 * time.Hour))},
+			Stats:    model.Stats{RecordsCount: 3, RecordsSize: 30, BodySize: 300, LastRecordAt: key.UTCTime(time2.Add(4 * time.Hour))},
 		},
 	}))
 	// node1[sliceF1S1Key] + node1[sliceF1S2Key] + node2[sliceF1S1Key] + node2[sliceF1S2Key]
-	assertFileStats(t, store, fileF1Key, 30+4+10+2, 300+40+100+20, time1.Add(4*time.Hour))
+	assertFileStats(t, store, fileF1Key, 30+4+10+2, 300+40+100+20, 3000+400+1000+200, time1.Add(4*time.Hour))
 	// node1[sliceF2S1Key] + node2[sliceF2S1Key]
-	assertFileStats(t, store, fileF2Key, 5+3, 50+30, time2.Add(4*time.Hour))
+	assertFileStats(t, store, fileF2Key, 5+3, 50+30, 500+300, time2.Add(4*time.Hour))
 
 	// Delete receiver - no stats
 	assert.NoError(t, store.DeleteReceiver(ctx, receiverKey))
-	stats, err = store.GetReceivedStatsByFile(ctx, fileF1Key)
+	stats, err = GetStatsFrom(ctx, store, sm.ReceivedStats().InFile(fileF1Key).GetAll())
 	assert.NoError(t, err)
 	assert.Empty(t, stats)
-	stats, err = store.GetReceivedStatsByFile(ctx, fileF2Key)
+	stats, err = GetStatsFrom(ctx, store, sm.ReceivedStats().InFile(fileF2Key).GetAll())
 	assert.NoError(t, err)
 	assert.Empty(t, stats)
 }
@@ -139,6 +142,7 @@ func TestStore_GetReceivedStatsByFile_Many(t *testing.T) {
 	t.Parallel()
 
 	ctx := context.Background()
+	sm := schema.New(validator.New().Validate)
 	store := newStoreForTest(t)
 
 	fileOpenedAt := time.Time{}.UTC().Add(time.Minute)
@@ -154,8 +158,8 @@ func TestStore_GetReceivedStatsByFile_Many(t *testing.T) {
 			stats = append(stats, model.SliceStats{
 				SliceKey: key.SliceKey{SliceID: key.SliceID(sliceOpenedAt), FileKey: fileKey},
 				Stats: model.Stats{
-					Count:        1,
-					Size:         10,
+					RecordsCount: 1,
+					RecordsSize:  10,
 					LastRecordAt: key.UTCTime(sliceOpenedAt.Add(1 * time.Minute)),
 				},
 			})
@@ -164,10 +168,10 @@ func TestStore_GetReceivedStatsByFile_Many(t *testing.T) {
 		assert.NoError(t, store.UpdateSliceReceivedStats(ctx, nodeID, stats))
 	}
 
-	stats, err := store.GetReceivedStatsByFile(ctx, fileKey)
+	stats, err := GetStatsFrom(ctx, store, sm.ReceivedStats().InFile(fileKey).GetAll())
 	assert.NoError(t, err)
-	assert.Equal(t, uint64(3*1000), stats.Count)
-	assert.Equal(t, uint64(3*10*1000), stats.Size)
+	assert.Equal(t, uint64(3*1000), stats.RecordsCount)
+	assert.Equal(t, uint64(3*10*1000), stats.RecordsSize)
 	assert.Equal(t, key.UTCTime(fileOpenedAt.Add(1000*time.Hour+1*time.Minute)), stats.LastRecordAt)
 }
 
@@ -175,6 +179,7 @@ func TestStore_GetReceivedStatsBySlice(t *testing.T) {
 	t.Parallel()
 
 	ctx := context.Background()
+	sm := schema.New(validator.New().Validate)
 	store := newStoreForTest(t)
 
 	time1 := time.Time{}.UTC().Add(time.Minute)
@@ -199,10 +204,10 @@ func TestStore_GetReceivedStatsBySlice(t *testing.T) {
 	}}))
 
 	// No stats
-	stats, err := store.GetReceivedStatsBySlice(ctx, slice1Key)
+	stats, err := GetStatsFrom(ctx, store, sm.ReceivedStats().InSlice(slice1Key).GetAll())
 	assert.NoError(t, err)
 	assert.Empty(t, stats)
-	stats, err = store.GetReceivedStatsBySlice(ctx, slice2Key)
+	stats, err = GetStatsFrom(ctx, store, sm.ReceivedStats().InSlice(slice2Key).GetAll())
 	assert.NoError(t, err)
 	assert.Empty(t, stats)
 
@@ -210,64 +215,64 @@ func TestStore_GetReceivedStatsBySlice(t *testing.T) {
 	assert.NoError(t, store.UpdateSliceReceivedStats(ctx, "node1", []model.SliceStats{
 		{
 			SliceKey: slice1Key,
-			Stats:    model.Stats{Count: 10, Size: 100, LastRecordAt: key.UTCTime(time1.Add(1 * time.Hour))},
+			Stats:    model.Stats{RecordsCount: 10, RecordsSize: 100, BodySize: 1000, LastRecordAt: key.UTCTime(time1.Add(1 * time.Hour))},
 		},
 		{
 			SliceKey: slice2Key,
-			Stats:    model.Stats{Count: 1, Size: 10, LastRecordAt: key.UTCTime(time2.Add(1 * time.Hour))},
+			Stats:    model.Stats{RecordsCount: 1, RecordsSize: 10, BodySize: 100, LastRecordAt: key.UTCTime(time2.Add(1 * time.Hour))},
 		},
 	}))
-	assertSliceStats(t, store, slice1Key, 10, 100, time1.Add(1*time.Hour))
-	assertSliceStats(t, store, slice2Key, 1, 10, time2.Add(1*time.Hour))
+	assertSliceStats(t, store, slice1Key, 10, 100, 1000, time1.Add(1*time.Hour))
+	assertSliceStats(t, store, slice2Key, 1, 10, 100, time2.Add(1*time.Hour))
 
 	// Update - node 1
 	assert.NoError(t, store.UpdateSliceReceivedStats(ctx, "node1", []model.SliceStats{
 		{
 			SliceKey: slice1Key,
-			Stats:    model.Stats{Count: 20, Size: 200, LastRecordAt: key.UTCTime(time1.Add(2 * time.Hour))},
+			Stats:    model.Stats{RecordsCount: 20, RecordsSize: 200, BodySize: 2000, LastRecordAt: key.UTCTime(time1.Add(2 * time.Hour))},
 		},
 		{
 			SliceKey: slice2Key,
-			Stats:    model.Stats{Count: 2, Size: 20, LastRecordAt: key.UTCTime(time2.Add(2 * time.Hour))},
+			Stats:    model.Stats{RecordsCount: 2, RecordsSize: 20, BodySize: 200, LastRecordAt: key.UTCTime(time2.Add(2 * time.Hour))},
 		},
 	}))
-	assertSliceStats(t, store, slice1Key, 20, 200, time1.Add(2*time.Hour))
-	assertSliceStats(t, store, slice2Key, 2, 20, time2.Add(2*time.Hour))
+	assertSliceStats(t, store, slice1Key, 20, 200, 2000, time1.Add(2*time.Hour))
+	assertSliceStats(t, store, slice2Key, 2, 20, 200, time2.Add(2*time.Hour))
 
 	// First sync - node 2
 	assert.NoError(t, store.UpdateSliceReceivedStats(ctx, "node2", []model.SliceStats{
 		{
 			SliceKey: slice1Key,
-			Stats:    model.Stats{Count: 100, Size: 1000, LastRecordAt: key.UTCTime(time1.Add(3 * time.Hour))},
+			Stats:    model.Stats{RecordsCount: 100, RecordsSize: 1000, BodySize: 10000, LastRecordAt: key.UTCTime(time1.Add(3 * time.Hour))},
 		},
 		{
 			SliceKey: slice2Key,
-			Stats:    model.Stats{Count: 10, Size: 100, LastRecordAt: key.UTCTime(time2.Add(3 * time.Hour))},
+			Stats:    model.Stats{RecordsCount: 10, RecordsSize: 100, BodySize: 1000, LastRecordAt: key.UTCTime(time2.Add(3 * time.Hour))},
 		},
 	}))
-	assertSliceStats(t, store, slice1Key, 20+100, 200+1000, time1.Add(3*time.Hour))
-	assertSliceStats(t, store, slice2Key, 2+10, 20+100, time2.Add(3*time.Hour))
+	assertSliceStats(t, store, slice1Key, 20+100, 200+1000, 2000+10000, time1.Add(3*time.Hour))
+	assertSliceStats(t, store, slice2Key, 2+10, 20+100, 200+1000, time2.Add(3*time.Hour))
 
 	// Update - node 2
 	assert.NoError(t, store.UpdateSliceReceivedStats(ctx, "node2", []model.SliceStats{
 		{
 			SliceKey: slice1Key,
-			Stats:    model.Stats{Count: 200, Size: 2000, LastRecordAt: key.UTCTime(time1.Add(4 * time.Hour))},
+			Stats:    model.Stats{RecordsCount: 200, RecordsSize: 2000, BodySize: 20000, LastRecordAt: key.UTCTime(time1.Add(4 * time.Hour))},
 		},
 		{
 			SliceKey: slice2Key,
-			Stats:    model.Stats{Count: 20, Size: 200, LastRecordAt: key.UTCTime(time2.Add(4 * time.Hour))},
+			Stats:    model.Stats{RecordsCount: 20, RecordsSize: 200, BodySize: 2000, LastRecordAt: key.UTCTime(time2.Add(4 * time.Hour))},
 		},
 	}))
-	assertSliceStats(t, store, slice1Key, 20+200, 200+2000, time1.Add(4*time.Hour))
-	assertSliceStats(t, store, slice2Key, 2+20, 20+200, time2.Add(4*time.Hour))
+	assertSliceStats(t, store, slice1Key, 20+200, 200+2000, 2000+20000, time1.Add(4*time.Hour))
+	assertSliceStats(t, store, slice2Key, 2+20, 20+200, 200+2000, time2.Add(4*time.Hour))
 
 	// Delete receiver - no stats
 	assert.NoError(t, store.DeleteReceiver(ctx, receiverKey))
-	stats, err = store.GetReceivedStatsBySlice(ctx, slice1Key)
+	stats, err = GetStatsFrom(ctx, store, sm.ReceivedStats().InSlice(slice1Key).GetAll())
 	assert.NoError(t, err)
 	assert.Empty(t, stats)
-	stats, err = store.GetReceivedStatsBySlice(ctx, slice2Key)
+	stats, err = GetStatsFrom(ctx, store, sm.ReceivedStats().InSlice(slice2Key).GetAll())
 	assert.NoError(t, err)
 	assert.Empty(t, stats)
 }
@@ -276,6 +281,7 @@ func TestStore_GetReceivedStatsBySlice_Many(t *testing.T) {
 	t.Parallel()
 
 	ctx := context.Background()
+	sm := schema.New(validator.New().Validate)
 	store := newStoreForTest(t)
 
 	fileOpenedAt := time.Time{}.UTC().Add(time.Minute)
@@ -291,8 +297,8 @@ func TestStore_GetReceivedStatsBySlice_Many(t *testing.T) {
 			{
 				SliceKey: sliceKey,
 				Stats: model.Stats{
-					Count:        1,
-					Size:         10,
+					RecordsCount: 1,
+					RecordsSize:  10,
 					LastRecordAt: key.UTCTime(fileOpenedAt.Add(time.Duration(n) * time.Minute)),
 				},
 			},
@@ -300,17 +306,17 @@ func TestStore_GetReceivedStatsBySlice_Many(t *testing.T) {
 	}
 
 	// Slice stats
-	stats, err := store.GetReceivedStatsBySlice(ctx, sliceKey)
+	stats, err := GetStatsFrom(ctx, store, sm.ReceivedStats().InSlice(sliceKey).GetAll())
 	assert.NoError(t, err)
-	assert.Equal(t, uint64(100), stats.Count)
-	assert.Equal(t, uint64(10*100), stats.Size)
+	assert.Equal(t, uint64(100), stats.RecordsCount)
+	assert.Equal(t, uint64(10*100), stats.RecordsSize)
 	assert.Equal(t, key.UTCTime(fileOpenedAt.Add(100*time.Minute)), stats.LastRecordAt)
 
 	// File stats
-	stats, err = store.GetReceivedStatsByFile(ctx, fileKey)
+	stats, err = GetStatsFrom(ctx, store, sm.ReceivedStats().InFile(fileKey).GetAll())
 	assert.NoError(t, err)
-	assert.Equal(t, uint64(100), stats.Count)
-	assert.Equal(t, uint64(10*100), stats.Size)
+	assert.Equal(t, uint64(100), stats.RecordsCount)
+	assert.Equal(t, uint64(10*100), stats.RecordsSize)
 	assert.Equal(t, key.UTCTime(fileOpenedAt.Add(100*time.Minute)), stats.LastRecordAt)
 }
 
@@ -331,16 +337,18 @@ func TestStore_UpdateSliceStats(t *testing.T) {
 		{
 			SliceKey: key.SliceKey{SliceID: key.SliceID(time1.Add(time.Hour)), FileKey: fileKey1},
 			Stats: model.Stats{
-				Count:        111,
-				Size:         1111,
+				RecordsCount: 111,
+				RecordsSize:  1111,
+				BodySize:     11111,
 				LastRecordAt: key.UTCTime(time1.Add(time.Hour * 2)),
 			},
 		},
 		{
 			SliceKey: key.SliceKey{SliceID: key.SliceID(time2.Add(time.Hour)), FileKey: fileKey2},
 			Stats: model.Stats{
-				Count:        222,
-				Size:         2222,
+				RecordsCount: 222,
+				RecordsSize:  2222,
+				BodySize:     22222,
 				LastRecordAt: key.UTCTime(time2.Add(time.Hour * 2)),
 			},
 		},
@@ -357,9 +365,10 @@ stats/received/00000123/my-receiver/my-export/0001-01-01T00:01:00.000Z/0001-01-0
   "exportId": "my-export",
   "fileId": "0001-01-01T00:01:00.000Z",
   "sliceId": "0001-01-01T01:01:00.000Z",
-  "count": 111,
-  "size": 1111,
-  "lastRecordAt": "0001-01-01T02:01:00.000Z"
+  "lastRecordAt": "0001-01-01T02:01:00.000Z",
+  "recordsCount": 111,
+  "recordsSize": 1111,
+  "bodySize": 11111
 }
 >>>>>
 
@@ -372,28 +381,33 @@ stats/received/00000123/my-receiver/my-export/0001-01-01T12:01:00.000Z/0001-01-0
   "exportId": "my-export",
   "fileId": "0001-01-01T12:01:00.000Z",
   "sliceId": "0001-01-01T13:01:00.000Z",
-  "count": 222,
-  "size": 2222,
-  "lastRecordAt": "0001-01-01T14:01:00.000Z"
+  "lastRecordAt": "0001-01-01T14:01:00.000Z",
+  "recordsCount": 222,
+  "recordsSize": 2222,
+  "bodySize": 22222
 }
 >>>>>
 `)
 }
 
-func assertFileStats(t *testing.T, store *Store, fileKey key.FileKey, count, size uint64, lastAt time.Time) {
+func assertFileStats(t *testing.T, store *Store, fileKey key.FileKey, recordsCount, recordsSize, bodySize uint64, lastAt time.Time) {
 	t.Helper()
-	stats, err := store.GetReceivedStatsByFile(context.Background(), fileKey)
+	sm := schema.New(validator.New().Validate)
+	stats, err := GetStatsFrom(context.Background(), store, sm.ReceivedStats().InFile(fileKey).GetAll())
 	assert.NoError(t, err)
-	assert.Equal(t, count, stats.Count)
-	assert.Equal(t, size, stats.Size)
+	assert.Equal(t, recordsCount, stats.RecordsCount)
+	assert.Equal(t, recordsSize, stats.RecordsSize)
+	assert.Equal(t, bodySize, stats.BodySize)
 	assert.Equal(t, key.UTCTime(lastAt), stats.LastRecordAt)
 }
 
-func assertSliceStats(t *testing.T, store *Store, sliceKey key.SliceKey, count, size uint64, lastAt time.Time) {
+func assertSliceStats(t *testing.T, store *Store, sliceKey key.SliceKey, recordsCount, recordsSize, bodySize uint64, lastAt time.Time) {
 	t.Helper()
-	stats, err := store.GetReceivedStatsBySlice(context.Background(), sliceKey)
+	sm := schema.New(validator.New().Validate)
+	stats, err := GetStatsFrom(context.Background(), store, sm.ReceivedStats().InSlice(sliceKey).GetAll())
 	assert.NoError(t, err)
-	assert.Equal(t, count, stats.Count)
-	assert.Equal(t, size, stats.Size)
+	assert.Equal(t, recordsCount, stats.RecordsCount)
+	assert.Equal(t, recordsSize, stats.RecordsSize)
+	assert.Equal(t, bodySize, stats.BodySize)
 	assert.Equal(t, key.UTCTime(lastAt), stats.LastRecordAt)
 }

--- a/internal/pkg/service/buffer/store/token.go
+++ b/internal/pkg/service/buffer/store/token.go
@@ -25,6 +25,17 @@ func (s *Store) ListTokens(ctx context.Context, receiverKey key.ReceiverKey) (ou
 	return tokens.Values(), nil
 }
 
+func (s *Store) GetToken(ctx context.Context, exportKey key.ExportKey) (out model.Token, err error) {
+	_, span := s.tracer.Start(ctx, "keboola.go.buffer.store.GetToken")
+	defer telemetry.EndSpan(span, &err)
+
+	resp, err := s.getTokenOp(ctx, exportKey).Do(ctx, s.client)
+	if err != nil {
+		return out, err
+	}
+	return resp.Value, err
+}
+
 func (s *Store) UpdateTokens(ctx context.Context, tokens []model.Token) (err error) {
 	_, span := s.tracer.Start(ctx, "keboola.go.buffer.store.UpdateTokens")
 	defer telemetry.EndSpan(span, &err)

--- a/internal/pkg/service/buffer/watcher/watcher.go
+++ b/internal/pkg/service/buffer/watcher/watcher.go
@@ -79,6 +79,6 @@ func NewAPINode(d apinode.Dependencies, opts ...apinode.Option) (*APINode, error
 	return apinode.New(d, opts...)
 }
 
-func NewWorkerNode(d apinode.Dependencies) (*WorkerNode, error) {
+func NewWorkerNode(d workernode.Dependencies) (*WorkerNode, error) {
 	return workernode.New(d)
 }

--- a/internal/pkg/service/buffer/worker/dependencies/dependencies.go
+++ b/internal/pkg/service/buffer/worker/dependencies/dependencies.go
@@ -10,6 +10,7 @@ package dependencies
 import (
 	"context"
 
+	"github.com/keboola/go-client/pkg/client"
 	"go.opentelemetry.io/otel/trace"
 
 	"github.com/keboola/keboola-as-code/internal/pkg/env"
@@ -26,6 +27,8 @@ import (
 // The container exists during the entire run of the Worker.
 type ForWorker interface {
 	serviceDependencies.ForService
+	HTTPClient() client.Client
+	StorageAPIHost() string
 	DistributionWorkerNode() *distribution.Node
 	WatcherWorkerNode() *watcher.WorkerNode
 	TaskWorkerNode() *task.Node

--- a/internal/pkg/service/buffer/worker/upload/close.go
+++ b/internal/pkg/service/buffer/worker/upload/close.go
@@ -7,7 +7,6 @@ import (
 
 	"github.com/keboola/keboola-as-code/internal/pkg/log"
 	"github.com/keboola/keboola-as-code/internal/pkg/service/buffer/store/model"
-	"github.com/keboola/keboola-as-code/internal/pkg/service/buffer/store/slicestate"
 	"github.com/keboola/keboola-as-code/internal/pkg/service/buffer/worker/task"
 	"github.com/keboola/keboola-as-code/internal/pkg/service/buffer/worker/task/orchestrator"
 	"github.com/keboola/keboola-as-code/internal/pkg/service/common/etcdop"
@@ -35,7 +34,7 @@ func (u *Uploader) closeSlices(ctx context.Context, wg *sync.WaitGroup, d depend
 
 				// Close the slice, no API node is writing to it.
 				slice := event.Value
-				if _, err := u.store.SetSliceState(ctx, &slice, slicestate.Uploading); err != nil {
+				if err := u.store.MarkSliceClosed(ctx, &slice); err != nil {
 					return "", err
 				}
 

--- a/internal/pkg/service/buffer/worker/upload/close.go
+++ b/internal/pkg/service/buffer/worker/upload/close.go
@@ -34,7 +34,7 @@ func (u *Uploader) closeSlices(ctx context.Context, wg *sync.WaitGroup, d depend
 
 				// Close the slice, no API node is writing to it.
 				slice := event.Value
-				if err := u.store.MarkSliceClosed(ctx, &slice); err != nil {
+				if err := u.store.CloseSlice(ctx, &slice); err != nil {
 					return "", err
 				}
 

--- a/internal/pkg/service/buffer/worker/upload/close_test.go
+++ b/internal/pkg/service/buffer/worker/upload/close_test.go
@@ -55,7 +55,8 @@ func TestSliceCloseTask(t *testing.T) {
 	clk.Add(time.Minute)
 	notEmptySliceKey := createExport(t, "my-receiver-2", "my-export-2", ctx, clk, client, str)
 	clk.Add(time.Minute)
-	createRecords(t, ctx, clk, apiDeps1, notEmptySliceKey.ReceiverKey, 1, 3)
+	createRecords(t, ctx, clk, apiDeps1, notEmptySliceKey.ReceiverKey, 1, 1)
+	createRecords(t, ctx, clk, apiDeps2, notEmptySliceKey.ReceiverKey, 2, 2)
 
 	// NOW = slice.closingAt = task.createdAt = 0001-01-01T00:01:01Z
 	clk.Add(time.Minute)

--- a/internal/pkg/service/buffer/worker/upload/close_test.go
+++ b/internal/pkg/service/buffer/worker/upload/close_test.go
@@ -12,7 +12,7 @@ import (
 
 	bufferDependencies "github.com/keboola/keboola-as-code/internal/pkg/service/buffer/dependencies"
 	"github.com/keboola/keboola-as-code/internal/pkg/service/buffer/store/slicestate"
-	workerservice "github.com/keboola/keboola-as-code/internal/pkg/service/buffer/worker/service"
+	"github.com/keboola/keboola-as-code/internal/pkg/service/buffer/worker/upload"
 	"github.com/keboola/keboola-as-code/internal/pkg/service/common/dependencies"
 	"github.com/keboola/keboola-as-code/internal/pkg/utils/errors"
 	"github.com/keboola/keboola-as-code/internal/pkg/utils/etcdhelper"
@@ -43,7 +43,7 @@ func TestSliceCloseTask(t *testing.T) {
 	// Start worker node
 	workerDeps := bufferDependencies.NewMockedDeps(t, opts...)
 	workerDeps.DebugLogger().ConnectTo(testhelper.VerboseStdout())
-	_, err := workerservice.New(workerDeps)
+	_, err := upload.NewUploader(workerDeps, upload.WithCloseSlices(true), upload.WithUploadSlices(false))
 	assert.NoError(t, err)
 
 	// The receiver, in the current state, is twice used by some requests, in the API node
@@ -142,7 +142,7 @@ slice/uploading/00000123/my-receiver/my-export/0001-01-01T00:00:01.000Z/0001-01-
         "type": "template",
         "name": "col06",
         "language": "jsonnet",
-        "content": "\"---\" + Body(\"key1\") + \"---\""
+        "content": "\"---\" + Body(\"key\") + \"---\""
       }
     ]
   },

--- a/internal/pkg/service/buffer/worker/upload/close_test.go
+++ b/internal/pkg/service/buffer/worker/upload/close_test.go
@@ -9,9 +9,11 @@ import (
 	"github.com/keboola/go-utils/pkg/wildcards"
 	gonanoid "github.com/matoous/go-nanoid/v2"
 	"github.com/stretchr/testify/assert"
+	etcd "go.etcd.io/etcd/client/v3"
 
 	bufferDependencies "github.com/keboola/keboola-as-code/internal/pkg/service/buffer/dependencies"
 	"github.com/keboola/keboola-as-code/internal/pkg/service/buffer/store/slicestate"
+	"github.com/keboola/keboola-as-code/internal/pkg/service/buffer/watcher"
 	"github.com/keboola/keboola-as-code/internal/pkg/service/buffer/worker/upload"
 	"github.com/keboola/keboola-as-code/internal/pkg/service/common/dependencies"
 	"github.com/keboola/keboola-as-code/internal/pkg/utils/errors"
@@ -30,46 +32,72 @@ func TestSliceCloseTask(t *testing.T) {
 	etcdNamespace := "unit-" + t.Name() + "-" + gonanoid.Must(8)
 	client := etcdhelper.ClientForTestWithNamespace(t, etcdNamespace)
 	opts := []dependencies.MockedOption{dependencies.WithClock(clk), dependencies.WithEtcdNamespace(etcdNamespace)}
-	str := bufferDependencies.NewMockedDeps(t, opts...).Store()
-
-	// Create an export
-	sliceKey := createExport(t, ctx, clk, client, str)
 
 	// Start API node
-	apiDeps := bufferDependencies.NewMockedDeps(t, opts...)
-	apiDeps.DebugLogger().ConnectTo(testhelper.VerboseStdout())
-	apiNode := apiDeps.WatcherAPINode()
+	apiDeps1 := bufferDependencies.NewMockedDeps(t, append(opts, dependencies.WithUniqueID("api-node-1"))...)
+	apiDeps1.DebugLogger().ConnectTo(testhelper.VerboseStdout())
+	apiNode := apiDeps1.WatcherAPINode()
+
+	// Some other API node is also running
+	apiDeps2 := bufferDependencies.NewMockedDeps(t, append(opts, dependencies.WithUniqueID("api-node-2"))...)
+	_, err := watcher.NewAPINode(apiDeps2)
+	assert.NoError(t, err)
 
 	// Start worker node
 	workerDeps := bufferDependencies.NewMockedDeps(t, opts...)
 	workerDeps.DebugLogger().ConnectTo(testhelper.VerboseStdout())
-	_, err := upload.NewUploader(workerDeps, upload.WithCloseSlices(true), upload.WithUploadSlices(false))
+	_, err = upload.NewUploader(workerDeps, upload.WithCloseSlices(true), upload.WithUploadSlices(false))
 	assert.NoError(t, err)
 
-	// The receiver, in the current state, is twice used by some requests, in the API node
-	_, found, unlockR1 := apiNode.GetReceiver(sliceKey.ReceiverKey)
-	assert.True(t, found)
-	_, found, unlockR2 := apiNode.GetReceiver(sliceKey.ReceiverKey)
-	assert.True(t, found)
+	// Create receivers and exports
+	str := apiDeps1.Store()
+	emptySliceKey := createExport(t, "my-receiver-1", "my-export-1", ctx, clk, client, str)
+	clk.Add(time.Minute)
+	notEmptySliceKey := createExport(t, "my-receiver-2", "my-export-2", ctx, clk, client, str)
+	clk.Add(time.Minute)
+	createRecords(t, ctx, clk, apiDeps1, notEmptySliceKey.ReceiverKey, 1, 3)
 
 	// NOW = slice.closingAt = task.createdAt = 0001-01-01T00:01:01Z
 	clk.Add(time.Minute)
 
-	// Slice is closing (mapping has been changed or upload conditions are met)
-	slice, err := str.GetSlice(ctx, sliceKey)
+	// Truncate init logs
+	apiDeps1.DebugLogger().Truncate()
+	workerDeps.DebugLogger().Truncate()
+
+	// The receiver, in the current state, is twice used by some requests, in the API node
+	_, found, unlockR1 := apiNode.GetReceiver(emptySliceKey.ReceiverKey)
+	assert.True(t, found)
+	_, found, unlockR2 := apiNode.GetReceiver(emptySliceKey.ReceiverKey)
+	assert.True(t, found)
+	_, found, unlockR3 := apiNode.GetReceiver(notEmptySliceKey.ReceiverKey)
+	assert.True(t, found)
+	workerDeps.DebugLogger().Info("---> locked")
+	apiDeps1.DebugLogger().Info("---> locked")
+
+	// Close the empty slice (mapping has been changed or upload conditions are met)
+	emptySlice, err := str.GetSlice(ctx, emptySliceKey)
 	assert.NoError(t, err)
 	header := etcdhelper.ExpectModification(t, client, func() {
-		assert.NoError(t, str.SetSliceState(ctx, &slice, slicestate.Closing))
+		assert.NoError(t, str.SetSliceState(ctx, &emptySlice, slicestate.Closing))
 	})
-
-	// Wait for sync of the Watcher in the API node
 	assert.Eventually(t, func() bool {
-		return apiDeps.WatcherAPINode().StateRev() == header.Revision
+		return apiNode.StateRev() >= header.Revision
 	}, time.Second, 10*time.Millisecond, "timeout")
-
-	// Wait until the worker node start wait for the API nodes
 	assert.Eventually(t, func() bool {
 		return workerDeps.WatcherWorkerNode().ListenersCount() == 1
+	}, time.Second, 10*time.Millisecond, "timeout")
+
+	// Close the not empty slice (mapping has been changed or upload conditions are met)
+	notEmptySlice, err := str.GetSlice(ctx, notEmptySliceKey)
+	assert.NoError(t, err)
+	header = etcdhelper.ExpectModification(t, client, func() {
+		assert.NoError(t, str.SetSliceState(ctx, &notEmptySlice, slicestate.Closing))
+	})
+	assert.Eventually(t, func() bool {
+		return apiNode.StateRev() >= header.Revision
+	}, time.Second, 10*time.Millisecond, "timeout")
+	assert.Eventually(t, func() bool {
+		return workerDeps.WatcherWorkerNode().ListenersCount() == 2
 	}, time.Second, 10*time.Millisecond, "timeout")
 
 	// NOW = slice.uploadingAt = task.finishedAt = 0001-01-01T00:01:31Z
@@ -77,112 +105,32 @@ func TestSliceCloseTask(t *testing.T) {
 
 	// Requests which were writing to the closing slice are completed.
 	// Worker can switch the slice from the closing to the uploading state.
-	workerDeps.DebugLogger().Info("---> first unlock")
-	apiDeps.DebugLogger().Info("---> first unlock")
+	workerDeps.DebugLogger().Info("---> unlocked")
+	apiDeps1.DebugLogger().Info("---> unlocked")
 	unlockR1()
-	workerDeps.DebugLogger().Info("---> second unlock")
-	apiDeps.DebugLogger().Info("---> second unlock")
 	unlockR2()
-
-	// Wait for the Worker task to finish
+	unlockR3()
 	assert.Eventually(t, func() bool {
 		return workerDeps.TaskWorkerNode().TasksCount() == 0
 	}, time.Second, 10*time.Millisecond, "timeout")
 
 	// Shutdown API node and worker
-	apiDeps.Process().Shutdown(errors.New("bye bye API"))
-	apiDeps.Process().WaitForShutdown()
+	apiDeps1.Process().Shutdown(errors.New("bye bye API"))
+	apiDeps1.Process().WaitForShutdown()
+	apiDeps2.Process().Shutdown(errors.New("bye bye API"))
+	apiDeps2.Process().WaitForShutdown()
 	workerDeps.Process().Shutdown(errors.New("bye bye Worker"))
 	workerDeps.Process().WaitForShutdown()
 
-	// Check etcd state
-	etcdhelper.AssertKVs(t, client, `
-%A
-<<<<<
-slice/uploading/00000123/my-receiver/my-export/0001-01-01T00:00:01.000Z/0001-01-01T00:00:01.000Z
------
-{
-  "projectId": 123,
-  "receiverId": "my-receiver",
-  "exportId": "my-export",
-  "fileId": "0001-01-01T00:00:01.000Z",
-  "sliceId": "0001-01-01T00:00:01.000Z",
-  "state": "uploading",
-  "mapping": {
-    "projectId": 123,
-    "receiverId": "my-receiver",
-    "exportId": "my-export",
-    "revisionId": 1,
-    "tableId": "in.c-bucket.table",
-    "incremental": false,
-    "columns": [
-      {
-        "type": "id",
-        "name": "col01"
-      },
-      {
-        "type": "datetime",
-        "name": "col02"
-      },
-      {
-        "type": "ip",
-        "name": "col03"
-      },
-      {
-        "type": "body",
-        "name": "col04"
-      },
-      {
-        "type": "headers",
-        "name": "col05"
-      },
-      {
-        "type": "template",
-        "name": "col06",
-        "language": "jsonnet",
-        "content": "\"---\" + Body(\"key\") + \"---\""
-      }
-    ]
-  },
-  "sliceNumber": 1,
-  "closingAt": "0001-01-01T00:01:01.000Z",
-  "uploadingAt": "0001-01-01T00:01:31.000Z"
-}
->>>>>
-
-<<<<<
-task/00000123/my-receiver/my-export/slice.close/0001-01-01T00:01:01.000Z_%c%c%c%c%c
------
-{
-  "projectId": 123,
-  "receiverId": "my-receiver",
-  "exportId": "my-export",
-  "type": "slice.close",
-  "createdAt": "0001-01-01T00:01:01.000Z",
-  "randomId": "%s",
-  "finishedAt": "0001-01-01T00:01:31.000Z",
-  "workerNode": "%s",
-  "lock": "slice.close/0001-01-01T00:00:01.000Z/0001-01-01T00:00:01.000Z",
-  "result": "slice closed",
-  "duration": 30000000000
-}
->>>>>
-`)
-
 	// Check logs
 	wildcards.Assert(t, `
-INFO  process unique id "%s"
-[api][watcher][etcd-session]INFO  creating etcd session
-[api][watcher][etcd-session]INFO  created etcd session | %s
-[api][watcher]INFO  reported revision "1"
-[api][watcher]INFO  state updated to the revision "%s"
-[api][watcher]INFO  reported revision "%s"
-[api][watcher]INFO  initialized | %s
 [api][watcher]INFO  locked revision "%s"
-[api][watcher]INFO  deleted slice/opened/00000123/my-receiver/my-export/0001-01-01T00:00:01.000Z/0001-01-01T00:00:01.000Z
+INFO  ---> locked
+[api][watcher]INFO  deleted slice/opened/00000123/my-receiver-1/my-export-1/0001-01-01T00:00:01.000Z/0001-01-01T00:00:01.000Z
 [api][watcher]INFO  state updated to the revision "%s"
-INFO  ---> first unlock
-INFO  ---> second unlock
+[api][watcher]INFO  deleted slice/opened/00000123/my-receiver-2/my-export-2/0001-01-01T00:01:01.000Z/0001-01-01T00:01:01.000Z
+[api][watcher]INFO  state updated to the revision "%s"
+INFO  ---> unlocked
 [api][watcher]INFO  unlocked revision "%s"
 [api][watcher]INFO  reported revision "%s"
 INFO  exiting (bye bye API)
@@ -193,22 +141,140 @@ INFO  exiting (bye bye API)
 [stats]INFO  received shutdown request
 [stats]INFO  shutdown done
 INFO  exited
-
-`, apiDeps.DebugLogger().AllMessages())
-
+`, apiDeps1.DebugLogger().AllMessages())
 	wildcards.Assert(t, `
-%A
-[orchestrator][slice.close]INFO  ready
-[orchestrator][slice.close]INFO  assigned "00000123/my-receiver/my-export/0001-01-01T00:00:01.000Z/0001-01-01T00:00:01.000Z"
-[task][%s]INFO  started task "00000123/my-receiver/my-export/slice.close/0001-01-01T00:01:01.000Z_%s"
-[task][%s]DEBUG  lock acquired "runtime/lock/task/00000123/my-receiver/my-export/slice.close/0001-01-01T00:00:01.000Z/0001-01-01T00:00:01.000Z"
+INFO  ---> locked
+[orchestrator][slice.close]INFO  assigned "00000123/my-receiver-1/my-export-1/%s"
+[task][%s]INFO  started task "00000123/my-receiver-1/my-export-1/slice.close/%s"
+[task][%s]DEBUG  lock acquired "runtime/lock/task/00000123/my-receiver-1/my-export-1/slice.close/%s"
 [task][%s]INFO  waiting until all API nodes switch to a revision >= %s
-INFO  ---> first unlock
-INFO  ---> second unlock
-[watcher][worker]INFO  revision updated to "%s", unblocked "1" listeners
-[task][%s]INFO  task succeeded (30s): slice closed
-[task][%s]DEBUG  lock released "runtime/lock/task/00000123/my-receiver/my-export/slice.close/0001-01-01T00:00:01.000Z/0001-01-01T00:00:01.000Z"
-%A
+[orchestrator][slice.close]INFO  assigned "00000123/my-receiver-2/my-export-2/%s"
+[task][%s]INFO  started task "00000123/my-receiver-2/my-export-2/slice.close/%s"
+[task][%s]DEBUG  lock acquired "runtime/lock/task/00000123/my-receiver-2/my-export-2/slice.close/%s"
+[task][%s]INFO  waiting until all API nodes switch to a revision >= %s
+INFO  ---> unlocked
+[watcher][worker]INFO  revision updated to "%s", unblocked "2" listeners
+[task][%s]INFO  task succeeded (30s): %A
+[task][%s]INFO  task succeeded (30s): %A
 INFO  exited
 `, workerDeps.DebugLogger().AllMessages())
+
+	// Check etcd state
+	assertStateAfterClose(t, client)
+}
+
+func assertStateAfterClose(t *testing.T, client *etcd.Client) {
+	t.Helper()
+	etcdhelper.AssertKVs(t, client, `
+<<<<<
+config/export/00000123/my-receiver-1/my-export-1
+-----
+%A
+>>>>>
+
+<<<<<
+config/export/00000123/my-receiver-2/my-export-2
+-----
+%A
+>>>>>
+
+<<<<<
+config/mapping/revision/00000123/my-receiver-1/my-export-1/00000001
+-----
+%A
+>>>>>
+
+<<<<<
+config/mapping/revision/00000123/my-receiver-2/my-export-2/00000001
+-----
+%A
+>>>>>
+
+<<<<<
+config/receiver/00000123/my-receiver-1
+-----
+%A
+>>>>>
+
+<<<<<
+config/receiver/00000123/my-receiver-2
+-----
+%A
+>>>>>
+
+<<<<<
+file/opened/00000123/my-receiver-1/my-export-1/0001-01-01T00:00:01.000Z
+-----
+%A
+>>>>>
+
+<<<<<
+file/opened/00000123/my-receiver-2/my-export-2/0001-01-01T00:01:01.000Z
+-----
+%A
+>>>>>
+
+<<<<<
+record/00000123/my-receiver-2/my-export-2/0001-01-01T00:01:01.000Z/0001-01-01T00:02:02.000Z_%s
+-----
+<<~~id~~>>,0001-01-01T00:02:02.000Z,1.2.3.4,"{""key"":""value001""}","{""Content-Type"":""application/json""}","""---value001---"""
+>>>>>
+
+<<<<<
+record/00000123/my-receiver-2/my-export-2/0001-01-01T00:01:01.000Z/0001-01-01T00:02:03.000Z_%s
+-----
+<<~~id~~>>,0001-01-01T00:02:03.000Z,1.2.3.4,"{""key"":""value002""}","{""Content-Type"":""application/json""}","""---value002---"""
+>>>>>
+
+<<<<<
+record/00000123/my-receiver-2/my-export-2/0001-01-01T00:01:01.000Z/0001-01-01T00:02:04.000Z_%s
+-----
+<<~~id~~>>,0001-01-01T00:02:04.000Z,1.2.3.4,"{""key"":""value003""}","{""Content-Type"":""application/json""}","""---value003---"""
+>>>>>
+
+<<<<<
+secret/export/token/00000123/my-receiver-1/my-export-1
+-----
+%A
+>>>>>
+
+<<<<<
+secret/export/token/00000123/my-receiver-2/my-export-2
+-----
+%A
+>>>>>
+
+<<<<<
+slice/uploading/00000123/my-receiver-1/my-export-1/0001-01-01T00:00:01.000Z/0001-01-01T00:00:01.000Z
+-----
+{
+%A
+  "state": "uploading",
+  "isEmpty": true,
+%A
+  "sliceNumber": 1,
+  "closingAt": "0001-01-01T00:03:04.000Z",
+  "uploadingAt": "0001-01-01T00:03:34.000Z"
+%A
+>>>>>
+
+<<<<<
+slice/uploading/00000123/my-receiver-2/my-export-2/0001-01-01T00:01:01.000Z/0001-01-01T00:01:01.000Z
+-----
+{
+%A
+  "state": "uploading",
+%A
+  "sliceNumber": 1,
+  "closingAt": "0001-01-01T00:03:04.000Z",
+  "uploadingAt": "0001-01-01T00:03:34.000Z",
+  "statistics": {
+    "lastRecordAt": "0001-01-01T00:02:04.000Z",
+    "recordsCount": 3,
+    "recordsSize": 396,
+    "bodySize": 54
+  }
+%A
+>>>>>
+`)
 }

--- a/internal/pkg/service/buffer/worker/upload/close_test.go
+++ b/internal/pkg/service/buffer/worker/upload/close_test.go
@@ -162,6 +162,11 @@ INFO  exited
 
 	// Check etcd state
 	assertStateAfterClose(t, client)
+
+	// After deleting the receivers, the database should remain empty
+	assert.NoError(t, str.DeleteReceiver(ctx, emptySlice.ReceiverKey))
+	assert.NoError(t, str.DeleteReceiver(ctx, notEmptySlice.ReceiverKey))
+	etcdhelper.AssertKVs(t, client, "")
 }
 
 func assertStateAfterClose(t *testing.T, client *etcd.Client) {

--- a/internal/pkg/service/buffer/worker/upload/close_test.go
+++ b/internal/pkg/service/buffer/worker/upload/close_test.go
@@ -59,9 +59,7 @@ func TestSliceCloseTask(t *testing.T) {
 	slice, err := str.GetSlice(ctx, sliceKey)
 	assert.NoError(t, err)
 	header := etcdhelper.ExpectModification(t, client, func() {
-		ok, err := str.SetSliceState(ctx, &slice, slicestate.Closing)
-		assert.True(t, ok)
-		assert.NoError(t, err)
+		assert.NoError(t, str.SetSliceState(ctx, &slice, slicestate.Closing))
 	})
 
 	// Wait for sync of the Watcher in the API node
@@ -192,6 +190,8 @@ INFO  exiting (bye bye API)
 [api][watcher]INFO  shutdown done
 [api][watcher][etcd-session]INFO  closing etcd session
 [api][watcher][etcd-session]INFO  closed etcd session | %s
+[stats]INFO  received shutdown request
+[stats]INFO  shutdown done
 INFO  exited
 
 `, apiDeps.DebugLogger().AllMessages())

--- a/internal/pkg/service/buffer/worker/upload/close_test.go
+++ b/internal/pkg/service/buffer/worker/upload/close_test.go
@@ -13,7 +13,6 @@ import (
 
 	bufferDependencies "github.com/keboola/keboola-as-code/internal/pkg/service/buffer/dependencies"
 	"github.com/keboola/keboola-as-code/internal/pkg/service/buffer/store/slicestate"
-	"github.com/keboola/keboola-as-code/internal/pkg/service/buffer/watcher"
 	"github.com/keboola/keboola-as-code/internal/pkg/service/buffer/worker/upload"
 	"github.com/keboola/keboola-as-code/internal/pkg/service/common/dependencies"
 	"github.com/keboola/keboola-as-code/internal/pkg/utils/errors"
@@ -40,13 +39,12 @@ func TestSliceCloseTask(t *testing.T) {
 
 	// Some other API node is also running
 	apiDeps2 := bufferDependencies.NewMockedDeps(t, append(opts, dependencies.WithUniqueID("api-node-2"))...)
-	_, err := watcher.NewAPINode(apiDeps2)
-	assert.NoError(t, err)
+	_ = apiDeps2.WatcherAPINode()
 
 	// Start worker node
 	workerDeps := bufferDependencies.NewMockedDeps(t, opts...)
 	workerDeps.DebugLogger().ConnectTo(testhelper.VerboseStdout())
-	_, err = upload.NewUploader(workerDeps, upload.WithCloseSlices(true), upload.WithUploadSlices(false))
+	_, err := upload.NewUploader(workerDeps, upload.WithCloseSlices(true), upload.WithUploadSlices(false))
 	assert.NoError(t, err)
 
 	// Create receivers and exports

--- a/internal/pkg/service/buffer/worker/upload/config.go
+++ b/internal/pkg/service/buffer/worker/upload/config.go
@@ -1,0 +1,33 @@
+package upload
+
+type config struct {
+	CloseSlices  bool
+	UploadSlices bool
+}
+
+type Option func(c *config)
+
+func newConfig(ops []Option) config {
+	c := config{
+		CloseSlices:  true,
+		UploadSlices: true,
+	}
+	for _, o := range ops {
+		o(&c)
+	}
+	return c
+}
+
+// WithCloseSlices enables/disables the close slices task.
+func WithCloseSlices(v bool) Option {
+	return func(c *config) {
+		c.CloseSlices = v
+	}
+}
+
+// WithUploadSlices enables/disables the upload slices task.
+func WithUploadSlices(v bool) Option {
+	return func(c *config) {
+		c.UploadSlices = v
+	}
+}

--- a/internal/pkg/service/buffer/worker/upload/uploader_test.go
+++ b/internal/pkg/service/buffer/worker/upload/uploader_test.go
@@ -48,7 +48,7 @@ func createRecords(t *testing.T, ctx context.Context, clk *clock.Mock, d bufferD
 
 	importer := receive.NewImporter(d)
 	d.RequestHeaderMutable().Set("Content-Type", "application/json")
-	for i := start; i <= count; i++ {
+	for i := start; i < start+count; i++ {
 		if clk != nil {
 			clk.Add(time.Second)
 		}

--- a/internal/pkg/service/buffer/worker/upload/uploader_test.go
+++ b/internal/pkg/service/buffer/worker/upload/uploader_test.go
@@ -2,12 +2,18 @@ package upload_test
 
 import (
 	"context"
+	"fmt"
+	"io"
+	"strings"
 	"testing"
+	"time"
 
 	"github.com/benbjohnson/clock"
 	"github.com/stretchr/testify/assert"
 	etcd "go.etcd.io/etcd/client/v3"
 
+	"github.com/keboola/keboola-as-code/internal/pkg/service/buffer/api/receive"
+	bufferDependencies "github.com/keboola/keboola-as-code/internal/pkg/service/buffer/dependencies"
 	"github.com/keboola/keboola-as-code/internal/pkg/service/buffer/store"
 	"github.com/keboola/keboola-as-code/internal/pkg/service/buffer/store/key"
 	"github.com/keboola/keboola-as-code/internal/pkg/service/buffer/store/model"
@@ -15,10 +21,12 @@ import (
 	"github.com/keboola/keboola-as-code/internal/pkg/utils/etcdhelper"
 )
 
+const receiverSecret = "XXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXX"
+
 // createExport creates receiver,export,mapping,file and slice.
-func createExport(t *testing.T, ctx context.Context, clk clock.Clock, client *etcd.Client, str *store.Store) key.SliceKey {
+func createExport(t *testing.T, receiverID, exportID string, ctx context.Context, clk clock.Clock, client *etcd.Client, str *store.Store) key.SliceKey {
 	t.Helper()
-	receiver := model.ReceiverForTest("my-receiver", 0, clk.Now())
+	receiver := model.ReceiverForTest(receiverID, 0, clk.Now())
 	columns := []column.Column{
 		column.ID{Name: "col01"},
 		column.Datetime{Name: "col02"},
@@ -27,10 +35,24 @@ func createExport(t *testing.T, ctx context.Context, clk clock.Clock, client *et
 		column.Headers{Name: "col05"},
 		column.Template{Name: "col06", Language: "jsonnet", Content: `"---" + Body("key") + "---"`},
 	}
-	export := model.ExportForTest(receiver.ReceiverKey, "my-export", "in.c-bucket.table", columns, clk.Now())
+	export := model.ExportForTest(receiver.ReceiverKey, exportID, "in.c-bucket.table", columns, clk.Now())
 	etcdhelper.ExpectModification(t, client, func() {
 		assert.NoError(t, str.CreateReceiver(ctx, receiver))
 		assert.NoError(t, str.CreateExport(ctx, export))
 	})
 	return export.OpenedSlice.SliceKey
+}
+
+func createRecords(t *testing.T, ctx context.Context, clk *clock.Mock, d bufferDependencies.Mocked, key key.ReceiverKey, start, count int) {
+	t.Helper()
+
+	importer := receive.NewImporter(d)
+	d.RequestHeaderMutable().Set("Content-Type", "application/json")
+	for i := start; i <= count; i++ {
+		if clk != nil {
+			clk.Add(time.Second)
+		}
+		body := io.NopCloser(strings.NewReader(fmt.Sprintf(`{"key":"value%03d"}`, i)))
+		assert.NoError(t, importer.CreateRecord(ctx, d, key, receiverSecret, body))
+	}
 }

--- a/internal/pkg/service/buffer/worker/upload/uploader_test.go
+++ b/internal/pkg/service/buffer/worker/upload/uploader_test.go
@@ -25,7 +25,7 @@ func createExport(t *testing.T, ctx context.Context, clk clock.Clock, client *et
 		column.IP{Name: "col03"},
 		column.Body{Name: "col04"},
 		column.Headers{Name: "col05"},
-		column.Template{Name: "col06", Language: "jsonnet", Content: `"---" + Body("key1") + "---"`},
+		column.Template{Name: "col06", Language: "jsonnet", Content: `"---" + Body("key") + "---"`},
 	}
 	export := model.ExportForTest(receiver.ReceiverKey, "my-export", "in.c-bucket.table", columns, clk.Now())
 	etcdhelper.ExpectModification(t, client, func() {

--- a/internal/pkg/service/common/etcdop/iterator/iterator_typed.go
+++ b/internal/pkg/service/common/etcdop/iterator/iterator_typed.go
@@ -48,7 +48,7 @@ func (v *ForEachOpT[T]) Op(ctx context.Context) (etcd.Op, error) {
 	// Other pages are loaded within MapResponse method, see below.
 	// Iterator always load next pages WithRevision,
 	// so all results, from all pages, are from the same revision.
-	return firstPageOp(v.def.prefix, v.def.pageSize, v.def.revision).Op(ctx)
+	return firstPageOp(v.def.prefix, v.def.end, v.def.pageSize, v.def.revision).Op(ctx)
 }
 
 func (v *ForEachOpT[T]) MapResponse(ctx context.Context, response op.Response) (result any, err error) {

--- a/internal/pkg/service/common/servicectx/servicectx_test.go
+++ b/internal/pkg/service/common/servicectx/servicectx_test.go
@@ -45,7 +45,9 @@ func TestProcess_Add(t *testing.T) {
 		logger.Info("end3")
 		op3.Done()
 	})
+	startShutdown := make(chan struct{})
 	proc.Add(func(ctx context.Context, shutdown ShutdownFn) {
+		<-startShutdown
 		shutdown(errors.New("operation failed"))
 	})
 	proc.OnShutdown(func() {
@@ -58,9 +60,10 @@ func TestProcess_Add(t *testing.T) {
 		op3.Wait()
 		logger.Info("onShutdown3")
 	})
-	proc.WaitForShutdown()
 
 	// Wait can be called multiple times
+	close(startShutdown)
+	proc.WaitForShutdown()
 	proc.WaitForShutdown()
 	proc.WaitForShutdown()
 	proc.WaitForShutdown()

--- a/internal/pkg/utils/testproject/project.go
+++ b/internal/pkg/utils/testproject/project.go
@@ -220,7 +220,7 @@ func (p *Project) SandboxesAPIClient() client.Client {
 func (p *Project) Clean() error {
 	p.logf("□ Cleaning project...")
 
-	ctx, cancel := context.WithTimeout(context.Background(), 3*time.Minute)
+	ctx, cancel := context.WithTimeout(context.Background(), 5*time.Minute)
 	defer cancel()
 
 	// Clean whole project - configs, buckets, schedules, sandbox instances, etc.

--- a/test/api/buffer/import/import/expected-etcd-kvs.txt
+++ b/test/api/buffer/import/import/expected-etcd-kvs.txt
@@ -220,8 +220,9 @@
   "exportId": "export-1",
   "fileId": "%s",
   "sliceId": "%s",
-  "count": 2,
-  "size": %d,
-  "lastRecordAt": "%s"
+  "lastRecordAt": "%s",
+  "recordsCount": 2,
+  "recordsSize": %d,
+  "bodySize": 48
 }
 >>>>>

--- a/test/api/buffer/receivers/delete/expected-etcd-kvs.txt
+++ b/test/api/buffer/receivers/delete/expected-etcd-kvs.txt
@@ -86,43 +86,6 @@
 >>>>>
 
 <<<<<
-/file/opened/%%TEST_KBC_PROJECT_ID_8DIG%%/receiver-c/export-2/%s
------
-{
-  "projectId": %%TEST_KBC_PROJECT_ID%%,
-  "receiverId": "receiver-c",
-  "exportId": "export-2",
-  "fileId": "%s",
-  "state": "opened",
-  "mapping": {
-    "projectId": %%TEST_KBC_PROJECT_ID%%,
-    "receiverId": "receiver-c",
-    "exportId": "export-2",
-    "revisionId": 1,
-    "tableId": "in.c-bucket.table",
-    "incremental": false,
-    "columns": [
-      {
-        "type": "id",
-        "name": "id"
-      },
-      {
-        "type": "body",
-        "name": "body"
-      }
-    ]
-  },
-  "storageResource": {
-    "id": %d,
-    "created": "%s",
-    "isSliced": true,
-    %A
-    "federationToken": true
-  }
-}
->>>>>
-
-<<<<<
 /secret/export/token/%%TEST_KBC_PROJECT_ID_8DIG%%/receiver-b/export-1
 -----
 %A
@@ -142,38 +105,6 @@
     "projectId": %%TEST_KBC_PROJECT_ID%%,
     "receiverId": "receiver-b",
     "exportId": "export-1",
-    "revisionId": 1,
-    "tableId": "in.c-bucket.table",
-    "incremental": false,
-    "columns": [
-      {
-        "type": "id",
-        "name": "id"
-      },
-      {
-        "type": "body",
-        "name": "body"
-      }
-    ]
-  },
-  "sliceNumber": 1
-}
->>>>>
-
-<<<<<
-/slice/opened/%%TEST_KBC_PROJECT_ID_8DIG%%/receiver-c/export-2/%s
------
-{
-  "projectId": %%TEST_KBC_PROJECT_ID%%,
-  "receiverId": "receiver-c",
-  "exportId": "export-2",
-  "fileId": "%s",
-  "sliceId": "%s",
-  "state": "opened",
-  "mapping": {
-    "projectId": %%TEST_KBC_PROJECT_ID%%,
-    "receiverId": "receiver-c",
-    "exportId": "export-2",
     "revisionId": 1,
     "tableId": "in.c-bucket.table",
     "incremental": false,


### PR DESCRIPTION
Part of: https://keboola.atlassian.net/browse/BA-40

Changes:
- Per node statistics are merged on slice close.
- Added `slice.IsEmpty` flag.
- Better tests.