### PR TITLE
etcdclient: Retry on error: mvcc: required revision is a future revision

### DIFF
--- a/internal/pkg/service/common/etcdop/iterator/iterator.go
+++ b/internal/pkg/service/common/etcdop/iterator/iterator.go
@@ -251,7 +251,7 @@ func nextPageOp(start, end string, pageSize int, revision int64) op.GetManyOp {
 
 	// Ensure atomicity
 	if revision > 0 {
-		opts = append(opts, etcd.WithRev(revision))
+		opts = append(opts, etcd.WithRev(revision), etcd.WithSerializable())
 	}
 
 	return op.NewGetManyOp(

--- a/internal/pkg/service/common/etcdop/iterator/iterator.go
+++ b/internal/pkg/service/common/etcdop/iterator/iterator.go
@@ -202,7 +202,7 @@ func (v *Iterator) nextPage() bool {
 	// Do with retry
 	_, raw, err := nextPageOp(v.start, v.end, v.config.pageSize, revision).DoWithRaw(v.ctx, v.client, v.opts...)
 	if err != nil {
-		v.err = errors.Errorf(`etcd iterator failed: cannot get page "%s", page=%d: %w`, v.start, v.page, err)
+		v.err = errors.Errorf(`etcd iterator failed: cannot get page "%s", page=%d, revision=%d: %w`, v.start, v.page, revision, err)
 		return false
 	}
 

--- a/provisioning/buffer/kubernetes/templates/api/deployment.yaml
+++ b/provisioning/buffer/kubernetes/templates/api/deployment.yaml
@@ -52,7 +52,7 @@ spec:
                   name: buffer-api
                   key: bufferApiHost
             - name: BUFFER_API_ETCD_ENDPOINT
-              value: buffer-etcd-headless.buffer.svc.cluster.local:2379
+              value: buffer-etcd.buffer.svc.cluster.local:2379
             - name: BUFFER_API_ETCD_USERNAME
               value: root
             - name: BUFFER_API_ETCD_PASSWORD

--- a/provisioning/buffer/kubernetes/templates/worker/deployment.yaml
+++ b/provisioning/buffer/kubernetes/templates/worker/deployment.yaml
@@ -45,7 +45,7 @@ spec:
                   name: buffer-worker
                   key: storageApiHost
             - name: BUFFER_WORKER_ETCD_ENDPOINT
-              value: buffer-etcd-headless.buffer.svc.cluster.local:2379
+              value: buffer-etcd.buffer.svc.cluster.local:2379
             - name: BUFFER_WORKER_ETCD_USERNAME
               value: root
             - name: BUFFER_WORKER_ETCD_PASSWORD

--- a/provisioning/templates-api/kubernetes/templates/api/deployment.yaml
+++ b/provisioning/templates-api/kubernetes/templates/api/deployment.yaml
@@ -48,7 +48,7 @@ spec:
             - name: TEMPLATES_API_ETCD_ENABLED
               value: "true"
             - name: TEMPLATES_API_ETCD_ENDPOINT
-              value: templates-api-etcd-headless.templates-api.svc.cluster.local:2379
+              value: templates-api-etcd.templates-api.svc.cluster.local:2379
             - name: TEMPLATES_API_ETCD_USERNAME
               value: root
             - name: TEMPLATES_API_ETCD_PASSWORD


### PR DESCRIPTION
Jira: https://keboola.atlassian.net/browse/PSGO-109

--------------


**Problem:** 

V logoch sa objavila par krat chyba `mvcc: required revision is a future revision`, tak som to preskumal:
- Jedna 1 z 3 etcd nodes mala vypadok, komunikovala, ale neprijmala aktializacie, zostala zaseknuta v nejakej `revision`.
- My sme sa chybne pripajali aj k `unhealthy` nodes, problem nastal v `iterator`, kde sa nahodne nejaka stránka nacitala z tejto `unhealthy` node, ... ktorá ale nemala pozadovanu `revision`. Zvysne 2 nodes ju mali, co stacilo na `quorum` a cluster fungoval dalej.
- Teda napriklad: prvu page sme nacitali z `healthy` node, zistili sme, ze aktualna `revision=123`, potom sme sa snazili ziskat dalsiu page z `unhealthy` node, v `revision=123`, ale ta odpovedala `required revision is a future revision`, lebo na taku verziu este nebola syncnuta.

**Riesenie:**
- Pridat retry.
- Nepripajat sa na `unhealthy` nodes.