### PR TITLE
upload: Update manifest after each slice upload

### DIFF
--- a/internal/pkg/service/buffer/storage/file/manager.go
+++ b/internal/pkg/service/buffer/storage/file/manager.go
@@ -92,7 +92,7 @@ func (m *Manager) UploadSlice(ctx context.Context, f model.File, s *model.Slice,
 	return err
 }
 
-func (m *Manager) UploadManifest(ctx context.Context, file *model.File, slices []*model.Slice) error {
+func (m *Manager) UploadManifest(ctx context.Context, file model.File, slices []model.Slice) error {
 	sliceFiles := make([]string, 0)
 	for _, s := range slices {
 		sliceFiles = append(sliceFiles, s.Filename())


### PR DESCRIPTION
Part of: https://keboola.atlassian.net/browse/BA-40

Changes:
- File manifest is updated after each slice upload.


------------------

Narazil som na problem:
- Mame nejaky subor, do ktoreho sme uz nahrali 3 slices.
- Nieco sa stane a 1h nejde platforma, za ten cas expiruju file credentials.
- (Ak ide platforma, tak pred expiraciou nahrame manifest a spustime import, to je OK).
- Ale teda platforma nejde, tak sme nevedeli zabranit expiracii credentials.
- Co s tym?
- Data uz v etcd nemame, su v subore, vo file store.
- Ten ale nevieme nahrat pretoze v nom chyba manifest.
- Napadlo mi teda, ze budeme updatovat manifest po kazdej nahratej slice.
- Vyzera to, ze to ide, a vieme subory v storage prepisovat.
- Vyskusal som to lokalne oproti S3 aj Azure.