### PR TITLE
fix(provisioning/etcd): add missing volumeMounts field

### DIFF
--- a/provisioning/common/etcd/values.yaml
+++ b/provisioning/common/etcd/values.yaml
@@ -266,11 +266,12 @@ extraDeploy:
                   {{- if .Values.defragmentation.cronjob.resources }}
                   resources: {{- toYaml .Values.defragmentation.cronjob.resources | nindent 16 }}
                   {{- end }}
-                    {{- if .Values.auth.client.secureTransport }}
+                  {{- if .Values.auth.client.secureTransport }}
+                  volumeMounts:
                     - name: certs
                       mountPath: /opt/bitnami/etcd/certs/client
                       readOnly: true
-                    {{- end }}
+                  {{- end }}
               volumes:
                 {{- if .Values.auth.client.secureTransport }}
                 - name: certs


### PR DESCRIPTION
In case etcd is configured to encrypt client-to-server communication using TLS certificates (with `auth.client.secureTransport: true`), the rendering of the etcd-defragger CronJob fails. Therefore the missing `volumeMounts` field was added to the CronJob.