### PR TITLE
etcd: fix container OOMKill and optimize memory usage

### DIFF
--- a/provisioning/buffer/kubernetes/templates/etcd.yaml
+++ b/provisioning/buffer/kubernetes/templates/etcd.yaml
@@ -4,9 +4,9 @@
 resources:
   requests:
     cpu: "200m"
-    memory: "768Mi"
+    memory: "2000Mi"
   limits:
-    memory: "768Mi"
+    memory: "2000Mi"
 
 # Run defragmentation each 2 hours
 defragmentation:

--- a/provisioning/common/etcd/values.yaml
+++ b/provisioning/common/etcd/values.yaml
@@ -53,6 +53,10 @@ removeMemberOnContainerTermination: false
 extraEnvVars:
   - name: ETCD_DISABLE_STORE_MEMBER_ID
     value: "yes"
+  # Optimize memory usage, see: https://etcd.io/docs/v3.5/tuning/#snapshots
+  # Default value in etcd v3.2+ is "100 000": https://etcd.io/docs/v3.5/op-guide/maintenance/#raft-log-retention
+  - name: ETCD_SNAPSHOT_COUNT
+    value: "10000"
 
 # The root password is used for authentication, the client gets a JWT token with short expiration.
 auth:


### PR DESCRIPTION
Jira: https://keboola.atlassian.net/browse/PSGO-139

-----------------------
### Problem

- Na `eu-central` stack začal klient testovať Buffer Service.
- Chodilo `~20` sprav za sekundu (čo je málo).
- No vyskytol sa problem s `buffer-etcd` memory, nestačilo `768MB` (plánovaných pre počiatočnú nízku zátaž).
- Všetky etcd nodes skončili s `OOMKill`.
- Po manuálnom zvýšení memory na `2GB` `buffer-etcd` cluster nabehol.
- Priebeh `memory usage` má pilovitý priebeh, čo naznačuje plnenie/čistenie nejakého buffra.
- Pri vyšsom počte import requestov sa interval skracuje.
![image](https://user-images.githubusercontent.com/19371734/226458725-378177a8-a699-4627-ad56-b390697ba380.png)

--------------

Zistil som, že to bude podľa všetkého nastavením `ETCD_SNAPSHOT_COUNT`:
- https://etcd.io/docs/v3.5/tuning/#snapshots (tu je uvedená stará default hodnota `10k`).
- Tu je už správna default hodnota `100k`: https://etcd.io/docs/v3.5/op-guide/maintenance/#raft-log-retention

```
If etcd’s memory usage and disk usage are too high, try lowering the snapshot threshold by setting the following on the command line:
```

-------

- V skratke táto hodnota znamená, koľko posledných hodnot drží etcd  v pamati (ale sú už aj na disku).
- Slúžia na odoslanie do dalších `follower/slave` nodes, ktoré dané informácie ešte nemajú (ale `n` = quorum nodes to už má aj tak uložené).
- Z grafu vidiet, že sa to zbytočne drží v pamati `~120min+`, pri aktuálnej zátaži.
- Default `100k` * avg message size (e.g., `10kB`) = `1GB` memory.
- New `10k` * avg message size (e.g., `10kB`) = `100MB` memory.
