### PR TITLE
Cliconfig pkg

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -17,6 +17,7 @@ require (
 	github.com/benbjohnson/clock v1.3.0
 	github.com/c2h5oh/datasize v0.0.0-20220606134207-859f65c6625b
 	github.com/cenkalti/backoff/v4 v4.2.0
+	github.com/davecgh/go-spew v1.1.1
 	github.com/fatih/color v1.14.1
 	github.com/go-playground/locales v0.14.1
 	github.com/go-playground/universal-translator v0.18.1
@@ -158,7 +159,6 @@ require (
 	github.com/coreos/go-semver v0.3.0 // indirect
 	github.com/coreos/go-systemd/v22 v22.4.0 // indirect
 	github.com/creack/pty v1.1.18 // indirect
-	github.com/davecgh/go-spew v1.1.1 // indirect
 	github.com/disintegration/imaging v1.6.2 // indirect
 	github.com/dlclark/regexp2 v1.7.0 // indirect
 	github.com/eliukblau/pixterm/pkg/ansimage v0.0.0-20191210081756-9fb6cf8c2f75 // indirect

--- a/internal/pkg/env/naming.go
+++ b/internal/pkg/env/naming.go
@@ -6,22 +6,23 @@ import (
 	"github.com/keboola/keboola-as-code/internal/pkg/utils/errors"
 )
 
-const Prefix = "KBC_"
-
-type NamingConvention struct{}
-
-func NewNamingConvention() *NamingConvention {
-	return &NamingConvention{}
+type NamingConvention struct {
+	prefix   string
+	replacer *strings.Replacer
 }
 
-// Replace converts flag name to ENV variable name
+func NewNamingConvention(prefix string) *NamingConvention {
+	return &NamingConvention{prefix: prefix, replacer: strings.NewReplacer("-", "_", ".", "_")}
+}
+
+// FlagToEnv converts flag name to ENV variable name
 // for example "storage-api-host" -> "KBC_STORAGE_API_HOST".
-func (*NamingConvention) Replace(flagName string) string {
+func (n *NamingConvention) FlagToEnv(flagName string) string {
 	if len(flagName) == 0 {
 		panic(errors.New("flag name cannot be empty"))
 	}
 
-	return Prefix + strings.ToUpper(strings.ReplaceAll(flagName, "-", "_"))
+	return n.prefix + strings.ToUpper(n.replacer.Replace(flagName))
 }
 
 func Files() []string {

--- a/internal/pkg/env/naming_test.go
+++ b/internal/pkg/env/naming_test.go
@@ -8,16 +8,16 @@ import (
 
 func TestEnvNamingConvention(t *testing.T) {
 	t.Parallel()
-	n := NewNamingConvention()
-	assert.Equal(t, "KBC_FOO", n.Replace("foo"))
-	assert.Equal(t, "KBC_FOO_BAR", n.Replace("foo-bar"))
-	assert.Equal(t, "KBC_FOO_BAR_BAZ", n.Replace("foo-Bar-BAZ"))
+	n := NewNamingConvention("KBC_")
+	assert.Equal(t, "KBC_FOO", n.FlagToEnv("foo"))
+	assert.Equal(t, "KBC_FOO_BAR", n.FlagToEnv("foo-bar"))
+	assert.Equal(t, "KBC_FOO_BAR_BAZ", n.FlagToEnv("foo-Bar-BAZ"))
 }
 
 func TestEnvNamingConventionFlagNameEmpty(t *testing.T) {
 	t.Parallel()
-	n := NewNamingConvention()
+	n := NewNamingConvention("KBC_")
 	assert.PanicsWithError(t, "flag name cannot be empty", func() {
-		n.Replace("")
+		n.FlagToEnv("")
 	})
 }

--- a/internal/pkg/service/cli/dialog/host.go
+++ b/internal/pkg/service/cli/dialog/host.go
@@ -3,8 +3,8 @@ package dialog
 import (
 	"net/url"
 
-	"github.com/keboola/keboola-as-code/internal/pkg/service/cli/options"
 	"github.com/keboola/keboola-as-code/internal/pkg/service/cli/prompt"
+	"github.com/keboola/keboola-as-code/internal/pkg/service/common/cliconfig"
 	"github.com/keboola/keboola-as-code/internal/pkg/utils/errors"
 	"github.com/keboola/keboola-as-code/internal/pkg/utils/strhelper"
 )
@@ -20,7 +20,7 @@ func (p *Dialogs) AskStorageAPIHost(d hostAndTokenDependencies) (string, error) 
 			Description: "Please enter Keboola Storage API host, eg. \"connection.keboola.com\".",
 			Validator:   StorageAPIHostValidator,
 		})
-	} else if opts.KeySetBy("storage-api-host") == options.SetByEnv {
+	} else if opts.KeySetBy("storage-api-host") == cliconfig.SetByEnv {
 		d.Logger().Infof(`Storage API host "%s" set from ENV.`, host)
 	}
 

--- a/internal/pkg/service/cli/dialog/token.go
+++ b/internal/pkg/service/cli/dialog/token.go
@@ -3,8 +3,8 @@ package dialog
 import (
 	"strings"
 
-	"github.com/keboola/keboola-as-code/internal/pkg/service/cli/options"
 	"github.com/keboola/keboola-as-code/internal/pkg/service/cli/prompt"
+	"github.com/keboola/keboola-as-code/internal/pkg/service/common/cliconfig"
 	"github.com/keboola/keboola-as-code/internal/pkg/utils/errors"
 )
 
@@ -20,7 +20,7 @@ func (p *Dialogs) AskStorageAPIToken(d hostAndTokenDependencies) (string, error)
 			Hidden:      true,
 			Validator:   prompt.ValueRequired,
 		})
-	} else if opts.KeySetBy("storage-api-token") == options.SetByEnv {
+	} else if opts.KeySetBy("storage-api-token") == cliconfig.SetByEnv {
 		d.Logger().Infof(`Storage API token set from ENV.`)
 	}
 

--- a/internal/pkg/service/cli/options/options_test.go
+++ b/internal/pkg/service/cli/options/options_test.go
@@ -10,6 +10,7 @@ import (
 	"github.com/keboola/keboola-as-code/internal/pkg/filesystem"
 	"github.com/keboola/keboola-as-code/internal/pkg/filesystem/aferofs"
 	"github.com/keboola/keboola-as-code/internal/pkg/log"
+	"github.com/keboola/keboola-as-code/internal/pkg/service/common/cliconfig"
 )
 
 func TestValuesPriority(t *testing.T) {
@@ -28,7 +29,7 @@ func TestValuesPriority(t *testing.T) {
 	err := options.Load(logger, env.Empty(), fs, &pflag.FlagSet{})
 	assert.NoError(t, err)
 	assert.Equal(t, "", options.GetString(key))
-	assert.Equal(t, SetByUnknown, options.KeySetBy(key))
+	assert.Equal(t, cliconfig.SetByUnknown, options.KeySetBy(key))
 
 	// 2. Lowest priority, flag default value
 	flags := &pflag.FlagSet{}
@@ -37,7 +38,7 @@ func TestValuesPriority(t *testing.T) {
 	err = options.Load(logger, env.Empty(), fs, flags)
 	assert.NoError(t, err)
 	assert.Equal(t, "default flag value", options.GetString(key))
-	assert.Equal(t, SetByFlagDefault, options.KeySetBy(key))
+	assert.Equal(t, cliconfig.SetByFlagDefault, options.KeySetBy(key))
 
 	// 3. Higher priority, ".env" file from project dir
 	assert.NoError(t, fs.WriteFile(filesystem.NewRawFile(".env", "KBC_STORAGE_API_TOKEN=1abcdef")))
@@ -45,7 +46,7 @@ func TestValuesPriority(t *testing.T) {
 	err = options.Load(logger, env.Empty(), fs, flags)
 	assert.NoError(t, err)
 	assert.Equal(t, "1abcdef", options.GetString(key))
-	assert.Equal(t, SetByEnv, options.KeySetBy(key))
+	assert.Equal(t, cliconfig.SetByEnv, options.KeySetBy(key))
 
 	// 4. Higher priority, ".env" file from working dir
 	assert.NoError(t, fs.WriteFile(filesystem.NewRawFile(filesystem.Join(workingDir, ".env"), "KBC_STORAGE_API_TOKEN=2abcdef")))
@@ -53,7 +54,7 @@ func TestValuesPriority(t *testing.T) {
 	err = options.Load(logger, env.Empty(), fs, flags)
 	assert.NoError(t, err)
 	assert.Equal(t, "2abcdef", options.GetString(key))
-	assert.Equal(t, SetByEnv, options.KeySetBy(key))
+	assert.Equal(t, cliconfig.SetByEnv, options.KeySetBy(key))
 
 	// 5. Higher priority , ENV defined in OS
 	osEnvs := env.Empty()
@@ -62,7 +63,7 @@ func TestValuesPriority(t *testing.T) {
 	err = options.Load(logger, osEnvs, fs, flags)
 	assert.NoError(t, err)
 	assert.Equal(t, "3abcdef", options.GetString(key))
-	assert.Equal(t, SetByEnv, options.KeySetBy(key))
+	assert.Equal(t, cliconfig.SetByEnv, options.KeySetBy(key))
 
 	// 6. Higher priority , flag value
 	assert.NoError(t, flags.Set(key, "4abcdef"))
@@ -70,7 +71,7 @@ func TestValuesPriority(t *testing.T) {
 	err = options.Load(logger, osEnvs, fs, flags)
 	assert.NoError(t, err)
 	assert.Equal(t, "4abcdef", options.GetString(key))
-	assert.Equal(t, SetByFlag, options.KeySetBy(key))
+	assert.Equal(t, cliconfig.SetByFlag, options.KeySetBy(key))
 
 	// 7. The highest priority, Set method
 	options = New()
@@ -78,7 +79,7 @@ func TestValuesPriority(t *testing.T) {
 	options.Set(key, "foo-bar")
 	assert.NoError(t, err)
 	assert.Equal(t, "foo-bar", options.GetString(key))
-	assert.Equal(t, SetManually, options.KeySetBy(key))
+	assert.Equal(t, cliconfig.SetManually, options.KeySetBy(key))
 }
 
 func TestDumpOptions(t *testing.T) {

--- a/internal/pkg/service/common/cliconfig/bind.go
+++ b/internal/pkg/service/common/cliconfig/bind.go
@@ -1,0 +1,63 @@
+package cliconfig
+
+import (
+	"github.com/spf13/pflag"
+	"github.com/spf13/viper"
+
+	"github.com/keboola/keboola-as-code/internal/pkg/env"
+)
+
+type SetBy int
+
+const (
+	SetByUnknown SetBy = iota
+	SetByFlag
+	SetByFlagDefault
+	SetByEnv
+	SetManually
+)
+
+// BindFlagsAndEnvToStruct binds flags and environment variables to a config struct.
+// Flags have priority over environment variables.
+func BindFlagsAndEnvToStruct(target any, flags *pflag.FlagSet, envs env.Provider, envNaming *env.NamingConvention) error {
+	v := viper.New()
+	if _, err := BindFlagsAndEnvToViper(v, flags, envs, envNaming); err != nil {
+		return err
+	}
+	if err := v.Unmarshal(target); err != nil {
+		return err
+	}
+	return nil
+}
+
+// BindFlagsAndEnvToViper binds flags and environment variables to a Viper instance.
+// Flags have priority over environment variables.
+func BindFlagsAndEnvToViper(v *viper.Viper, flags *pflag.FlagSet, envs env.Provider, envNaming *env.NamingConvention) (map[string]SetBy, error) {
+	// Bind flags
+	if err := v.BindPFlags(flags); err != nil {
+		return nil, err
+	}
+
+	// Search for ENV for each know flag
+	setBy := make(map[string]SetBy)
+	fromEnvs := make(map[string]interface{})
+	flags.VisitAll(func(flag *pflag.Flag) {
+		envName := envNaming.FlagToEnv(flag.Name)
+		if flag.Changed {
+			setBy[flag.Name] = SetByFlag
+		} else if value, found := envs.Lookup(envName); found {
+			fromEnvs[flag.Name] = value
+			setBy[flag.Name] = SetByEnv
+		} else {
+			setBy[flag.Name] = SetByFlagDefault
+		}
+	})
+
+	// Set fromEnvs map as a config, it has < priority as a flag,
+	// so flag value is used if set, otherwise ENV is used.
+	if err := v.MergeConfigMap(fromEnvs); err != nil {
+		return nil, err
+	}
+
+	return setBy, nil
+}

--- a/internal/pkg/service/common/cliconfig/bind_test.go
+++ b/internal/pkg/service/common/cliconfig/bind_test.go
@@ -1,0 +1,155 @@
+package cliconfig_test
+
+import (
+	"testing"
+
+	"github.com/spf13/pflag"
+	"github.com/spf13/viper"
+	"github.com/stretchr/testify/assert"
+
+	"github.com/keboola/keboola-as-code/internal/pkg/env"
+	"github.com/keboola/keboola-as-code/internal/pkg/service/common/cliconfig"
+)
+
+func TestBindFlagsAndEnvToStruct_Default(t *testing.T) {
+	t.Parallel()
+
+	fs := pflag.NewFlagSet("", pflag.ContinueOnError)
+	envs := env.Empty()
+
+	fs.String("string", "value1", "")
+	fs.Int("int", 123, "")
+	fs.Float64("float", 4.56, "")
+	fs.String("nested.foo-123", "foo", "")
+	fs.Int("nested.bar", 789, "")
+	fs.String("string-with-usage", "value2", "An usage text.")
+
+	target := Config{}
+	assert.NoError(t, fs.Parse([]string{}))
+	assert.NoError(t, cliconfig.BindFlagsAndEnvToStruct(&target, fs, envs, env.NewNamingConvention("MY_APP_")))
+	assert.Equal(t, Config{
+		String: "value1",
+		Int:    123,
+		Float:  4.56,
+		Nested: Nested{
+			Foo: "foo",
+			Bar: 789,
+		},
+		StringWithUsage: "value2",
+	}, target)
+}
+
+func TestBindFlagsAndEnvToStruct_Flags(t *testing.T) {
+	t.Parallel()
+
+	fs := pflag.NewFlagSet("", pflag.ContinueOnError)
+	envs := env.Empty()
+
+	fs.String("string", "value1", "")
+	fs.Int("int", 123, "")
+	fs.Float64("float", 4.56, "")
+	fs.String("nested.foo-123", "foo", "")
+	fs.Int("nested.bar", 789, "")
+	fs.String("string-with-usage", "value2", "An usage text.")
+
+	assert.NoError(t, fs.Parse([]string{
+		"--string", "abc",
+		"--int", "1000",
+		"--float", "78.90",
+		"--nested.foo-123", "def",
+		"--nested.bar", "2000",
+		"--string-with-usage", "",
+	}))
+
+	target := Config{}
+	assert.NoError(t, cliconfig.BindFlagsAndEnvToStruct(&target, fs, envs, env.NewNamingConvention("MY_APP_")))
+	assert.Equal(t, Config{
+		String: "abc",
+		Int:    1000,
+		Float:  78.90,
+		Nested: Nested{
+			Foo: "def",
+			Bar: 2000,
+		},
+		StringWithUsage: "",
+	}, target)
+}
+
+func TestBindFlagsAndEnvToStruct_Env(t *testing.T) {
+	t.Parallel()
+
+	fs := pflag.NewFlagSet("", pflag.ContinueOnError)
+	envs := env.Empty()
+
+	fs.String("string", "value1", "")
+	fs.Int("int", 123, "")
+	fs.Float64("float", 4.56, "")
+	fs.String("nested.foo-123", "foo", "")
+	fs.Int("nested.bar", 789, "")
+	fs.String("string-with-usage", "value2", "An usage text.")
+
+	envs.Set("MY_APP_STRING", "abc")
+	envs.Set("MY_APP_INT", "1000")
+	envs.Set("MY_APP_FLOAT", "78.90")
+	envs.Set("MY_APP_NESTED_FOO_123", "def")
+	envs.Set("MY_APP_NESTED_BAR", "2000")
+	envs.Set("MY_APP_STRING_WITH_USAGE", "")
+
+	target := Config{}
+	assert.NoError(t, cliconfig.BindFlagsAndEnvToStruct(&target, fs, envs, env.NewNamingConvention("MY_APP_")))
+	assert.Equal(t, Config{
+		String: "abc",
+		Int:    1000,
+		Float:  78.90,
+		Nested: Nested{
+			Foo: "def",
+			Bar: 2000,
+		},
+		StringWithUsage: "",
+	}, target)
+}
+
+func TestBindFlagsAndEnvToViper(t *testing.T) {
+	t.Parallel()
+
+	config := Config{String: "default value"}
+	flags := []string{
+		"--int", "1000",
+		"--float", "78.90",
+		"--nested.foo-123", "abc",
+	}
+	envNaming := env.NewNamingConvention("MY_APP_")
+	envs := env.Empty()
+	envs.Set("MY_APP_NESTED_FOO_123", "def") // not applied, flag has higher priority
+	envs.Set("MY_APP_NESTED_BAR", "9999")
+
+	// Generate and parse flags
+	fs := pflag.NewFlagSet("", pflag.ContinueOnError)
+	assert.NoError(t, cliconfig.GenerateFlags(config, fs))
+	assert.NoError(t, fs.Parse(flags))
+
+	// Bind flags and environment variables to the config struct
+	v := viper.New()
+	setBy, err := cliconfig.BindFlagsAndEnvToViper(v, fs, envs, envNaming)
+	assert.NoError(t, err)
+
+	// Assert
+	assert.Equal(t, map[string]any{
+		"int":               1000,
+		"float":             "78.9",
+		"string":            "default value",
+		"string-with-usage": "",
+		"nested": map[string]any{
+			"bar":     "9999",
+			"foo-123": "abc",
+		},
+	}, v.AllSettings())
+	assert.Equal(t, map[string]cliconfig.SetBy{
+		"int":               cliconfig.SetByFlag,
+		"float":             cliconfig.SetByFlag,
+		"string":            cliconfig.SetByFlagDefault,
+		"string-with-usage": cliconfig.SetByFlagDefault,
+		"nested.bar":        cliconfig.SetByEnv,
+		"nested.foo-123":    cliconfig.SetByFlag,
+	}, setBy)
+}

--- a/internal/pkg/service/common/cliconfig/doc.go
+++ b/internal/pkg/service/common/cliconfig/doc.go
@@ -1,0 +1,6 @@
+// Package cliconfig provides functionality for generating flags from a config structure,
+// and mapping flags and environment variables to the config structure.
+// This package is based on the [Viper] library.
+//
+// [Viper]: https://github.com/spf13/viper
+package cliconfig

--- a/internal/pkg/service/common/cliconfig/example_test.go
+++ b/internal/pkg/service/common/cliconfig/example_test.go
@@ -1,0 +1,117 @@
+package cliconfig_test
+
+import (
+	"fmt"
+	"regexp"
+
+	"github.com/davecgh/go-spew/spew"
+	"github.com/spf13/pflag"
+	"github.com/spf13/viper"
+
+	"github.com/keboola/keboola-as-code/internal/pkg/env"
+	"github.com/keboola/keboola-as-code/internal/pkg/service/common/cliconfig"
+)
+
+func ExampleGenerateFlags() {
+	defaultConfig := Config{String: "default value"}
+
+	fs := pflag.NewFlagSet("", pflag.ContinueOnError)
+	err := cliconfig.GenerateFlags(defaultConfig, fs)
+	if err != nil {
+		panic(err)
+	}
+
+	// List flags, trim whitespaces
+	usage := fs.FlagUsages()
+	usage = regexp.MustCompile(`\s+\n`).ReplaceAllString(usage, "\n")
+	fmt.Print(usage)
+
+	// output:
+	//       --float float
+	//       --int int
+	//       --nested.bar int
+	//       --nested.foo-123 string
+	//       --string string               (default "default value")
+	//       --string-with-usage string   An usage text.
+}
+
+func ExampleBindFlagsAndEnvToStruct() {
+	config := Config{String: "default value"}
+	flags := []string{
+		"--int", "1000",
+		"--float", "78.90",
+		"--nested.foo-123", "abc",
+	}
+	envNaming := env.NewNamingConvention("MY_APP_")
+	envs := env.Empty()
+	envs.Set("MY_APP_NESTED_FOO_123", "def") // not applied, flag has higher priority
+	envs.Set("MY_APP_NESTED_BAR", "9999")
+
+	// Generate and parse flags
+	fs := pflag.NewFlagSet("", pflag.ContinueOnError)
+	err := cliconfig.GenerateFlags(config, fs)
+	if err != nil {
+		panic(err)
+	}
+	err = fs.Parse(flags)
+	if err != nil {
+		panic(err)
+	}
+
+	// Bind flags and environment variables to the config struct
+	err = cliconfig.BindFlagsAndEnvToStruct(&config, fs, envs, envNaming)
+	if err != nil {
+		panic(err)
+	}
+
+	spew.Dump(config)
+
+	// output:
+	// (cliconfig_test.Config) {
+	//  Ignored: (string) "",
+	//  String: (string) (len=13) "default value",
+	//  Int: (int) 1000,
+	//  Float: (float64) 78.9,
+	//  StringWithUsage: (string) "",
+	//  Nested: (cliconfig_test.Nested) {
+	//   Ignored: (string) "",
+	//   Foo: (string) (len=3) "abc",
+	//   Bar: (int) 9999
+	//  }
+	// }
+}
+
+func ExampleBindFlagsAndEnvToViper() {
+	config := Config{String: "default value"}
+	flags := []string{
+		"--int", "1000",
+		"--float", "78.90",
+		"--nested.foo-123", "abc",
+	}
+	envNaming := env.NewNamingConvention("MY_APP_")
+	envs := env.Empty()
+	envs.Set("MY_APP_NESTED_FOO_123", "def") // not applied, flag has higher priority
+	envs.Set("MY_APP_NESTED_BAR", "9999")
+
+	// Generate and parse flags
+	fs := pflag.NewFlagSet("", pflag.ContinueOnError)
+	err := cliconfig.GenerateFlags(config, fs)
+	if err != nil {
+		panic(err)
+	}
+	err = fs.Parse(flags)
+	if err != nil {
+		panic(err)
+	}
+
+	// Bind flags and environment variables to the config struct
+	v := viper.New()
+	_, err = cliconfig.BindFlagsAndEnvToViper(v, fs, envs, envNaming)
+	if err != nil {
+		panic(err)
+	}
+
+	fmt.Print(v.AllSettings())
+
+	// output: map[float:78.9 int:1000 nested:map[bar:9999 foo-123:abc] string:default value string-with-usage:]
+}

--- a/internal/pkg/service/common/cliconfig/fixture_test.go
+++ b/internal/pkg/service/common/cliconfig/fixture_test.go
@@ -1,0 +1,16 @@
+package cliconfig_test
+
+type Config struct {
+	Ignored         string
+	String          string  `mapstructure:"string"`
+	Int             int     `mapstructure:"int"`
+	Float           float64 `mapstructure:"float"`
+	StringWithUsage string  `mapstructure:"string-with-usage" usage:"An usage text."`
+	Nested          Nested  `mapstructure:"nested"`
+}
+
+type Nested struct {
+	Ignored string
+	Foo     string `mapstructure:"foo-123"`
+	Bar     int    `mapstructure:"bar"`
+}

--- a/internal/pkg/service/common/cliconfig/flags.go
+++ b/internal/pkg/service/common/cliconfig/flags.go
@@ -1,0 +1,65 @@
+package cliconfig
+
+import (
+	"reflect"
+	"strings"
+
+	"github.com/spf13/pflag"
+
+	"github.com/keboola/keboola-as-code/internal/pkg/utils/errors"
+)
+
+// GenerateFlags generates flags from the config structure to the FlagSet.
+// Each field tagged by "mapstructure" tag is mapped to one flag.
+// The config parameter can be a structure or a pointer to a structure.
+// Field can optionally have a "usage" tag.
+// Field value will be set as a default value if it is not zero.
+// Inspired by: https://stackoverflow.com/a/72893101
+func GenerateFlags(config any, fs *pflag.FlagSet) error {
+	return flagsFromStruct(config, fs, nil)
+}
+
+func flagsFromStruct(config any, fs *pflag.FlagSet, parents []string) error {
+	structValue := reflect.ValueOf(config)
+	if structValue.Kind() == reflect.Pointer {
+		structValue = structValue.Elem()
+	}
+
+	if structValue.Kind() != reflect.Struct {
+		return errors.Errorf(`type "%s" is not a struct or a pointer to a struct, it cannot be mapped to the FlagSet`, structValue.Type().String())
+	}
+
+	structType := structValue.Type()
+	for i := 0; i < structType.NumField(); i++ {
+		fieldType := structType.Field(i)
+		fieldValue := structValue.Field(i)
+
+		partName, found := fieldType.Tag.Lookup("mapstructure")
+		if !found {
+			continue
+		}
+
+		fieldPath := append(parents, partName)
+		flagName := strings.Join(fieldPath, ".")
+		usage := fieldType.Tag.Get("usage")
+
+		switch fieldValue.Kind() {
+		case reflect.String:
+			def, _ := fieldValue.Interface().(string)
+			fs.String(flagName, def, usage)
+		case reflect.Int:
+			def, _ := fieldValue.Interface().(int)
+			fs.Int(flagName, def, usage)
+		case reflect.Float64:
+			def, _ := fieldValue.Interface().(float64)
+			fs.Float64(flagName, def, usage)
+		default:
+			parents = append([]string{}, parents...)
+			if err := flagsFromStruct(fieldValue.Interface(), fs, fieldPath); err != nil {
+				return err
+			}
+		}
+	}
+
+	return nil
+}

--- a/internal/pkg/service/common/cliconfig/flags_test.go
+++ b/internal/pkg/service/common/cliconfig/flags_test.go
@@ -1,0 +1,84 @@
+package cliconfig_test
+
+import (
+	"strings"
+	"testing"
+
+	"github.com/spf13/pflag"
+	"github.com/stretchr/testify/assert"
+
+	"github.com/keboola/keboola-as-code/internal/pkg/service/common/cliconfig"
+)
+
+func TestGenerateFlags_NotStruct(t *testing.T) {
+	t.Parallel()
+
+	fs1 := pflag.NewFlagSet("", pflag.ContinueOnError)
+	err := cliconfig.GenerateFlags("invalid", fs1)
+	if assert.Error(t, err) {
+		assert.Equal(t, `type "string" is not a struct or a pointer to a struct, it cannot be mapped to the FlagSet`, err.Error())
+	}
+}
+
+func TestGenerateFlags_Empty(t *testing.T) {
+	t.Parallel()
+
+	in := Config{}
+
+	expected := `
+      --float float                
+      --int int                    
+      --nested.bar int             
+      --nested.foo-123 string      
+      --string string              
+      --string-with-usage string   An usage text.
+`
+
+	// Struct
+	fs1 := pflag.NewFlagSet("", pflag.ContinueOnError)
+	err := cliconfig.GenerateFlags(in, fs1)
+	assert.NoError(t, err)
+	assert.Equal(t, strings.TrimLeft(expected, "\n"), fs1.FlagUsages())
+
+	// Struct pointer
+	fs2 := pflag.NewFlagSet("", pflag.ContinueOnError)
+	err = cliconfig.GenerateFlags(&in, fs2)
+	assert.NoError(t, err)
+	assert.Equal(t, strings.TrimLeft(expected, "\n"), fs2.FlagUsages())
+}
+
+func TestGenerateFlags_Default(t *testing.T) {
+	t.Parallel()
+
+	in := Config{
+		String:          "value1",
+		Int:             123,
+		Float:           4.56,
+		StringWithUsage: "value2",
+		Nested: Nested{
+			Foo: "foo",
+			Bar: 789,
+		},
+	}
+
+	expected := `
+      --float float                 (default 4.56)
+      --int int                     (default 123)
+      --nested.bar int              (default 789)
+      --nested.foo-123 string       (default "foo")
+      --string string               (default "value1")
+      --string-with-usage string   An usage text. (default "value2")
+`
+
+	// Struct
+	fs1 := pflag.NewFlagSet("", pflag.ContinueOnError)
+	err := cliconfig.GenerateFlags(in, fs1)
+	assert.NoError(t, err)
+	assert.Equal(t, strings.TrimLeft(expected, "\n"), fs1.FlagUsages())
+
+	// Struct pointer
+	fs2 := pflag.NewFlagSet("", pflag.ContinueOnError)
+	err = cliconfig.GenerateFlags(&in, fs2)
+	assert.NoError(t, err)
+	assert.Equal(t, strings.TrimLeft(expected, "\n"), fs2.FlagUsages())
+}


### PR DESCRIPTION
Part of:
- https://keboola.atlassian.net/browse/PSGO-144
  - For a test.
- https://keboola.atlassian.net/browse/PSGO-108

Changes:
- Created the `cliconfig` package, a separated package:
  - To bind flags and ENVs to a config struct (moved from the `options` pkg, improved).
  - To generate flags from a config struct (new).