### PR TITLE
Fix table preview width

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -102,8 +102,8 @@ require (
 	golang.org/x/crypto v0.6.0 // indirect
 	golang.org/x/mod v0.8.0 // indirect
 	golang.org/x/net v0.7.0 // indirect
-	golang.org/x/sys v0.5.0 // indirect
-	golang.org/x/term v0.5.0 // indirect
+	golang.org/x/sys v0.6.0 // indirect
+	golang.org/x/term v0.6.0
 	golang.org/x/text v0.7.0
 	golang.org/x/time v0.1.0 // indirect
 	golang.org/x/tools v0.6.1-0.20230222164832-25d2519c8696

--- a/go.sum
+++ b/go.sum
@@ -2157,8 +2157,6 @@ golang.org/x/sys v0.0.0-20220811171246-fbc7d0a398ab/go.mod h1:oPkhp1MJrh7nUepCBc
 golang.org/x/sys v0.0.0-20220908164124-27713097b956/go.mod h1:oPkhp1MJrh7nUepCBck5+mAzfO9JrbApNNgaTdGDITg=
 golang.org/x/sys v0.0.0-20221010170243-090e33056c14/go.mod h1:oPkhp1MJrh7nUepCBck5+mAzfO9JrbApNNgaTdGDITg=
 golang.org/x/sys v0.4.0/go.mod h1:oPkhp1MJrh7nUepCBck5+mAzfO9JrbApNNgaTdGDITg=
-golang.org/x/sys v0.5.0 h1:MUK/U/4lj1t1oPg0HfuXDN/Z1wv31ZJ/YcPiGccS4DU=
-golang.org/x/sys v0.5.0/go.mod h1:oPkhp1MJrh7nUepCBck5+mAzfO9JrbApNNgaTdGDITg=
 golang.org/x/sys v0.6.0 h1:MVltZSvRTcU2ljQOhs94SXPftV6DCNnZViHeQps87pQ=
 golang.org/x/sys v0.6.0/go.mod h1:oPkhp1MJrh7nUepCBck5+mAzfO9JrbApNNgaTdGDITg=
 golang.org/x/term v0.0.0-20201117132131-f5c789dd3221/go.mod h1:Nr5EML6q2oocZ2LXRh80K7BxOlk5/8JxuGnuhpl+muw=
@@ -2168,8 +2166,6 @@ golang.org/x/term v0.0.0-20210503060354-a79de5458b56/go.mod h1:tfny5GFUkzUvx4ps4
 golang.org/x/term v0.0.0-20210615171337-6886f2dfbf5b/go.mod h1:jbD1KX2456YbFQfuXm/mYQcufACuNUgVhRMnK/tPxf8=
 golang.org/x/term v0.0.0-20210927222741-03fcf44c2211/go.mod h1:jbD1KX2456YbFQfuXm/mYQcufACuNUgVhRMnK/tPxf8=
 golang.org/x/term v0.4.0/go.mod h1:9P2UbLfCdcvo3p/nzKvsmas4TnlujnuoV9hGgYzW1lQ=
-golang.org/x/term v0.5.0 h1:n2a8QNdAb0sZNpU9R1ALUXBbY+w51fCQDN+7EdxNBsY=
-golang.org/x/term v0.5.0/go.mod h1:jMB1sMXY+tzblOD4FWmEbocvup2/aLOaQEp7JmGp78k=
 golang.org/x/term v0.6.0 h1:clScbb1cHjoCkyRbWwBEUZ5H/tIFu5TAXIqaZD0Gcjw=
 golang.org/x/term v0.6.0/go.mod h1:m6U89DPEgQRMq3DNkDClhWw02AUbt2daBVO4cn4Hv9U=
 golang.org/x/text v0.0.0-20170915032832-14c0d48ead0c/go.mod h1:NqM8EUOU14njkJ3fqMW+pc6Ldnwhi/IjpwHt7yyuwOQ=

--- a/go.sum
+++ b/go.sum
@@ -2159,6 +2159,8 @@ golang.org/x/sys v0.0.0-20221010170243-090e33056c14/go.mod h1:oPkhp1MJrh7nUepCBc
 golang.org/x/sys v0.4.0/go.mod h1:oPkhp1MJrh7nUepCBck5+mAzfO9JrbApNNgaTdGDITg=
 golang.org/x/sys v0.5.0 h1:MUK/U/4lj1t1oPg0HfuXDN/Z1wv31ZJ/YcPiGccS4DU=
 golang.org/x/sys v0.5.0/go.mod h1:oPkhp1MJrh7nUepCBck5+mAzfO9JrbApNNgaTdGDITg=
+golang.org/x/sys v0.6.0 h1:MVltZSvRTcU2ljQOhs94SXPftV6DCNnZViHeQps87pQ=
+golang.org/x/sys v0.6.0/go.mod h1:oPkhp1MJrh7nUepCBck5+mAzfO9JrbApNNgaTdGDITg=
 golang.org/x/term v0.0.0-20201117132131-f5c789dd3221/go.mod h1:Nr5EML6q2oocZ2LXRh80K7BxOlk5/8JxuGnuhpl+muw=
 golang.org/x/term v0.0.0-20201126162022-7de9c90e9dd1/go.mod h1:bj7SfCRtBDWHUb9snDiAeCFNEtKQo2Wmx5Cou7ajbmo=
 golang.org/x/term v0.0.0-20210220032956-6a3ed077a48d/go.mod h1:bj7SfCRtBDWHUb9snDiAeCFNEtKQo2Wmx5Cou7ajbmo=
@@ -2168,6 +2170,8 @@ golang.org/x/term v0.0.0-20210927222741-03fcf44c2211/go.mod h1:jbD1KX2456YbFQfuX
 golang.org/x/term v0.4.0/go.mod h1:9P2UbLfCdcvo3p/nzKvsmas4TnlujnuoV9hGgYzW1lQ=
 golang.org/x/term v0.5.0 h1:n2a8QNdAb0sZNpU9R1ALUXBbY+w51fCQDN+7EdxNBsY=
 golang.org/x/term v0.5.0/go.mod h1:jMB1sMXY+tzblOD4FWmEbocvup2/aLOaQEp7JmGp78k=
+golang.org/x/term v0.6.0 h1:clScbb1cHjoCkyRbWwBEUZ5H/tIFu5TAXIqaZD0Gcjw=
+golang.org/x/term v0.6.0/go.mod h1:m6U89DPEgQRMq3DNkDClhWw02AUbt2daBVO4cn4Hv9U=
 golang.org/x/text v0.0.0-20170915032832-14c0d48ead0c/go.mod h1:NqM8EUOU14njkJ3fqMW+pc6Ldnwhi/IjpwHt7yyuwOQ=
 golang.org/x/text v0.3.0/go.mod h1:NqM8EUOU14njkJ3fqMW+pc6Ldnwhi/IjpwHt7yyuwOQ=
 golang.org/x/text v0.3.1-0.20180807135948-17ff2d5776d2/go.mod h1:NqM8EUOU14njkJ3fqMW+pc6Ldnwhi/IjpwHt7yyuwOQ=

--- a/internal/pkg/service/cli/cmd/remote/table/preview.go
+++ b/internal/pkg/service/cli/cmd/remote/table/preview.go
@@ -75,9 +75,9 @@ func PreviewCommand(p dependencies.Provider) *cobra.Command {
 	cmd.Flags().Uint("limit", 100, "limit the number of exported rows")
 	cmd.Flags().String("where", "", "filter columns by value")
 	cmd.Flags().String("order", "", "order by one or more columns")
-	cmd.Flags().String("format", preview.TableFormatPretty, "order by one or more columns")
-	cmd.Flags().StringP("out", "o", "", "export table a file")
-	cmd.Flags().Bool("force", false, "overwrite the output file")
+	cmd.Flags().String("format", preview.TableFormatPretty, "output format (json/csv/pretty)")
+	cmd.Flags().StringP("out", "o", "", "export table to a file")
+	cmd.Flags().Bool("force", false, "overwrite the output file if it already exists")
 
 	return cmd
 }

--- a/pkg/lib/operation/project/remote/table/preview/render.go
+++ b/pkg/lib/operation/project/remote/table/preview/render.go
@@ -83,7 +83,7 @@ func renderPretty(table *keboola.TablePreview, adaptWidth bool) string {
 	var b strings.Builder
 
 	truncate := func(s string, max int) string {
-		if !adaptWidth || len(s) < 3 || len(s) <= max-3 {
+		if !adaptWidth || len(s) <= max {
 			return s
 		}
 		return fmt.Sprintf("%s...", s[:max-3])
@@ -107,10 +107,10 @@ func renderPretty(table *keboola.TablePreview, adaptWidth bool) string {
 		b.WriteString(boxV)
 		cols, last := widths[:len(widths)-1], widths[len(widths)-1]
 		for i, w := range cols {
-			fmt.Fprintf(&b, " %-*s ", w, truncate(data[i], w-2))
+			fmt.Fprintf(&b, " %-*s ", w, truncate(data[i], w))
 			b.WriteString(boxV)
 		}
-		fmt.Fprintf(&b, " %-*s ", last, truncate(data[len(data)-1], last-2))
+		fmt.Fprintf(&b, " %-*s ", last, truncate(data[len(data)-1], last))
 		b.WriteString(boxV)
 		b.WriteString("\n")
 	}

--- a/pkg/lib/operation/project/remote/table/preview/render_test.go
+++ b/pkg/lib/operation/project/remote/table/preview/render_test.go
@@ -94,7 +94,7 @@ func TestRenderPretty(t *testing.T) {
 	}
 
 	for _, c := range cases {
-		actual := normalizeTable(renderPretty(c.input))
+		actual := normalizeTable(renderPretty(c.input, false))
 		expected := normalizeTable(c.expected)
 
 		assert.Equal(t, expected, actual)

--- a/test/cli/help/table-preview/expected-stdout
+++ b/test/cli/help/table-preview/expected-stdout
@@ -13,11 +13,11 @@ Flags:
       --changed-since string      only export rows imported after this date
       --changed-until string      only export rows imported before this date
       --columns strings           comma-separated list of columns to export
-      --force                     overwrite the output file
-      --format string             order by one or more columns (default "pretty")
+      --force                     overwrite the output file if it already exists
+      --format string             output format (json/csv/pretty) (default "pretty")
       --limit uint                limit the number of exported rows (default 100)
       --order string              order by one or more columns
-  -o, --out string                export table a file
+  -o, --out string                export table to a file
   -H, --storage-api-host string   storage API host, eg. "connection.keboola.com"
       --where string              filter columns by value
 


### PR DESCRIPTION
Když byly v row dlouhé values, tak se mohlo stát, že table "přeteče" v konzoli a zobrazí se ti špagety:
![image](https://user-images.githubusercontent.com/1665677/223089219-88f6d356-e2ad-4466-b201-cb80b1413358.png)


Přidal jsem kontrolu terminal size a jednoduchý flexbox algoritmus, který vypočítá max šířku pro každý column a pak values větší než ten max ořízne:
![image](https://user-images.githubusercontent.com/1665677/223089116-8847e7bb-f2e9-4262-a048-dece601b91a9.png)

Když jde jen o preview, tak mi přijde ok takhle oříznout ty values. `--format csv` a `--format json` to nedělá, jen `--format pretty`.