### PR TITLE
Increase buffer-etcd memory

### DIFF
--- a/provisioning/buffer/kubernetes/templates/etcd.yaml
+++ b/provisioning/buffer/kubernetes/templates/etcd.yaml
@@ -4,9 +4,9 @@
 resources:
   requests:
     cpu: "200m"
-    memory: "768Mi"
+    memory: "2000Mi"
   limits:
-    memory: "768Mi"
+    memory: "2000Mi"
 
 # Run defragmentation each 2 hours
 defragmentation:


### PR DESCRIPTION
Slack: https://keboola.slack.com/archives/C01JZN3U26Q/p1679126844162519

Changes:
- Increased memory request/limit of the buffer etcd from `768MiB` -> `2000MiB`.

-------------------

Note: 
V CI spustame `MiniKube`, nasadi sa stara verzia, nasadi sa nova verzia, spravi sa diff, a ten sa tu posle ako komentar.

V `Buffer Kubernetes Diff [CI]` nevidno zmenu `memory resource`, pretoze v CI sa limits odstranuju, nevoslo by sa to:
https://github.com/keboola/keboola-as-code/blob/eca61dd5d92448e12d22ca130ff191faa42eb264/provisioning/buffer/kubernetes/build.sh#L24-L34