### PR TITLE
Remove last occurrence of Envs() dependency

### DIFF
--- a/internal/pkg/service/cli/cmd/cmd.go
+++ b/internal/pkg/service/cli/cmd/cmd.go
@@ -124,7 +124,8 @@ func NewRootCommand(stdin io.Reader, stdout io.Writer, stderr io.Writer, envs *e
 	flags.StringP("working-dir", "d", "", "use other working directory")
 	flags.StringP("storage-api-token", "t", "", "storage API token from your project")
 	flags.BoolP("verbose", "v", false, "print details")
-	flags.BoolP("verbose-api", "", false, "log each API request and response")
+	flags.Bool("verbose-api", false, "log each API request and response")
+	flags.Bool("version-check", true, "checks if there is a newer version of the CLI")
 
 	// Root command flags
 	root.Flags().SortFlags = true
@@ -158,7 +159,7 @@ func NewRootCommand(stdin io.Reader, stdout io.Writer, stderr io.Writer, envs *e
 		p.Set(dependencies.NewProvider(cmd.Context(), envs, root.logger, root.fs, dialog.New(prompt, root.options), root.options))
 
 		// Check version
-		if err := versionCheck.Run(cmd.Context(), p.BaseDependencies()); err != nil {
+		if err := versionCheck.Run(cmd.Context(), root.options.GetBool("version-check"), p.BaseDependencies()); err != nil {
 			// Ignore error, send to logs
 			root.logger.Debugf(`Version check: %s.`, err.Error())
 		} else {

--- a/internal/pkg/service/cli/cmd/cmd_test.go
+++ b/internal/pkg/service/cli/cmd/cmd_test.go
@@ -102,6 +102,7 @@ func TestCliCmdPersistentFlags(t *testing.T) {
 		"storage-api-token",
 		"verbose",
 		"verbose-api",
+		"version-check",
 		"working-dir",
 	}
 	assert.Equal(t, expected, names)

--- a/internal/pkg/service/common/task/cleanup.go
+++ b/internal/pkg/service/common/task/cleanup.go
@@ -58,7 +58,7 @@ func (n *Node) Cleanup() (err error) {
 
 			// Handle error
 			if errs.Len() > 0 {
-				ErrResult(errs)
+				return ErrResult(errs)
 			}
 
 			return OkResult(infoMsg)

--- a/internal/pkg/version/check_remote_test.go
+++ b/internal/pkg/version/check_remote_test.go
@@ -11,7 +11,6 @@ import (
 
 	"github.com/keboola/keboola-as-code/internal/pkg/build"
 	"github.com/keboola/keboola-as-code/internal/pkg/encoding/json"
-	"github.com/keboola/keboola-as-code/internal/pkg/env"
 	"github.com/keboola/keboola-as-code/internal/pkg/log"
 )
 
@@ -83,7 +82,7 @@ func createMockedChecker(t *testing.T) (*checker, log.DebugLogger) {
 
 	// Client with mocked http transport
 	logger := log.NewDebugLogger()
-	c := NewGitHubChecker(context.Background(), logger, env.Empty())
+	c := NewGitHubChecker(context.Background(), logger, false)
 	c.client = c.client.WithTransport(httpTransport).WithRetry(client.TestingRetry())
 	return c, logger
 }

--- a/pkg/lib/operation/version/check/operation.go
+++ b/pkg/lib/operation/version/check/operation.go
@@ -4,23 +4,21 @@ import (
 	"context"
 
 	"github.com/keboola/keboola-as-code/internal/pkg/build"
-	"github.com/keboola/keboola-as-code/internal/pkg/env"
 	"github.com/keboola/keboola-as-code/internal/pkg/log"
 	"github.com/keboola/keboola-as-code/internal/pkg/telemetry"
 	"github.com/keboola/keboola-as-code/internal/pkg/version"
 )
 
 type dependencies interface {
-	Envs() env.Provider
 	Logger() log.Logger
 	Telemetry() telemetry.Telemetry
 }
 
-func Run(ctx context.Context, d dependencies) (err error) {
+func Run(ctx context.Context, skip bool, d dependencies) (err error) {
 	ctx, span := d.Telemetry().Tracer().Start(ctx, "keboola.go.operation.version.check")
 	defer span.End(&err)
 
 	return version.
-		NewGitHubChecker(ctx, d.Logger(), d.Envs()).
+		NewGitHubChecker(ctx, d.Logger(), skip).
 		CheckIfLatest(build.BuildVersion)
 }

--- a/test/cli/environment/log-file/out/log-file.txt
+++ b/test/cli/environment/log-file/out/log-file.txt
@@ -6,6 +6,7 @@ DEBUG	Os/Arch:    %s
 DEBUG	Running command [%s --log-file ./log-file.txt]
 DEBUG	Parsed options:
 DEBUG	  log-file = "./log-file.txt"
+DEBUG	  version-check = "false"
 DEBUG	Default options:
 DEBUG	  help = false
 DEBUG	  non-interactive = false

--- a/test/cli/help/fix-paths/expected-stdout
+++ b/test/cli/help/fix-paths/expected-stdout
@@ -12,10 +12,4 @@ Flags:
       --dry-run   print what needs to be done
 
 Global Flags:
-  -h, --help                       print help for command
-  -l, --log-file string            path to a log file for details
-      --non-interactive            disable interactive dialogs
-  -t, --storage-api-token string   storage API token from your project
-  -v, --verbose                    print details
-      --verbose-api                log each API request and response
-  -d, --working-dir string         use other working directory
+%A

--- a/test/cli/help/main/expected-stdout
+++ b/test/cli/help/main/expected-stdout
@@ -107,6 +107,7 @@ Flags:
   -v, --verbose                    print details
       --verbose-api                log each API request and response
   -V, --version                    print version
+      --version-check              checks if there is a newer version of the CLI (default true)
   -d, --working-dir string         use other working directory
 
 Use "kbc [command] --help" for more information about a command.

--- a/test/cli/help/remote-dbt-generate-env/expected-stdout
+++ b/test/cli/help/remote-dbt-generate-env/expected-stdout
@@ -9,10 +9,4 @@ Flags:
   -W, --workspace-id string       id of the workspace to use
 
 Global Flags:
-  -h, --help                       print help for command
-  -l, --log-file string            path to a log file for details
-      --non-interactive            disable interactive dialogs
-  -t, --storage-api-token string   storage API token from your project
-  -v, --verbose                    print details
-      --verbose-api                log each API request and response
-  -d, --working-dir string         use other working directory
+%A

--- a/test/cli/help/remote-dbt-generate-profile/expected-stdout
+++ b/test/cli/help/remote-dbt-generate-profile/expected-stdout
@@ -7,10 +7,4 @@ Flags:
   -T, --target-name string   target name of the profile
 
 Global Flags:
-  -h, --help                       print help for command
-  -l, --log-file string            path to a log file for details
-      --non-interactive            disable interactive dialogs
-  -t, --storage-api-token string   storage API token from your project
-  -v, --verbose                    print details
-      --verbose-api                log each API request and response
-  -d, --working-dir string         use other working directory
+%A

--- a/test/cli/help/remote-dbt-generate-sources/expected-stdout
+++ b/test/cli/help/remote-dbt-generate-sources/expected-stdout
@@ -8,10 +8,4 @@ Flags:
   -T, --target-name string        target name of the profile
 
 Global Flags:
-  -h, --help                       print help for command
-  -l, --log-file string            path to a log file for details
-      --non-interactive            disable interactive dialogs
-  -t, --storage-api-token string   storage API token from your project
-  -v, --verbose                    print details
-      --verbose-api                log each API request and response
-  -d, --working-dir string         use other working directory
+%A

--- a/test/cli/help/remote-dbt-init/expected-stdout
+++ b/test/cli/help/remote-dbt-init/expected-stdout
@@ -9,10 +9,4 @@ Flags:
   -W, --workspace-name string     name of workspace to create
 
 Global Flags:
-  -h, --help                       print help for command
-  -l, --log-file string            path to a log file for details
-      --non-interactive            disable interactive dialogs
-  -t, --storage-api-token string   storage API token from your project
-  -v, --verbose                    print details
-      --verbose-api                log each API request and response
-  -d, --working-dir string         use other working directory
+%A

--- a/test/cli/help/remote-file-upload/expected-stdout
+++ b/test/cli/help/remote-file-upload/expected-stdout
@@ -12,10 +12,4 @@ Flags:
   -H, --storage-api-host string   storage API host, eg. "connection.keboola.com"
 
 Global Flags:
-  -h, --help                       print help for command
-  -l, --log-file string            path to a log file for details
-      --non-interactive            disable interactive dialogs
-  -t, --storage-api-token string   storage API token from your project
-  -v, --verbose                    print details
-      --verbose-api                log each API request and response
-  -d, --working-dir string         use other working directory
+%A

--- a/test/cli/help/remote-job-run/expected-stdout
+++ b/test/cli/help/remote-job-run/expected-stdout
@@ -15,10 +15,4 @@ Flags:
       --timeout string            how long to wait for job to finish (default "5m")
 
 Global Flags:
-  -h, --help                       print help for command
-  -l, --log-file string            path to a log file for details
-      --non-interactive            disable interactive dialogs
-  -t, --storage-api-token string   storage API token from your project
-  -v, --verbose                    print details
-      --verbose-api                log each API request and response
-  -d, --working-dir string         use other working directory
+%A

--- a/test/cli/help/remote-job/expected-stdout
+++ b/test/cli/help/remote-job/expected-stdout
@@ -7,12 +7,6 @@ Available Commands:
   remote job run  Run one or multiple jobs.
 
 Global Flags:
-  -h, --help                       print help for command
-  -l, --log-file string            path to a log file for details
-      --non-interactive            disable interactive dialogs
-  -t, --storage-api-token string   storage API token from your project
-  -v, --verbose                    print details
-      --verbose-api                log each API request and response
-  -d, --working-dir string         use other working directory
+%A
 
 Use "kbc remote job [command] --help" for more information about a command.

--- a/test/cli/help/remote-table-detail/expected-stdout
+++ b/test/cli/help/remote-table-detail/expected-stdout
@@ -11,10 +11,4 @@ Flags:
   -H, --storage-api-host string   storage API host, eg. "connection.keboola.com"
 
 Global Flags:
-  -h, --help                       print help for command
-  -l, --log-file string            path to a log file for details
-      --non-interactive            disable interactive dialogs
-  -t, --storage-api-token string   storage API token from your project
-  -v, --verbose                    print details
-      --verbose-api                log each API request and response
-  -d, --working-dir string         use other working directory
+%A

--- a/test/cli/help/remote-table-download/expected-stdout
+++ b/test/cli/help/remote-table-download/expected-stdout
@@ -19,10 +19,4 @@ Flags:
       --where string              filter columns by value
 
 Global Flags:
-  -h, --help                       print help for command
-  -l, --log-file string            path to a log file for details
-      --non-interactive            disable interactive dialogs
-  -t, --storage-api-token string   storage API token from your project
-  -v, --verbose                    print details
-      --verbose-api                log each API request and response
-  -d, --working-dir string         use other working directory
+%A

--- a/test/cli/help/remote-table-import/expected-stdout
+++ b/test/cli/help/remote-table-import/expected-stdout
@@ -16,10 +16,4 @@ Flags:
   -H, --storage-api-host string   storage API host, eg. "connection.keboola.com"
 
 Global Flags:
-  -h, --help                       print help for command
-  -l, --log-file string            path to a log file for details
-      --non-interactive            disable interactive dialogs
-  -t, --storage-api-token string   storage API token from your project
-  -v, --verbose                    print details
-      --verbose-api                log each API request and response
-  -d, --working-dir string         use other working directory
+%A

--- a/test/cli/help/remote-table-preview/expected-stdout
+++ b/test/cli/help/remote-table-preview/expected-stdout
@@ -22,10 +22,4 @@ Flags:
       --where string              filter columns by value
 
 Global Flags:
-  -h, --help                       print help for command
-  -l, --log-file string            path to a log file for details
-      --non-interactive            disable interactive dialogs
-  -t, --storage-api-token string   storage API token from your project
-  -v, --verbose                    print details
-      --verbose-api                log each API request and response
-  -d, --working-dir string         use other working directory
+%A

--- a/test/cli/help/remote-table-unload/expected-stdout
+++ b/test/cli/help/remote-table-unload/expected-stdout
@@ -18,10 +18,4 @@ Flags:
       --where string              filter columns by value
 
 Global Flags:
-  -h, --help                       print help for command
-  -l, --log-file string            path to a log file for details
-      --non-interactive            disable interactive dialogs
-  -t, --storage-api-token string   storage API token from your project
-  -v, --verbose                    print details
-      --verbose-api                log each API request and response
-  -d, --working-dir string         use other working directory
+%A

--- a/test/cli/help/remote-table-upload/expected-stdout
+++ b/test/cli/help/remote-table-upload/expected-stdout
@@ -18,10 +18,4 @@ Flags:
   -H, --storage-api-host string   storage API host, eg. "connection.keboola.com"
 
 Global Flags:
-  -h, --help                       print help for command
-  -l, --log-file string            path to a log file for details
-      --non-interactive            disable interactive dialogs
-  -t, --storage-api-token string   storage API token from your project
-  -v, --verbose                    print details
-      --verbose-api                log each API request and response
-  -d, --working-dir string         use other working directory
+%A

--- a/test/cli/help/remote-table/expected-stdout
+++ b/test/cli/help/remote-table/expected-stdout
@@ -12,12 +12,6 @@ Available Commands:
   remote table download  Download data from a storage table.
 
 Global Flags:
-  -h, --help                       print help for command
-  -l, --log-file string            path to a log file for details
-      --non-interactive            disable interactive dialogs
-  -t, --storage-api-token string   storage API token from your project
-  -v, --verbose                    print details
-      --verbose-api                log each API request and response
-  -d, --working-dir string         use other working directory
+%A
 
 Use "kbc remote table [command] --help" for more information about a command.

--- a/test/cli/help/remote-workspace-create/expected-stdout
+++ b/test/cli/help/remote-workspace-create/expected-stdout
@@ -10,10 +10,4 @@ Flags:
       --type string               type of the workspace
 
 Global Flags:
-  -h, --help                       print help for command
-  -l, --log-file string            path to a log file for details
-      --non-interactive            disable interactive dialogs
-  -t, --storage-api-token string   storage API token from your project
-  -v, --verbose                    print details
-      --verbose-api                log each API request and response
-  -d, --working-dir string         use other working directory
+%A

--- a/test/cli/help/remote-workspace-delete/expected-stdout
+++ b/test/cli/help/remote-workspace-delete/expected-stdout
@@ -8,10 +8,4 @@ Flags:
   -W, --workspace-id string       id of the workspace to delete
 
 Global Flags:
-  -h, --help                       print help for command
-  -l, --log-file string            path to a log file for details
-      --non-interactive            disable interactive dialogs
-  -t, --storage-api-token string   storage API token from your project
-  -v, --verbose                    print details
-      --verbose-api                log each API request and response
-  -d, --working-dir string         use other working directory
+%A

--- a/test/cli/help/remote-workspace-detail/expected-stdout
+++ b/test/cli/help/remote-workspace-detail/expected-stdout
@@ -8,10 +8,4 @@ Flags:
   -W, --workspace-id string       id of the workspace to fetch
 
 Global Flags:
-  -h, --help                       print help for command
-  -l, --log-file string            path to a log file for details
-      --non-interactive            disable interactive dialogs
-  -t, --storage-api-token string   storage API token from your project
-  -v, --verbose                    print details
-      --verbose-api                log each API request and response
-  -d, --working-dir string         use other working directory
+%A

--- a/test/cli/help/remote-workspace-list/expected-stdout
+++ b/test/cli/help/remote-workspace-list/expected-stdout
@@ -7,10 +7,4 @@ Flags:
   -H, --storage-api-host string   storage API host, eg. "connection.keboola.com"
 
 Global Flags:
-  -h, --help                       print help for command
-  -l, --log-file string            path to a log file for details
-      --non-interactive            disable interactive dialogs
-  -t, --storage-api-token string   storage API token from your project
-  -v, --verbose                    print details
-      --verbose-api                log each API request and response
-  -d, --working-dir string         use other working directory
+%A

--- a/test/cli/help/workflows/expected-stdout
+++ b/test/cli/help/workflows/expected-stdout
@@ -20,10 +20,4 @@ Flags:
       --ci-validate             create workflow to validate all branches on change (default true)
 
 Global Flags:
-  -h, --help                       print help for command
-  -l, --log-file string            path to a log file for details
-      --non-interactive            disable interactive dialogs
-  -t, --storage-api-token string   storage API token from your project
-  -v, --verbose                    print details
-      --verbose-api                log each API request and response
-  -d, --working-dir string         use other working directory
+%A


### PR DESCRIPTION
Part of: https://keboola.atlassian.net/browse/PSGO-226

Changes:
- Removed `Envs()` dependency and its last usage.

-----------

Uz dlhsie sa snazim zbavit priameho pouzitia ENVs v kode, zostalo uz iba posledne mieste, co odstranuje tento PR.