### PR TITLE
Fix nil panic

### DIFF
--- a/internal/pkg/service/buffer/storage/table/manager.go
+++ b/internal/pkg/service/buffer/storage/table/manager.go
@@ -161,5 +161,8 @@ func (m *Manager) createBucket(ctx context.Context, rb rollback.Builder, bucketI
 		})
 		return bucket, nil
 	})
-	return bucket.(*keboola.Bucket), err
+	if err != nil {
+		return nil, err
+	}
+	return bucket.(*keboola.Bucket), nil
 }


### PR DESCRIPTION
Jira: https://keboola.atlassian.net/browse/PSGO-127

Ak sa nepodari vytvorit v BA novy bucket, tak nastne panic:
![image](https://user-images.githubusercontent.com/19371734/224929331-038082e6-ce8e-48a9-8c7b-50ab5e56359a.png)

Je to preto, lebo `nil` typu `any`, nie je to iste ako `nil` typu `*keboola.Bucket`, co nastave v pripade chyby pri vytvarani bucketu:

![image](https://user-images.githubusercontent.com/19371734/224928784-207d5403-5507-4e9f-a183-e6315493ca87.png)


