### PR TITLE
CLI JSON schema validation: improve err msgs, add workaround for test_connection

### DIFF
--- a/internal/pkg/encoding/json/schema/schema.go
+++ b/internal/pkg/encoding/json/schema/schema.go
@@ -133,12 +133,16 @@ func processErrors(errs []*jsonschema.ValidationError) error {
 		path := strings.TrimLeft(e.InstanceLocation, "/")
 		path = strings.ReplaceAll(path, "/", ".")
 		msg := strings.ReplaceAll(e.Message, `'`, `"`)
-		
+
 		switch {
 		case len(e.Causes) > 0:
 			// Process nested errors
 			if err := processErrors(e.Causes); err != nil {
-				docErrs.Append(err)
+				if e.Message == "" {
+					docErrs.Append(err)
+				} else {
+					docErrs.Append(errors.PrefixError(err, e.Message))
+				}
 			}
 		case isSchemaErr:
 			// Required field in a JSON schema should be an array of required nested fields.

--- a/internal/pkg/encoding/json/schema/schema.go
+++ b/internal/pkg/encoding/json/schema/schema.go
@@ -133,7 +133,7 @@ func processErrors(errs []*jsonschema.ValidationError, parentIsSchemaErr bool) e
 		isSchemaErr := !strings.HasPrefix(e.AbsoluteKeywordLocation, pseudoSchemaFile)
 		path := strings.TrimLeft(e.InstanceLocation, "/")
 		path = strings.ReplaceAll(path, "/", ".")
-		msg := strings.ReplaceAll(e.Message, `'`, `"`)
+		msg := strings.ReplaceAll(strings.ReplaceAll(e.Message, `'`, `"`), `n"t`, `n't`)
 
 		var formattedErr error
 		switch {
@@ -143,7 +143,7 @@ func processErrors(errs []*jsonschema.ValidationError, parentIsSchemaErr bool) e
 				if e.Message == "" || e.Message == "doesn't validate with ''" || e.Message == `'' is invalid:` {
 					formattedErr = err
 				} else {
-					formattedErr = errors.PrefixError(err, e.Message)
+					formattedErr = errors.PrefixError(err, msg)
 				}
 			}
 		case isSchemaErr:

--- a/internal/pkg/encoding/json/schema/schema.go
+++ b/internal/pkg/encoding/json/schema/schema.go
@@ -139,7 +139,7 @@ func processErrors(errs []*jsonschema.ValidationError, parentIsSchemaErr bool) e
 		case len(e.Causes) > 0:
 			// Process nested errors.
 			if err := processErrors(e.Causes, isSchemaErr || parentIsSchemaErr); err != nil {
-				if e.Message == "" || e.Message == "doesn't validate with ''" {
+				if e.Message == "" || e.Message == "doesn't validate with ''" || e.Message == `'' is invalid:` {
 					formattedErr = err
 				} else {
 					formattedErr = errors.PrefixError(err, e.Message)

--- a/internal/pkg/encoding/json/schema/schema.go
+++ b/internal/pkg/encoding/json/schema/schema.go
@@ -17,7 +17,7 @@ import (
 )
 
 // pseudoSchemaFile - the validated schema is registered as this resource.
-const pseudoSchemaFile = "/schema.json"
+const pseudoSchemaFile = "file:///schema.json"
 
 func ValidateObjects(logger log.Logger, objects model.ObjectStates) error {
 	errs := errors.NewMultiError()
@@ -129,7 +129,8 @@ func processErrors(errs []*jsonschema.ValidationError, parentIsSchemaErr bool) e
 	schemaErrs := errors.NewMultiError()
 	docErrs := errors.NewMultiError()
 	for _, e := range errs {
-		isSchemaErr := !strings.HasPrefix(e.AbsoluteKeywordLocation, "file://"+pseudoSchemaFile)
+		// Schema error does not start with our pseudo schema file.
+		isSchemaErr := !strings.HasPrefix(e.AbsoluteKeywordLocation, pseudoSchemaFile)
 		path := strings.TrimLeft(e.InstanceLocation, "/")
 		path = strings.ReplaceAll(path, "/", ".")
 		msg := strings.ReplaceAll(e.Message, `'`, `"`)

--- a/internal/pkg/encoding/json/schema/schema_test.go
+++ b/internal/pkg/encoding/json/schema/schema_test.go
@@ -55,7 +55,7 @@ func TestValidateObjects_Error(t *testing.T) {
 	assert.Equal(t, strings.TrimSpace(expectedErr), err.Error())
 }
 
-func TestValidateObjects_InvalidSchema_JSON(t *testing.T) {
+func TestValidateObjects_InvalidSchema_InvalidJSON(t *testing.T) {
 	t.Parallel()
 	invalidSchema := []byte(`{...`)
 	err := ValidateContent(invalidSchema, orderedmap.FromPairs([]orderedmap.Pair{
@@ -75,22 +75,43 @@ invalid JSON schema:
 	assert.Equal(t, strings.TrimSpace(expected), err.Error())
 }
 
-func TestValidateObjects_InvalidSchema_FieldType(t *testing.T) {
+func TestValidateObjects_Ignore_TestConnectionButton(t *testing.T) {
+	t.Parallel()
+	invalidSchema := []byte(`
+{
+  "type": "object",
+  "$schema": "http://json-schema.org/draft-04/schema#",
+  "properties": {
+    "test_connection": {
+      "type": "button"
+    }
+  }
+}
+`)
+
+	assert.NoError(t, ValidateContent(invalidSchema, orderedmap.FromPairs([]orderedmap.Pair{
+		{
+			Key:   "parameters",
+			Value: orderedmap.FromPairs([]orderedmap.Pair{{Key: "key", Value: "value"}}),
+		},
+	})))
+}
+
+func TestValidateObjects_InvalidSchema_InvalidType(t *testing.T) {
 	t.Parallel()
 	invalidSchema := []byte(`{"properties":false}`)
 	err := ValidateContent(invalidSchema, orderedmap.FromPairs([]orderedmap.Pair{
 		{
-			Key: "parameters",
-			Value: orderedmap.FromPairs([]orderedmap.Pair{
-				{Key: "key1", Value: "value1"},
-				{Key: "key2", Value: "value2"},
-			}),
+			Key:   "parameters",
+			Value: orderedmap.FromPairs([]orderedmap.Pair{{Key: "key", Value: "value"}}),
 		},
 	}))
 	assert.Error(t, err)
 	expected := `
 invalid JSON schema:
-- "properties" is invalid: expected object, but got boolean
+- allOf failed:
+  - doesn't validate with 'https://json-schema.org/draft/2020-12/meta/applicator#':
+    - "properties" is invalid: expected object, but got boolean
 `
 	assert.Equal(t, strings.TrimSpace(expected), err.Error())
 }
@@ -121,10 +142,61 @@ func TestValidateObjects_SkipEmpty(t *testing.T) {
 	assert.NoError(t, ValidateContent(schema, content))
 }
 
-func TestValidateObjects_InvalidSchema_Warning(t *testing.T) {
+func TestValidateObjects_InvalidSchema_Warning1(t *testing.T) {
 	t.Parallel()
 	invalidSchema := []byte(`{"properties": {"key1": {"properties": true}}}`)
+	expectedLogs := `
+WARN  config JSON schema of the component "foo.bar" is invalid, please contact support:
+- allOf failed:
+  - doesn't validate with 'https://json-schema.org/draft/2020-12/meta/applicator#':
+    - doesn't validate with 'https://json-schema.org/draft/2020-12/schema#':
+      - allOf failed:
+        - doesn't validate with 'https://json-schema.org/draft/2020-12/meta/applicator#':
+          - "properties.key1.properties" is invalid: expected object, but got boolean
+WARN  config row JSON schema of the component "foo.bar" is invalid, please contact support:
+- allOf failed:
+  - doesn't validate with 'https://json-schema.org/draft/2020-12/meta/applicator#':
+    - doesn't validate with 'https://json-schema.org/draft/2020-12/schema#':
+      - allOf failed:
+        - doesn't validate with 'https://json-schema.org/draft/2020-12/meta/applicator#':
+          - "properties.key1.properties" is invalid: expected object, but got boolean
+`
+	testInvalidComponentSchema(t, invalidSchema, expectedLogs)
+}
 
+func TestValidateObjects_InvalidSchema_Warning2(t *testing.T) {
+	t.Parallel()
+	invalidSchema := []byte(`
+{
+  "type": "object",
+  "$schema": "http://json-schema.org/draft-04/schema#",
+  "properties": {
+    "foo": {
+      "type": "bar"
+    }
+  }
+}
+`)
+	expectedLogs := `
+WARN  config JSON schema of the component "foo.bar" is invalid, please contact support:
+- anyOf failed:
+  - doesn't validate with '/definitions/simpleTypes':
+    - "properties.foo.type" is invalid: value must be one of "array", "boolean", "integer", "null", "number", "object", "string"
+  - "properties.foo.type" is invalid: expected array, but got string
+WARN  config row JSON schema of the component "foo.bar" is invalid, please contact support:
+- anyOf failed:
+  - doesn't validate with '/definitions/simpleTypes':
+    - "properties.foo.type" is invalid: value must be one of "array", "boolean", "integer", "null", "number", "object", "string"
+  - "properties.foo.type" is invalid: expected array, but got string
+`
+	testInvalidComponentSchema(t, invalidSchema, expectedLogs)
+}
+
+func testInvalidComponentSchema(t *testing.T, invalidSchema []byte, expectedLogs string) {
+	t.Helper()
+
+	// Create component, config and row definitions
+	logger := log.NewDebugLogger()
 	componentID := keboola.ComponentID("foo.bar")
 	components := model.NewComponentsMap(keboola.Components{
 		{
@@ -145,8 +217,6 @@ func TestValidateObjects_InvalidSchema_Warning(t *testing.T) {
 			}),
 		},
 	})
-
-	logger := log.NewDebugLogger()
 	registry := state.NewRegistry(knownpaths.NewNop(), naming.NewRegistry(), components, model.SortByID)
 	assert.NoError(t, registry.Set(&model.ConfigState{
 		ConfigManifest: &model.ConfigManifest{ConfigKey: model.ConfigKey{ComponentID: componentID}},
@@ -161,15 +231,7 @@ func TestValidateObjects_InvalidSchema_Warning(t *testing.T) {
 	content := orderedmap.New()
 	content.Set(`parameters`, orderedmap.New())
 	assert.NoError(t, ValidateObjects(logger, registry))
-
-	// Check logs
-	expected := `
-WARN  config JSON schema of the component "foo.bar" is invalid, please contact support:
-- "properties.key1.properties" is invalid: expected object, but got boolean
-WARN  config row JSON schema of the component "foo.bar" is invalid, please contact support:
-- "properties.key1.properties" is invalid: expected object, but got boolean
-`
-	assert.Equal(t, strings.TrimLeft(expected, "\n"), logger.AllMessages())
+	assert.Equal(t, strings.TrimLeft(expectedLogs, "\n"), logger.AllMessages())
 }
 
 func getTestSchema() []byte {

--- a/internal/pkg/encoding/json/schema/schema_test.go
+++ b/internal/pkg/encoding/json/schema/schema_test.go
@@ -110,7 +110,7 @@ func TestValidateObjects_InvalidSchema_InvalidType(t *testing.T) {
 	expected := `
 invalid JSON schema:
 - allOf failed:
-  - doesn't validate with 'https://json-schema.org/draft/2020-12/meta/applicator#':
+  - doesn't validate with "https://json-schema.org/draft/2020-12/meta/applicator#":
     - "properties" is invalid: expected object, but got boolean
 `
 	assert.Equal(t, strings.TrimSpace(expected), err.Error())
@@ -148,17 +148,17 @@ func TestValidateObjects_InvalidSchema_Warning1(t *testing.T) {
 	expectedLogs := `
 WARN  config JSON schema of the component "foo.bar" is invalid, please contact support:
 - allOf failed:
-  - doesn't validate with 'https://json-schema.org/draft/2020-12/meta/applicator#':
-    - doesn't validate with 'https://json-schema.org/draft/2020-12/schema#':
+  - doesn't validate with "https://json-schema.org/draft/2020-12/meta/applicator#":
+    - doesn't validate with "https://json-schema.org/draft/2020-12/schema#":
       - allOf failed:
-        - doesn't validate with 'https://json-schema.org/draft/2020-12/meta/applicator#':
+        - doesn't validate with "https://json-schema.org/draft/2020-12/meta/applicator#":
           - "properties.key1.properties" is invalid: expected object, but got boolean
 WARN  config row JSON schema of the component "foo.bar" is invalid, please contact support:
 - allOf failed:
-  - doesn't validate with 'https://json-schema.org/draft/2020-12/meta/applicator#':
-    - doesn't validate with 'https://json-schema.org/draft/2020-12/schema#':
+  - doesn't validate with "https://json-schema.org/draft/2020-12/meta/applicator#":
+    - doesn't validate with "https://json-schema.org/draft/2020-12/schema#":
       - allOf failed:
-        - doesn't validate with 'https://json-schema.org/draft/2020-12/meta/applicator#':
+        - doesn't validate with "https://json-schema.org/draft/2020-12/meta/applicator#":
           - "properties.key1.properties" is invalid: expected object, but got boolean
 `
 	testInvalidComponentSchema(t, invalidSchema, expectedLogs)
@@ -180,12 +180,12 @@ func TestValidateObjects_InvalidSchema_Warning2(t *testing.T) {
 	expectedLogs := `
 WARN  config JSON schema of the component "foo.bar" is invalid, please contact support:
 - anyOf failed:
-  - doesn't validate with '/definitions/simpleTypes':
+  - doesn't validate with "/definitions/simpleTypes":
     - "properties.foo.type" is invalid: value must be one of "array", "boolean", "integer", "null", "number", "object", "string"
   - "properties.foo.type" is invalid: expected array, but got string
 WARN  config row JSON schema of the component "foo.bar" is invalid, please contact support:
 - anyOf failed:
-  - doesn't validate with '/definitions/simpleTypes':
+  - doesn't validate with "/definitions/simpleTypes":
     - "properties.foo.type" is invalid: value must be one of "array", "boolean", "integer", "null", "number", "object", "string"
   - "properties.foo.type" is invalid: expected array, but got string
 `


### PR DESCRIPTION
Jira: https://keboola.atlassian.net/browse/PSGO-201
Slack: https://keboola.slack.com/archives/CMTBFNLF8/p1682425905053459

Changes:
- JSON schema validation errors are more verbose.
- Improved detection of errors in the JSON schema (not JSON document).
- Add workaround for `test_connection` definition, used by the UI.

------------

Opat, okomentovane po commitoch.