### PR TITLE
Calculate apdex metric in Go code

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -48,6 +48,7 @@ require (
 	github.com/spf13/viper v1.15.0
 	github.com/stretchr/testify v1.8.3
 	github.com/umisama/go-regexpcache v0.0.0-20150417035358-2444a542492f
+	github.com/urfave/negroni v1.0.0
 	github.com/writeas/go-strip-markdown v2.0.1+incompatible
 	go.etcd.io/etcd/api/v3 v3.5.9
 	go.etcd.io/etcd/client/v3 v3.5.9

--- a/go.sum
+++ b/go.sum
@@ -2046,6 +2046,8 @@ github.com/urfave/cli v0.0.0-20171014202726-7bc6a0acffa5/go.mod h1:70zkFmudgCuE/
 github.com/urfave/cli v1.20.0/go.mod h1:70zkFmudgCuE/ngEzBv17Jvp/497gISqfk5gWijbERA=
 github.com/urfave/cli v1.22.1/go.mod h1:Gos4lmkARVdJ6EkW0WaNv/tZAAMe9V7XWyB60NtXRu0=
 github.com/urfave/cli v1.22.2/go.mod h1:Gos4lmkARVdJ6EkW0WaNv/tZAAMe9V7XWyB60NtXRu0=
+github.com/urfave/negroni v1.0.0 h1:kIimOitoypq34K7TG7DUaJ9kq/N4Ofuwi1sjz0KipXc=
+github.com/urfave/negroni v1.0.0/go.mod h1:Meg73S6kFm/4PpbYdq35yYWoCZ9mS/YSx+lKnmiohz4=
 github.com/vishvananda/netlink v0.0.0-20181108222139-023a6dafdcdf/go.mod h1:+SR5DhBJrl6ZM7CoCKvpw5BKroDKQ+PJqOg65H/2ktk=
 github.com/vishvananda/netlink v1.1.0/go.mod h1:cTgwzPIzzgDAYoQrMm0EdrjRUBkTqKYppBueQtXaqoE=
 github.com/vishvananda/netlink v1.1.1-0.20201029203352-d40f9887b852/go.mod h1:twkDnbuQxJYemMlGd4JFIcuhgX83tXhKS2B/PRMpOho=

--- a/internal/pkg/service/common/httpserver/middleware/otel_apdex.go
+++ b/internal/pkg/service/common/httpserver/middleware/otel_apdex.go
@@ -1,0 +1,70 @@
+package middleware
+
+import (
+	"context"
+	"fmt"
+	"net/http"
+	"time"
+
+	"go.opentelemetry.io/otel/metric"
+
+	"github.com/keboola/keboola-as-code/internal/pkg/telemetry"
+)
+
+// apdexCounter is a helper to calculate apdex metric and process it by OpenTelemetry.
+
+// Apdex[T] is a value between 0.0-1.0, it is defined by the formula:
+// = (satisfied_requests_count + tolerated_requests_count/2) / total_requests_count
+//
+// Ranges:
+// - Satisfied request:  no server error AND duration < T
+// - Tolerated request:  no server error AND T < duration < 4T
+// - Frustrated request: server error OR duration > 4T
+//
+// As a metric, it is calculated cumulatively, therefore:
+// - Satisfied request  contributes with 1.0 to the total AVG value.
+// - Tolerated request  contributes with 0.5 to the total AVG value.
+// - Frustrated request contributes with 0.0 to the total AVG value.
+type apdexCounter struct {
+	counter    metric.Int64Counter
+	thresholds []*apdexThreshold
+}
+
+type apdexThreshold struct {
+	sum         metric.Float64Counter
+	satisfiedMs float64
+	toleratedMs float64
+}
+
+func newApdexCounter(meter metric.Meter, thresholds []time.Duration) *apdexCounter {
+	out := &apdexCounter{counter: telemetry.MustInstrument(meter.Int64Counter("keboola_go_http_server_apdex_count"))}
+	for _, satisfied := range thresholds {
+		out.thresholds = append(out.thresholds, &apdexThreshold{
+			sum:         telemetry.MustInstrument(meter.Float64Counter(fmt.Sprintf("keboola_go_http_server_apdex_%d_sum", satisfied.Milliseconds()))),
+			satisfiedMs: float64(satisfied.Milliseconds()),
+			toleratedMs: float64(4 * satisfied.Milliseconds()),
+		})
+	}
+	return out
+}
+
+func (c *apdexCounter) Add(ctx context.Context, method string, statusCode int, durationMs float64, opts ...metric.AddOption) {
+	// Ignore fast/no-operation options method
+	if method == http.MethodOptions {
+		return
+	}
+
+	c.counter.Add(ctx, 1, opts...)
+	for _, t := range c.thresholds {
+		var value float64
+		switch {
+		case durationMs <= t.satisfiedMs && statusCode < http.StatusInternalServerError:
+			value = 1
+		case durationMs <= t.toleratedMs && statusCode < http.StatusInternalServerError:
+			value = 0.5
+		default:
+			value = 0
+		}
+		t.sum.Add(ctx, value, opts...)
+	}
+}

--- a/internal/pkg/service/common/httpserver/middleware/otel_apdex_test.go
+++ b/internal/pkg/service/common/httpserver/middleware/otel_apdex_test.go
@@ -1,0 +1,109 @@
+package middleware
+
+import (
+	"context"
+	"net/http"
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/assert"
+	"go.opentelemetry.io/otel/sdk/metric/metricdata"
+
+	"github.com/keboola/keboola-as-code/internal/pkg/telemetry"
+)
+
+type testRequest struct {
+	DurationMs float64
+	StatusCode int
+}
+
+type testCase struct {
+	Name               string
+	Requests           []testRequest
+	ExpectedApdexT500  float64
+	ExpectedApdexT1000 float64
+}
+
+func TestApdex(t *testing.T) {
+	t.Parallel()
+	ctx := context.Background()
+
+	cases := []testCase{
+		{
+			Name:               "server error, apdex=0",
+			Requests:           []testRequest{{DurationMs: 1, StatusCode: 500}, {DurationMs: 1, StatusCode: 503}},
+			ExpectedApdexT500:  0,
+			ExpectedApdexT1000: 0,
+		},
+		{
+			Name:               "client error, satisfied duration",
+			Requests:           []testRequest{{DurationMs: 1, StatusCode: 400}, {DurationMs: 1, StatusCode: 403}},
+			ExpectedApdexT500:  1,
+			ExpectedApdexT1000: 1,
+		},
+		{
+			Name:               "ok, satisfied duration",
+			Requests:           []testRequest{{DurationMs: 1, StatusCode: 200}, {DurationMs: 1, StatusCode: 201}},
+			ExpectedApdexT500:  1,
+			ExpectedApdexT1000: 1,
+		},
+		{
+			Name:               "ok, tolerated/satisfied duration",
+			Requests:           []testRequest{{DurationMs: 700, StatusCode: 200}, {DurationMs: 800, StatusCode: 201}},
+			ExpectedApdexT500:  0.5, // T=500ms < 700ms,800ms < 4T=2000ms --> tolerated range --> apdex=0.5
+			ExpectedApdexT1000: 1,   //           700ms,800ms <  T=1000ms --> satisfied range --> apdex=1
+		},
+		{
+			Name:               "ok, frustrated/tolerated duration",
+			Requests:           []testRequest{{DurationMs: 2400, StatusCode: 200}, {DurationMs: 2500, StatusCode: 201}},
+			ExpectedApdexT500:  0,   // 2400ms,2500ms > 4T=2000ms            --> frustrated range --> apdex=0
+			ExpectedApdexT1000: 0.5, // T=1000ms < 2400ms,2500ms < 4T=4000ms --> tolerated range  --> apdex=0.5
+		},
+		{
+			Name:               "ok, frustrated duration",
+			Requests:           []testRequest{{DurationMs: 10000, StatusCode: 200}, {DurationMs: 11000, StatusCode: 201}},
+			ExpectedApdexT500:  0,
+			ExpectedApdexT1000: 0,
+		},
+		{
+			Name: "mix",
+			Requests: []testRequest{
+				{DurationMs: 10000, StatusCode: 200},
+				{DurationMs: 11000, StatusCode: 201},
+				{DurationMs: 700, StatusCode: 200},
+				{DurationMs: 800, StatusCode: 201},
+				{DurationMs: 1, StatusCode: 400},
+				{DurationMs: 1, StatusCode: 403},
+				{DurationMs: 1, StatusCode: 500},
+				{DurationMs: 1, StatusCode: 503},
+			},
+			ExpectedApdexT500:  0.375, // (satisfied:2 + tolerated:2/2)/all:8
+			ExpectedApdexT1000: 0.500, // (satisfied:4 + tolerated:0/2)/all:8
+		},
+	}
+
+	for _, tc := range cases {
+		tel := telemetry.NewForTest(t)
+		counters := newApdexCounter(tel.MeterProvider().Meter("test"), []time.Duration{
+			500 * time.Millisecond,
+			1000 * time.Millisecond,
+		})
+		for _, req := range tc.Requests {
+			counters.Add(ctx, http.MethodGet, req.StatusCode, req.DurationMs)
+		}
+
+		metrics := tel.Metrics(t)
+		assert.Len(t, metrics, 3)
+		assert.Equal(t, "keboola_go_http_server_apdex_count", metrics[0].Name)
+		assert.Equal(t, "keboola_go_http_server_apdex_500_sum", metrics[1].Name)
+		assert.Equal(t, "keboola_go_http_server_apdex_1000_sum", metrics[2].Name)
+		assert.Len(t, metrics[0].Data.(metricdata.Sum[int64]).DataPoints, 1)
+		assert.Len(t, metrics[1].Data.(metricdata.Sum[float64]).DataPoints, 1)
+		assert.Len(t, metrics[2].Data.(metricdata.Sum[float64]).DataPoints, 1)
+		countData := metrics[0].Data.(metricdata.Sum[int64]).DataPoints[0]
+		t500Data := metrics[1].Data.(metricdata.Sum[float64]).DataPoints[0]
+		t1000Data := metrics[2].Data.(metricdata.Sum[float64]).DataPoints[0]
+		assert.Equal(t, tc.ExpectedApdexT500, t500Data.Value/float64(countData.Value))
+		assert.Equal(t, tc.ExpectedApdexT1000, t1000Data.Value/float64(countData.Value))
+	}
+}

--- a/internal/pkg/service/common/httpserver/middleware/otel_test.go
+++ b/internal/pkg/service/common/httpserver/middleware/otel_test.go
@@ -201,6 +201,10 @@ func expectedMetrics() []metricdata.Metrics {
 		attribute.Int("http.status_code", http.StatusInternalServerError),
 		attribute.String("endpoint.name", "my-endpoint"),
 	)
+	apdexAttrs := attribute.NewSet(
+		attribute.String("http.route", "/api/item/:id/:secret1"),
+		attribute.String("endpoint.name", "my-endpoint"),
+	)
 	return []metricdata.Metrics{
 		{
 			Name:        "keboola.go.http.server.request_content_length",
@@ -236,6 +240,53 @@ func expectedMetrics() []metricdata.Metrics {
 						Bounds:     []float64{0, 5, 10, 25, 50, 75, 100, 250, 500, 750, 1000, 2500, 5000, 7500, 10000},
 						Attributes: attrs,
 					},
+				},
+			},
+		},
+		{
+			Name:        "keboola_go_http_server_apdex_count",
+			Description: "",
+			Data: metricdata.Sum[int64]{
+				Temporality: 1,
+				IsMonotonic: true,
+				DataPoints: []metricdata.DataPoint[int64]{
+					{Value: 1, Attributes: apdexAttrs},
+				},
+			},
+		},
+		{
+			Name:        "keboola_go_http_server_apdex_500_sum",
+			Description: "",
+			Data: metricdata.Sum[float64]{
+				Temporality: 1,
+				IsMonotonic: true,
+				DataPoints: []metricdata.DataPoint[float64]{
+					// status code = 500, apdex=0
+					{Value: 0, Attributes: apdexAttrs},
+				},
+			},
+		},
+		{
+			Name:        "keboola_go_http_server_apdex_1000_sum",
+			Description: "",
+			Data: metricdata.Sum[float64]{
+				Temporality: 1,
+				IsMonotonic: true,
+				DataPoints: []metricdata.DataPoint[float64]{
+					// status code = 500, apdex=0
+					{Value: 0, Attributes: apdexAttrs},
+				},
+			},
+		},
+		{
+			Name:        "keboola_go_http_server_apdex_2000_sum",
+			Description: "",
+			Data: metricdata.Sum[float64]{
+				Temporality: 1,
+				IsMonotonic: true,
+				DataPoints: []metricdata.DataPoint[float64]{
+					// status code = 500, apdex=0
+					{Value: 0, Attributes: apdexAttrs},
 				},
 			},
 		},

--- a/internal/pkg/telemetry/meter.go
+++ b/internal/pkg/telemetry/meter.go
@@ -16,20 +16,20 @@ type meter struct {
 
 func (m *meter) Counter(name, desc, unit string, opts ...metric.Int64CounterOption) metric.Int64Counter {
 	opts = append(opts, metric.WithDescription(desc), metric.WithUnit(unit))
-	return mustInstrument(m.meter.Int64Counter(name, opts...))
+	return MustInstrument(m.meter.Int64Counter(name, opts...))
 }
 
 func (m *meter) UpDownCounter(name, desc, unit string, opts ...metric.Int64UpDownCounterOption) metric.Int64UpDownCounter {
 	opts = append(opts, metric.WithDescription(desc), metric.WithUnit(unit))
-	return mustInstrument(m.meter.Int64UpDownCounter(name, opts...))
+	return MustInstrument(m.meter.Int64UpDownCounter(name, opts...))
 }
 
 func (m *meter) Histogram(name, desc, unit string, opts ...metric.Float64HistogramOption) metric.Float64Histogram {
 	opts = append(opts, metric.WithDescription(desc), metric.WithUnit(unit))
-	return mustInstrument(m.meter.Float64Histogram(name, opts...))
+	return MustInstrument(m.meter.Float64Histogram(name, opts...))
 }
 
-func mustInstrument[T any](instrument T, err error) T {
+func MustInstrument[T any](instrument T, err error) T {
 	if err != nil {
 		panic(err)
 	}


### PR DESCRIPTION
Jira: https://keboola.atlassian.net/browse/PSGO-209

Narazil som este na jeden problem pri alertoch:
- Myslel som si, ze co viem zobrazit ako graf, tak na to viem aj nastavit alert.
- Ale v DD to tak uplne nie je, ... `apdex` som pocital s existujuciach metrik cez `Add Formula`.
- Pre graf to stacilo, ale prekvapenie je v aletroch, kde nie je moznost `Average`.
- A `apdex` je hodnota `0.0-1.0` (ratio), ako `rollup` (last 5 minutes) nedava zmysel `sum`, zmysel dava iba `min` lebo `avg`.
![image](https://github.com/keboola/keboola-as-code/assets/19371734/caee1f57-8324-4f99-adcb-9d2dbe443c85)

Riesenie:
- Preto som presunul vypocet apdex do Go kodu, ako nove metriky.
- Rovno som definoval 3 metriky: **T=**`500ms`(4T=`2000ms`), `1000ms`(4T=`4000ms`),`2000ms`(4T=`8000ms`).


--------------

Update: 

Medzicasom som zistil, ze sa `sum` na obrazku sa aplikuje na `A` a `B` a nie na `Formula`, ked je pouzite `as_count` :man_facepalming: . Tyka sa to iba monitoringu. Takze sa to tam vypocitat da. Skoda, ze tam  k tomu nedaju aspon link na dokumentaciu.

https://docs.datadoghq.com/monitors/guide/as-count-in-monitor-evaluations/
![image](https://github.com/keboola/keboola-as-code/assets/19371734/c1eceed4-167f-4583-8d6b-bedc8182b66e)

... ale uz to tu pocitanie v kode necham, da sa tak jednoduchsie skontrolovat, ze sa to pocita spravne, teraz to vyzera takto:
![image](https://github.com/keboola/keboola-as-code/assets/19371734/6f0a1c32-c5b6-4a26-8a6f-5e826e05e71b)

----------------

BTW: Suffix k nazvu metriky `.count` si pridava DataDog sam, vyzera to blbo, ale neriesim.
