### PR TITLE
BA: Disable verbose logs - lock/unlock

### DIFF
--- a/internal/pkg/service/buffer/watcher/apinode/revision.go
+++ b/internal/pkg/service/buffer/watcher/apinode/revision.go
@@ -156,7 +156,7 @@ func (s *RevisionSyncer) Lock() UnlockFn {
 	s.revInUse[currentRev]++ // if the map key is missing, zero value is given
 	if usedCount := s.revInUse[currentRev]; usedCount == 1 {
 		// Log the locked revision on the first use
-		s.logger.Infof(`locked revision "%v"`, currentRev)
+		s.logger.Debugf(`locked revision "%v"`, currentRev)
 	}
 	s.lock.Unlock()
 
@@ -172,7 +172,7 @@ func (s *RevisionSyncer) unlockRevision(rev int64) {
 	s.revInUse[rev]--
 	if v := s.revInUse[rev]; v == 0 {
 		delete(s.revInUse, rev)
-		s.logger.Infof(`unlocked revision "%v"`, rev)
+		s.logger.Debugf(`unlocked revision "%v"`, rev)
 	}
 	s.lock.Unlock()
 }

--- a/internal/pkg/service/buffer/watcher/apinode/revision_test.go
+++ b/internal/pkg/service/buffer/watcher/apinode/revision_test.go
@@ -161,12 +161,12 @@ DEBUG  >>> statistics sync
 INFO  reported revision "1"
 DEBUG  >>> statistics sync
 INFO  reported revision "30"
-INFO  locked revision "30"
-INFO  locked revision "50"
-INFO  unlocked revision "30"
+DEBUG  locked revision "30"
+DEBUG  locked revision "50"
+DEBUG  unlocked revision "30"
 DEBUG  >>> statistics sync
 INFO  reported revision "50"
-INFO  unlocked revision "50"
+DEBUG  unlocked revision "50"
 DEBUG  >>> statistics sync
 INFO  reported revision "70"
 [etcd-session]INFO  closing etcd session


### PR DESCRIPTION
Jira: https://keboola.atlassian.net/browse/PSGO-227

Changes:
- Verbose logs triggered by import endpoint `locked/unlocked revision` have been switched from INFO to DEBUG level.