### PR TITLE
Update GH Actions + downgrade GHA windows runner

### DIFF
--- a/.github/workflows/release-cli.yml
+++ b/.github/workflows/release-cli.yml
@@ -191,7 +191,7 @@ jobs:
       - release
     env:
       VERSION: ${{ needs.version.outputs.VERSION }}
-    runs-on: windows-latest
+    runs-on: windows-2019
     permissions:
       id-token: write
       contents: read
@@ -384,7 +384,7 @@ jobs:
       - release-msi-windows
     env:
       VERSION: ${{ needs.version.outputs.VERSION }}
-    runs-on: windows-latest
+    runs-on: windows-2019
     steps:
       - name: Check out the repo
         uses: actions/checkout@v3
@@ -521,7 +521,7 @@ jobs:
       - update-repositories
     env:
       VERSION: ${{ needs.version.outputs.VERSION }}
-    runs-on: windows-latest
+    runs-on: windows-2019
     steps:
       - name: Download MSI
         shell: bash

--- a/.github/workflows/release-cli.yml
+++ b/.github/workflows/release-cli.yml
@@ -293,10 +293,10 @@ jobs:
         uses: actions/checkout@v3
 
       - name: Setup Docker Buildx
-        uses: docker/setup-buildx-action@v1
+        uses: docker/setup-buildx-action@v2
 
       - name: Docker login
-        uses: docker/login-action@v1
+        uses: docker/login-action@v2
         with:
           username: ${{ env.DOCKERHUB_USER }}
           password: ${{ env.DOCKERHUB_TOKEN }}

--- a/.github/workflows/release-service-buffer.yml
+++ b/.github/workflows/release-service-buffer.yml
@@ -64,7 +64,7 @@ jobs:
         uses: docker/setup-buildx-action@v2
 
       - name: Docker login
-        uses: docker/login-action@v1
+        uses: docker/login-action@v2
         with:
           username: ${{ env.DOCKERHUB_USER }}
           password: ${{ env.DOCKERHUB_TOKEN }}

--- a/.github/workflows/release-service-templates.yml
+++ b/.github/workflows/release-service-templates.yml
@@ -55,7 +55,7 @@ jobs:
         uses: docker/setup-buildx-action@v2
 
       - name: Docker login
-        uses: docker/login-action@v1
+        uses: docker/login-action@v2
         with:
           username: ${{ env.DOCKERHUB_USER }}
           password: ${{ env.DOCKERHUB_TOKEN }}

--- a/.github/workflows/test-e2e-cli.yml
+++ b/.github/workflows/test-e2e-cli.yml
@@ -59,7 +59,7 @@ jobs:
             os: macos-latest
             projects: TEST_PROJECTS_MACOS
           - name: windows
-            os: windows-latest
+            os: windows-2019
             projects: TEST_PROJECTS_WINDOWS
     runs-on: ${{ matrix.os }}
     steps:
@@ -89,4 +89,3 @@ jobs:
         env:
           VERSION: ${{ inputs.version }}
           TEST_KBC_PROJECTS: ${{ env[matrix.projects] }}
-

--- a/.github/workflows/test-unit.yml
+++ b/.github/workflows/test-unit.yml
@@ -47,7 +47,7 @@ jobs:
             os: macos-latest
             projects: TEST_PROJECTS_MACOS
           - name: windows
-            os: windows-latest
+            os: windows-2019
             projects: TEST_PROJECTS_WINDOWS
     runs-on: ${{ matrix.os }}
     steps:
@@ -89,4 +89,3 @@ jobs:
           UNIT_ETCD_USERNAME: root
           UNIT_ETCD_PASSWORD: toor
           UNIT_ETCD_NAMESPACE: buffer
-


### PR DESCRIPTION
No, nic zásadnějšího s tím asi zatím neuděláme (když teda odmyslím možnost vypnout testy na Mac a Win na push a nechat je třeba jen na merge) ale downgrade na `windows-2019` o pár minut pomohl. 🙂 

![CleanShot 2023-02-02 at 11 46 22](https://user-images.githubusercontent.com/215660/216304454-c06d0cd9-1af0-40d5-896a-208208d22944.jpg)

viz.
- https://github.com/actions/runner-images/issues/3577
- https://github.com/actions/runner-images/issues/5166
- https://github.com/Lombiq/GitHub-Actions/issues/32


Taky jsem poupdatoval pár akcí co hlásily používanou deprecated Node verzi. (Ještě tam zbývají `Apple-Actions/import-codesign-certs` a `microsoft/setup-msbuild` ale obě nebyly updatovaný dva roky, tak nevím. 🙂)