### PR TITLE
upload: Use WithFromSameRev in the reader, test records with max size

### DIFF
--- a/internal/pkg/service/buffer/worker/upload/reader.go
+++ b/internal/pkg/service/buffer/worker/upload/reader.go
@@ -1,0 +1,59 @@
+package upload
+
+import (
+	"bytes"
+	"context"
+	"io"
+	"strconv"
+
+	"github.com/keboola/keboola-as-code/internal/pkg/service/buffer/store/model"
+	"github.com/keboola/keboola-as-code/internal/pkg/service/buffer/store/model/column"
+	"github.com/keboola/keboola-as-code/internal/pkg/utils/errors"
+)
+
+func (u *Uploader) newRecordsReader(ctx context.Context, slice model.Slice) io.Reader {
+	out, in := io.Pipe()
+	go func() {
+		var err error
+		defer func() {
+			if closeErr := in.CloseWithError(err); closeErr != nil {
+				u.logger.Errorf(`cannot close records reader pipe: %w`, closeErr)
+			}
+		}()
+
+		count := uint64(0)
+		id := slice.IDRange.Start
+		idPlaceholder := []byte(column.IDPlaceholder)
+		if id < 1 {
+			panic(errors.Errorf(`record ID must be > 0, found "%v"`, id))
+		}
+
+		// Read records
+		records := u.schema.Records().InSlice(slice.SliceKey).GetAll().Do(ctx, u.etcdClient)
+		for records.Next() {
+			row := records.Value().Value
+			row = bytes.ReplaceAll(row, idPlaceholder, []byte(strconv.FormatUint(id, 10)))
+			_, err = in.Write(row)
+			if err != nil {
+				return
+			}
+			count++
+			id++
+		}
+
+		// Check iterator error
+		err = records.Err()
+		if err != nil {
+			return
+		}
+
+		// Check records count
+		if count != slice.Statistics.RecordsCount {
+			u.logger.Errorf(
+				`unexpected number of uploaded records, expected "%d", found "%d"`,
+				slice.Statistics.RecordsCount, count,
+			)
+		}
+	}()
+	return out
+}

--- a/internal/pkg/service/buffer/worker/upload/reader.go
+++ b/internal/pkg/service/buffer/worker/upload/reader.go
@@ -33,10 +33,15 @@ func newRecordsReader(ctx context.Context, logger log.Logger, client *etcd.Clien
 			panic(errors.Errorf(`record ID must be > 0, found "%v"`, id))
 		}
 
-		// Read records
-		records := u.schema.Records().InSlice(slice.SliceKey).GetAll().Do(ctx, u.etcdClient)
-		for records.Next() {
-			row := records.Value().Value
+		// Read records.
+		// It is guaranteed that new records are not added to the prefix, and existing ones are not changed.
+		// Therefore, the WithFromSameRev(false) is used.
+		// This also prevents ErrCompacted, because we are not requesting a specific version.
+		pageSize := 100
+		records := schema.Records().InSlice(slice.SliceKey)
+		itr := records.GetAll(iterator.WithPageSize(pageSize), iterator.WithFromSameRev(false)).Do(ctx, client)
+		for itr.Next() {
+			row := itr.Value().Value
 			row = bytes.ReplaceAll(row, idPlaceholder, []byte(strconv.FormatUint(id, 10)))
 			_, err = in.Write(row)
 			if err != nil {
@@ -47,7 +52,7 @@ func newRecordsReader(ctx context.Context, logger log.Logger, client *etcd.Clien
 		}
 
 		// Check iterator error
-		err = records.Err()
+		err = itr.Err()
 		if err != nil {
 			return
 		}

--- a/internal/pkg/service/buffer/worker/upload/reader_test.go
+++ b/internal/pkg/service/buffer/worker/upload/reader_test.go
@@ -1,0 +1,67 @@
+package upload
+
+import (
+	"context"
+	"io"
+	"testing"
+	"time"
+
+	"github.com/benbjohnson/clock"
+	"github.com/c2h5oh/datasize"
+	gonanoid "github.com/matoous/go-nanoid/v2"
+	"github.com/stretchr/testify/assert"
+
+	"github.com/keboola/keboola-as-code/internal/pkg/log"
+	"github.com/keboola/keboola-as-code/internal/pkg/service/buffer/store/key"
+	"github.com/keboola/keboola-as-code/internal/pkg/service/buffer/store/model"
+	"github.com/keboola/keboola-as-code/internal/pkg/service/buffer/store/schema"
+	"github.com/keboola/keboola-as-code/internal/pkg/utils/etcdhelper"
+	"github.com/keboola/keboola-as-code/internal/pkg/validator"
+)
+
+func TestRecordsReader(t *testing.T) {
+	t.Parallel()
+
+	ctx, cancel := context.WithTimeout(context.Background(), 30*time.Second)
+	defer cancel()
+	client := etcdhelper.ClientForTest(t)
+
+	recordsCount := 5
+	recordSize := datasize.MB
+	value := gonanoid.Must(int(recordSize))
+
+	clk := clock.NewMock()
+	clk.Set(time.Time{}.Add(time.Second))
+	logger := log.NewDebugLogger()
+	sm := schema.New(validator.New().Validate)
+	receiverKey := key.ReceiverKey{ProjectID: 123, ReceiverID: "my-receiver"}
+	exportKey := key.ExportKey{ReceiverKey: receiverKey, ExportID: "my-export"}
+	fileKey := key.FileKey{ExportKey: exportKey, FileID: key.FileID(clk.Now())}
+	sliceKey := key.SliceKey{FileKey: fileKey, SliceID: key.SliceID(clk.Now())}
+	slice := model.Slice{
+		SliceKey:   sliceKey,
+		Statistics: &model.Stats{RecordsCount: uint64(recordsCount)},
+		IDRange:    &model.SliceIDRange{Start: 1, Count: uint64(recordsCount)},
+	}
+
+	// Create records
+	// t.Logf(`write start: %s`, time.Now())
+	for i := 0; i < recordsCount; i++ {
+		clk.Add(time.Second)
+		recordKey := key.RecordKey{SliceKey: sliceKey, ReceivedAt: key.ReceivedAt(clk.Now()), RandomSuffix: "abcde"}
+		assert.NoError(t, sm.Records().ByKey(recordKey).Put(value).Do(ctx, client))
+	}
+	// t.Logf(`write end: %s`, time.Now())
+
+	// Read all
+	// start := time.Now()
+	// t.Logf(`read start: %s`, start)
+	reader := newRecordsReader(ctx, logger, client, sm, slice)
+	rSize, err := io.Copy(io.Discard, reader)
+	assert.NoError(t, err)
+	assert.Equal(t, (recordSize * datasize.ByteSize(recordsCount)).String(), datasize.ByteSize(rSize).String())
+	// end := time.Now()
+	// t.Logf(`read end: %s`, end)
+	// t.Logf(`duration: %s`, end.Sub(start))
+	// t.Logf(`size: %s`, datasize.ByteSize(rSize).HumanReadable())
+}

--- a/internal/pkg/service/buffer/worker/upload/upload.go
+++ b/internal/pkg/service/buffer/worker/upload/upload.go
@@ -1,10 +1,7 @@
 package upload
 
 import (
-	"bytes"
 	"context"
-	"io"
-	"strconv"
 	"sync"
 	"time"
 
@@ -13,7 +10,6 @@ import (
 	"github.com/keboola/keboola-as-code/internal/pkg/log"
 	"github.com/keboola/keboola-as-code/internal/pkg/service/buffer/storage/file"
 	"github.com/keboola/keboola-as-code/internal/pkg/service/buffer/store/model"
-	"github.com/keboola/keboola-as-code/internal/pkg/service/buffer/store/model/column"
 	"github.com/keboola/keboola-as-code/internal/pkg/service/buffer/worker/task"
 	"github.com/keboola/keboola-as-code/internal/pkg/service/buffer/worker/task/orchestrator"
 	"github.com/keboola/keboola-as-code/internal/pkg/service/common/etcdop"
@@ -93,51 +89,4 @@ func (u *Uploader) uploadSlices(ctx context.Context, wg *sync.WaitGroup, d depen
 			}
 		},
 	})
-}
-
-func (u *Uploader) newRecordsReader(ctx context.Context, slice model.Slice) io.Reader {
-	out, in := io.Pipe()
-	go func() {
-		var err error
-		defer func() {
-			if closeErr := in.CloseWithError(err); closeErr != nil {
-				u.logger.Errorf(`cannot close records reader pipe: %w`, closeErr)
-			}
-		}()
-
-		count := uint64(0)
-		id := slice.IDRange.Start
-		idPlaceholder := []byte(column.IDPlaceholder)
-		if id < 1 {
-			panic(errors.Errorf(`record ID must be > 0, found "%v"`, id))
-		}
-
-		// Read records
-		records := u.schema.Records().InSlice(slice.SliceKey).GetAll().Do(ctx, u.etcdClient)
-		for records.Next() {
-			row := records.Value().Value
-			row = bytes.ReplaceAll(row, idPlaceholder, []byte(strconv.FormatUint(id, 10)))
-			_, err = in.Write(row)
-			if err != nil {
-				return
-			}
-			count++
-			id++
-		}
-
-		// Check iterator error
-		err = records.Err()
-		if err != nil {
-			return
-		}
-
-		// Check records count
-		if count != slice.Statistics.RecordsCount {
-			u.logger.Errorf(
-				`unexpected number of uploaded records, expected "%d", found "%d"`,
-				slice.Statistics.RecordsCount, count,
-			)
-		}
-	}()
-	return out
 }

--- a/internal/pkg/service/buffer/worker/upload/upload.go
+++ b/internal/pkg/service/buffer/worker/upload/upload.go
@@ -76,7 +76,8 @@ func (u *Uploader) uploadSlices(ctx context.Context, wg *sync.WaitGroup, d depen
 				files := file.NewManager(d.Clock(), apiClient, u.config.uploadTransport)
 
 				// Upload slice, set statistics
-				if err := files.UploadSlice(ctx, fileRes, &slice, u.newRecordsReader(ctx, slice)); err != nil {
+				reader := newRecordsReader(ctx, u.logger, u.etcdClient, u.schema, slice)
+				if err := files.UploadSlice(ctx, fileRes, &slice, reader); err != nil {
 					return "", errors.Errorf(`file upload failed: %w`, err)
 				}
 

--- a/internal/pkg/service/common/etcdop/iterator/iterator_typed.go
+++ b/internal/pkg/service/common/etcdop/iterator/iterator_typed.go
@@ -33,7 +33,7 @@ func NewTyped[R any](start string, serde *serde.Serde, opts ...Option) Definitio
 // Do converts iterator definition to the iterator.
 func (v DefinitionT[T]) Do(ctx context.Context, client etcd.KV, opts ...op.Option) *IteratorT[T] {
 	out := &IteratorT[T]{Iterator: newIterator(v.config).Do(ctx, client, opts...)}
-	out.serde = v.serde
+	out.config.serde = v.serde
 	return out
 }
 
@@ -87,7 +87,7 @@ func (v *IteratorT[T]) Next() bool {
 
 	// Decode item
 	v.currentValue = op.KeyValueT[T]{Kv: v.values[v.currentIndex]}
-	if err := v.serde.Decode(v.ctx, v.currentValue.Kv, &v.currentValue.Value); err != nil {
+	if err := v.config.serde.Decode(v.ctx, v.currentValue.Kv, &v.currentValue.Value); err != nil {
 		v.err = errors.Errorf(`etcd iterator failed: cannot decode key "%s", page=%d, index=%d: %w`, v.currentValue.Kv.Key, v.page, v.currentIndex, err)
 	}
 	return v.err == nil

--- a/internal/pkg/service/common/etcdop/iterator/iterator_typed_test.go
+++ b/internal/pkg/service/common/etcdop/iterator/iterator_typed_test.go
@@ -31,6 +31,7 @@ type testCaseT struct {
 	name         string
 	kvCount      int
 	pageSize     int
+	options      []iterator.Option
 	expected     []resultT
 	expectedLogs string
 }
@@ -113,7 +114,7 @@ ETCD_REQUEST[%d] ✔️️  GET ["some/prefix/", "some/prefix0") | rev: %d | cou
 			expectedLogs: `
 ETCD_REQUEST[%d] ➡️  GET ["some/prefix/", "some/prefix0")
 ETCD_REQUEST[%d] ✔️️  GET ["some/prefix/", "some/prefix0") | rev: %d | count: 4 | %s
-ETCD_REQUEST[%d] ➡️  GET ["some/prefix/foo004", "some/prefix0")
+ETCD_REQUEST[%d] ➡️  GET ["some/prefix/foo004", "some/prefix0") | rev: %d
 ETCD_REQUEST[%d] ✔️️  GET ["some/prefix/foo004", "some/prefix0") | rev: %d | count: 1 | %s
 `,
 		},
@@ -131,14 +132,15 @@ ETCD_REQUEST[%d] ✔️️  GET ["some/prefix/foo004", "some/prefix0") | rev: %d
 			expectedLogs: `
 ETCD_REQUEST[%d] ➡️  GET ["some/prefix/", "some/prefix0")
 ETCD_REQUEST[%d] ✔️️  GET ["some/prefix/", "some/prefix0") | rev: %d | count: 5 | %s
-ETCD_REQUEST[%d] ➡️  GET ["some/prefix/foo004", "some/prefix0")
+ETCD_REQUEST[%d] ➡️  GET ["some/prefix/foo004", "some/prefix0") | rev: %d
 ETCD_REQUEST[%d] ✔️️  GET ["some/prefix/foo004", "some/prefix0") | rev: %d | count: 2 | %s
 `,
 		},
 		{
-			name:     "page size = 1",
+			name:     "WithFromSameRev = false",
 			kvCount:  5,
 			pageSize: 1,
+			options:  []iterator.Option{iterator.WithFromSameRev(false)},
 			expected: []resultT{
 				{key: "some/prefix/foo001", value: obj{"bar001"}},
 				{key: "some/prefix/foo002", value: obj{"bar002"}},
@@ -167,16 +169,17 @@ ETCD_REQUEST[%d] ✔️️  GET ["some/prefix/foo005", "some/prefix0") | rev: %d
 		client := etcdhelper.ClientForTest(t)
 		client.KV = etcdhelper.KVLogWrapper(client.KV, &logs)
 		prefix := generateKVsT(t, tc.kvCount, ctx, client)
+		ops := append([]iterator.Option{iterator.WithPageSize(tc.pageSize)}, tc.options...)
 
 		// Test iteration methods
 		logs.Reset()
-		actual := iterateAllT(t, prefix.GetAll(iterator.WithPageSize(tc.pageSize)), ctx, client)
+		actual := iterateAllT(t, prefix.GetAll(ops...), ctx, client)
 		assert.Equal(t, tc.expected, actual, tc.name)
 		wildcards.Assert(t, tc.expectedLogs, logs.String(), tc.name)
 
 		// Test All method
 		logs.Reset()
-		actualKvs, err := prefix.GetAll(iterator.WithPageSize(tc.pageSize)).Do(ctx, client).All()
+		actualKvs, err := prefix.GetAll(ops...).Do(ctx, client).All()
 		assert.NoError(t, err)
 		actual = make([]resultT, 0)
 		for _, kv := range actualKvs {
@@ -187,7 +190,7 @@ ETCD_REQUEST[%d] ✔️️  GET ["some/prefix/foo005", "some/prefix0") | rev: %d
 
 		// Test ForEachKV method
 		logs.Reset()
-		itr := prefix.GetAll(iterator.WithPageSize(tc.pageSize)).Do(ctx, client)
+		itr := prefix.GetAll(ops...).Do(ctx, client)
 		actual = make([]resultT, 0)
 		assert.NoError(t, itr.ForEachKV(func(kv op.KeyValueT[obj], header *iterator.Header) error {
 			assert.NotNil(t, header)
@@ -199,7 +202,7 @@ ETCD_REQUEST[%d] ✔️️  GET ["some/prefix/foo005", "some/prefix0") | rev: %d
 
 		// Test ForEachValue method
 		logs.Reset()
-		itr = prefix.GetAll(iterator.WithPageSize(tc.pageSize)).Do(ctx, client)
+		itr = prefix.GetAll(ops...).Do(ctx, client)
 		values := make([]obj, 0)
 		assert.NoError(t, itr.ForEachValue(func(value obj, header *iterator.Header) error {
 			assert.NotNil(t, header)

--- a/internal/pkg/utils/etcdhelper/logger.go
+++ b/internal/pkg/utils/etcdhelper/logger.go
@@ -5,6 +5,7 @@ import (
 	"context"
 	"fmt"
 	"io"
+	"strconv"
 	"strings"
 	"sync/atomic"
 	"time"
@@ -77,6 +78,10 @@ func (v *kvWrapper) start(op *Op, opName, key, value string) string {
 	if key != "" {
 		var out strings.Builder
 		out.WriteString(fmt.Sprintf(`➡️  %s %s`, opName, key))
+		if op.Rev() > 0 {
+			out.WriteString(" | rev: ")
+			out.WriteString(strconv.FormatInt(op.Rev(), 10))
+		}
 		if value != "" {
 			out.WriteString(" | value:")
 			out.WriteString("\n")


### PR DESCRIPTION
Part of: https://keboola.atlassian.net/browse/BA-40

Changes:
- Tested `1MB` records with the records reader.
- Added `WithFromSameRev(false)` option for the iterator.
