### PR TITLE
Use span name "keboola.go.task" for all background tasks

### DIFF
--- a/docs/telemetry.md
+++ b/docs/telemetry.md
@@ -100,3 +100,19 @@ the [pkg/client/trace/otel](https://github.com/keboola/go-client/tree/main/pkg/c
 | `keboola_go_http_request_duration`              | Duration of a low-level HTTP request. Each redirect and retry is tracked separately.                   |
 | `keboola_go_http_request_content_length.count`  | Request content length.                                                                                |
 | `keboola_go_http_response_content_length.count` | Response content length.                                                                               |
+
+## Background Tasks
+
+### Spans
+
+| Span                     | Description                                                               |
+|--------------------------|---------------------------------------------------------------------------|
+| `keboola.go.task`        | A background task. The `resource.name` attribute is set to the task type. |
+
+
+### Metrics
+
+| Span                       | Description                         |
+|----------------------------|-------------------------------------|
+| `keboola_go_task_running`  | Number of running background tasks. |
+| `keboola_go_task_duration` | Duration of background tasks.       |

--- a/internal/pkg/service/buffer/api/dependencies/dependencies.go
+++ b/internal/pkg/service/buffer/api/dependencies/dependencies.go
@@ -34,7 +34,6 @@ import (
 	"github.com/keboola/keboola-as-code/internal/pkg/env"
 	"github.com/keboola/keboola-as-code/internal/pkg/log"
 	"github.com/keboola/keboola-as-code/internal/pkg/service/buffer/api/config"
-	bufferConfig "github.com/keboola/keboola-as-code/internal/pkg/service/buffer/config"
 	serviceDependencies "github.com/keboola/keboola-as-code/internal/pkg/service/buffer/dependencies"
 	"github.com/keboola/keboola-as-code/internal/pkg/service/buffer/statistics"
 	"github.com/keboola/keboola-as-code/internal/pkg/service/buffer/storage/file"
@@ -177,7 +176,7 @@ func NewDepsForProjectRequest(publicDeps ForPublicRequest, ctx context.Context, 
 	d.tokenManager = token.NewManager(d)
 	d.tableManager = table.NewManager(d.KeboolaProjectAPI())
 	d.fileManager = file.NewManager(d.Clock(), d.KeboolaProjectAPI(), nil)
-	d.taskNode, err = task.NewNode(d, task.WithSpanNamePrefix(bufferConfig.SpanNamePrefix))
+	d.taskNode, err = task.NewNode(d)
 	if err != nil {
 		return nil, err
 	}

--- a/internal/pkg/service/buffer/config/config.go
+++ b/internal/pkg/service/buffer/config/config.go
@@ -10,8 +10,7 @@ import (
 )
 
 const (
-	EnvPrefix      = "BUFFER_API_"
-	SpanNamePrefix = "keboola.go.buffer.task"
+	EnvPrefix = "BUFFER_API_"
 )
 
 // Config is a common config of the Buffer Service.

--- a/internal/pkg/service/buffer/dependencies/mocked.go
+++ b/internal/pkg/service/buffer/dependencies/mocked.go
@@ -9,7 +9,6 @@ import (
 	"github.com/stretchr/testify/assert"
 
 	apiConfig "github.com/keboola/keboola-as-code/internal/pkg/service/buffer/api/config"
-	"github.com/keboola/keboola-as-code/internal/pkg/service/buffer/config"
 	"github.com/keboola/keboola-as-code/internal/pkg/service/buffer/event"
 	"github.com/keboola/keboola-as-code/internal/pkg/service/buffer/statistics"
 	"github.com/keboola/keboola-as-code/internal/pkg/service/buffer/storage/file"
@@ -140,7 +139,7 @@ func (v *mocked) WatcherWorkerNode() *watcher.WorkerNode {
 func (v *mocked) TaskNode() *task.Node {
 	if v.taskWorkerNode == nil {
 		var err error
-		v.taskWorkerNode, err = task.NewNode(v, task.WithSpanNamePrefix(config.SpanNamePrefix))
+		v.taskWorkerNode, err = task.NewNode(v)
 		assert.NoError(v.t, err)
 	}
 	return v.taskWorkerNode

--- a/internal/pkg/service/buffer/worker/dependencies/dependencies.go
+++ b/internal/pkg/service/buffer/worker/dependencies/dependencies.go
@@ -12,7 +12,6 @@ import (
 
 	"github.com/keboola/keboola-as-code/internal/pkg/env"
 	"github.com/keboola/keboola-as-code/internal/pkg/log"
-	bufferConfig "github.com/keboola/keboola-as-code/internal/pkg/service/buffer/config"
 	serviceDependencies "github.com/keboola/keboola-as-code/internal/pkg/service/buffer/dependencies"
 	"github.com/keboola/keboola-as-code/internal/pkg/service/buffer/event"
 	"github.com/keboola/keboola-as-code/internal/pkg/service/buffer/watcher"
@@ -68,7 +67,7 @@ func NewWorkerDeps(ctx context.Context, proc *servicectx.Process, cfg config.Con
 
 	d.watcherNode, err = watcher.NewWorkerNode(d)
 
-	d.taskNode, err = task.NewNode(d, task.WithSpanNamePrefix(bufferConfig.SpanNamePrefix))
+	d.taskNode, err = task.NewNode(d)
 	if err != nil {
 		return nil, err
 	}

--- a/internal/pkg/service/common/task/cleanup.go
+++ b/internal/pkg/service/common/task/cleanup.go
@@ -6,6 +6,7 @@ import (
 
 	etcd "go.etcd.io/etcd/client/v3"
 	"go.opentelemetry.io/otel/attribute"
+	"go.opentelemetry.io/otel/trace"
 
 	"github.com/keboola/keboola-as-code/internal/pkg/service/common/etcdop"
 	"github.com/keboola/keboola-as-code/internal/pkg/service/common/etcdop/iterator"
@@ -58,7 +59,7 @@ func (n *Node) Cleanup() (err error) {
 	}()
 
 	// Setup telemetry
-	ctx, span := n.tracer.Start(ctx, n.config.spanNamePrefix+".cleanup")
+	ctx, span := n.tracer.Start(ctx, spanName, trace.WithAttributes(attribute.String("resource.name", "tasks.cleanup")))
 	defer span.End(&err)
 
 	// Go through tasks and delete old ones

--- a/internal/pkg/service/common/task/config.go
+++ b/internal/pkg/service/common/task/config.go
@@ -14,20 +14,12 @@ const (
 type NodeOption func(c *nodeConfig)
 
 type nodeConfig struct {
-	spanNamePrefix string
 	taskEtcdPrefix string
 	ttlSeconds     int
 }
 
 func defaultNodeConfig() nodeConfig {
 	return nodeConfig{taskEtcdPrefix: DefaultTaskEtcdPrefix, ttlSeconds: DefaultSessionTTL}
-}
-
-// WithSpanNamePrefix defines prefix for tracing spans.
-func WithSpanNamePrefix(p string) NodeOption {
-	return func(c *nodeConfig) {
-		c.spanNamePrefix = p
-	}
 }
 
 // WithTaskEtcdPrefix defines prefix for tasks records in etcd.

--- a/internal/pkg/service/common/task/node.go
+++ b/internal/pkg/service/common/task/node.go
@@ -28,6 +28,7 @@ import (
 
 const (
 	LockEtcdPrefix = etcdop.Prefix("runtime/lock/task")
+	spanName       = "keboola.go.task"
 )
 
 type Fn func(ctx context.Context, logger log.Logger) Result
@@ -205,7 +206,7 @@ func (n *Node) runTask(logger log.Logger, task Task, cfg Config) {
 	}
 
 	// Setup telemetry
-	ctx, span := n.tracer.Start(ctx, n.config.spanNamePrefix+"."+cfg.Type, trace.WithAttributes(spanStartAttrs(&task)...))
+	ctx, span := n.tracer.Start(ctx, spanName, trace.WithAttributes(spanStartAttrs(&task)...))
 	n.meters.running.Add(ctx, 1, metric.WithAttributes(meterStartAttrs(&task)...))
 
 	// Process results in defer to catch panic

--- a/internal/pkg/service/common/task/node_test.go
+++ b/internal/pkg/service/common/task/node_test.go
@@ -211,7 +211,7 @@ task/123/my-receiver/my-export/some.task/%s
 	tel.AssertSpans(t,
 		tracetest.SpanStubs{
 			{
-				Name:     "keboola.go.buffer.task.some.task",
+				Name:     "keboola.go.task",
 				SpanKind: trace.SpanKindInternal,
 				SpanContext: trace.NewSpanContext(trace.SpanContextConfig{
 					TraceID:    tel.TraceID(1),
@@ -220,6 +220,7 @@ task/123/my-receiver/my-export/some.task/%s
 				}),
 				Status: tracesdk.Status{Code: codes.Ok},
 				Attributes: []attribute.KeyValue{
+					attribute.String("resource.name", "some.task"),
 					attribute.String("project_id", "123"),
 					attribute.String("task_id", "<dynamic>"),
 					attribute.String("task_type", "some.task"),
@@ -233,7 +234,7 @@ task/123/my-receiver/my-export/some.task/%s
 				},
 			},
 			{
-				Name:     "keboola.go.buffer.task.some.task",
+				Name:     "keboola.go.task",
 				SpanKind: trace.SpanKindInternal,
 				SpanContext: trace.NewSpanContext(trace.SpanContextConfig{
 					TraceID:    tel.TraceID(2),
@@ -242,6 +243,7 @@ task/123/my-receiver/my-export/some.task/%s
 				}),
 				Status: tracesdk.Status{Code: codes.Ok},
 				Attributes: []attribute.KeyValue{
+					attribute.String("resource.name", "some.task"),
 					attribute.String("project_id", "123"),
 					attribute.String("task_id", "<dynamic>"),
 					attribute.String("task_type", "some.task"),
@@ -487,7 +489,7 @@ task/123/my-receiver/my-export/some.task/%s
 	tel.AssertSpans(t,
 		tracetest.SpanStubs{
 			{
-				Name:     "keboola.go.buffer.task.some.task",
+				Name:     "keboola.go.task",
 				SpanKind: trace.SpanKindInternal,
 				SpanContext: trace.NewSpanContext(trace.SpanContextConfig{
 					TraceID:    tel.TraceID(1),
@@ -496,6 +498,7 @@ task/123/my-receiver/my-export/some.task/%s
 				}),
 				Status: tracesdk.Status{Code: codes.Error, Description: "some error (1) - expected"},
 				Attributes: []attribute.KeyValue{
+					attribute.String("resource.name", "some.task"),
 					attribute.String("project_id", "123"),
 					attribute.String("task_id", "<dynamic>"),
 					attribute.String("task_type", "some.task"),
@@ -521,7 +524,7 @@ task/123/my-receiver/my-export/some.task/%s
 				},
 			},
 			{
-				Name:     "keboola.go.buffer.task.some.task",
+				Name:     "keboola.go.task",
 				SpanKind: trace.SpanKindInternal,
 				SpanContext: trace.NewSpanContext(trace.SpanContextConfig{
 					TraceID:    tel.TraceID(2),
@@ -530,6 +533,7 @@ task/123/my-receiver/my-export/some.task/%s
 				}),
 				Status: tracesdk.Status{Code: codes.Error, Description: "some error (2) - unexpected"},
 				Attributes: []attribute.KeyValue{
+					attribute.String("resource.name", "some.task"),
 					attribute.String("project_id", "123"),
 					attribute.String("task_id", "<dynamic>"),
 					attribute.String("task_type", "some.task"),
@@ -725,7 +729,7 @@ task/123/my-receiver/my-export/some.task/%s
 func createNode(t *testing.T, etcdNamespace string, logs io.Writer, tel telemetry.ForTest, nodeName string) (*task.Node, dependencies.Mocked) {
 	t.Helper()
 	d := createDeps(t, etcdNamespace, logs, tel, nodeName)
-	node, err := task.NewNode(d, task.WithSpanNamePrefix("keboola.go.buffer.task"))
+	node, err := task.NewNode(d)
 	assert.NoError(t, err)
 	return node, d
 }

--- a/internal/pkg/service/common/task/trace.go
+++ b/internal/pkg/service/common/task/trace.go
@@ -39,6 +39,7 @@ func meterEndAttrs(task *Task, r Result) []attribute.KeyValue {
 
 func spanStartAttrs(task *Task) []attribute.KeyValue {
 	return []attribute.KeyValue{
+		attribute.String("resource.name", task.Type),
 		attribute.String("project_id", task.ProjectID.String()),
 		attribute.String("task_id", task.TaskID.String()),
 		attribute.String("task_type", task.Type),

--- a/internal/pkg/service/templates/api/config/config.go
+++ b/internal/pkg/service/templates/api/config/config.go
@@ -14,7 +14,6 @@ import (
 
 const (
 	EnvPrefix              = "TEMPLATES_API_"
-	SpanNamePrefix         = "keboola.go.templates.task"
 	DefaultCleanupInterval = 1 * time.Hour
 )
 

--- a/internal/pkg/service/templates/api/dependencies/mocked.go
+++ b/internal/pkg/service/templates/api/dependencies/mocked.go
@@ -61,7 +61,7 @@ func (v *mocked) Store() *store.Store {
 func (v *mocked) TaskNode() *task.Node {
 	if v.taskNode == nil {
 		var err error
-		v.taskNode, err = task.NewNode(v, task.WithSpanNamePrefix(config.SpanNamePrefix))
+		v.taskNode, err = task.NewNode(v)
 		assert.NoError(v.t, err)
 	}
 	return v.taskNode

--- a/internal/pkg/service/templates/api/dependencies/service.go
+++ b/internal/pkg/service/templates/api/dependencies/service.go
@@ -97,7 +97,7 @@ func NewServiceDeps(
 		schema:     schema.New(validateFn),
 	}
 	serviceDeps.store = store.New(serviceDeps)
-	serviceDeps.taskNode, err = task.NewNode(serviceDeps, task.WithSpanNamePrefix(config.SpanNamePrefix))
+	serviceDeps.taskNode, err = task.NewNode(serviceDeps)
 	if err != nil {
 		return nil, err
 	}


### PR DESCRIPTION
Jira: https://keboola.atlassian.net/browse/PSGO-219

Changes:
- All background tasks generates span with same name `keboola.go.task`.
- So the span can be used as Buffer Worker APM primary operation.
![image](https://github.com/keboola/keboola-as-code/assets/19371734/9f9ef892-1494-4ca0-af6c-2e8479a7d135)
