### PR TITLE
Increase templates-api memory

### DIFF
--- a/provisioning/templates-api/kubernetes/templates/api/deployment.yaml
+++ b/provisioning/templates-api/kubernetes/templates/api/deployment.yaml
@@ -31,15 +31,15 @@ spec:
           resources:
             requests:
               cpu: "200m"
-              memory: "512Mi"
+              memory: "768Mi"
             limits:
-              memory: "512Mi"
+              memory: "768Mi"
           ports:
             - containerPort: 8000
           env:
             # 80% of the resources.limits.memory
             - name: GOMEMLIMIT
-              value: "400MiB"
+              value: "550MiB"
             - name: KBC_STORAGE_API_HOST
               valueFrom:
                 configMapKeyRef:


### PR DESCRIPTION
Changes:
- Increased memory for Templates API pod `512MB -> 768MB`.

![image](https://user-images.githubusercontent.com/19371734/214518215-3851a8f0-c8cd-4da5-8584-78f332f8cc96.png)
