### PR TITLE
Update go-client to 1.11.0

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -28,7 +28,7 @@ require (
 	github.com/jarcoal/httpmock v1.3.0
 	github.com/joho/godotenv v1.4.0
 	github.com/jpillora/longestcommon v0.0.0-20161227235612-adb9d91ee629
-	github.com/keboola/go-client v1.10.2-0.20230313090434-abdf92a215c0
+	github.com/keboola/go-client v1.11.0
 	github.com/keboola/go-utils v0.8.1
 	github.com/klauspost/pgzip v1.2.5
 	github.com/kylelemons/godebug v1.1.0

--- a/go.sum
+++ b/go.sum
@@ -1105,8 +1105,8 @@ github.com/karrick/godirwalk v1.8.0/go.mod h1:H5KPZjojv4lE+QYImBI8xVtrBRgYrIVsaR
 github.com/karrick/godirwalk v1.10.3/go.mod h1:RoGL9dQei4vP9ilrpETWE8CLOZ1kiN0LhBygSwrAsHA=
 github.com/kballard/go-shellquote v0.0.0-20180428030007-95032a82bc51 h1:Z9n2FFNUXsshfwJMBgNA0RU6/i7WVaAegv3PtuIHPMs=
 github.com/kballard/go-shellquote v0.0.0-20180428030007-95032a82bc51/go.mod h1:CzGEWj7cYgsdH8dAjBGEr58BoE7ScuLd+fwFZ44+/x8=
-github.com/keboola/go-client v1.10.2-0.20230313090434-abdf92a215c0 h1:plOeTTaWOprkEKzza7b207J9/hoh3KW08pTpkJTGEWo=
-github.com/keboola/go-client v1.10.2-0.20230313090434-abdf92a215c0/go.mod h1:k14KdMDen9+pEIt13I+XjuiKN+kOfrO7OvbKz4mw57s=
+github.com/keboola/go-client v1.11.0 h1:38R+aWNq14wt2Kes7rlqnAvBZGDza6lPUSdFzOtPXYY=
+github.com/keboola/go-client v1.11.0/go.mod h1:k14KdMDen9+pEIt13I+XjuiKN+kOfrO7OvbKz4mw57s=
 github.com/keboola/go-jsonnet v0.19.1 h1:vdWv6lKNX2WdZl4R8PCOnOWINIjdcwmLqNssU7OUv+Y=
 github.com/keboola/go-jsonnet v0.19.1/go.mod h1:pSOb2+VoKZjVbIB4z58am8q15yWO/VTEp6n1GxW3x0I=
 github.com/keboola/go-utils v0.8.1 h1:nkTiAX9Me9NHvEkopm762BKV+iMNDqWyXmBsOTVDmyE=


### PR DESCRIPTION
https://github.com/keboola/go-client/releases/tag/v1.11.0