### PR TITLE
Cleanup updates: decrease log level, update intervals

### DIFF
--- a/internal/pkg/service/buffer/cleanup/node.go
+++ b/internal/pkg/service/buffer/cleanup/node.go
@@ -22,7 +22,7 @@ import (
 
 const (
 	// FileExpirationDays defines how old files are to be deleted.
-	FileExpirationDays = 14
+	FileExpirationDays = 1
 	// MaxTasksPerNode limits number of parallel cleanup tasks per node.
 	MaxTasksPerNode        = 20
 	ReceiverCleanupTimeout = 5 * time.Minute

--- a/internal/pkg/service/buffer/cleanup/node_test.go
+++ b/internal/pkg/service/buffer/cleanup/node_test.go
@@ -23,7 +23,7 @@ import (
 	"github.com/keboola/keboola-as-code/internal/pkg/utils/etcdhelper"
 )
 
-func Test_Cleanup(t *testing.T) {
+func TestCleanup(t *testing.T) {
 	t.Parallel()
 
 	ctx := context.Background()
@@ -207,10 +207,10 @@ func Test_Cleanup(t *testing.T) {
 [task][00001000/github/receiver.cleanup/%s]DEBUG  lock acquired "runtime/lock/task/00001000/github/receiver.cleanup"
 [cleanup]INFO  started "1" receiver cleanup tasks
 %A
-[task][00001000/github/receiver.cleanup/%s]INFO  deleted task "00001000/github/some.task/2006-01-02T08:04:05.000Z_abcdef"
+[task][00001000/github/receiver.cleanup/%s]DEBUG  deleted task "00001000/github/some.task/2006-01-02T08:04:05.000Z_abcdef"
 [task][00001000/github/receiver.cleanup/%s]INFO  deleted "1" tasks
-[task][00001000/github/receiver.cleanup/%s]INFO  deleted slice "00001000/github/first/2006-01-02T08:04:05.000Z"
-[task][00001000/github/receiver.cleanup/%s]INFO  deleted file "00001000/github/first/2006-01-02T08:04:05.000Z"
+[task][00001000/github/receiver.cleanup/%s]DEBUG  deleted slice "00001000/github/first/2006-01-02T08:04:05.000Z"
+[task][00001000/github/receiver.cleanup/%s]DEBUG  deleted file "00001000/github/first/2006-01-02T08:04:05.000Z"
 [task][00001000/github/receiver.cleanup/%s]INFO  deleted "1" files, "1" slices, "1" records
 [task][00001000/github/receiver.cleanup/%s]INFO  task succeeded (%s): receiver "00001000/github" has been cleaned
 [task][00001000/github/receiver.cleanup/%s]DEBUG  lock released "runtime/lock/task/00001000/github/receiver.cleanup"

--- a/internal/pkg/service/buffer/cleanup/task.go
+++ b/internal/pkg/service/buffer/cleanup/task.go
@@ -73,9 +73,7 @@ func (t *Task) deleteExpiredTasks(ctx context.Context) error {
 		ForEachKV(func(kv op.KeyValueT[model.Task], header *iterator.Header) error {
 			if kv.Value.IsForCleanup() {
 				if err := etcdop.Key(kv.Key()).Delete().DoOrErr(ctx, t.client); err == nil {
-					//nolint:godox
-					// TODO switch to Debugf
-					t.logger.Infof(`deleted task "%s"`, kv.Value.TaskKey.String())
+					t.logger.Debugf(`deleted task "%s"`, kv.Value.TaskKey.String())
 					deletedTasksCount++
 				} else {
 					errs.Append(err)
@@ -163,9 +161,7 @@ func (t *Task) deleteFile(ctx context.Context, file model.File) (slicesCount, re
 
 			// Delete the slice
 			if err := etcdop.Key(kv.Key()).Delete().DoOrErr(ctx, t.client); err == nil {
-				//nolint:godox
-				// TODO switch to Debugf
-				t.logger.Infof(`deleted slice "%s"`, file.FileKey.String())
+				t.logger.Debugf(`deleted slice "%s"`, file.FileKey.String())
 				slicesCount++
 			} else {
 				errs.Append(err)
@@ -179,8 +175,6 @@ func (t *Task) deleteFile(ctx context.Context, file model.File) (slicesCount, re
 		return 0, 0, err
 	}
 
-	//nolint:godox
-	// TODO switch to Debugf
-	t.logger.Infof(`deleted file "%s"`, file.FileKey.String())
+	t.logger.Debugf(`deleted file "%s"`, file.FileKey.String())
 	return slicesCount, recordsCount, nil
 }

--- a/internal/pkg/service/buffer/cleanup/task.go
+++ b/internal/pkg/service/buffer/cleanup/task.go
@@ -29,9 +29,6 @@ type Task struct {
 	receiverKey key.ReceiverKey
 }
 
-func StartTask(k key.ReceiverKey) {
-}
-
 func newTask(d dependencies, logger log.Logger, k key.ReceiverKey) *Task {
 	return &Task{
 		clock:       d.Clock(),

--- a/internal/pkg/service/buffer/worker/config/config.go
+++ b/internal/pkg/service/buffer/worker/config/config.go
@@ -16,7 +16,7 @@ const (
 	// DefaultCheckConditionsInterval defines how often it will be checked upload and import conditions.
 	DefaultCheckConditionsInterval = 30 * time.Second
 	// DefaultCleanupInterval defines how often old tasks and files will be checked and deleted.
-	DefaultCleanupInterval = 1 * time.Hour
+	DefaultCleanupInterval = 15 * time.Minute
 )
 
 // Config of the Buffer Worker.

--- a/internal/pkg/service/buffer/worker/service/cleanup_test.go
+++ b/internal/pkg/service/buffer/worker/service/cleanup_test.go
@@ -99,8 +99,8 @@ func TestCleanup(t *testing.T) {
 [task][00001000/github/receiver.cleanup/%s]DEBUG  lock acquired "runtime/lock/task/00001000/github/receiver.cleanup"
 [service][cleanup]INFO  started "1" receiver cleanup tasks
 [task][00001000/github/receiver.cleanup/%s]INFO  deleted "0" tasks
-[task][00001000/github/receiver.cleanup/%s]INFO  deleted slice "00001000/github/first/%s"
-[task][00001000/github/receiver.cleanup/%s]INFO  deleted file "00001000/github/first/%s"
+[task][00001000/github/receiver.cleanup/%s]DEBUG  deleted slice "00001000/github/first/%s"
+[task][00001000/github/receiver.cleanup/%s]DEBUG  deleted file "00001000/github/first/%s"
 [task][00001000/github/receiver.cleanup/%s]INFO  deleted "1" files, "1" slices, "0" records
 [task][00001000/github/receiver.cleanup/%s]INFO  task succeeded (%s): receiver "00001000/github" has been cleaned
 [task][00001000/github/receiver.cleanup/%s]DEBUG  lock released "runtime/lock/task/00001000/github/receiver.cleanup"


### PR DESCRIPTION
Jira: https://keboola.atlassian.net/browse/PSGO-109

Changes:
- Decreased log level from `INFO` -> `DEBUG`.
- The cleanup is called often to test it properly.