### PR TITLE
Add buffered records size quota per receiver

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -16,7 +16,8 @@ services:
       # For Templates API
       - TEMPLATES_API_STORAGE_API_HOST
       # For Buffer API
-      - BUFFER_API_PUBLIC_ADDRESS=buffer.keboola.local
+      - BUFFER_API_STORAGE_API_HOST
+      - BUFFER_API_PUBLIC_ADDRESS
       # Disable DataDog integration
       - TEMPLATES_API_DATADOG_ENABLED=false
       - BUFFER_API_DATADOG_ENABLED=false

--- a/docs/buffer/benchmarks.md
+++ b/docs/buffer/benchmarks.md
@@ -2,13 +2,14 @@
 
 1. Start the server:
 ```
-export KBC_STORAGE_API_HOST=connection.keboola.com
+export BUFFER_API_PUBLIC_ADDRESS=http://localhost:10000
+export BUFFER_API_STORAGE_API_HOST=connection.keboola.com
 docker-compose run -u "$UID:$GID"  -p 10000:8000 --rm dev make run-buffer-api-once
 ```
 2. Run the benchmark:
 ```
 export API_TOKEN=<token>
-export API_HOST=http://localhost:10000
+export API_HOST=$BUFFER_API_PUBLIC_ADDRESS
 docker-compose run -u "$UID:$GID" k6 run /scripts/k6/buffer-api/<name>
 ```
 

--- a/internal/pkg/service/buffer/api/receive/quota/quota.go
+++ b/internal/pkg/service/buffer/api/receive/quota/quota.go
@@ -1,0 +1,89 @@
+// Package quota provides limitation of a receiver buffered records size in etcd.
+// This will prevent etcd from filling up if data cannot be sent to file storage fast enough
+// or if it is not possible to upload data at all.
+package quota
+
+import (
+	"context"
+	"sync"
+
+	"github.com/benbjohnson/clock"
+	"github.com/c2h5oh/datasize"
+
+	"github.com/keboola/keboola-as-code/internal/pkg/service/buffer/api/config"
+	"github.com/keboola/keboola-as-code/internal/pkg/service/buffer/statistics"
+	"github.com/keboola/keboola-as-code/internal/pkg/service/buffer/store/key"
+	"github.com/keboola/keboola-as-code/internal/pkg/utils/errors"
+)
+
+type Quota struct {
+	clock  clock.Clock
+	config config.Config
+	stats  *statistics.CacheNode
+
+	// cache computed stats, to improve import throughput
+	cache     bufferedSizeMap
+	cacheLock *sync.RWMutex
+}
+type bufferedSizeMap = map[key.ReceiverKey]datasize.ByteSize
+
+type dependencies interface {
+	APIConfig() config.Config
+	Clock() clock.Clock
+	StatsCache() *statistics.CacheNode
+}
+
+func New(ctx context.Context, wg *sync.WaitGroup, d dependencies) *Quota {
+	q := &Quota{
+		clock:     d.Clock(),
+		config:    d.APIConfig(),
+		stats:     d.StatsCache(),
+		cacheLock: &sync.RWMutex{},
+		cache:     make(bufferedSizeMap),
+	}
+
+	// Periodically invalidates the cache.
+	wg.Add(1)
+	go func() {
+		defer wg.Done()
+		ticker := q.clock.Ticker(q.config.ReceiverBufferSizeCacheTTL)
+		defer ticker.Stop()
+		for {
+			select {
+			case <-ctx.Done():
+				return
+			case <-ticker.C:
+				q.cacheLock.Lock()
+				q.cache = make(bufferedSizeMap, len(q.cache))
+				q.cacheLock.Unlock()
+			}
+		}
+	}()
+
+	return q
+}
+
+// Check checks whether the size of records that one receiver can buffer in etcd has not been exceeded.
+func (i *Quota) Check(k key.ReceiverKey) error {
+	// Load bufferedBytes from the fast cache.
+	i.cacheLock.RLock()
+	buffered, found := i.cache[k]
+	i.cacheLock.RUnlock()
+
+	// If not found, then calculate statistics from the slower cache.
+	if !found {
+		buffered = i.stats.ReceiverStats(k).Buffered.RecordsSize
+		i.cacheLock.Lock()
+		i.cache[k] = buffered
+		i.cacheLock.Unlock()
+	}
+
+	if limit := i.config.ReceiverBufferSize; buffered > limit {
+		return errors.Errorf(
+			`no free space in the buffer: receiver "%s" has "%s" buffered for upload, limit is "%s"`,
+			k.ReceiverID, buffered.HumanReadable(), limit.HumanReadable(),
+		)
+	}
+
+	return nil
+}

--- a/internal/pkg/service/buffer/dependencies/dependencies.go
+++ b/internal/pkg/service/buffer/dependencies/dependencies.go
@@ -29,7 +29,7 @@ type ForService interface {
 	EtcdClient() *etcd.Client
 	Schema() *schema.Schema
 	Store() *store.Store
-	StatsCacheNode() *statistics.CacheNode
+	StatsCache() *statistics.CacheNode
 }
 
 func NewServiceDeps(
@@ -132,6 +132,6 @@ func (v *forService) Store() *store.Store {
 	return v.store
 }
 
-func (v *forService) StatsCacheNode() *statistics.CacheNode {
+func (v *forService) StatsCache() *statistics.CacheNode {
 	return v.statsCache
 }

--- a/internal/pkg/service/buffer/dependencies/mocked.go
+++ b/internal/pkg/service/buffer/dependencies/mocked.go
@@ -34,7 +34,7 @@ type Mocked interface {
 	DistributionWorkerNode() *distribution.Node
 	WatcherWorkerNode() *watcher.WorkerNode
 	TaskNode() *task.Node
-	StatsCacheNode() *statistics.CacheNode
+	StatsCache() *statistics.CacheNode
 	EventSender() *event.Sender
 
 	APIConfig() apiConfig.Config
@@ -145,7 +145,7 @@ func (v *mocked) TaskNode() *task.Node {
 	return v.taskWorkerNode
 }
 
-func (v *mocked) StatsCacheNode() *statistics.CacheNode {
+func (v *mocked) StatsCache() *statistics.CacheNode {
 	if v.statsCacheNode == nil {
 		var err error
 		v.statsCacheNode, err = statistics.NewCacheNode(v)

--- a/internal/pkg/service/buffer/statistics/cache/cache.go
+++ b/internal/pkg/service/buffer/statistics/cache/cache.go
@@ -94,6 +94,10 @@ func (n *Node) ExportStats(k key.ExportKey) model.StatsByType {
 	return n.statsFor(k.String())
 }
 
+func (n *Node) ReceiverStats(k key.ReceiverKey) model.StatsByType {
+	return n.statsFor(k.String())
+}
+
 func (n *Node) statsFor(prefix string) (out model.StatsByType) {
 	n.cache.Atomic(func(t *prefixtree.Tree[model.Stats]) {
 		t.WalkPrefix(prefixBuffered+prefix, func(_ string, v model.Stats) bool {
@@ -103,11 +107,13 @@ func (n *Node) statsFor(prefix string) (out model.StatsByType) {
 		})
 		t.WalkPrefix(prefixUploading+prefix, func(_ string, v model.Stats) bool {
 			out.Total = out.Total.Add(v)
+			out.Buffered = out.Buffered.Add(v)
 			out.Uploading = out.Uploading.Add(v)
 			return false
 		})
 		t.WalkPrefix(prefixFailed+prefix, func(_ string, v model.Stats) bool {
 			out.Total = out.Total.Add(v)
+			out.Buffered = out.Buffered.Add(v)
 			out.Uploading = out.Uploading.Add(v)
 			return false
 		})

--- a/internal/pkg/service/buffer/statistics/cache/cache_test.go
+++ b/internal/pkg/service/buffer/statistics/cache/cache_test.go
@@ -98,7 +98,7 @@ func TestCacheNode(t *testing.T) {
 		if v := cache.SliceStats(slice1Key); v.Uploading.RecordsCount == 2 {
 			assert.Equal(t, model.StatsByType{
 				Total:     model.Stats{LastRecordAt: model.UTCTime(clk.Now()), RecordsCount: 2, RecordsSize: 30, BodySize: 33},
-				Buffered:  model.Stats{},
+				Buffered:  model.Stats{LastRecordAt: model.UTCTime(clk.Now()), RecordsCount: 2, RecordsSize: 30, BodySize: 33},
 				Uploading: model.Stats{LastRecordAt: model.UTCTime(clk.Now()), RecordsCount: 2, RecordsSize: 30, BodySize: 33},
 				Uploaded:  model.Stats{},
 			}, v)
@@ -113,7 +113,7 @@ func TestCacheNode(t *testing.T) {
 		if v := cache.SliceStats(slice1Key); v.Uploading.RecordsCount == 2 {
 			assert.Equal(t, model.StatsByType{
 				Total:     model.Stats{LastRecordAt: model.UTCTime(clk.Now()), RecordsCount: 2, RecordsSize: 30, BodySize: 33},
-				Buffered:  model.Stats{},
+				Buffered:  model.Stats{LastRecordAt: model.UTCTime(clk.Now()), RecordsCount: 2, RecordsSize: 30, BodySize: 33},
 				Uploading: model.Stats{LastRecordAt: model.UTCTime(clk.Now()), RecordsCount: 2, RecordsSize: 30, BodySize: 33},
 				Uploaded:  model.Stats{},
 			}, v)
@@ -173,7 +173,7 @@ func TestCacheNode(t *testing.T) {
 		if v := cache.FileStats(fileKey); v.Uploading.RecordsCount == 3 {
 			assert.Equal(t, model.StatsByType{
 				Total:     model.Stats{LastRecordAt: model.UTCTime(clk.Now()), RecordsCount: 5, RecordsSize: 330, BodySize: 363, FileSize: 44, FileGZipSize: 4},
-				Buffered:  model.Stats{},
+				Buffered:  model.Stats{LastRecordAt: model.UTCTime(clk.Now()), RecordsCount: 3, RecordsSize: 300, BodySize: 330},
 				Uploading: model.Stats{LastRecordAt: model.UTCTime(clk.Now()), RecordsCount: 3, RecordsSize: 300, BodySize: 330},
 				Uploaded:  model.Stats{LastRecordAt: model.UTCTime(slice1.OpenedAt()), RecordsCount: 2, RecordsSize: 30, BodySize: 33, FileSize: 44, FileGZipSize: 4},
 			}, v)

--- a/internal/pkg/service/buffer/store/model/stats.go
+++ b/internal/pkg/service/buffer/store/model/stats.go
@@ -30,7 +30,7 @@ type Stats struct {
 type StatsByType struct {
 	// Received = active + closed + uploaded
 	Total Stats
-	// Buffered = all in active state group, buffered in the etcd
+	// Buffered = all in active, closed state group, size of buffered data in the etcd
 	Buffered Stats
 	// Uploading = all in closed state group, in the process of uploading from the etcd to the file storage
 	Uploading Stats

--- a/internal/pkg/service/buffer/worker/service/service.go
+++ b/internal/pkg/service/buffer/worker/service/service.go
@@ -49,7 +49,7 @@ type dependencies interface {
 	Store() *store.Store
 	WatcherWorkerNode() *watcher.WorkerNode
 	DistributionWorkerNode() *distribution.Node
-	StatsCacheNode() *statistics.CacheNode
+	StatsCache() *statistics.CacheNode
 	TaskNode() *task.Node
 	EventSender() *event.Sender
 }
@@ -84,7 +84,7 @@ func New(d dependencies) (*Service, error) {
 		s.dist = d.DistributionWorkerNode()
 	}
 	if s.config.ConditionsCheck {
-		s.stats = d.StatsCacheNode()
+		s.stats = d.StatsCache()
 		s.tasks = d.TaskNode()
 		init = append(init, s.checkConditions(ctx, wg))
 	}

--- a/internal/pkg/service/common/errors/insufficientstorage.go
+++ b/internal/pkg/service/common/errors/insufficientstorage.go
@@ -1,0 +1,29 @@
+package errors
+
+import (
+	"net/http"
+)
+
+type InsufficientStorageError struct {
+	err error
+}
+
+func NewInsufficientStorageError(err error) InsufficientStorageError {
+	return InsufficientStorageError{err: err}
+}
+
+func (InsufficientStorageError) ErrorName() string {
+	return "insufficientStorage"
+}
+
+func (e InsufficientStorageError) StatusCode() int {
+	return http.StatusInsufficientStorage
+}
+
+func (e InsufficientStorageError) Error() string {
+	return e.err.Error()
+}
+
+func (e InsufficientStorageError) ErrorUserMessage() string {
+	return e.Error()
+}

--- a/scripts/k6/buffer-api/common.js
+++ b/scripts/k6/buffer-api/common.js
@@ -1,4 +1,6 @@
 import http from "k6/http";
+import {sleep, check} from 'k6';
+import { Counter } from 'k6/metrics';
 import {randomString} from 'https://jslib.k6.io/k6-utils/1.2.0/index.js';
 
 const TOKEN = __ENV.API_TOKEN;
@@ -11,6 +13,8 @@ const commonHeaders = {
     "Content-Type": "application/json",
     "X-StorageApi-Token": TOKEN,
 };
+
+const errors_metrics = new Counter("failed_imports");
 
 export const options = {
     scenarios: {
@@ -35,21 +39,45 @@ export const options = {
 export function setupReceiver(exports) {
     if (!TOKEN) throw new Error("Please set the `API_TOKEN` env var.");
 
-    let id = "buffer-" + randomString(8)
+    const receiverId = "buffer-" + randomString(8)
     let res = post("v1/receivers", {
-        id: id,
+        id: receiverId,
         name: "Buffer API Static Benchmark",
         exports: exports,
     });
-    if (res.status !== 200) {
+    if (res.status !== 202) {
         console.error(res);
-        throw new Error("failed to create receiver");
+        throw new Error("failed to create receiver task");
     }
 
-    let url = res.json().url;
-    url = url.slice(url.indexOf("v1"));
+    const createReceiverTimeoutSec = 60
+    const taskUrl = res.json().url
+    for (let retries = createReceiverTimeoutSec; retries > 0; retries--) {
+        res = get(taskUrl)
+        if (res.status !== 200) {
+            throw new Error("failed to get receiver task");
+        }
+        if (res.status !== "processing") {
+            if (res.error) {
+                throw new Error("failed to create receiver: " + res.error);
+            }
+            break
+        }
+        sleep(1000)
+    }
 
-    return {id, url}
+    res = get(`v1/receivers/${receiverId}`);
+    if (res.status !== 200) {
+        throw new Error("failed to get receiver");
+    }
+
+    const receiverUrl = res.json().url
+    if (!receiverUrl) {
+        throw new Error("receiver url is not set");
+    }
+
+    console.log("Receiver url: " + receiverUrl)
+    return {id: receiverId, url: receiverUrl}
 }
 
 export function teardownReceiver(receiverId) {
@@ -60,15 +88,37 @@ export function teardownReceiver(receiverId) {
     }
 }
 
-export function post(endpoint, data, headers = {}) {
-    return http.post(`${HOST}/${endpoint}`, JSON.stringify(data), {
+export function get(url, headers = {}) {
+    return http.get(normalizeUrl(url), {
         headers: Object.assign({}, commonHeaders, headers),
     });
 }
 
-export function del(endpoint, headers = {}) {
-    return http.del(`${HOST}/${endpoint}`, null, {
+export function post(url, data, headers = {}) {
+    return http.post(normalizeUrl(url), JSON.stringify(data), {
         headers: Object.assign({}, commonHeaders, headers),
     });
 }
 
+export function del(url, headers = {}) {
+    return http.del(normalizeUrl(url), null, {
+        headers: Object.assign({}, commonHeaders, headers),
+    });
+}
+
+export function normalizeUrl(url) {
+    if (url.indexOf('http://') !== 0 && url.indexOf('https://') !== 0) {
+        url = `${HOST}/${url}`
+    }
+    return url
+}
+
+export function checkResponse(res) {
+    let passed = check(res, {
+        "status is 200": (r) => r.status === 200,
+    })
+    if (!passed) {
+        console.error(`Request to ${res.request.url} with status ${res.status} failed the checks!`, res);
+        errors_metrics.add(1, {url: res.request.url});
+    }
+}

--- a/scripts/k6/buffer-api/static.js
+++ b/scripts/k6/buffer-api/static.js
@@ -1,5 +1,5 @@
 import * as common from "./common.js";
-import { post } from "./common.js";
+import {checkResponse, post} from "./common.js";
 
 export const options = common.options;
 
@@ -34,6 +34,6 @@ export function teardown(data) {
 }
 
 export default function (data) {
-  post(data.receiver.url, data.payload, data.headers);
+  checkResponse(post(data.receiver.url, data.payload, data.headers));
 }
 

--- a/scripts/k6/buffer-api/template.js
+++ b/scripts/k6/buffer-api/template.js
@@ -1,5 +1,5 @@
 import * as common from "./common.js";
-import { post } from "./common.js";
+import {checkResponse, post} from "./common.js";
 
 export const options = common.options;
 
@@ -39,5 +39,5 @@ export function teardown(data) {
 }
 
 export default function (data) {
-  post(data.receiver.url, data.payload, data.headers);
+  checkResponse(post(data.receiver.url, data.payload, data.headers));
 }

--- a/test/buffer/worker/998_size_quota_test.go
+++ b/test/buffer/worker/998_size_quota_test.go
@@ -1,0 +1,45 @@
+package worker
+
+import (
+	"io"
+	"strings"
+	"time"
+
+	"github.com/stretchr/testify/assert"
+
+	"github.com/keboola/keboola-as-code/internal/pkg/service/buffer/api/gen/buffer"
+)
+
+// test998BufferSizeOverflow tests reaching the maximum size of buffered data,
+// the API stops accepting requests for the receiver.
+func (ts *testSuite) test998BufferSizeOverflow() {
+	// Wait for cache invalidation
+	time.Sleep(statisticsSyncInterval + receiverBufferSizeCacheTTL + time.Millisecond)
+
+	// Fill buffer size over the maximum (size is checked before import).
+	// Maximum record size (1MB) is not exceeded.
+	n := ts.RandomAPINode()
+	bytes := strings.Repeat("-", int(receiverBufferSize.Bytes()+1))
+	assert.NoError(ts.t, n.Service.Import(n.Dependencies, &buffer.ImportPayload{
+		ProjectID:  buffer.ProjectID(ts.project.ID()),
+		ReceiverID: ts.receiver.ID,
+		Secret:     ts.secret,
+	}, io.NopCloser(strings.NewReader(`{"key": "`+bytes+`"}`))))
+
+	// Wait for cache invalidation
+	time.Sleep(statisticsSyncInterval + receiverBufferSizeCacheTTL + time.Millisecond)
+
+	// Next request is rejected.
+	n = ts.RandomAPINode()
+	err := n.Service.Import(n.Dependencies, &buffer.ImportPayload{
+		ProjectID:  buffer.ProjectID(ts.project.ID()),
+		ReceiverID: ts.receiver.ID,
+		Secret:     ts.secret,
+	}, io.NopCloser(strings.NewReader(`{"key": "foo"}`)))
+	if assert.Error(ts.t, err) {
+		// Note: The request payload is buffered for 2 exports, therefore the size is 200KB+.
+		assert.Equal(ts.t, `no free space in the buffer: receiver "my-receiver" has "200.1 KB" buffered for upload, limit is "100.0 KB"`, err.Error())
+	}
+
+	ts.TruncateLogs()
+}

--- a/test/buffer/worker/test_case_test.go
+++ b/test/buffer/worker/test_case_test.go
@@ -25,6 +25,7 @@ import (
 	"github.com/keboola/keboola-as-code/internal/pkg/filesystem"
 	"github.com/keboola/keboola-as-code/internal/pkg/idgenerator"
 	"github.com/keboola/keboola-as-code/internal/pkg/log"
+	apiConfig "github.com/keboola/keboola-as-code/internal/pkg/service/buffer/api/config"
 	"github.com/keboola/keboola-as-code/internal/pkg/service/buffer/api/gen/buffer"
 	apiService "github.com/keboola/keboola-as-code/internal/pkg/service/buffer/api/service"
 	bufferDependencies "github.com/keboola/keboola-as-code/internal/pkg/service/buffer/dependencies"
@@ -39,10 +40,13 @@ import (
 )
 
 const (
-	apiNodesCount        = 5
-	workerNodesCount     = 5
-	uploadCountThreshold = 5
-	importCountThreshold = 10
+	apiNodesCount              = 5
+	workerNodesCount           = 5
+	uploadCountThreshold       = 5
+	importCountThreshold       = 10
+	statisticsSyncInterval     = 500 * time.Millisecond
+	receiverBufferSizeCacheTTL = 500 * time.Millisecond
+	receiverBufferSize         = 100 * datasize.KB
 )
 
 type testSuite struct {
@@ -142,6 +146,11 @@ func startCluster(t *testing.T, ctx context.Context, testDir string, project *te
 				dependencies.WithLoggerPrefix(fmt.Sprintf(`[%s]`, nodeID)),
 				dependencies.WithRequestHeader(header),
 			)...)
+			d.SetAPIConfigOps(
+				apiConfig.WithStatisticsSyncInterval(statisticsSyncInterval),
+				apiConfig.WithReceiverBufferSize(receiverBufferSize),
+				apiConfig.WithReceiverBufferSizeCacheTTL(receiverBufferSizeCacheTTL),
+			)
 			svc := apiService.New(d)
 			out.apiNodes[i] = &apiNode{Dependencies: d, Service: svc}
 		}()

--- a/test/buffer/worker/worker_test.go
+++ b/test/buffer/worker/worker_test.go
@@ -28,6 +28,7 @@ func TestBufferWorkerE2E(t *testing.T) {
 	ts.test002SliceUpload()
 	ts.test003FileImport()
 	ts.test004EmptyFileAndSlice()
+	ts.test998BufferSizeOverflow()
 	ts.test999Cleanup()
 
 	// Shutdown all nodes


### PR DESCRIPTION
Jira: https://keboola.atlassian.net/browse/PSGO-144

Changes:
- If receiver has more than `50MB` buffered in the etcd, new imports are blocked.
- It prevents "full DB" problem.
- It can happen, for example, if the token is refreshed, and we cannot upload new records to the file storage.