### PR TITLE
Handle closed connection by client - log HTTP code 499

### DIFF
--- a/internal/pkg/service/common/errors/statuscode_test.go
+++ b/internal/pkg/service/common/errors/statuscode_test.go
@@ -1,0 +1,27 @@
+package errors
+
+import (
+	"context"
+	"net/http"
+	"net/url"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+
+	"github.com/keboola/keboola-as-code/internal/pkg/utils/errors"
+)
+
+func TestHTTPCodeFrom(t *testing.T) {
+	t.Parallel()
+	assert.Equal(t, StatusClientClosedRequest, HTTPCodeFrom(context.Canceled))
+	assert.Equal(t, http.StatusInternalServerError, HTTPCodeFrom(context.DeadlineExceeded))
+	assert.Equal(t, http.StatusInternalServerError, HTTPCodeFrom(errors.New("some error")))
+	assert.Equal(t, http.StatusConflict, HTTPCodeFrom(NewResourceAlreadyExistsError("<what>", "<key>", "<in>")))
+	assert.Equal(t, http.StatusBadRequest, HTTPCodeFrom(NewBadRequestError(errors.New("message"))))
+	assert.Equal(t, http.StatusNotFound, HTTPCodeFrom(NewEndpointNotFoundError(&url.URL{Host: "host.local"})))
+	assert.Equal(t, http.StatusInsufficientStorage, HTTPCodeFrom(NewInsufficientStorageError(errors.New("message"))))
+	assert.Equal(t, http.StatusInternalServerError, HTTPCodeFrom(NewNotImplementedError()))
+	assert.Equal(t, http.StatusRequestEntityTooLarge, HTTPCodeFrom(NewPayloadTooLargeError(errors.New("message"))))
+	assert.Equal(t, http.StatusNotFound, HTTPCodeFrom(NewResourceNotFoundError("<what>", "<key>", "<in>")))
+	assert.Equal(t, http.StatusUnsupportedMediaType, HTTPCodeFrom(NewUnsupportedMediaTypeError(errors.New("message"))))
+}

--- a/internal/pkg/service/common/httpserver/error.go
+++ b/internal/pkg/service/common/httpserver/error.go
@@ -63,7 +63,7 @@ func (wr *ErrorWriter) WriteOrErr(ctx context.Context, w http.ResponseWriter, er
 
 	// Normalize error name
 	if !strings.Contains(response.Name, ".") {
-		// Normalize error name, eg., "missing_field" to "buffer.missingField"
+		// Normalize error name, e.g., "missing_field" to "buffer.missingField"
 		response.Name = wr.errorNamePrefix + strcase.ToLowerCamel(response.Name)
 	}
 


### PR DESCRIPTION
Jira: https://keboola.atlassian.net/browse/PSGO-195

Changes:
- `context.Canceled` error is logged as client error (499), not as server error (500).