### PR TITLE
Telemetry cleanup 

### DIFF
--- a/internal/pkg/service/buffer/api/dependencies/dependencies.go
+++ b/internal/pkg/service/buffer/api/dependencies/dependencies.go
@@ -116,7 +116,7 @@ type forProjectRequest struct {
 
 func NewServerDeps(ctx context.Context, proc *servicectx.Process, cfg config.Config, envs env.Provider, logger log.Logger, tel telemetry.Telemetry) (v ForServer, err error) {
 	ctx, span := tel.Tracer().Start(ctx, "keboola.go.buffer.api.dependencies.NewServerDeps")
-	defer telemetry.EndSpan(span, &err)
+	defer span.End(&err)
 
 	// Create service dependencies
 	userAgent := "keboola-buffer-api"
@@ -143,7 +143,7 @@ func NewServerDeps(ctx context.Context, proc *servicectx.Process, cfg config.Con
 
 func NewDepsForPublicRequest(serverDeps ForServer, req *http.Request) ForPublicRequest {
 	ctx, span := serverDeps.Telemetry().Tracer().Start(req.Context(), "keboola.go.buffer.api.dependencies.NewDepsForPublicRequest")
-	defer telemetry.EndSpan(span, nil)
+	defer span.End(nil)
 
 	requestId, _ := ctx.Value(middleware.RequestIDCtxKey).(string)
 
@@ -158,7 +158,7 @@ func NewDepsForPublicRequest(serverDeps ForServer, req *http.Request) ForPublicR
 
 func NewDepsForProjectRequest(publicDeps ForPublicRequest, ctx context.Context, tokenStr string) (v ForProjectRequest, err error) {
 	ctx, span := publicDeps.Telemetry().Tracer().Start(ctx, "keboola.go.buffer.api.dependencies.NewDepsForProjectRequest")
-	defer telemetry.EndSpan(span, &err)
+	defer span.End(&err)
 
 	projectDeps, err := dependencies.NewProjectDeps(ctx, publicDeps, publicDeps, tokenStr)
 	if err != nil {

--- a/internal/pkg/service/buffer/dependencies/dependencies.go
+++ b/internal/pkg/service/buffer/dependencies/dependencies.go
@@ -41,7 +41,7 @@ func NewServiceDeps(
 	userAgent string,
 ) (d ForService, err error) {
 	ctx, span := tel.Tracer().Start(ctx, "keboola.go.buffer.dependencies.NewServiceDeps")
-	defer telemetry.EndSpan(span, &err)
+	defer span.End(&err)
 
 	// Create base HTTP client for all API requests to other APIs
 	httpClient := httpclient.New(

--- a/internal/pkg/service/buffer/store/export.go
+++ b/internal/pkg/service/buffer/store/export.go
@@ -13,7 +13,6 @@ import (
 	serviceError "github.com/keboola/keboola-as-code/internal/pkg/service/common/errors"
 	"github.com/keboola/keboola-as-code/internal/pkg/service/common/etcdop/iterator"
 	"github.com/keboola/keboola-as-code/internal/pkg/service/common/etcdop/op"
-	"github.com/keboola/keboola-as-code/internal/pkg/telemetry"
 	"github.com/keboola/keboola-as-code/internal/pkg/utils/errors"
 )
 
@@ -23,7 +22,7 @@ import (
 // - ResourceAlreadyExistsError.
 func (s *Store) CreateExport(ctx context.Context, export model.Export) (err error) {
 	ctx, span := s.telemetry.Tracer().Start(ctx, "keboola.go.buffer.store.CreateExport")
-	defer telemetry.EndSpan(span, &err)
+	defer span.End(&err)
 
 	return op.
 		Atomic().
@@ -76,7 +75,7 @@ func (s *Store) createExportBaseOp(_ context.Context, export model.ExportBase) o
 
 func (s *Store) UpdateExport(ctx context.Context, k key.ExportKey, fn func(model.Export) (model.Export, error)) (err error) {
 	ctx, span := s.telemetry.Tracer().Start(ctx, "keboola.go.buffer.store.UpdateExport")
-	defer telemetry.EndSpan(span, &err)
+	defer span.End(&err)
 
 	var export *model.Export
 	return op.Atomic().
@@ -139,7 +138,7 @@ func (s *Store) updateExportBaseOp(_ context.Context, export model.ExportBase) o
 // - ResourceAlreadyExistsError.
 func (s *Store) CheckCreateExport(ctx context.Context, exportKey key.ExportKey) (err error) {
 	ctx, span := s.telemetry.Tracer().Start(ctx, "keboola.go.buffer.store.CheckCreateExport")
-	defer telemetry.EndSpan(span, &err)
+	defer span.End(&err)
 
 	err = s.getExportBaseOp(ctx, exportKey).DoOrErr(ctx, s.client)
 	if err == nil {
@@ -157,7 +156,7 @@ func (s *Store) CheckCreateExport(ctx context.Context, exportKey key.ExportKey) 
 // - ResourceNotFoundError.
 func (s *Store) GetExport(ctx context.Context, exportKey key.ExportKey) (r model.Export, err error) {
 	ctx, span := s.telemetry.Tracer().Start(ctx, "keboola.go.buffer.store.GetExport")
-	defer telemetry.EndSpan(span, &err)
+	defer span.End(&err)
 	return s.getExportOp(ctx, exportKey).Do(ctx, s.client)
 }
 
@@ -200,7 +199,7 @@ func (s *Store) getExportBaseOp(_ context.Context, exportKey key.ExportKey) op.F
 // ListExports from the store.
 func (s *Store) ListExports(ctx context.Context, receiverKey key.ReceiverKey, ops ...iterator.Option) (exports []model.Export, err error) {
 	ctx, span := s.telemetry.Tracer().Start(ctx, "keboola.go.buffer.store.ListExports")
-	defer telemetry.EndSpan(span, &err)
+	defer span.End(&err)
 
 	// Load sub-objects in parallel, stop at the first error
 	exportsMap := make(map[key.ExportKey]*model.Export)
@@ -278,7 +277,7 @@ func (s *Store) exportBaseIterator(_ context.Context, receiverKey key.ReceiverKe
 // - ResourceNotFoundError.
 func (s *Store) DeleteExport(ctx context.Context, exportKey key.ExportKey) (err error) {
 	ctx, span := s.telemetry.Tracer().Start(ctx, "keboola.go.buffer.store.DeleteReceiver")
-	defer telemetry.EndSpan(span, &err)
+	defer span.End(&err)
 
 	_, err = op.MergeToTxn(
 		s.deleteExportBaseOp(ctx, exportKey),

--- a/internal/pkg/service/buffer/store/mapping.go
+++ b/internal/pkg/service/buffer/store/mapping.go
@@ -9,7 +9,6 @@ import (
 	"github.com/keboola/keboola-as-code/internal/pkg/service/buffer/store/model"
 	serviceError "github.com/keboola/keboola-as-code/internal/pkg/service/common/errors"
 	"github.com/keboola/keboola-as-code/internal/pkg/service/common/etcdop/op"
-	"github.com/keboola/keboola-as-code/internal/pkg/telemetry"
 	"github.com/keboola/keboola-as-code/internal/pkg/utils/errors"
 )
 
@@ -18,7 +17,7 @@ import (
 // - CountLimitReachedError.
 func (s *Store) CreateMapping(ctx context.Context, mapping model.Mapping) (err error) {
 	ctx, span := s.telemetry.Tracer().Start(ctx, "keboola.go.buffer.store.CreateMapping")
-	defer telemetry.EndSpan(span, &err)
+	defer span.End(&err)
 
 	if mapping.RevisionID != 0 {
 		return errors.New("unexpected state: mapping revision ID should be 0, it is generated on create")
@@ -89,7 +88,7 @@ func (s *Store) updateMappingOp(_ context.Context, mapping model.Mapping) op.NoR
 // GetLatestMapping fetches the current mapping from the store.
 func (s *Store) GetLatestMapping(ctx context.Context, exportKey key.ExportKey) (r model.Mapping, err error) {
 	ctx, span := s.telemetry.Tracer().Start(ctx, "keboola.go.buffer.store.GetLatestMapping")
-	defer telemetry.EndSpan(span, &err)
+	defer span.End(&err)
 
 	kv, err := s.getLatestMappingOp(ctx, exportKey).Do(ctx, s.client)
 	if err != nil {
@@ -118,7 +117,7 @@ func (s *Store) getLatestMappingOp(_ context.Context, exportKey key.ExportKey, o
 // - ResourceNotFoundError.
 func (s *Store) GetMapping(ctx context.Context, mappingKey key.MappingKey) (r model.Mapping, err error) {
 	ctx, span := s.telemetry.Tracer().Start(ctx, "keboola.go.buffer.store.GetMapping")
-	defer telemetry.EndSpan(span, &err)
+	defer span.End(&err)
 
 	kv, err := s.getMappingOp(ctx, mappingKey).Do(ctx, s.client)
 	if err != nil {

--- a/internal/pkg/service/buffer/store/receiver.go
+++ b/internal/pkg/service/buffer/store/receiver.go
@@ -11,7 +11,6 @@ import (
 	serviceError "github.com/keboola/keboola-as-code/internal/pkg/service/common/errors"
 	"github.com/keboola/keboola-as-code/internal/pkg/service/common/etcdop/iterator"
 	"github.com/keboola/keboola-as-code/internal/pkg/service/common/etcdop/op"
-	"github.com/keboola/keboola-as-code/internal/pkg/telemetry"
 	"github.com/keboola/keboola-as-code/internal/pkg/utils/errors"
 )
 
@@ -21,7 +20,7 @@ import (
 // - ResourceAlreadyExistsError.
 func (s *Store) CreateReceiver(ctx context.Context, receiver model.Receiver) (err error) {
 	ctx, span := s.telemetry.Tracer().Start(ctx, "keboola.go.buffer.store.CreateReceiver")
-	defer telemetry.EndSpan(span, &err)
+	defer span.End(&err)
 
 	// Check exports count
 	if len(receiver.Exports) >= MaxExportsPerReceiver {
@@ -87,7 +86,7 @@ func (s *Store) createReceiverBaseOp(_ context.Context, receiver model.ReceiverB
 // - ResourceAlreadyExistsError.
 func (s *Store) CheckCreateReceiver(ctx context.Context, receiverKey key.ReceiverKey) (err error) {
 	ctx, span := s.telemetry.Tracer().Start(ctx, "keboola.go.buffer.store.CheckCreateReceiver")
-	defer telemetry.EndSpan(span, &err)
+	defer span.End(&err)
 
 	err = s.getReceiverBaseOp(ctx, receiverKey).DoOrErr(ctx, s.client)
 	if err == nil {
@@ -105,7 +104,7 @@ func (s *Store) CheckCreateReceiver(ctx context.Context, receiverKey key.Receive
 // - ResourceNotFoundError.
 func (s *Store) GetReceiver(ctx context.Context, receiverKey key.ReceiverKey) (r model.Receiver, err error) {
 	ctx, span := s.telemetry.Tracer().Start(ctx, "keboola.go.buffer.store.GetReceiver")
-	defer telemetry.EndSpan(span, &err)
+	defer span.End(&err)
 
 	receiverBase, err := s.getReceiverBaseOp(ctx, receiverKey).Do(ctx, s.client)
 	if err != nil {
@@ -138,7 +137,7 @@ func (s *Store) getReceiverBaseOp(_ context.Context, receiverKey key.ReceiverKey
 
 func (s *Store) UpdateReceiver(ctx context.Context, k key.ReceiverKey, fn func(base model.ReceiverBase) (model.ReceiverBase, error)) (err error) {
 	ctx, span := s.telemetry.Tracer().Start(ctx, "keboola.go.buffer.store.UpdateReceiver")
-	defer telemetry.EndSpan(span, &err)
+	defer span.End(&err)
 
 	var receiver *model.ReceiverBase
 	return op.Atomic().
@@ -171,7 +170,7 @@ func (s *Store) updateReceiverBaseOp(_ context.Context, receiver model.ReceiverB
 // - ResourceNotFoundError.
 func (s *Store) ListReceivers(ctx context.Context, projectID keboola.ProjectID) (receivers []model.Receiver, err error) {
 	ctx, span := s.telemetry.Tracer().Start(ctx, "keboola.go.buffer.store.ListReceivers")
-	defer telemetry.EndSpan(span, &err)
+	defer span.End(&err)
 
 	err = s.
 		receiversIterator(ctx, projectID).Do(ctx, s.client).
@@ -203,7 +202,7 @@ func (s *Store) receiversIterator(_ context.Context, projectID keboola.ProjectID
 // - ResourceNotFoundError.
 func (s *Store) DeleteReceiver(ctx context.Context, receiverKey key.ReceiverKey) (err error) {
 	ctx, span := s.telemetry.Tracer().Start(ctx, "keboola.go.buffer.store.DeleteReceiver")
-	defer telemetry.EndSpan(span, &err)
+	defer span.End(&err)
 
 	_, err = op.MergeToTxn(
 		s.deleteReceiverBaseOp(ctx, receiverKey),

--- a/internal/pkg/service/buffer/store/record.go
+++ b/internal/pkg/service/buffer/store/record.go
@@ -10,13 +10,12 @@ import (
 	"github.com/keboola/keboola-as-code/internal/pkg/service/buffer/store/key"
 	serviceError "github.com/keboola/keboola-as-code/internal/pkg/service/common/errors"
 	"github.com/keboola/keboola-as-code/internal/pkg/service/common/etcdop/op"
-	"github.com/keboola/keboola-as-code/internal/pkg/telemetry"
 	"github.com/keboola/keboola-as-code/internal/pkg/utils/errors"
 )
 
 func (s *Store) CreateRecord(ctx context.Context, recordKey key.RecordKey, csvRow string) (err error) {
 	ctx, span := s.telemetry.Tracer().Start(ctx, "keboola.go.buffer.store.CreateRecord")
-	defer telemetry.EndSpan(span, &err)
+	defer span.End(&err)
 
 	if recordKey.RandomSuffix == "" {
 		recordKey.RandomSuffix = idgenerator.Random(5)
@@ -37,7 +36,7 @@ func (s *Store) CreateRecord(ctx context.Context, recordKey key.RecordKey, csvRo
 
 func (s *Store) CountRecords(ctx context.Context, k key.SliceKey) (count uint64, err error) {
 	ctx, span := s.telemetry.Tracer().Start(ctx, "keboola.go.buffer.store.RecordsCount")
-	defer telemetry.EndSpan(span, &err)
+	defer span.End(&err)
 	err = s.countRecordsOp(k, &count).DoOrErr(ctx, s.client)
 	return count, err
 }

--- a/internal/pkg/service/buffer/store/slice.go
+++ b/internal/pkg/service/buffer/store/slice.go
@@ -14,13 +14,12 @@ import (
 	"github.com/keboola/keboola-as-code/internal/pkg/service/common/etcdop/iterator"
 	"github.com/keboola/keboola-as-code/internal/pkg/service/common/etcdop/op"
 	"github.com/keboola/keboola-as-code/internal/pkg/service/common/utctime"
-	"github.com/keboola/keboola-as-code/internal/pkg/telemetry"
 	"github.com/keboola/keboola-as-code/internal/pkg/utils/errors"
 )
 
 func (s *Store) CreateSlice(ctx context.Context, slice model.Slice) (err error) {
 	ctx, span := s.telemetry.Tracer().Start(ctx, "keboola.go.buffer.store.CreateSlice")
-	defer telemetry.EndSpan(span, &err)
+	defer span.End(&err)
 
 	_, err = s.createSliceOp(ctx, slice).Do(ctx, s.client)
 	return err
@@ -42,7 +41,7 @@ func (s *Store) createSliceOp(_ context.Context, slice model.Slice) op.BoolOp {
 
 func (s *Store) GetSlice(ctx context.Context, sliceKey key.SliceKey) (r model.Slice, err error) {
 	ctx, span := s.telemetry.Tracer().Start(ctx, "keboola.go.buffer.store.GetSlice")
-	defer telemetry.EndSpan(span, &err)
+	defer span.End(&err)
 
 	slice, err := s.getSliceOp(ctx, sliceKey).Do(ctx, s.client)
 	if err != nil {
@@ -82,7 +81,7 @@ func (s *Store) getOpenedSliceOp(_ context.Context, exportKey key.ExportKey, opt
 
 func (s *Store) ListUploadedSlices(ctx context.Context, fileKey key.FileKey) (r []model.Slice, err error) {
 	ctx, span := s.telemetry.Tracer().Start(ctx, "keboola.go.buffer.store.GetAllUploadedSlices")
-	defer telemetry.EndSpan(span, &err)
+	defer span.End(&err)
 
 	slices, err := s.listUploadedSlicesOp(ctx, fileKey).Do(ctx, s.client).All()
 	if err != nil {
@@ -98,7 +97,7 @@ func (s *Store) listUploadedSlicesOp(_ context.Context, fileKey key.FileKey) ite
 
 func (s *Store) CloseSlice(ctx context.Context, slice *model.Slice) (err error) {
 	ctx, span := s.telemetry.Tracer().Start(ctx, "keboola.go.buffer.store.CloseSlice")
-	defer telemetry.EndSpan(span, &err)
+	defer span.End(&err)
 	k := slice.SliceKey
 	statsPfx := s.schema.ReceivedStats().InSlice(k)
 	var recordsCount uint64
@@ -196,7 +195,7 @@ func (s *Store) ScheduleSliceForRetry(ctx context.Context, slice *model.Slice) e
 // False is returned, if the given file is already in the target state.
 func (s *Store) SetSliceState(ctx context.Context, slice *model.Slice, to slicestate.State) (err error) { //nolint:dupl
 	ctx, span := s.telemetry.Tracer().Start(ctx, "keboola.go.buffer.store.SetSliceState")
-	defer telemetry.EndSpan(span, &err)
+	defer span.End(&err)
 
 	txn, err := s.setSliceStateOp(ctx, s.clock.Now(), slice, to)
 	if err != nil {

--- a/internal/pkg/service/buffer/store/stats_received.go
+++ b/internal/pkg/service/buffer/store/stats_received.go
@@ -6,7 +6,6 @@ import (
 
 	"github.com/keboola/keboola-as-code/internal/pkg/service/buffer/store/model"
 	"github.com/keboola/keboola-as-code/internal/pkg/service/common/etcdop/op"
-	"github.com/keboola/keboola-as-code/internal/pkg/telemetry"
 	"github.com/keboola/keboola-as-code/internal/pkg/utils/errors"
 )
 
@@ -14,7 +13,7 @@ const maxStatsPerTxn = 50
 
 func (s *Store) UpdateSliceReceivedStats(ctx context.Context, nodeID string, stats []model.SliceStats) (err error) {
 	ctx, span := s.telemetry.Tracer().Start(ctx, "keboola.go.buffer.store.UpdateSliceReceivedStats")
-	defer telemetry.EndSpan(span, &err)
+	defer span.End(&err)
 
 	var currentTxn *op.TxnOp
 	var allTxn []*op.TxnOp

--- a/internal/pkg/service/buffer/store/task.go
+++ b/internal/pkg/service/buffer/store/task.go
@@ -8,12 +8,11 @@ import (
 	serviceError "github.com/keboola/keboola-as-code/internal/pkg/service/common/errors"
 	"github.com/keboola/keboola-as-code/internal/pkg/service/common/etcdop/op"
 	"github.com/keboola/keboola-as-code/internal/pkg/service/common/task"
-	"github.com/keboola/keboola-as-code/internal/pkg/telemetry"
 )
 
 func (s *Store) GetTask(ctx context.Context, taskKey task.Key) (r task.Task, err error) {
 	ctx, span := s.telemetry.Tracer().Start(ctx, "keboola.go.buffer.store.GetTask")
-	defer telemetry.EndSpan(span, &err)
+	defer span.End(&err)
 
 	tsk, err := s.getTaskOp(ctx, taskKey).Do(ctx, s.client)
 	if err != nil {

--- a/internal/pkg/service/buffer/store/token.go
+++ b/internal/pkg/service/buffer/store/token.go
@@ -10,12 +10,11 @@ import (
 	serviceError "github.com/keboola/keboola-as-code/internal/pkg/service/common/errors"
 	"github.com/keboola/keboola-as-code/internal/pkg/service/common/etcdop/iterator"
 	"github.com/keboola/keboola-as-code/internal/pkg/service/common/etcdop/op"
-	"github.com/keboola/keboola-as-code/internal/pkg/telemetry"
 )
 
 func (s *Store) ListTokens(ctx context.Context, receiverKey key.ReceiverKey) (out []model.Token, err error) {
 	ctx, span := s.telemetry.Tracer().Start(ctx, "keboola.go.buffer.store.ListTokens")
-	defer telemetry.EndSpan(span, &err)
+	defer span.End(&err)
 
 	tokens, err := s.getReceiverTokensOp(ctx, receiverKey).Do(ctx, s.client).All()
 	if err != nil {
@@ -27,7 +26,7 @@ func (s *Store) ListTokens(ctx context.Context, receiverKey key.ReceiverKey) (ou
 
 func (s *Store) GetToken(ctx context.Context, exportKey key.ExportKey) (out model.Token, err error) {
 	ctx, span := s.telemetry.Tracer().Start(ctx, "keboola.go.buffer.store.GetToken")
-	defer telemetry.EndSpan(span, &err)
+	defer span.End(&err)
 
 	resp, err := s.getTokenOp(ctx, exportKey).Do(ctx, s.client)
 	if err != nil {
@@ -38,7 +37,7 @@ func (s *Store) GetToken(ctx context.Context, exportKey key.ExportKey) (out mode
 
 func (s *Store) UpdateTokens(ctx context.Context, tokens []model.Token) (err error) {
 	ctx, span := s.telemetry.Tracer().Start(ctx, "keboola.go.buffer.store.UpdateTokens")
-	defer telemetry.EndSpan(span, &err)
+	defer span.End(&err)
 
 	ops := make([]op.Op, 0, len(tokens))
 	for _, token := range tokens {

--- a/internal/pkg/service/buffer/task/orchestrator/orchestrator.go
+++ b/internal/pkg/service/buffer/task/orchestrator/orchestrator.go
@@ -10,7 +10,6 @@ import (
 
 	"github.com/benbjohnson/clock"
 	etcd "go.etcd.io/etcd/client/v3"
-	"go.opentelemetry.io/otel/trace"
 
 	"github.com/keboola/keboola-as-code/internal/pkg/log"
 	"github.com/keboola/keboola-as-code/internal/pkg/service/buffer/worker/distribution"
@@ -107,7 +106,7 @@ type Source[T any] struct {
 type orchestrator[T any] struct {
 	clock  clock.Clock
 	logger log.Logger
-	tracer trace.Tracer
+	tracer telemetry.Tracer
 	client *etcd.Client
 	dist   *distribution.Node
 	tasks  *task.Node
@@ -211,7 +210,7 @@ func (o orchestrator[R]) watch(ctx context.Context, wg *sync.WaitGroup, timeout 
 		GetAllAndWatch(ctx, o.client, o.config.Source.WatchEtcdOps...).
 		SetupConsumer(o.logger).
 		WithOnClose(func(err error) {
-			telemetry.EndSpan(span, &err)
+			span.End(&err)
 			close(done)
 		}).
 		WithForEach(func(events []etcdop.WatchEventT[R], header *etcdop.Header, _ bool) {

--- a/internal/pkg/service/buffer/worker/dependencies/dependencies.go
+++ b/internal/pkg/service/buffer/worker/dependencies/dependencies.go
@@ -46,7 +46,7 @@ type forWorker struct {
 
 func NewWorkerDeps(ctx context.Context, proc *servicectx.Process, cfg config.Config, envs env.Provider, logger log.Logger, tel telemetry.Telemetry) (v ForWorker, err error) {
 	ctx, span := tel.Tracer().Start(ctx, "keboola.go.buffer.worker.dependencies.NewWorkerDeps")
-	defer telemetry.EndSpan(span, &err)
+	defer span.End(&err)
 
 	// Create service dependencies
 	userAgent := "keboola-buffer-worker"

--- a/internal/pkg/service/common/dependencies/project.go
+++ b/internal/pkg/service/common/dependencies/project.go
@@ -10,7 +10,6 @@ import (
 	"go.opentelemetry.io/otel/attribute"
 
 	"github.com/keboola/keboola-as-code/internal/pkg/service/common/httpserver/middleware"
-	"github.com/keboola/keboola-as-code/internal/pkg/telemetry"
 	"github.com/keboola/keboola-as-code/internal/pkg/utils/strhelper"
 )
 
@@ -46,7 +45,7 @@ func newProjectDepsConfig(opts []ProjectDepsOption) projectDepsConfig {
 
 func NewProjectDeps(ctx context.Context, base Base, public Public, tokenStr string, opts ...ProjectDepsOption) (v Project, err error) {
 	ctx, span := base.Telemetry().Tracer().Start(ctx, "keboola.go.common.dependencies.NewProjectDeps")
-	defer telemetry.EndSpan(span, &err)
+	defer span.End(&err)
 
 	// Set attributes before token verification
 	reqSpan, _ := middleware.RequestSpan(ctx)

--- a/internal/pkg/service/common/dependencies/public.go
+++ b/internal/pkg/service/common/dependencies/public.go
@@ -8,7 +8,6 @@ import (
 
 	"github.com/keboola/keboola-as-code/internal/pkg/log"
 	"github.com/keboola/keboola-as-code/internal/pkg/model"
-	"github.com/keboola/keboola-as-code/internal/pkg/telemetry"
 )
 
 // public dependencies container implements Public interface.
@@ -52,13 +51,13 @@ func WithLogIndexLoading(v bool) PublicDepsOption {
 
 func NewPublicDeps(ctx context.Context, base Base, storageAPIHost string, opts ...PublicDepsOption) (v Public, err error) {
 	ctx, span := base.Telemetry().Tracer().Start(ctx, "kac.lib.dependencies.NewPublicDeps")
-	defer telemetry.EndSpan(span, &err)
+	defer span.End(&err)
 	return newPublicDeps(ctx, base, storageAPIHost, opts...)
 }
 
 func newPublicDeps(ctx context.Context, base Base, storageAPIHost string, opts ...PublicDepsOption) (v *public, err error) {
 	ctx, span := base.Telemetry().Tracer().Start(ctx, "keboola.go.common.dependencies.NewPublicDeps")
-	defer telemetry.EndSpan(span, &err)
+	defer span.End(&err)
 
 	cfg := newPublicDepsConfig(opts)
 	v = &public{base: base, storageAPIHost: storageAPIHost}
@@ -111,7 +110,7 @@ func newPublicDeps(ctx context.Context, base Base, storageAPIHost string, opts .
 func storageAPIIndexWithComponents(ctx context.Context, d Base, keboolaPublicAPI *keboola.API) (index *keboola.IndexComponents, err error) {
 	startTime := time.Now()
 	ctx, span := d.Telemetry().Tracer().Start(ctx, "keboola.go.common.dependencies.public.storageApiIndexWithComponents")
-	defer telemetry.EndSpan(span, &err)
+	defer span.End(&err)
 
 	index, err = keboolaPublicAPI.IndexComponentsRequest().Send(ctx)
 	if err != nil {

--- a/internal/pkg/service/common/dependencies/public.go
+++ b/internal/pkg/service/common/dependencies/public.go
@@ -111,7 +111,6 @@ func newPublicDeps(ctx context.Context, base Base, storageAPIHost string, opts .
 func storageAPIIndexWithComponents(ctx context.Context, d Base, keboolaPublicAPI *keboola.API) (index *keboola.IndexComponents, err error) {
 	startTime := time.Now()
 	ctx, span := d.Telemetry().Tracer().Start(ctx, "keboola.go.common.dependencies.public.storageApiIndexWithComponents")
-	span.SetAttributes(telemetry.KeepSpan())
 	defer telemetry.EndSpan(span, &err)
 
 	index, err = keboolaPublicAPI.IndexComponentsRequest().Send(ctx)

--- a/internal/pkg/service/common/etcdclient/etcdclient.go
+++ b/internal/pkg/service/common/etcdclient/etcdclient.go
@@ -110,7 +110,7 @@ func WithLogger(v log.Logger) Option {
 // The client terminates the connection when the context is done.
 func New(ctx context.Context, proc *servicectx.Process, tel telemetry.Telemetry, endpoint, namespace string, opts ...Option) (c *etcd.Client, err error) {
 	ctx, span := tel.Tracer().Start(ctx, "keboola.go.common.dependencies.EtcdClient")
-	defer telemetry.EndSpan(span, &err)
+	defer span.End(&err)
 
 	// Apply options
 	conf := config{

--- a/internal/pkg/service/common/task/cleanup.go
+++ b/internal/pkg/service/common/task/cleanup.go
@@ -10,7 +10,6 @@ import (
 	"github.com/keboola/keboola-as-code/internal/pkg/service/common/etcdop"
 	"github.com/keboola/keboola-as-code/internal/pkg/service/common/etcdop/iterator"
 	"github.com/keboola/keboola-as-code/internal/pkg/service/common/etcdop/op"
-	"github.com/keboola/keboola-as-code/internal/pkg/telemetry"
 	"github.com/keboola/keboola-as-code/internal/pkg/utils/errors"
 )
 
@@ -60,7 +59,7 @@ func (n *Node) Cleanup() (err error) {
 
 	// Setup telemetry
 	ctx, span := n.tracer.Start(ctx, n.config.spanNamePrefix+".cleanup")
-	telemetry.EndSpan(span, &err)
+	defer span.End(&err)
 
 	// Go through tasks and delete old ones
 	deletedTasksCount := int64(0)

--- a/internal/pkg/service/common/task/node.go
+++ b/internal/pkg/service/common/task/node.go
@@ -35,7 +35,7 @@ type Fn func(ctx context.Context, logger log.Logger) Result
 // Node represents a cluster Worker node on which tasks are run.
 // See comments in the StartTask method.
 type Node struct {
-	tracer   trace.Tracer
+	tracer   telemetry.Tracer
 	clock    clock.Clock
 	logger   log.Logger
 	client   *etcd.Client
@@ -212,7 +212,7 @@ func (n *Node) runTask(logger log.Logger, task Task, cfg Config) {
 
 	// Process results in defer to catch panic
 	var result Result
-	defer telemetry.EndSpan(span, &result.error)
+	defer span.End(&result.error)
 
 	// Do operation
 	startTime := n.clock.Now()

--- a/internal/pkg/service/common/task/node.go
+++ b/internal/pkg/service/common/task/node.go
@@ -202,7 +202,6 @@ func (n *Node) runTask(logger log.Logger, task Task, cfg Config) {
 
 	// Setup telemetry
 	ctx, span := n.tracer.Start(ctx, n.config.spanNamePrefix+"."+cfg.Type, trace.WithAttributes(
-		telemetry.KeepSpan(),
 		attribute.String("projectId", task.ProjectID.String()),
 		attribute.String("taskId", task.TaskID.String()),
 		attribute.String("taskType", cfg.Type),

--- a/internal/pkg/service/templates/api/dependencies/dependencies.go
+++ b/internal/pkg/service/templates/api/dependencies/dependencies.go
@@ -106,7 +106,7 @@ type forProjectRequest struct {
 
 func NewServerDeps(ctx context.Context, proc *servicectx.Process, cfg config.Config, envs env.Provider, logger log.Logger, tel telemetry.Telemetry) (v ForServer, err error) {
 	ctx, span := tel.Tracer().Start(ctx, "keboola.go.templates.api.dependencies.dependencies.NewServerDeps")
-	defer telemetry.EndSpan(span, &err)
+	defer span.End(&err)
 
 	// Create service dependencies
 	userAgent := "keboola-templates-api"
@@ -133,7 +133,7 @@ func NewServerDeps(ctx context.Context, proc *servicectx.Process, cfg config.Con
 
 func NewDepsForPublicRequest(serverDeps ForServer, req *http.Request) ForPublicRequest {
 	ctx, span := serverDeps.Telemetry().Tracer().Start(req.Context(), "keboola.go.templates.api.dependencies.NewDepsForPublicRequest")
-	defer telemetry.EndSpan(span, nil)
+	defer span.End(nil)
 
 	requestId, _ := ctx.Value(middleware.RequestIDCtxKey).(string)
 
@@ -147,7 +147,7 @@ func NewDepsForPublicRequest(serverDeps ForServer, req *http.Request) ForPublicR
 
 func NewDepsForProjectRequest(publicDeps ForPublicRequest, ctx context.Context, tokenStr string) (v ForProjectRequest, err error) {
 	ctx, span := publicDeps.Telemetry().Tracer().Start(ctx, "keboola.go.templates.api.dependencies.NewDepsForProjectRequest")
-	defer telemetry.EndSpan(span, &err)
+	defer span.End(&err)
 
 	projectDeps, err := dependencies.NewProjectDeps(ctx, publicDeps, publicDeps, tokenStr)
 	if err != nil {
@@ -234,7 +234,7 @@ func (v *forProjectRequest) ProjectRepositories() *model.TemplateRepositories {
 
 func (v *forProjectRequest) Template(ctx context.Context, reference model.TemplateRef) (tmpl *template.Template, err error) {
 	ctx, span := v.Telemetry().Tracer().Start(ctx, "keboola.go.templates.api.dependencies.Template")
-	defer telemetry.EndSpan(span, &err)
+	defer span.End(&err)
 
 	// Get repository
 	repo, err := v.cachedTemplateRepository(ctx, reference.Repository())
@@ -248,7 +248,7 @@ func (v *forProjectRequest) Template(ctx context.Context, reference model.Templa
 
 func (v *forProjectRequest) TemplateRepository(ctx context.Context, definition model.TemplateRepository) (tmpl *repository.Repository, err error) {
 	ctx, span := v.Telemetry().Tracer().Start(ctx, "keboola.go.templates.api.dependencies.TemplateRepository")
-	defer telemetry.EndSpan(span, &err)
+	defer span.End(&err)
 
 	repo, err := v.cachedTemplateRepository(ctx, definition)
 	if err != nil {
@@ -260,7 +260,7 @@ func (v *forProjectRequest) TemplateRepository(ctx context.Context, definition m
 func (v *forProjectRequest) cachedTemplateRepository(ctx context.Context, definition model.TemplateRepository) (repo *repositoryManager.CachedRepository, err error) {
 	if _, found := v.repositories[definition.Hash()]; !found {
 		ctx, span := v.Telemetry().Tracer().Start(ctx, "keboola.go.templates.api.dependencies.cachedTemplateRepository")
-		defer telemetry.EndSpan(span, &err)
+		defer span.End(&err)
 
 		// Get git repository
 		repo, unlockFn, err := v.RepositoryManager().Repository(ctx, definition)

--- a/internal/pkg/service/templates/api/dependencies/service.go
+++ b/internal/pkg/service/templates/api/dependencies/service.go
@@ -41,7 +41,7 @@ func NewServiceDeps(
 	userAgent string,
 ) (d ForService, err error) {
 	ctx, span := tel.Tracer().Start(ctx, "keboola.go.templates.dependencies.NewServiceDeps")
-	defer telemetry.EndSpan(span, &err)
+	defer span.End(&err)
 
 	// Create base HTTP client for all API requests to other APIs
 	httpClient := httpclient.New(

--- a/internal/pkg/service/templates/api/service/mapper.go
+++ b/internal/pkg/service/templates/api/service/mapper.go
@@ -15,7 +15,6 @@ import (
 	"github.com/keboola/keboola-as-code/internal/pkg/service/templates/api/config"
 	"github.com/keboola/keboola-as-code/internal/pkg/service/templates/api/dependencies"
 	. "github.com/keboola/keboola-as-code/internal/pkg/service/templates/api/gen/templates"
-	"github.com/keboola/keboola-as-code/internal/pkg/telemetry"
 	"github.com/keboola/keboola-as-code/internal/pkg/template"
 	"github.com/keboola/keboola-as-code/internal/pkg/template/context/upgrade"
 	"github.com/keboola/keboola-as-code/internal/pkg/template/input"
@@ -89,7 +88,7 @@ func formatTaskURL(apiHost string, k task.Key) string {
 
 func RepositoriesResponse(ctx context.Context, d dependencies.ForProjectRequest) (out *Repositories, err error) {
 	ctx, span := d.Telemetry().Tracer().Start(ctx, "api.server.templates.mapper.RepositoriesResponse")
-	defer telemetry.EndSpan(span, &err)
+	defer span.End(&err)
 
 	out = &Repositories{}
 	for _, repoRef := range d.ProjectRepositories().All() {
@@ -104,7 +103,7 @@ func RepositoriesResponse(ctx context.Context, d dependencies.ForProjectRequest)
 
 func RepositoryResponse(ctx context.Context, d dependencies.ForProjectRequest, v *repository.Repository) *Repository {
 	_, span := d.Telemetry().Tracer().Start(ctx, "api.server.templates.mapper.RepositoryResponse")
-	defer telemetry.EndSpan(span, nil)
+	defer span.End(nil)
 
 	repo := v.Definition()
 	author := v.Manifest().Author()
@@ -121,7 +120,7 @@ func RepositoryResponse(ctx context.Context, d dependencies.ForProjectRequest, v
 
 func TemplatesResponse(ctx context.Context, d dependencies.ForProjectRequest, repo *repository.Repository, templates []repository.TemplateRecord) (out *Templates, err error) {
 	ctx, span := d.Telemetry().Tracer().Start(ctx, "api.server.templates.mapper.TemplatesResponse")
-	defer telemetry.EndSpan(span, &err)
+	defer span.End(&err)
 
 	out = &Templates{Repository: RepositoryResponse(ctx, d, repo), Templates: make([]*Template, 0)}
 	for _, tmpl := range templates {
@@ -138,7 +137,7 @@ func TemplatesResponse(ctx context.Context, d dependencies.ForProjectRequest, re
 
 func TemplateResponse(ctx context.Context, d dependencies.ForProjectRequest, tmpl *repository.TemplateRecord, author *Author) (out *Template, err error) {
 	ctx, span := d.Telemetry().Tracer().Start(ctx, "api.server.templates.mapper.TemplateResponse")
-	defer telemetry.EndSpan(span, &err)
+	defer span.End(&err)
 
 	defaultVersion, err := tmpl.DefaultVersionOrErr()
 	if err != nil {
@@ -165,7 +164,7 @@ func TemplateResponse(ctx context.Context, d dependencies.ForProjectRequest, tmp
 
 func TemplateDetailResponse(ctx context.Context, d dependencies.ForProjectRequest, repo *repository.Repository, tmpl *repository.TemplateRecord) (out *TemplateDetail, err error) {
 	ctx, span := d.Telemetry().Tracer().Start(ctx, "api.server.templates.mapper.TemplateDetailResponse")
-	defer telemetry.EndSpan(span, &err)
+	defer span.End(&err)
 
 	defaultVersion, err := tmpl.DefaultVersionOrErr()
 	if err != nil {
@@ -213,7 +212,7 @@ func VersionDetailResponse(d dependencies.ForProjectRequest, template *template.
 
 func VersionDetailExtendedResponse(ctx context.Context, d dependencies.ForProjectRequest, repo *repository.Repository, template *template.Template) (out *VersionDetailExtended, err error) {
 	ctx, span := d.Telemetry().Tracer().Start(ctx, "api.server.templates.mapper.VersionDetailExtendedResponse")
-	defer telemetry.EndSpan(span, &err)
+	defer span.End(&err)
 
 	repoResponse := RepositoryResponse(ctx, d, repo)
 	tmplRec := template.TemplateRecord()
@@ -265,7 +264,7 @@ func ComponentsResponse(d dependencies.ForProjectRequest, in []string) (out []st
 
 func UpgradeInstanceInputsResponse(ctx context.Context, d dependencies.ForProjectRequest, prjState *project.State, branchKey model.BranchKey, instance *model.TemplateInstance, tmpl *template.Template) (out *Inputs) {
 	ctx, span := d.Telemetry().Tracer().Start(ctx, "api.server.templates.mapper.UpgradeInstanceInputsResponse")
-	defer telemetry.EndSpan(span, nil)
+	defer span.End(nil)
 
 	stepsGroupsExt := upgrade.ExportInputsValues(d.Logger().InfoWriter(), prjState.State(), branchKey, instance.InstanceID, tmpl.Inputs())
 	return InputsResponse(ctx, d, stepsGroupsExt)
@@ -273,7 +272,7 @@ func UpgradeInstanceInputsResponse(ctx context.Context, d dependencies.ForProjec
 
 func InputsResponse(ctx context.Context, d dependencies.ForProjectRequest, stepsGroups input.StepsGroupsExt) (out *Inputs) {
 	ctx, span := d.Telemetry().Tracer().Start(ctx, "api.server.templates.mapper.InputsResponse")
-	defer telemetry.EndSpan(span, nil)
+	defer span.End(nil)
 
 	out = &Inputs{StepGroups: make([]*StepGroup, 0)}
 	initialValues := make([]*StepPayload, 0)
@@ -356,7 +355,7 @@ func OptionsResponse(options input.Options) (out []*InputOption) {
 
 func InstancesResponse(ctx context.Context, d dependencies.ForProjectRequest, prjState *project.State, branchKey model.BranchKey) (out *Instances, err error) {
 	ctx, span := d.Telemetry().Tracer().Start(ctx, "api.server.templates.mapper.InstancesResponse")
-	defer telemetry.EndSpan(span, &err)
+	defer span.End(&err)
 
 	// Get branch state
 	branch, found := prjState.GetOrNil(branchKey).(*model.BranchState)
@@ -416,7 +415,7 @@ func InstancesResponse(ctx context.Context, d dependencies.ForProjectRequest, pr
 
 func InstanceResponse(ctx context.Context, d dependencies.ForProjectRequest, prjState *project.State, branchKey model.BranchKey, instanceId string) (out *InstanceDetail, err error) {
 	ctx, span := d.Telemetry().Tracer().Start(ctx, "api.server.templates.mapper.InstanceResponse")
-	defer telemetry.EndSpan(span, &err)
+	defer span.End(&err)
 
 	// Get branch state
 	branch, found := prjState.GetOrNil(branchKey).(*model.BranchState)

--- a/internal/pkg/service/templates/api/service/service.go
+++ b/internal/pkg/service/templates/api/service/service.go
@@ -23,7 +23,6 @@ import (
 	"github.com/keboola/keboola-as-code/internal/pkg/service/templates/api/config"
 	"github.com/keboola/keboola-as-code/internal/pkg/service/templates/api/dependencies"
 	. "github.com/keboola/keboola-as-code/internal/pkg/service/templates/api/gen/templates"
-	"github.com/keboola/keboola-as-code/internal/pkg/telemetry"
 	"github.com/keboola/keboola-as-code/internal/pkg/template"
 	"github.com/keboola/keboola-as-code/internal/pkg/template/repository"
 	"github.com/keboola/keboola-as-code/internal/pkg/template/repository/manifest"
@@ -299,7 +298,7 @@ func (s *service) InstancesIndex(d dependencies.ForProjectRequest, payload *Inst
 
 func (s *service) InstanceIndex(d dependencies.ForProjectRequest, payload *InstanceIndexPayload) (res *InstanceDetail, err error) {
 	_, span := d.Telemetry().Tracer().Start(d.RequestCtx(), "api.server.templates.service.InstanceIndex")
-	defer telemetry.EndSpan(span, &err)
+	defer span.End(&err)
 
 	branchKey, err := getBranch(d, payload.Branch)
 	if err != nil {

--- a/internal/pkg/service/templates/store/store.go
+++ b/internal/pkg/service/templates/store/store.go
@@ -4,7 +4,6 @@ package store
 import (
 	"github.com/benbjohnson/clock"
 	etcd "go.etcd.io/etcd/client/v3"
-	"go.opentelemetry.io/otel/trace"
 
 	"github.com/keboola/keboola-as-code/internal/pkg/log"
 	"github.com/keboola/keboola-as-code/internal/pkg/service/templates/store/schema"
@@ -15,7 +14,7 @@ type Store struct {
 	clock  clock.Clock
 	logger log.Logger
 	client *etcd.Client
-	tracer trace.Tracer
+	tracer telemetry.Tracer
 	schema *schema.Schema
 }
 
@@ -31,7 +30,7 @@ func New(d dependencies) *Store {
 	return newFrom(d.Clock(), d.Logger(), d.Telemetry().Tracer(), d.EtcdClient(), d.Schema())
 }
 
-func newFrom(clock clock.Clock, logger log.Logger, tracer trace.Tracer, etcdClient *etcd.Client, schema *schema.Schema) *Store {
+func newFrom(clock clock.Clock, logger log.Logger, tracer telemetry.Tracer, etcdClient *etcd.Client, schema *schema.Schema) *Store {
 	return &Store{
 		clock:  clock,
 		logger: logger,

--- a/internal/pkg/service/templates/store/task.go
+++ b/internal/pkg/service/templates/store/task.go
@@ -8,12 +8,11 @@ import (
 	serviceError "github.com/keboola/keboola-as-code/internal/pkg/service/common/errors"
 	"github.com/keboola/keboola-as-code/internal/pkg/service/common/etcdop/op"
 	"github.com/keboola/keboola-as-code/internal/pkg/service/common/task"
-	"github.com/keboola/keboola-as-code/internal/pkg/telemetry"
 )
 
 func (s *Store) GetTask(ctx context.Context, taskKey task.Key) (r task.Task, err error) {
 	ctx, span := s.tracer.Start(ctx, "keboola.go.templates.store.GetTask")
-	defer telemetry.EndSpan(span, &err)
+	defer span.End(&err)
 
 	tsk, err := s.getTaskOp(ctx, taskKey).Do(ctx, s.client)
 	if err != nil {

--- a/internal/pkg/telemetry/span.go
+++ b/internal/pkg/telemetry/span.go
@@ -1,19 +1,33 @@
 package telemetry
 
 import (
+	"go.opentelemetry.io/otel/attribute"
 	"go.opentelemetry.io/otel/codes"
 	"go.opentelemetry.io/otel/trace"
 )
 
-func EndSpan(span trace.Span, errPtr *error) {
+type Span interface {
+	End(errPtr *error, opts ...trace.SpanEndOption)
+	SetAttributes(kv ...attribute.KeyValue)
+}
+
+type span struct {
+	span trace.Span
+}
+
+func (s *span) SetAttributes(kv ...attribute.KeyValue) {
+	s.span.SetAttributes(kv...)
+}
+
+func (s *span) End(errPtr *error, opts ...trace.SpanEndOption) {
 	if errPtr != nil {
 		err := *errPtr
 		if err != nil {
-			span.RecordError(err)
-			span.SetStatus(codes.Error, err.Error())
+			s.span.RecordError(err)
+			s.span.SetStatus(codes.Error, err.Error())
 		} else {
-			span.SetStatus(codes.Ok, "OK")
+			s.span.SetStatus(codes.Ok, "")
 		}
 	}
-	span.End()
+	s.span.End(opts...)
 }

--- a/internal/pkg/telemetry/span.go
+++ b/internal/pkg/telemetry/span.go
@@ -1,23 +1,9 @@
 package telemetry
 
 import (
-	"go.opentelemetry.io/otel/attribute"
 	"go.opentelemetry.io/otel/codes"
 	"go.opentelemetry.io/otel/trace"
-	ddext "gopkg.in/DataDog/dd-trace-go.v1/ddtrace/ext"
 )
-
-func SampleRate(v float64) attribute.KeyValue {
-	return attribute.Float64(ddext.EventSampleRate, v)
-}
-
-func KeepSpan() attribute.KeyValue {
-	return attribute.Bool(ddext.ManualKeep, true)
-}
-
-func DropSpan() attribute.KeyValue {
-	return attribute.Bool(ddext.ManualDrop, true)
-}
 
 func EndSpan(span trace.Span, errPtr *error) {
 	if errPtr != nil {

--- a/internal/pkg/telemetry/telemetry.go
+++ b/internal/pkg/telemetry/telemetry.go
@@ -16,7 +16,8 @@ const (
 // Use TracerProvider() and MeterProvider() to use a 3rd party instrumentations library.
 type Telemetry interface {
 	// Tracer for app-specific traces, it is used directly by the app code.
-	Tracer() trace.Tracer
+	// The app code uses the modified Tracer, with a modified End method,
+	Tracer() Tracer
 	// TracerProvider for 3rd party instrumentations, it should not be used directly in the app code.
 	TracerProvider() trace.TracerProvider
 	// Meter for app-specific metrics, it is used directly by the app code.
@@ -28,7 +29,7 @@ type Telemetry interface {
 type telemetry struct {
 	tracerProvider trace.TracerProvider
 	meterProvider  metric.MeterProvider
-	tracer         trace.Tracer
+	tracer         Tracer
 	meter          metric.Meter
 }
 
@@ -65,12 +66,12 @@ func NewTelemetry(tpFactory func() (trace.TracerProvider, error), mpFactory func
 	return &telemetry{
 		tracerProvider: tracerProvider,
 		meterProvider:  meterProvider,
-		tracer:         tracerProvider.Tracer(appName),
+		tracer:         &tracer{tracerProvider.Tracer(appName)},
 		meter:          meterProvider.Meter(appName),
 	}, nil
 }
 
-func (t *telemetry) Tracer() trace.Tracer {
+func (t *telemetry) Tracer() Tracer {
 	return t.tracer
 }
 

--- a/internal/pkg/telemetry/tracer.go
+++ b/internal/pkg/telemetry/tracer.go
@@ -2,6 +2,7 @@ package telemetry
 
 import (
 	"context"
+
 	"go.opentelemetry.io/otel/trace"
 )
 

--- a/internal/pkg/telemetry/tracer.go
+++ b/internal/pkg/telemetry/tracer.go
@@ -1,0 +1,19 @@
+package telemetry
+
+import (
+	"context"
+	"go.opentelemetry.io/otel/trace"
+)
+
+type Tracer interface {
+	Start(ctx context.Context, spanName string, opts ...trace.SpanStartOption) (context.Context, Span)
+}
+
+type tracer struct {
+	tracer trace.Tracer
+}
+
+func (t *tracer) Start(ctx context.Context, spanName string, opts ...trace.SpanStartOption) (context.Context, Span) {
+	ctx, s := t.tracer.Start(ctx, spanName, opts...)
+	return ctx, &span{span: s}
+}

--- a/internal/pkg/template/repository/fs/fs.go
+++ b/internal/pkg/template/repository/fs/fs.go
@@ -30,7 +30,7 @@ func OnlyForTemplate(ref model.TemplateRef) Option {
 
 func For(ctx context.Context, d dependencies, ref model.TemplateRepository, opts ...Option) (fs filesystem.Fs, err error) {
 	ctx, span := d.Telemetry().Tracer().Start(ctx, "keboola.go.declarative.templates.repository.fs.For")
-	defer telemetry.EndSpan(span, &err)
+	defer span.End(&err)
 
 	switch ref.Type {
 	case model.RepositoryTypeDir:

--- a/internal/pkg/template/repository/fs/gitfs.go
+++ b/internal/pkg/template/repository/fs/gitfs.go
@@ -8,7 +8,6 @@ import (
 	"github.com/keboola/keboola-as-code/internal/pkg/filesystem/aferofs"
 	"github.com/keboola/keboola-as-code/internal/pkg/git"
 	"github.com/keboola/keboola-as-code/internal/pkg/model"
-	"github.com/keboola/keboola-as-code/internal/pkg/telemetry"
 	"github.com/keboola/keboola-as-code/internal/pkg/template"
 	"github.com/keboola/keboola-as-code/internal/pkg/template/repository"
 	"github.com/keboola/keboola-as-code/internal/pkg/utils/errors"
@@ -18,7 +17,7 @@ import (
 // Sparse checkout is used to load only the needed files.
 func gitFsFor(ctx context.Context, d dependencies, definition model.TemplateRepository, opts ...Option) (memoryFs filesystem.Fs, err error) {
 	ctx, span := d.Telemetry().Tracer().Start(ctx, "keboola.go.declarative.templates.repository.fs.gitFsFor")
-	defer telemetry.EndSpan(span, &err)
+	defer span.End(&err)
 
 	ctx, cancel := context.WithTimeout(ctx, 30*time.Second)
 	defer cancel()

--- a/internal/pkg/template/template.go
+++ b/internal/pkg/template/template.go
@@ -356,7 +356,7 @@ func (t *Template) LoadState(ctx Context, options loadState.Options, d dependenc
 
 func (t *Template) evaluate(ctx Context) (tmpl *evaluatedTemplate, err error) {
 	_, span := t.deps.Telemetry().Tracer().Start(ctx, "keboola.go.declarative.template.evaluate")
-	defer telemetry.EndSpan(span, &err)
+	defer span.End(&err)
 
 	// Evaluate manifest
 	evaluatedManifest, err := t.manifestFile.Evaluate(ctx.JsonnetContext())

--- a/pkg/lib/operation/dbt/generate/env/operation.go
+++ b/pkg/lib/operation/dbt/generate/env/operation.go
@@ -28,7 +28,7 @@ type dependencies interface {
 
 func Run(ctx context.Context, o Options, d dependencies) (err error) {
 	ctx, span := d.Telemetry().Tracer().Start(ctx, "keboola.go.operation.dbt.generate.env")
-	defer telemetry.EndSpan(span, &err)
+	defer span.End(&err)
 
 	// Check that we are in dbt directory
 	if _, _, err := d.LocalDbtProject(ctx); err != nil {

--- a/pkg/lib/operation/dbt/generate/profile/operation.go
+++ b/pkg/lib/operation/dbt/generate/profile/operation.go
@@ -27,7 +27,7 @@ const profilePath = "profiles.yml"
 
 func Run(ctx context.Context, o Options, d dependencies) (err error) {
 	ctx, span := d.Telemetry().Tracer().Start(ctx, "keboola.go.operation.dbt.generate.profile")
-	defer telemetry.EndSpan(span, &err)
+	defer span.End(&err)
 
 	// Get dbt project
 	project, _, err := d.LocalDbtProject(ctx)

--- a/pkg/lib/operation/dbt/generate/sources/operation.go
+++ b/pkg/lib/operation/dbt/generate/sources/operation.go
@@ -29,7 +29,7 @@ type dependencies interface {
 
 func Run(ctx context.Context, o Options, d dependencies) (err error) {
 	ctx, span := d.Telemetry().Tracer().Start(ctx, "keboola.go.operation.dbt.generate.sources")
-	defer telemetry.EndSpan(span, &err)
+	defer span.End(&err)
 
 	// Get dbt project
 	project, _, err := d.LocalDbtProject(ctx)

--- a/pkg/lib/operation/dbt/init/operation.go
+++ b/pkg/lib/operation/dbt/init/operation.go
@@ -30,7 +30,7 @@ type dependencies interface {
 
 func Run(ctx context.Context, o DbtInitOptions, d dependencies) (err error) {
 	ctx, span := d.Telemetry().Tracer().Start(ctx, "keboola.go.operation.dbt.init")
-	defer telemetry.EndSpan(span, &err)
+	defer span.End(&err)
 
 	// Check that we are in dbt directory
 	if _, _, err := d.LocalDbtProject(ctx); err != nil {

--- a/pkg/lib/operation/dbt/listbuckets/listbuckets.go
+++ b/pkg/lib/operation/dbt/listbuckets/listbuckets.go
@@ -19,7 +19,7 @@ type dependencies interface {
 
 func Run(ctx context.Context, o Options, d dependencies) (buckets []Bucket, err error) {
 	ctx, span := d.Telemetry().Tracer().Start(ctx, "keboola.go.operation.dbt.listBuckets")
-	defer telemetry.EndSpan(span, &err)
+	defer span.End(&err)
 
 	tablesList, err := d.KeboolaProjectAPI().ListTablesRequest(keboola.WithBuckets()).Send(ctx)
 	if err != nil {

--- a/pkg/lib/operation/project/local/create/config/operation.go
+++ b/pkg/lib/operation/project/local/create/config/operation.go
@@ -28,7 +28,7 @@ type dependencies interface {
 
 func Run(ctx context.Context, projectState *project.State, o Options, d dependencies) (err error) {
 	ctx, span := d.Telemetry().Tracer().Start(ctx, "keboola.go.operation.project.local.create.config")
-	defer telemetry.EndSpan(span, &err)
+	defer span.End(&err)
 
 	logger := d.Logger()
 

--- a/pkg/lib/operation/project/local/create/row/operation.go
+++ b/pkg/lib/operation/project/local/create/row/operation.go
@@ -29,7 +29,7 @@ type dependencies interface {
 
 func Run(ctx context.Context, projectState *project.State, o Options, d dependencies) (err error) {
 	ctx, span := d.Telemetry().Tracer().Start(ctx, "keboola.go.operation.project.local.create.row")
-	defer telemetry.EndSpan(span, &err)
+	defer span.End(&err)
 
 	logger := d.Logger()
 

--- a/pkg/lib/operation/project/local/encrypt/operation.go
+++ b/pkg/lib/operation/project/local/encrypt/operation.go
@@ -25,7 +25,7 @@ type dependencies interface {
 
 func Run(ctx context.Context, projectState *project.State, o Options, d dependencies) (err error) {
 	ctx, span := d.Telemetry().Tracer().Start(ctx, "keboola.go.operation.project.local.encrypt")
-	defer telemetry.EndSpan(span, &err)
+	defer span.End(&err)
 
 	logger := d.Logger()
 

--- a/pkg/lib/operation/project/local/envfiles/create/operation.go
+++ b/pkg/lib/operation/project/local/envfiles/create/operation.go
@@ -21,7 +21,7 @@ type dependencies interface {
 
 func Run(ctx context.Context, fs filesystem.Fs, d dependencies) (err error) {
 	ctx, span := d.Telemetry().Tracer().Start(ctx, "keboola.go.operation.project.local.envfiles.create")
-	defer telemetry.EndSpan(span, &err)
+	defer span.End(&err)
 
 	logger := d.Logger()
 

--- a/pkg/lib/operation/project/local/manifest/create/operation.go
+++ b/pkg/lib/operation/project/local/manifest/create/operation.go
@@ -28,7 +28,7 @@ type dependencies interface {
 
 func Run(ctx context.Context, fs filesystem.Fs, o Options, d dependencies) (m *project.Manifest, err error) {
 	ctx, span := d.Telemetry().Tracer().Start(ctx, "keboola.go.operation.project.local.manifest.create")
-	defer telemetry.EndSpan(span, &err)
+	defer span.End(&err)
 
 	logger := d.Logger()
 

--- a/pkg/lib/operation/project/local/manifest/load/operation.go
+++ b/pkg/lib/operation/project/local/manifest/load/operation.go
@@ -20,7 +20,7 @@ type dependencies interface {
 
 func Run(ctx context.Context, fs filesystem.Fs, o Options, d dependencies) (m *project.Manifest, err error) {
 	ctx, span := d.Telemetry().Tracer().Start(ctx, "keboola.go.operation.project.local.manifest.load")
-	defer telemetry.EndSpan(span, &err)
+	defer span.End(&err)
 
 	logger := d.Logger()
 

--- a/pkg/lib/operation/project/local/manifest/save/operation.go
+++ b/pkg/lib/operation/project/local/manifest/save/operation.go
@@ -16,7 +16,7 @@ type Dependencies interface {
 
 func Run(ctx context.Context, m *project.Manifest, fs filesystem.Fs, d Dependencies) (changed bool, err error) {
 	ctx, span := d.Telemetry().Tracer().Start(ctx, "keboola.go.operation.project.local.manifest.load")
-	defer telemetry.EndSpan(span, &err)
+	defer span.End(&err)
 
 	// Save if manifest is changed
 	if m.IsChanged() {

--- a/pkg/lib/operation/project/local/metadir/create/operation.go
+++ b/pkg/lib/operation/project/local/metadir/create/operation.go
@@ -16,7 +16,7 @@ type dependencies interface {
 
 func Run(ctx context.Context, fs filesystem.Fs, d dependencies) (err error) {
 	ctx, span := d.Telemetry().Tracer().Start(ctx, "keboola.go.operation.project.local.metadir.create")
-	defer telemetry.EndSpan(span, &err)
+	defer span.End(&err)
 
 	if err := fs.Mkdir(filesystem.MetadataDir); err != nil {
 		return errors.Errorf("cannot create metadata directory \"%s\": %w", filesystem.MetadataDir, err)

--- a/pkg/lib/operation/project/local/persist/operation.go
+++ b/pkg/lib/operation/project/local/persist/operation.go
@@ -27,7 +27,7 @@ type dependencies interface {
 
 func Run(ctx context.Context, projectState *project.State, o Options, d dependencies) (err error) {
 	ctx, span := d.Telemetry().Tracer().Start(ctx, "keboola.go.operation.project.local.persist")
-	defer telemetry.EndSpan(span, &err)
+	defer span.End(&err)
 
 	logger := d.Logger()
 

--- a/pkg/lib/operation/project/local/rename/operation.go
+++ b/pkg/lib/operation/project/local/rename/operation.go
@@ -23,7 +23,7 @@ type dependencies interface {
 
 func Run(ctx context.Context, projectState *project.State, o Options, d dependencies) (changed bool, err error) {
 	ctx, span := d.Telemetry().Tracer().Start(ctx, "keboola.go.operation.project.local.rename")
-	defer telemetry.EndSpan(span, &err)
+	defer span.End(&err)
 
 	logger := d.Logger()
 

--- a/pkg/lib/operation/project/local/template/delete/operation.go
+++ b/pkg/lib/operation/project/local/template/delete/operation.go
@@ -25,7 +25,7 @@ type dependencies interface {
 
 func Run(ctx context.Context, projectState *project.State, o Options, d dependencies) (err error) {
 	ctx, span := d.Telemetry().Tracer().Start(ctx, "keboola.go.operation.project.local.template.delete")
-	defer telemetry.EndSpan(span, &err)
+	defer span.End(&err)
 
 	logger := d.Logger()
 

--- a/pkg/lib/operation/project/local/template/list/operation.go
+++ b/pkg/lib/operation/project/local/template/list/operation.go
@@ -16,7 +16,7 @@ type dependencies interface {
 
 func Run(ctx context.Context, branch *model.BranchState, d dependencies) (err error) {
 	ctx, span := d.Telemetry().Tracer().Start(ctx, "keboola.go.operation.project.local.template.list")
-	defer telemetry.EndSpan(span, &err)
+	defer span.End(&err)
 
 	w := d.Logger().InfoWriter()
 

--- a/pkg/lib/operation/project/local/template/rename/operation.go
+++ b/pkg/lib/operation/project/local/template/rename/operation.go
@@ -26,7 +26,7 @@ type dependencies interface {
 
 func Run(ctx context.Context, projectState *project.State, o Options, d dependencies) (err error) {
 	ctx, span := d.Telemetry().Tracer().Start(ctx, "keboola.go.operation.project.local.template.rename")
-	defer telemetry.EndSpan(span, &err)
+	defer span.End(&err)
 
 	logger := d.Logger()
 

--- a/pkg/lib/operation/project/local/template/upgrade/operation.go
+++ b/pkg/lib/operation/project/local/template/upgrade/operation.go
@@ -35,7 +35,7 @@ type dependencies interface {
 
 func Run(ctx context.Context, projectState *project.State, tmpl *template.Template, o Options, d dependencies) (result *use.Result, err error) {
 	ctx, span := d.Telemetry().Tracer().Start(ctx, "keboola.go.operation.project.local.template.upgrade")
-	defer telemetry.EndSpan(span, &err)
+	defer span.End(&err)
 
 	// Create tickets provider, to generate new IDs, if needed
 	tickets := d.ObjectIDGeneratorFactory()(ctx)

--- a/pkg/lib/operation/project/local/template/use/operation.go
+++ b/pkg/lib/operation/project/local/template/use/operation.go
@@ -58,7 +58,7 @@ func LoadTemplateOptions() loadState.Options {
 
 func Run(ctx context.Context, projectState *project.State, tmpl *template.Template, o Options, d dependencies) (result *Result, err error) {
 	ctx, span := d.Telemetry().Tracer().Start(ctx, "keboola.go.operation.project.local.template.use")
-	defer telemetry.EndSpan(span, &err)
+	defer span.End(&err)
 
 	// Create tickets provider, to generate new IDS
 	tickets := d.ObjectIDGeneratorFactory()(ctx)

--- a/pkg/lib/operation/project/local/validate/config/operation.go
+++ b/pkg/lib/operation/project/local/validate/config/operation.go
@@ -29,7 +29,7 @@ type dependencies interface {
 
 func Run(ctx context.Context, o Options, d dependencies) (err error) {
 	ctx, span := d.Telemetry().Tracer().Start(ctx, "keboola.go.operation.project.local.validate.config")
-	defer telemetry.EndSpan(span, &err)
+	defer span.End(&err)
 	logger := d.Logger()
 
 	// Get component

--- a/pkg/lib/operation/project/local/validate/operation.go
+++ b/pkg/lib/operation/project/local/validate/operation.go
@@ -23,7 +23,7 @@ type dependencies interface {
 
 func Run(ctx context.Context, projectState *project.State, o Options, d dependencies) (err error) {
 	ctx, span := d.Telemetry().Tracer().Start(ctx, "keboola.go.operation.project.local.validate")
-	defer telemetry.EndSpan(span, &err)
+	defer span.End(&err)
 
 	logger := d.Logger()
 

--- a/pkg/lib/operation/project/local/validate/row/operation.go
+++ b/pkg/lib/operation/project/local/validate/row/operation.go
@@ -29,7 +29,7 @@ type dependencies interface {
 
 func Run(ctx context.Context, o Options, d dependencies) (err error) {
 	ctx, span := d.Telemetry().Tracer().Start(ctx, "keboola.go.operation.project.local.validate.row")
-	defer telemetry.EndSpan(span, &err)
+	defer span.End(&err)
 	logger := d.Logger()
 
 	// Get component

--- a/pkg/lib/operation/project/local/validate/schema/operation.go
+++ b/pkg/lib/operation/project/local/validate/schema/operation.go
@@ -22,7 +22,7 @@ type dependencies interface {
 
 func Run(ctx context.Context, o Options, d dependencies) (err error) {
 	ctx, span := d.Telemetry().Tracer().Start(ctx, "keboola.go.operation.project.local.validate.schema")
-	defer telemetry.EndSpan(span, &err)
+	defer span.End(&err)
 	logger := d.Logger()
 
 	// Read schema

--- a/pkg/lib/operation/project/local/workflows/generate/operation.go
+++ b/pkg/lib/operation/project/local/workflows/generate/operation.go
@@ -27,7 +27,7 @@ type dependencies interface {
 
 func Run(ctx context.Context, fs filesystem.Fs, o Options, d dependencies) (err error) {
 	ctx, span := d.Telemetry().Tracer().Start(ctx, "keboola.go.operation.project.local.workflows.generate")
-	defer telemetry.EndSpan(span, &err)
+	defer span.End(&err)
 
 	if !o.Enabled() {
 		return nil

--- a/pkg/lib/operation/project/remote/create/branch/operation.go
+++ b/pkg/lib/operation/project/remote/create/branch/operation.go
@@ -24,7 +24,7 @@ type dependencies interface {
 
 func Run(ctx context.Context, o Options, d dependencies) (branch *keboola.Branch, err error) {
 	ctx, span := d.Telemetry().Tracer().Start(ctx, "keboola.go.operation.project.remote.create.branch")
-	defer telemetry.EndSpan(span, &err)
+	defer span.End(&err)
 
 	logger := d.Logger()
 

--- a/pkg/lib/operation/project/remote/create/bucket/operation.go
+++ b/pkg/lib/operation/project/remote/create/bucket/operation.go
@@ -26,7 +26,7 @@ type dependencies interface {
 
 func Run(ctx context.Context, o Options, d dependencies) (err error) {
 	ctx, span := d.Telemetry().Tracer().Start(ctx, "keboola.go.operation.project.remote.create.bucket")
-	defer telemetry.EndSpan(span, &err)
+	defer span.End(&err)
 
 	logger := d.Logger()
 

--- a/pkg/lib/operation/project/remote/create/table/operation.go
+++ b/pkg/lib/operation/project/remote/create/table/operation.go
@@ -27,7 +27,7 @@ type dependencies interface {
 
 func Run(ctx context.Context, o Options, d dependencies) (err error) {
 	ctx, span := d.Telemetry().Tracer().Start(ctx, "keboola.go.operation.project.remote.create.table")
-	defer telemetry.EndSpan(span, &err)
+	defer span.End(&err)
 
 	opts := make([]keboola.CreateTableOption, 0)
 	if len(o.PrimaryKey) > 0 {

--- a/pkg/lib/operation/project/remote/file/download/operation.go
+++ b/pkg/lib/operation/project/remote/file/download/operation.go
@@ -62,7 +62,7 @@ func (o *Options) GetOutput(file string) (io.WriteCloser, error) {
 
 func Run(ctx context.Context, opts Options, d dependencies) (err error) {
 	ctx, span := d.Telemetry().Tracer().Start(ctx, "keboola.go.operation.project.remote.file.download")
-	defer telemetry.EndSpan(span, &err)
+	defer span.End(&err)
 
 	if opts.File.IsSliced {
 		if !opts.AllowSliced {

--- a/pkg/lib/operation/project/remote/file/upload/operation.go
+++ b/pkg/lib/operation/project/remote/file/upload/operation.go
@@ -31,7 +31,7 @@ type Options struct {
 
 func Run(ctx context.Context, o Options, d dependencies) (f *keboola.FileUploadCredentials, err error) {
 	ctx, span := d.Telemetry().Tracer().Start(ctx, "keboola.go.operation.project.remote.file.upload")
-	defer telemetry.EndSpan(span, &err)
+	defer span.End(&err)
 
 	opts := make([]keboola.CreateFileOption, 0)
 	if len(o.Tags) > 0 {

--- a/pkg/lib/operation/project/remote/job/run/operation.go
+++ b/pkg/lib/operation/project/remote/job/run/operation.go
@@ -29,7 +29,7 @@ type RunOptions struct {
 
 func Run(ctx context.Context, o RunOptions, d dependencies) (err error) {
 	ctx, span := d.Telemetry().Tracer().Start(ctx, "keboola.go.operation.project.remote.job.run")
-	defer telemetry.EndSpan(span, &err)
+	defer span.End(&err)
 
 	timeoutCtx, cancel := context.WithTimeout(ctx, o.Timeout)
 	defer cancel()

--- a/pkg/lib/operation/project/remote/table/detail/operation.go
+++ b/pkg/lib/operation/project/remote/table/detail/operation.go
@@ -19,7 +19,7 @@ type dependencies interface {
 
 func Run(ctx context.Context, tableID keboola.TableID, d dependencies) (err error) {
 	ctx, span := d.Telemetry().Tracer().Start(ctx, "keboola.go.operation.project.remote.table.detail")
-	defer telemetry.EndSpan(span, &err)
+	defer span.End(&err)
 
 	table, err := d.KeboolaProjectAPI().GetTableRequest(tableID).Send(ctx)
 	if err != nil {

--- a/pkg/lib/operation/project/remote/table/import/operation.go
+++ b/pkg/lib/operation/project/remote/table/import/operation.go
@@ -32,7 +32,7 @@ type Options struct {
 
 func Run(ctx context.Context, o Options, d dependencies) (err error) {
 	ctx, span := d.Telemetry().Tracer().Start(ctx, "keboola.go.operation.project.remote.table.import")
-	defer telemetry.EndSpan(span, &err)
+	defer span.End(&err)
 
 	if !checkTableExists(ctx, d, o.TableID) {
 		d.Logger().Infof(`Table "%s" does not exist, creating it.`, o.TableID)

--- a/pkg/lib/operation/project/remote/table/preview/operation.go
+++ b/pkg/lib/operation/project/remote/table/preview/operation.go
@@ -42,7 +42,7 @@ type ColumnOrder struct {
 
 func Run(ctx context.Context, o Options, d dependencies) (err error) {
 	ctx, span := d.Telemetry().Tracer().Start(ctx, "keboola.go.operation.project.remote.table.preview")
-	defer telemetry.EndSpan(span, &err)
+	defer span.End(&err)
 
 	d.Logger().Infof(`Fetching table "%s", please wait.`, o.TableID.String())
 

--- a/pkg/lib/operation/project/remote/table/unload/operation.go
+++ b/pkg/lib/operation/project/remote/table/unload/operation.go
@@ -45,7 +45,7 @@ func ParseFormat(format string) (keboola.UnloadFormat, error) {
 
 func Run(ctx context.Context, o Options, d dependencies) (file *keboola.UnloadedFile, err error) {
 	ctx, span := d.Telemetry().Tracer().Start(ctx, "keboola.go.operation.project.remote.table.unload")
-	defer telemetry.EndSpan(span, &err)
+	defer span.End(&err)
 
 	request := d.KeboolaProjectAPI().NewTableUnloadRequest(o.TableID).
 		WithChangedSince(o.ChangedSince).

--- a/pkg/lib/operation/project/remote/workspace/create/operation.go
+++ b/pkg/lib/operation/project/remote/workspace/create/operation.go
@@ -25,7 +25,7 @@ type dependencies interface {
 
 func Run(ctx context.Context, o CreateOptions, d dependencies) (err error) {
 	ctx, span := d.Telemetry().Tracer().Start(ctx, "keboola.go.operation.project.remote.workspace.create")
-	defer telemetry.EndSpan(span, &err)
+	defer span.End(&err)
 
 	logger := d.Logger()
 

--- a/pkg/lib/operation/project/remote/workspace/delete/operation.go
+++ b/pkg/lib/operation/project/remote/workspace/delete/operation.go
@@ -18,7 +18,7 @@ type dependencies interface {
 
 func Run(ctx context.Context, d dependencies, branchID keboola.BranchID, workspace *keboola.WorkspaceWithConfig) (err error) {
 	ctx, span := d.Telemetry().Tracer().Start(ctx, "keboola.go.operation.project.remote.workspace.delete")
-	defer telemetry.EndSpan(span, &err)
+	defer span.End(&err)
 
 	logger := d.Logger()
 

--- a/pkg/lib/operation/project/remote/workspace/detail/operation.go
+++ b/pkg/lib/operation/project/remote/workspace/detail/operation.go
@@ -18,7 +18,7 @@ type dependencies interface {
 
 func Run(ctx context.Context, d dependencies, configID keboola.ConfigID) (err error) {
 	ctx, span := d.Telemetry().Tracer().Start(ctx, "keboola.go.operation.project.remote.workspace.create")
-	defer telemetry.EndSpan(span, &err)
+	defer span.End(&err)
 
 	logger := d.Logger()
 

--- a/pkg/lib/operation/project/remote/workspace/list/operation.go
+++ b/pkg/lib/operation/project/remote/workspace/list/operation.go
@@ -19,7 +19,7 @@ type dependencies interface {
 
 func Run(ctx context.Context, d dependencies) (err error) {
 	ctx, span := d.Telemetry().Tracer().Start(ctx, "keboola.go.operation.project.remote.workspace.list")
-	defer telemetry.EndSpan(span, &err)
+	defer span.End(&err)
 
 	logger := d.Logger()
 

--- a/pkg/lib/operation/project/sync/diff/create/operation.go
+++ b/pkg/lib/operation/project/sync/diff/create/operation.go
@@ -18,7 +18,7 @@ type dependencies interface {
 
 func Run(ctx context.Context, o Options, d dependencies) (results *diff.Results, err error) {
 	ctx, span := d.Telemetry().Tracer().Start(ctx, "keboola.go.operation.project.sync.diff.create")
-	defer telemetry.EndSpan(span, &err)
+	defer span.End(&err)
 
 	differ := diff.NewDiffer(o.Objects)
 	results, err = differ.Diff()

--- a/pkg/lib/operation/project/sync/diff/printdiff/operation.go
+++ b/pkg/lib/operation/project/sync/diff/printdiff/operation.go
@@ -22,7 +22,7 @@ type dependencies interface {
 
 func Run(ctx context.Context, projectState *project.State, o Options, d dependencies) (results *diff.Results, err error) {
 	ctx, span := d.Telemetry().Tracer().Start(ctx, "keboola.go.operation.project.sync.diff.print")
-	defer telemetry.EndSpan(span, &err)
+	defer span.End(&err)
 
 	logger := d.Logger()
 

--- a/pkg/lib/operation/project/sync/init/operation.go
+++ b/pkg/lib/operation/project/sync/init/operation.go
@@ -40,7 +40,7 @@ type dependencies interface {
 
 func Run(ctx context.Context, o Options, d dependencies) (err error) {
 	ctx, span := d.Telemetry().Tracer().Start(ctx, "keboola.go.operation.project.sync.init")
-	defer telemetry.EndSpan(span, &err)
+	defer span.End(&err)
 
 	logger := d.Logger()
 

--- a/pkg/lib/operation/project/sync/pull/operation.go
+++ b/pkg/lib/operation/project/sync/pull/operation.go
@@ -36,7 +36,7 @@ func LoadStateOptions(force bool) loadState.Options {
 
 func Run(ctx context.Context, projectState *project.State, o Options, d dependencies) (err error) {
 	ctx, span := d.Telemetry().Tracer().Start(ctx, "keboola.go.operation.project.sync.pull")
-	defer telemetry.EndSpan(span, &err)
+	defer span.End(&err)
 
 	logger := d.Logger()
 

--- a/pkg/lib/operation/project/sync/push/operation.go
+++ b/pkg/lib/operation/project/sync/push/operation.go
@@ -32,7 +32,7 @@ type dependencies interface {
 
 func Run(ctx context.Context, projectState *project.State, o Options, d dependencies) (err error) {
 	ctx, span := d.Telemetry().Tracer().Start(ctx, "keboola.go.operation.project.sync.push")
-	defer telemetry.EndSpan(span, &err)
+	defer span.End(&err)
 
 	logger := d.Logger()
 

--- a/pkg/lib/operation/repository/checkout/operation.go
+++ b/pkg/lib/operation/repository/checkout/operation.go
@@ -22,7 +22,6 @@ type dependencies interface {
 
 func Run(ctx context.Context, def model.TemplateRepository, d dependencies) (repo *git.RemoteRepository, err error) {
 	ctx, span := d.Telemetry().Tracer().Start(ctx, "keboola.go.operation.repository.checkout")
-	span.SetAttributes(telemetry.KeepSpan())
 	defer telemetry.EndSpan(span, &err)
 
 	// Create context with timeout

--- a/pkg/lib/operation/repository/checkout/operation.go
+++ b/pkg/lib/operation/repository/checkout/operation.go
@@ -22,7 +22,7 @@ type dependencies interface {
 
 func Run(ctx context.Context, def model.TemplateRepository, d dependencies) (repo *git.RemoteRepository, err error) {
 	ctx, span := d.Telemetry().Tracer().Start(ctx, "keboola.go.operation.repository.checkout")
-	defer telemetry.EndSpan(span, &err)
+	defer span.End(&err)
 
 	// Create context with timeout
 	ctx, cancel := context.WithTimeout(ctx, Timeout)

--- a/pkg/lib/operation/repository/pull/operation.go
+++ b/pkg/lib/operation/repository/pull/operation.go
@@ -20,7 +20,7 @@ type dependencies interface {
 
 func Run(ctx context.Context, repo *git.RemoteRepository, d dependencies) (result *git.PullResult, err error) {
 	ctx, span := d.Telemetry().Tracer().Start(ctx, "keboola.go.operation.repository.pull")
-	defer telemetry.EndSpan(span, &err)
+	defer span.End(&err)
 
 	// Context with timeout
 	ctx, cancel := context.WithTimeout(ctx, Timeout)

--- a/pkg/lib/operation/repository/pull/operation.go
+++ b/pkg/lib/operation/repository/pull/operation.go
@@ -20,7 +20,6 @@ type dependencies interface {
 
 func Run(ctx context.Context, repo *git.RemoteRepository, d dependencies) (result *git.PullResult, err error) {
 	ctx, span := d.Telemetry().Tracer().Start(ctx, "keboola.go.operation.repository.pull")
-	span.SetAttributes(telemetry.KeepSpan())
 	defer telemetry.EndSpan(span, &err)
 
 	// Context with timeout

--- a/pkg/lib/operation/state/load/operation.go
+++ b/pkg/lib/operation/state/load/operation.go
@@ -134,7 +134,7 @@ func Run(ctx context.Context, container state.ObjectsContainer, o OptionsWithFil
 	span.SetAttributes(attribute.String("remote.filter", json.MustEncodeString(o.RemoteFilter, false)))
 	span.SetAttributes(attribute.Bool("local.load", o.LoadLocalState))
 	span.SetAttributes(attribute.String("local.filter", json.MustEncodeString(o.LocalFilter, false)))
-	defer telemetry.EndSpan(span, &err)
+	defer span.End(&err)
 
 	logger := d.Logger()
 	loadOptions := state.LoadOptions{

--- a/pkg/lib/operation/status/operation.go
+++ b/pkg/lib/operation/status/operation.go
@@ -24,7 +24,7 @@ type dependencies interface {
 
 func Run(ctx context.Context, d dependencies) (err error) {
 	ctx, span := d.Telemetry().Tracer().Start(ctx, "keboola.go.operation.status")
-	defer telemetry.EndSpan(span, &err)
+	defer span.End(&err)
 
 	logger := d.Logger()
 

--- a/pkg/lib/operation/template/load/operation.go
+++ b/pkg/lib/operation/template/load/operation.go
@@ -17,7 +17,7 @@ type dependencies interface {
 
 func Run(ctx context.Context, d dependencies, repository *repository.Repository, reference model.TemplateRef) (tmpl *template.Template, err error) {
 	ctx, span := d.Telemetry().Tracer().Start(ctx, "keboola.go.operation.template.load")
-	defer telemetry.EndSpan(span, &err)
+	defer span.End(&err)
 
 	// Get template
 	templateRecord, err := repository.RecordByIDOrErr(reference.TemplateID())

--- a/pkg/lib/operation/template/local/create/operation.go
+++ b/pkg/lib/operation/template/local/create/operation.go
@@ -43,7 +43,7 @@ type dependencies interface {
 
 func Run(ctx context.Context, o Options, d dependencies) (err error) {
 	ctx, span := d.Telemetry().Tracer().Start(ctx, "keboola.go.operation.template.local.create")
-	defer telemetry.EndSpan(span, &err)
+	defer span.End(&err)
 
 	// Get repository
 	repo, _, err := d.LocalTemplateRepository(ctx)

--- a/pkg/lib/operation/template/local/dir/create/operation.go
+++ b/pkg/lib/operation/template/local/dir/create/operation.go
@@ -19,7 +19,7 @@ type dependencies interface {
 
 func Run(ctx context.Context, repositoryDir filesystem.Fs, o Options, d dependencies) (fs filesystem.Fs, err error) {
 	ctx, span := d.Telemetry().Tracer().Start(ctx, "keboola.go.operation.template.local.dir.create")
-	defer telemetry.EndSpan(span, &err)
+	defer span.End(&err)
 
 	// Create template dir
 	if err := repositoryDir.Mkdir(o.Path); err != nil {

--- a/pkg/lib/operation/template/local/inputs/create/operation.go
+++ b/pkg/lib/operation/template/local/inputs/create/operation.go
@@ -17,7 +17,7 @@ type dependencies interface {
 
 func Run(ctx context.Context, fs filesystem.Fs, d dependencies) (inputs *template.StepsGroups, err error) {
 	ctx, span := d.Telemetry().Tracer().Start(ctx, "keboola.go.operation.template.local.inputs.create")
-	defer telemetry.EndSpan(span, &err)
+	defer span.End(&err)
 
 	logger := d.Logger()
 

--- a/pkg/lib/operation/template/local/inputs/save/operation.go
+++ b/pkg/lib/operation/template/local/inputs/save/operation.go
@@ -16,7 +16,7 @@ type dependencies interface {
 
 func Run(ctx context.Context, stepGroups template.StepsGroups, fs filesystem.Fs, d dependencies) (err error) {
 	ctx, span := d.Telemetry().Tracer().Start(ctx, "keboola.go.operation.template.local.inputs.create")
-	defer telemetry.EndSpan(span, &err)
+	defer span.End(&err)
 
 	if err := stepGroups.Save(fs); err != nil {
 		return err

--- a/pkg/lib/operation/template/local/manifest/create/operation.go
+++ b/pkg/lib/operation/template/local/manifest/create/operation.go
@@ -16,7 +16,7 @@ type dependencies interface {
 
 func Run(ctx context.Context, fs filesystem.Fs, d dependencies) (m *template.Manifest, err error) {
 	ctx, span := d.Telemetry().Tracer().Start(ctx, "keboola.go.operation.template.local.manifest.create")
-	defer telemetry.EndSpan(span, &err)
+	defer span.End(&err)
 
 	// Create
 	templateManifest := template.NewManifest()

--- a/pkg/lib/operation/template/local/manifest/load/operation.go
+++ b/pkg/lib/operation/template/local/manifest/load/operation.go
@@ -16,7 +16,7 @@ type dependencies interface {
 
 func Run(ctx context.Context, fs filesystem.Fs, d dependencies) (m *template.ManifestFile, err error) {
 	ctx, span := d.Telemetry().Tracer().Start(ctx, "keboola.go.operation.template.local.manifest.load")
-	defer telemetry.EndSpan(span, &err)
+	defer span.End(&err)
 
 	logger := d.Logger()
 

--- a/pkg/lib/operation/template/local/manifest/save/operation.go
+++ b/pkg/lib/operation/template/local/manifest/save/operation.go
@@ -16,7 +16,7 @@ type Dependencies interface {
 
 func Run(ctx context.Context, m *template.Manifest, fs filesystem.Fs, d Dependencies) (changed bool, err error) {
 	ctx, span := d.Telemetry().Tracer().Start(ctx, "keboola.go.operation.template.local.manifest.save")
-	defer telemetry.EndSpan(span, &err)
+	defer span.End(&err)
 
 	// Save if manifest is changed
 	if m.IsChanged() {

--- a/pkg/lib/operation/template/local/repository/describe/operation.go
+++ b/pkg/lib/operation/template/local/repository/describe/operation.go
@@ -17,7 +17,7 @@ type dependencies interface {
 
 func Run(ctx context.Context, tmpl *template.Template, d dependencies) (err error) {
 	ctx, span := d.Telemetry().Tracer().Start(ctx, "keboola.go.operation.template.local.repository.describe")
-	defer telemetry.EndSpan(span, &err)
+	defer span.End(&err)
 
 	w := d.Logger().InfoWriter()
 

--- a/pkg/lib/operation/template/local/repository/init/operation.go
+++ b/pkg/lib/operation/template/local/repository/init/operation.go
@@ -18,7 +18,7 @@ type dependencies interface {
 
 func Run(ctx context.Context, d dependencies) (err error) {
 	ctx, span := d.Telemetry().Tracer().Start(ctx, "keboola.go.operation.template.local.repository.init")
-	defer telemetry.EndSpan(span, &err)
+	defer span.End(&err)
 
 	logger := d.Logger()
 

--- a/pkg/lib/operation/template/local/repository/list/operation.go
+++ b/pkg/lib/operation/template/local/repository/list/operation.go
@@ -15,7 +15,7 @@ type dependencies interface {
 
 func Run(ctx context.Context, repo *repository.Repository, d dependencies) (err error) {
 	ctx, span := d.Telemetry().Tracer().Start(ctx, "keboola.go.operation.template.local.repository.list")
-	defer telemetry.EndSpan(span, &err)
+	defer span.End(&err)
 
 	w := d.Logger().InfoWriter()
 

--- a/pkg/lib/operation/template/local/repository/manifest/create/operation.go
+++ b/pkg/lib/operation/template/local/repository/manifest/create/operation.go
@@ -16,7 +16,7 @@ type dependencies interface {
 
 func Run(ctx context.Context, emptyDir filesystem.Fs, d dependencies) (m *manifest.Manifest, err error) {
 	ctx, span := d.Telemetry().Tracer().Start(ctx, "keboola.go.operation.template.local.repository.manifest.create")
-	defer telemetry.EndSpan(span, &err)
+	defer span.End(&err)
 
 	logger := d.Logger()
 

--- a/pkg/lib/operation/template/local/repository/manifest/load/operation.go
+++ b/pkg/lib/operation/template/local/repository/manifest/load/operation.go
@@ -16,7 +16,7 @@ type dependencies interface {
 
 func Run(ctx context.Context, fs filesystem.Fs, d dependencies) (m *repositoryManifest.Manifest, err error) {
 	ctx, span := d.Telemetry().Tracer().Start(ctx, "keboola.go.operation.template.local.repository.manifest.load")
-	defer telemetry.EndSpan(span, &err)
+	defer span.End(&err)
 
 	logger := d.Logger()
 

--- a/pkg/lib/operation/template/local/repository/manifest/save/operation.go
+++ b/pkg/lib/operation/template/local/repository/manifest/save/operation.go
@@ -16,7 +16,7 @@ type Dependencies interface {
 
 func Run(ctx context.Context, m *repositoryManifest.Manifest, fs filesystem.Fs, d Dependencies) (changed bool, err error) {
 	ctx, span := d.Telemetry().Tracer().Start(ctx, "keboola.go.operation.template.local.repository.manifest.load")
-	defer telemetry.EndSpan(span, &err)
+	defer span.End(&err)
 
 	// Save if manifest has been changed
 	if m.IsChanged() {

--- a/pkg/lib/operation/template/local/test/run/operation.go
+++ b/pkg/lib/operation/template/local/test/run/operation.go
@@ -38,7 +38,7 @@ type dependencies interface {
 
 func Run(ctx context.Context, tmpl *template.Template, o Options, d dependencies) (err error) {
 	ctx, span := d.Telemetry().Tracer().Start(ctx, "keboola.go.operation.template.test.run")
-	defer telemetry.EndSpan(span, &err)
+	defer span.End(&err)
 
 	tempDir, err := os.MkdirTemp("", "kac-test-template-") //nolint:forbidigo
 	if err != nil {

--- a/pkg/lib/operation/template/repository/load/operation.go
+++ b/pkg/lib/operation/template/repository/load/operation.go
@@ -42,7 +42,7 @@ func OnlyForTemplate(ref model.TemplateRef) Option {
 
 func Run(ctx context.Context, d dependencies, ref model.TemplateRepository, opts ...Option) (repo *repository.Repository, err error) {
 	ctx, span := d.Telemetry().Tracer().Start(ctx, "keboola.go.operation.template.repository.load")
-	defer telemetry.EndSpan(span, &err)
+	defer span.End(&err)
 
 	// Create config and apply options
 	cnf := config{}

--- a/pkg/lib/operation/template/sync/diff/create/operation.go
+++ b/pkg/lib/operation/template/sync/diff/create/operation.go
@@ -18,7 +18,7 @@ type dependencies interface {
 
 func Run(ctx context.Context, o Options, d dependencies) (results *diff.Results, err error) {
 	ctx, span := d.Telemetry().Tracer().Start(ctx, "keboola.go.operation.template.sync.diff.create")
-	defer telemetry.EndSpan(span, &err)
+	defer span.End(&err)
 
 	differ := diff.NewDiffer(o.Objects)
 	results, err = differ.Diff()

--- a/pkg/lib/operation/template/sync/pull/operation.go
+++ b/pkg/lib/operation/template/sync/pull/operation.go
@@ -36,7 +36,7 @@ func LoadStateOptions() loadState.Options {
 
 func Run(ctx context.Context, tmpl *template.Template, o Options, d dependencies) (err error) {
 	ctx, span := d.Telemetry().Tracer().Start(ctx, "keboola.go.operation.template.sync.pull")
-	defer telemetry.EndSpan(span, &err)
+	defer span.End(&err)
 
 	logger := d.Logger()
 

--- a/pkg/lib/operation/version/check/operation.go
+++ b/pkg/lib/operation/version/check/operation.go
@@ -18,7 +18,7 @@ type dependencies interface {
 
 func Run(ctx context.Context, d dependencies) (err error) {
 	ctx, span := d.Telemetry().Tracer().Start(ctx, "keboola.go.operation.version.check")
-	defer telemetry.EndSpan(span, &err)
+	defer span.End(&err)
 
 	return version.
 		NewGitHubChecker(ctx, d.Logger(), d.Envs()).


### PR DESCRIPTION
Part of: https://keboola.atlassian.net/browse/PSGO-207

- Removed deprecated utils from the `telemetry` pkg.
- `telemetry.EndSpan` has been replaced by the `span.End` method.