### PR TITLE
Add metrics for background tasks

### DIFF
--- a/cmd/buffer-api/main.go
+++ b/cmd/buffer-api/main.go
@@ -82,7 +82,7 @@ func run() error {
 	}
 
 	// Setup telemetry
-	tel, err := telemetry.NewTelemetry(
+	tel, err := telemetry.New(
 		func() (trace.TracerProvider, error) {
 			tracerProvider := ddotel.NewTracerProvider(
 				tracer.WithLogger(telemetry.NewDDLogger(logger)),

--- a/cmd/buffer-worker/main.go
+++ b/cmd/buffer-worker/main.go
@@ -70,7 +70,7 @@ func run() error {
 	}
 
 	// Setup telemetry
-	tel, err := telemetry.NewTelemetry(
+	tel, err := telemetry.New(
 		func() (trace.TracerProvider, error) {
 			tracerProvider := ddotel.NewTracerProvider(
 				tracer.WithLogger(telemetry.NewDDLogger(logger)),

--- a/cmd/templates-api/main.go
+++ b/cmd/templates-api/main.go
@@ -81,7 +81,7 @@ func run() error {
 	}
 
 	// Setup telemetry
-	tel, err := telemetry.NewTelemetry(
+	tel, err := telemetry.New(
 		func() (trace.TracerProvider, error) {
 			tracerProvider := ddotel.NewTracerProvider(
 				tracer.WithLogger(telemetry.NewDDLogger(logger)),

--- a/internal/pkg/service/buffer/store/store_test.go
+++ b/internal/pkg/service/buffer/store/store_test.go
@@ -18,5 +18,5 @@ func newStoreForTest(t *testing.T) *Store {
 	now, _ := time.Parse(time.RFC3339, "2010-01-01T01:01:01+07:00")
 	clk := clock.NewMock()
 	clk.Set(now)
-	return newFrom(clk, log.NewNopLogger(), telemetry.NewNopTelemetry(), etcdhelper.ClientForTest(t), schema.New(validator.New().Validate))
+	return newFrom(clk, log.NewNopLogger(), telemetry.NewNop(), etcdhelper.ClientForTest(t), schema.New(validator.New().Validate))
 }

--- a/internal/pkg/service/cli/dependencies/base.go
+++ b/internal/pkg/service/cli/dependencies/base.go
@@ -34,7 +34,7 @@ type dbtProjectValue struct {
 
 func newBaseDeps(commandCtx context.Context, envs env.Provider, logger log.Logger, httpClient client.Client, fs filesystem.Fs, dialogs *dialog.Dialogs, opts *options.Options) *base {
 	return &base{
-		Base:       dependencies.NewBaseDeps(envs, logger, telemetry.NewNopTelemetry(), httpClient),
+		Base:       dependencies.NewBaseDeps(envs, logger, telemetry.NewNop(), httpClient),
 		commandCtx: commandCtx,
 		fs:         fs,
 		fsInfo:     FsInfo{fs: fs},

--- a/internal/pkg/service/common/dependencies/public_test.go
+++ b/internal/pkg/service/common/dependencies/public_test.go
@@ -16,7 +16,7 @@ import (
 func TestNewPublicDeps_LazyLoadComponents(t *testing.T) {
 	t.Parallel()
 	httpClient := httpclient.New()
-	baseDeps := newBaseDeps(env.Empty(), log.NewNopLogger(), telemetry.NewNopTelemetry(), clock.New(), httpClient)
+	baseDeps := newBaseDeps(env.Empty(), log.NewNopLogger(), telemetry.NewNop(), clock.New(), httpClient)
 
 	// Create public deps without loading components.
 	deps, err := newPublicDeps(context.Background(), baseDeps, "https://connection.keboola.com")

--- a/internal/pkg/service/common/httpserver/middleware/otel_test.go
+++ b/internal/pkg/service/common/httpserver/middleware/otel_test.go
@@ -77,7 +77,15 @@ func TestOpenTelemetryMiddleware(t *testing.T) {
 	assert.Equal(t, "OK", rec.Body.String())
 
 	// Assert
-	tel.AssertSpans(t, expectedSpans(tel))
+	tel.AssertSpans(t, expectedSpans(tel), telemetry.WithAttributeMapper(func(attr attribute.KeyValue) attribute.KeyValue {
+		if attr.Key == "http.request_id" && len(attr.Value.AsString()) > 0 {
+			return attribute.String(string(attr.Key), "<dynamic>")
+		}
+		if attr.Key == "http.response.header.x-request-id" && len(attr.Value.AsString()) > 0 {
+			return attribute.String(string(attr.Key), "<dynamic>")
+		}
+		return attr
+	}))
 	tel.AssertMetrics(t, expectedMetrics())
 }
 

--- a/internal/pkg/service/common/task/cleanup_test.go
+++ b/internal/pkg/service/common/task/cleanup_test.go
@@ -13,6 +13,7 @@ import (
 	"github.com/keboola/keboola-as-code/internal/pkg/service/common/etcdop"
 	"github.com/keboola/keboola-as-code/internal/pkg/service/common/task"
 	"github.com/keboola/keboola-as-code/internal/pkg/service/common/utctime"
+	"github.com/keboola/keboola-as-code/internal/pkg/telemetry"
 	"github.com/keboola/keboola-as-code/internal/pkg/utils/errors"
 	"github.com/keboola/keboola-as-code/internal/pkg/utils/etcdhelper"
 	"github.com/keboola/keboola-as-code/internal/pkg/utils/ioutil"
@@ -27,7 +28,7 @@ func TestCleanup(t *testing.T) {
 	etcdNamespace := "unit-" + t.Name() + "-" + idgenerator.Random(8)
 	logs := ioutil.NewAtomicWriter()
 	client := etcdhelper.ClientForTestWithNamespace(t, etcdNamespace)
-	node, d := createNode(t, etcdNamespace, logs, "node1")
+	node, d := createNode(t, etcdNamespace, logs, telemetry.NewForTest(t), "node1")
 	taskPrefix := etcdop.NewTypedPrefix[task.Task](task.DefaultTaskEtcdPrefix, d.EtcdSerde())
 
 	// Add task without a finishedAt timestamp but too old - will be deleted

--- a/internal/pkg/service/common/task/node_test.go
+++ b/internal/pkg/service/common/task/node_test.go
@@ -10,12 +10,19 @@ import (
 	"github.com/keboola/go-utils/pkg/wildcards"
 	"github.com/stretchr/testify/assert"
 	etcd "go.etcd.io/etcd/client/v3"
+	"go.opentelemetry.io/otel/attribute"
+	"go.opentelemetry.io/otel/codes"
+	"go.opentelemetry.io/otel/sdk/metric/metricdata"
+	tracesdk "go.opentelemetry.io/otel/sdk/trace"
+	"go.opentelemetry.io/otel/sdk/trace/tracetest"
+	"go.opentelemetry.io/otel/trace"
 
 	"github.com/keboola/keboola-as-code/internal/pkg/idgenerator"
 	"github.com/keboola/keboola-as-code/internal/pkg/log"
 	bufferDependencies "github.com/keboola/keboola-as-code/internal/pkg/service/buffer/dependencies"
 	"github.com/keboola/keboola-as-code/internal/pkg/service/common/dependencies"
 	"github.com/keboola/keboola-as-code/internal/pkg/service/common/task"
+	"github.com/keboola/keboola-as-code/internal/pkg/telemetry"
 	"github.com/keboola/keboola-as-code/internal/pkg/utils/errors"
 	"github.com/keboola/keboola-as-code/internal/pkg/utils/etcdhelper"
 	"github.com/keboola/keboola-as-code/internal/pkg/utils/ioutil"
@@ -38,11 +45,13 @@ func TestSuccessfulTask(t *testing.T) {
 	etcdNamespace := "unit-" + t.Name() + "-" + idgenerator.Random(8)
 	client := etcdhelper.ClientForTestWithNamespace(t, etcdNamespace)
 	logs := ioutil.NewAtomicWriter()
+	tel := telemetry.NewForTest(t)
 
 	// Create nodes
-	node1, _ := createNode(t, etcdNamespace, logs, "node1")
-	node2, _ := createNode(t, etcdNamespace, logs, "node2")
+	node1, _ := createNode(t, etcdNamespace, logs, tel, "node1")
+	node2, _ := createNode(t, etcdNamespace, logs, tel, "node2")
 	logs.Truncate()
+	tel.Reset()
 
 	// Start a task
 	taskWork := make(chan struct{})
@@ -197,6 +206,86 @@ task/123/my-receiver/my-export/some.task/%s
 [node2][task][123/my-receiver/my-export/some.task/%s]INFO  task succeeded (%s): some result (2)
 [node2][task][123/my-receiver/my-export/some.task/%s]DEBUG  lock released "runtime/lock/task/my-lock"
 `, logs.String())
+
+	// Check spans
+	tel.AssertSpans(t,
+		tracetest.SpanStubs{
+			{
+				Name:     "keboola.go.buffer.task.some.task",
+				SpanKind: trace.SpanKindInternal,
+				SpanContext: trace.NewSpanContext(trace.SpanContextConfig{
+					TraceID:    tel.TraceID(1),
+					SpanID:     tel.SpanID(1),
+					TraceFlags: trace.FlagsSampled,
+				}),
+				Status: tracesdk.Status{Code: codes.Ok},
+				Attributes: []attribute.KeyValue{
+					attribute.String("project_id", "123"),
+					attribute.String("task_id", "<dynamic>"),
+					attribute.String("task_type", "some.task"),
+					attribute.String("lock", "<dynamic>"),
+					attribute.String("node", "node1"),
+					attribute.String("created_at", "<dynamic>"),
+					attribute.String("duration_sec", "<dynamic>"),
+					attribute.String("finished_at", "<dynamic>"),
+					attribute.Bool("is_success", true),
+					attribute.String("result_outputs.key", "value"),
+				},
+			},
+			{
+				Name:     "keboola.go.buffer.task.some.task",
+				SpanKind: trace.SpanKindInternal,
+				SpanContext: trace.NewSpanContext(trace.SpanContextConfig{
+					TraceID:    tel.TraceID(2),
+					SpanID:     tel.SpanID(2),
+					TraceFlags: trace.FlagsSampled,
+				}),
+				Status: tracesdk.Status{Code: codes.Ok},
+				Attributes: []attribute.KeyValue{
+					attribute.String("project_id", "123"),
+					attribute.String("task_id", "<dynamic>"),
+					attribute.String("task_type", "some.task"),
+					attribute.String("lock", "<dynamic>"),
+					attribute.String("node", "node2"),
+					attribute.String("created_at", "<dynamic>"),
+					attribute.String("duration_sec", "<dynamic>"),
+					attribute.String("finished_at", "<dynamic>"),
+					attribute.Bool("is_success", true),
+				},
+			},
+		},
+		telemetry.WithAttributeMapper(func(attr attribute.KeyValue) attribute.KeyValue {
+			switch attr.Key {
+			case "task_id", "lock", "created_at", "duration_sec", "finished_at":
+				return attribute.String(string(attr.Key), "<dynamic>")
+			}
+			return attr
+		}),
+	)
+
+	// Check metrics
+	histBounds := []float64{0, 5, 10, 25, 50, 75, 100, 250, 500, 750, 1000, 2500, 5000, 7500, 10000} // ms
+	tel.AssertMetrics(t, []metricdata.Metrics{
+		{
+			Name:        "keboola.go.task.duration",
+			Description: "Background task duration.",
+			Unit:        "ms",
+			Data: metricdata.Histogram[float64]{
+				Temporality: 1,
+				DataPoints: []metricdata.HistogramDataPoint[float64]{
+					{
+						Count:  2,
+						Bounds: histBounds,
+						Attributes: attribute.NewSet(
+							attribute.String("task_type", "some.task"),
+							attribute.Bool("is_success", true),
+							attribute.String("error_type", ""),
+						),
+					},
+				},
+			},
+		},
+	})
 }
 
 func TestFailedTask(t *testing.T) {
@@ -214,11 +303,13 @@ func TestFailedTask(t *testing.T) {
 	etcdNamespace := "unit-" + t.Name() + "-" + idgenerator.Random(8)
 	client := etcdhelper.ClientForTestWithNamespace(t, etcdNamespace)
 	logs := ioutil.NewAtomicWriter()
+	tel := telemetry.NewForTest(t)
 
 	// Create nodes
-	node1, _ := createNode(t, etcdNamespace, logs, "node1")
-	node2, _ := createNode(t, etcdNamespace, logs, "node2")
+	node1, _ := createNode(t, etcdNamespace, logs, tel, "node1")
+	node2, _ := createNode(t, etcdNamespace, logs, tel, "node2")
 	logs.Truncate()
+	tel.Reset()
 
 	// Start a task
 	taskWork := make(chan struct{})
@@ -373,6 +464,108 @@ task/123/my-receiver/my-export/some.task/%s
 [node2][task][123/my-receiver/my-export/some.task/%s]WARN  task failed (%s): some error (2) [%s]
 [node2][task][123/my-receiver/my-export/some.task/%s]DEBUG  lock released "runtime/lock/task/my-lock"
 `, logs.String())
+
+	// Check spans
+	tel.AssertSpans(t,
+		tracetest.SpanStubs{
+			{
+				Name:     "keboola.go.buffer.task.some.task",
+				SpanKind: trace.SpanKindInternal,
+				SpanContext: trace.NewSpanContext(trace.SpanContextConfig{
+					TraceID:    tel.TraceID(1),
+					SpanID:     tel.SpanID(1),
+					TraceFlags: trace.FlagsSampled,
+				}),
+				Status: tracesdk.Status{Code: codes.Error, Description: "some error (1)"},
+				Attributes: []attribute.KeyValue{
+					attribute.String("project_id", "123"),
+					attribute.String("task_id", "<dynamic>"),
+					attribute.String("task_type", "some.task"),
+					attribute.String("lock", "<dynamic>"),
+					attribute.String("node", "node1"),
+					attribute.String("created_at", "<dynamic>"),
+					attribute.String("duration_sec", "<dynamic>"),
+					attribute.String("finished_at", "<dynamic>"),
+					attribute.Bool("is_success", false),
+					attribute.String("error", "some error (1)"),
+					attribute.String("error_type", "other"),
+					attribute.String("result_outputs.key", "value"),
+				},
+				Events: []tracesdk.Event{
+					{
+						Name: "exception",
+						Attributes: []attribute.KeyValue{
+							attribute.String("exception.type", "*errors.withStack"),
+							attribute.String("exception.message", "some error (1)"),
+						},
+					},
+				},
+			},
+			{
+				Name:     "keboola.go.buffer.task.some.task",
+				SpanKind: trace.SpanKindInternal,
+				SpanContext: trace.NewSpanContext(trace.SpanContextConfig{
+					TraceID:    tel.TraceID(2),
+					SpanID:     tel.SpanID(2),
+					TraceFlags: trace.FlagsSampled,
+				}),
+				Status: tracesdk.Status{Code: codes.Error, Description: "some error (2)"},
+				Attributes: []attribute.KeyValue{
+					attribute.String("project_id", "123"),
+					attribute.String("task_id", "<dynamic>"),
+					attribute.String("task_type", "some.task"),
+					attribute.String("lock", "<dynamic>"),
+					attribute.String("node", "node2"),
+					attribute.String("created_at", "<dynamic>"),
+					attribute.String("duration_sec", "<dynamic>"),
+					attribute.String("finished_at", "<dynamic>"),
+					attribute.Bool("is_success", false),
+					attribute.String("error", "some error (2)"),
+					attribute.String("error_type", "other"),
+				},
+				Events: []tracesdk.Event{
+					{
+						Name: "exception",
+						Attributes: []attribute.KeyValue{
+							attribute.String("exception.type", "*errors.withStack"),
+							attribute.String("exception.message", "some error (2)"),
+						},
+					},
+				},
+			},
+		},
+		telemetry.WithAttributeMapper(func(attr attribute.KeyValue) attribute.KeyValue {
+			switch attr.Key {
+			case "task_id", "lock", "created_at", "duration_sec", "finished_at":
+				return attribute.String(string(attr.Key), "<dynamic>")
+			}
+			return attr
+		}),
+	)
+
+	// Check metrics
+	histBounds := []float64{0, 5, 10, 25, 50, 75, 100, 250, 500, 750, 1000, 2500, 5000, 7500, 10000} // ms
+	tel.AssertMetrics(t, []metricdata.Metrics{
+		{
+			Name:        "keboola.go.task.duration",
+			Description: "Background task duration.",
+			Unit:        "ms",
+			Data: metricdata.Histogram[float64]{
+				Temporality: 1,
+				DataPoints: []metricdata.HistogramDataPoint[float64]{
+					{
+						Count:  2,
+						Bounds: histBounds,
+						Attributes: attribute.NewSet(
+							attribute.String("task_type", "some.task"),
+							attribute.Bool("is_success", false),
+							attribute.String("error_type", "other"),
+						),
+					},
+				},
+			},
+		},
+	})
 }
 
 func TestWorkerNodeShutdownDuringTask(t *testing.T) {
@@ -391,9 +584,10 @@ func TestWorkerNodeShutdownDuringTask(t *testing.T) {
 	etcdNamespace := "unit-" + t.Name() + "-" + idgenerator.Random(8)
 	client := etcdhelper.ClientForTestWithNamespace(t, etcdNamespace)
 	logs := ioutil.NewAtomicWriter()
+	tel := telemetry.NewForTest(t)
 
 	// Create node
-	node1, d := createNode(t, etcdNamespace, logs, "node1")
+	node1, d := createNode(t, etcdNamespace, logs, tel, "node1")
 	logs.Truncate()
 
 	// Start a task
@@ -472,20 +666,21 @@ task/123/my-receiver/my-export/some.task/%s
 `, logs.String())
 }
 
-func createNode(t *testing.T, etcdNamespace string, logs io.Writer, nodeName string) (*task.Node, dependencies.Mocked) {
+func createNode(t *testing.T, etcdNamespace string, logs io.Writer, tel telemetry.ForTest, nodeName string) (*task.Node, dependencies.Mocked) {
 	t.Helper()
-	d := createDeps(t, etcdNamespace, logs, nodeName)
+	d := createDeps(t, etcdNamespace, logs, tel, nodeName)
 	node, err := task.NewNode(d, task.WithSpanNamePrefix("keboola.go.buffer.task"))
 	assert.NoError(t, err)
 	return node, d
 }
 
-func createDeps(t *testing.T, etcdNamespace string, logs io.Writer, nodeName string) bufferDependencies.Mocked {
+func createDeps(t *testing.T, etcdNamespace string, logs io.Writer, tel telemetry.ForTest, nodeName string) bufferDependencies.Mocked {
 	t.Helper()
 	d := bufferDependencies.NewMockedDeps(
 		t,
 		dependencies.WithUniqueID(nodeName),
 		dependencies.WithLoggerPrefix(fmt.Sprintf("[%s]", nodeName)),
+		dependencies.WithTelemetry(tel),
 		dependencies.WithEtcdNamespace(etcdNamespace),
 	)
 	if logs != nil {

--- a/internal/pkg/service/common/task/trace.go
+++ b/internal/pkg/service/common/task/trace.go
@@ -1,0 +1,105 @@
+package task
+
+import (
+	"context"
+	"net"
+	"sort"
+
+	"github.com/spf13/cast"
+	"go.opentelemetry.io/otel/attribute"
+	"go.opentelemetry.io/otel/metric"
+
+	"github.com/keboola/keboola-as-code/internal/pkg/utils/errors"
+)
+
+type meters struct {
+	taskDuration metric.Float64Histogram
+}
+
+func newMeters(meter metric.Meter) *meters {
+	return &meters{
+		taskDuration: histogram(meter, "keboola.go.task.duration", "Background task duration.", "ms"),
+	}
+}
+
+func meterAttrs(task *Task, errType string) []attribute.KeyValue {
+	return []attribute.KeyValue{
+		attribute.String("task_type", task.Type),
+		attribute.Bool("is_success", task.IsSuccessful()),
+		attribute.String("error_type", errType),
+	}
+}
+
+func spanStartAttrs(task *Task) []attribute.KeyValue {
+	return []attribute.KeyValue{
+		attribute.String("project_id", task.ProjectID.String()),
+		attribute.String("task_id", task.TaskID.String()),
+		attribute.String("task_type", task.Type),
+		attribute.String("lock", task.Lock.Key()),
+		attribute.String("node", task.Node),
+		attribute.String("created_at", task.CreatedAt.String()),
+	}
+}
+
+func spanEndAttrs(task *Task, errType string) []attribute.KeyValue {
+	out := []attribute.KeyValue{
+		attribute.Float64("duration_sec", task.Duration.Seconds()),
+		attribute.String("finished_at", task.FinishedAt.String()),
+		attribute.Bool("is_success", task.IsSuccessful()),
+	}
+
+	// Add result/error
+	if task.IsSuccessful() {
+		attribute.String("result", task.Result)
+	} else {
+		out = append(
+			out,
+			attribute.String("error", task.Error),
+			attribute.String("error_type", errType),
+		)
+	}
+
+	// Add task outputs
+	{
+		var attrs []attribute.KeyValue
+		for k, v := range task.Outputs {
+			attrs = append(attrs, attribute.String("result_outputs."+k, cast.ToString(v)))
+		}
+		sort.SliceStable(attrs, func(i, j int) bool {
+			return attrs[i].Key < attrs[j].Key
+		})
+		out = append(out, attrs...)
+	}
+
+	return out
+}
+
+func histogram(meter metric.Meter, name, desc, unit string) metric.Float64Histogram {
+	return mustInstrument(meter.Float64Histogram(name, metric.WithDescription(desc), metric.WithUnit(unit)))
+}
+
+func mustInstrument[T any](instrument T, err error) T {
+	if err != nil {
+		panic(err)
+	}
+	return instrument
+}
+
+func errorType(err error) string {
+	var netErr net.Error
+	errors.As(err, &netErr)
+	switch {
+	case err == nil:
+		return ""
+	case errors.Is(err, context.Canceled):
+		return "context_canceled"
+	case errors.Is(err, context.DeadlineExceeded):
+		return "deadline_exceeded"
+	case netErr != nil && netErr.Timeout():
+		return "net_timeout"
+	case netErr != nil:
+		return "net"
+	default:
+		return "other"
+	}
+}

--- a/internal/pkg/service/common/task/trace_test.go
+++ b/internal/pkg/service/common/task/trace_test.go
@@ -1,0 +1,22 @@
+package task
+
+import (
+	"context"
+	"net"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+
+	"github.com/keboola/keboola-as-code/internal/pkg/utils/errors"
+)
+
+func TestErrorType(t *testing.T) {
+	t.Parallel()
+	assert.Equal(t, "", errorType(nil))
+	assert.Equal(t, "other", errorType(errors.New("some error")))
+	assert.Equal(t, "context_canceled", errorType(errors.Errorf(`some error: %w`, context.Canceled)))
+	assert.Equal(t, "deadline_exceeded", errorType(errors.Errorf(`some error: %w`, context.DeadlineExceeded)))
+	assert.Equal(t, "net", errorType(&net.DNSError{}))
+	assert.Equal(t, "net_timeout", errorType(&net.DNSError{IsTimeout: true}))
+	assert.Equal(t, "other", errorType(errors.New("some error")))
+}

--- a/internal/pkg/telemetry/telemetry.go
+++ b/internal/pkg/telemetry/telemetry.go
@@ -33,12 +33,12 @@ type telemetry struct {
 	meter          metric.Meter
 }
 
-func NewNopTelemetry() Telemetry {
-	tel, _ := NewTelemetry(nil, nil)
+func NewNop() Telemetry {
+	tel, _ := New(nil, nil)
 	return tel
 }
 
-func NewTelemetry(tpFactory func() (trace.TracerProvider, error), mpFactory func() (metric.MeterProvider, error)) (Telemetry, error) {
+func New(tpFactory func() (trace.TracerProvider, error), mpFactory func() (metric.MeterProvider, error)) (Telemetry, error) {
 	var err error
 	var tracerProvider trace.TracerProvider
 	var meterProvider metric.MeterProvider


### PR DESCRIPTION
Part of: https://keboola.atlassian.net/browse/PSGO-207

Changes:
- Added `metrics` for background tasks.
- Added tests for spans and metrics.