### PR TITLE
increase etcd max size 2GB->8GB

### DIFF
--- a/provisioning/buffer/kubernetes/templates/etcd.yaml
+++ b/provisioning/buffer/kubernetes/templates/etcd.yaml
@@ -12,8 +12,3 @@ resources:
 defragmentation:
   cronjob:
     schedule: "0 */2 * * *"
-
-# Set disk size
-persistence:
-  enabled: true
-  size: 10Gi

--- a/provisioning/common/etcd/values.yaml
+++ b/provisioning/common/etcd/values.yaml
@@ -53,6 +53,9 @@ removeMemberOnContainerTermination: false
 extraEnvVars:
   - name: ETCD_DISABLE_STORE_MEMBER_ID
     value: "yes"
+  # Set max DB size to 8GB, it is the recommended maximum.
+  - name: ETCD_QUOTA_BACKEND_BYTES
+    value: "8589934592"
   # Optimize memory usage, see: https://etcd.io/docs/v3.5/tuning/#snapshots
   # Default value in etcd v3.2+ is "100 000": https://etcd.io/docs/v3.5/op-guide/maintenance/#raft-log-retention
   - name: ETCD_SNAPSHOT_COUNT
@@ -88,10 +91,10 @@ networkPolicy:
           matchLabels:
             app: datadog-agent
 
-# Records are persisted
+# Set disk size
 persistence:
   enabled: true
-  size: 512Mi
+  size: 10Gi
 
 # At least 51% of the cluster must be available during rollout,
 # otherwise, the quorum is lost and the cluster will not work.

--- a/provisioning/templates-api/common.sh
+++ b/provisioning/templates-api/common.sh
@@ -33,6 +33,11 @@ kubectl apply -f ./kubernetes/deploy/namespace.yaml
 # Get etcd root password, if it is already present
 export ETCD_ROOT_PASSWORD=$(kubectl get secret --namespace "$NAMESPACE" templates-api-etcd -o jsonpath="{.data.etcd-root-password}" 2>/dev/null | base64 -d)
 
+# TEMPORARY:
+# Delete StatefulSet, keep pods, to resize the PVC disks.
+kubectl delete sts --namespace "$NAMESPACE" "templates-api-etcd"
+kubectl delete pvc --namespace "$NAMESPACE" "data-templates-api-etcd-0"
+
 # Deploy etcd cluster
 helm repo add --force-update bitnami https://charts.bitnami.com/bitnami
 helm upgrade \


### PR DESCRIPTION
Jira: https://keboola.atlassian.net/browse/PSGO-144

Ochranu pred "full DB" sme pripravili: https://github.com/keboola/keboola-as-code/pull/1257

Zostava posledna vec ...

Problem: Zabudli sme nastavit maximalnu velkost etcd db, aj ked disk sme nastavili vacsi.

-----------------

Aktualny stav:

**Buffer:**
- 10GB disk
- 2GB db size, by default

**Templates:**
- 512MB disk
- 2GB db size, by default

------------

Po uprave:

**Buffer aj Templates:**
- 10GB disk
- 8GB db size, by ENV

------------

Templates API pouziva etcd aktualne iba na `locks` ale v blizkej buducnosti, s pridanim podpory storage, sa tam budu ukladat aj `tasks`, ... kedze vytvorenie tabuliek bude trva dlhsie a teda aplikacia sablony bude musiet by async request.

Predpokladam, ze `10GB` disk nestoji prakticky nic.