### PR TITLE
Remove RequestCtx dependency, add missing request timeout

### DIFF
--- a/cmd/templates-api/main.go
+++ b/cmd/templates-api/main.go
@@ -116,7 +116,7 @@ func run() error {
 	}
 
 	// Create service.
-	svc, err := service.New(apiScp)
+	svc, err := service.New(ctx, apiScp)
 	if err != nil {
 		return err
 	}

--- a/internal/pkg/service/buffer/api/gen/buffer/endpoints.go
+++ b/internal/pkg/service/buffer/api/gen/buffer/endpoints.go
@@ -95,7 +95,7 @@ func (e *Endpoints) Use(m func(goa.Endpoint) goa.Endpoint) {
 func NewAPIRootIndexEndpoint(s Service) goa.Endpoint {
 	return func(ctx context.Context, req interface{}) (interface{}, error) {
 		deps := ctx.Value(dependencies.PublicRequestScopeCtxKey).(dependencies.PublicRequestScope)
-		return nil, s.APIRootIndex(deps)
+		return nil, s.APIRootIndex(ctx, deps)
 	}
 }
 
@@ -104,7 +104,7 @@ func NewAPIRootIndexEndpoint(s Service) goa.Endpoint {
 func NewAPIVersionIndexEndpoint(s Service) goa.Endpoint {
 	return func(ctx context.Context, req interface{}) (interface{}, error) {
 		deps := ctx.Value(dependencies.PublicRequestScopeCtxKey).(dependencies.PublicRequestScope)
-		return s.APIVersionIndex(deps)
+		return s.APIVersionIndex(ctx, deps)
 	}
 }
 
@@ -113,7 +113,7 @@ func NewAPIVersionIndexEndpoint(s Service) goa.Endpoint {
 func NewHealthCheckEndpoint(s Service) goa.Endpoint {
 	return func(ctx context.Context, req interface{}) (interface{}, error) {
 		deps := ctx.Value(dependencies.PublicRequestScopeCtxKey).(dependencies.PublicRequestScope)
-		return s.HealthCheck(deps)
+		return s.HealthCheck(ctx, deps)
 	}
 }
 
@@ -133,7 +133,7 @@ func NewCreateReceiverEndpoint(s Service, authAPIKeyFn security.AuthAPIKeyFunc) 
 			return nil, err
 		}
 		deps := ctx.Value(dependencies.ProjectRequestScopeCtxKey).(dependencies.ProjectRequestScope)
-		return s.CreateReceiver(deps, p)
+		return s.CreateReceiver(ctx, deps, p)
 	}
 }
 
@@ -153,7 +153,7 @@ func NewUpdateReceiverEndpoint(s Service, authAPIKeyFn security.AuthAPIKeyFunc) 
 			return nil, err
 		}
 		deps := ctx.Value(dependencies.ProjectRequestScopeCtxKey).(dependencies.ProjectRequestScope)
-		return s.UpdateReceiver(deps, p)
+		return s.UpdateReceiver(ctx, deps, p)
 	}
 }
 
@@ -173,7 +173,7 @@ func NewListReceiversEndpoint(s Service, authAPIKeyFn security.AuthAPIKeyFunc) g
 			return nil, err
 		}
 		deps := ctx.Value(dependencies.ProjectRequestScopeCtxKey).(dependencies.ProjectRequestScope)
-		return s.ListReceivers(deps, p)
+		return s.ListReceivers(ctx, deps, p)
 	}
 }
 
@@ -193,7 +193,7 @@ func NewGetReceiverEndpoint(s Service, authAPIKeyFn security.AuthAPIKeyFunc) goa
 			return nil, err
 		}
 		deps := ctx.Value(dependencies.ProjectRequestScopeCtxKey).(dependencies.ProjectRequestScope)
-		return s.GetReceiver(deps, p)
+		return s.GetReceiver(ctx, deps, p)
 	}
 }
 
@@ -213,7 +213,7 @@ func NewDeleteReceiverEndpoint(s Service, authAPIKeyFn security.AuthAPIKeyFunc) 
 			return nil, err
 		}
 		deps := ctx.Value(dependencies.ProjectRequestScopeCtxKey).(dependencies.ProjectRequestScope)
-		return nil, s.DeleteReceiver(deps, p)
+		return nil, s.DeleteReceiver(ctx, deps, p)
 	}
 }
 
@@ -233,7 +233,7 @@ func NewRefreshReceiverTokensEndpoint(s Service, authAPIKeyFn security.AuthAPIKe
 			return nil, err
 		}
 		deps := ctx.Value(dependencies.ProjectRequestScopeCtxKey).(dependencies.ProjectRequestScope)
-		return s.RefreshReceiverTokens(deps, p)
+		return s.RefreshReceiverTokens(ctx, deps, p)
 	}
 }
 
@@ -253,7 +253,7 @@ func NewCreateExportEndpoint(s Service, authAPIKeyFn security.AuthAPIKeyFunc) go
 			return nil, err
 		}
 		deps := ctx.Value(dependencies.ProjectRequestScopeCtxKey).(dependencies.ProjectRequestScope)
-		return s.CreateExport(deps, p)
+		return s.CreateExport(ctx, deps, p)
 	}
 }
 
@@ -273,7 +273,7 @@ func NewGetExportEndpoint(s Service, authAPIKeyFn security.AuthAPIKeyFunc) goa.E
 			return nil, err
 		}
 		deps := ctx.Value(dependencies.ProjectRequestScopeCtxKey).(dependencies.ProjectRequestScope)
-		return s.GetExport(deps, p)
+		return s.GetExport(ctx, deps, p)
 	}
 }
 
@@ -293,7 +293,7 @@ func NewListExportsEndpoint(s Service, authAPIKeyFn security.AuthAPIKeyFunc) goa
 			return nil, err
 		}
 		deps := ctx.Value(dependencies.ProjectRequestScopeCtxKey).(dependencies.ProjectRequestScope)
-		return s.ListExports(deps, p)
+		return s.ListExports(ctx, deps, p)
 	}
 }
 
@@ -313,7 +313,7 @@ func NewUpdateExportEndpoint(s Service, authAPIKeyFn security.AuthAPIKeyFunc) go
 			return nil, err
 		}
 		deps := ctx.Value(dependencies.ProjectRequestScopeCtxKey).(dependencies.ProjectRequestScope)
-		return s.UpdateExport(deps, p)
+		return s.UpdateExport(ctx, deps, p)
 	}
 }
 
@@ -333,7 +333,7 @@ func NewDeleteExportEndpoint(s Service, authAPIKeyFn security.AuthAPIKeyFunc) go
 			return nil, err
 		}
 		deps := ctx.Value(dependencies.ProjectRequestScopeCtxKey).(dependencies.ProjectRequestScope)
-		return nil, s.DeleteExport(deps, p)
+		return nil, s.DeleteExport(ctx, deps, p)
 	}
 }
 
@@ -343,7 +343,7 @@ func NewImportEndpoint(s Service) goa.Endpoint {
 	return func(ctx context.Context, req interface{}) (interface{}, error) {
 		ep := req.(*ImportRequestData)
 		deps := ctx.Value(dependencies.PublicRequestScopeCtxKey).(dependencies.PublicRequestScope)
-		return nil, s.Import(deps, ep.Payload, ep.Body)
+		return nil, s.Import(ctx, deps, ep.Payload, ep.Body)
 	}
 }
 
@@ -363,6 +363,6 @@ func NewGetTaskEndpoint(s Service, authAPIKeyFn security.AuthAPIKeyFunc) goa.End
 			return nil, err
 		}
 		deps := ctx.Value(dependencies.ProjectRequestScopeCtxKey).(dependencies.ProjectRequestScope)
-		return s.GetTask(deps, p)
+		return s.GetTask(ctx, deps, p)
 	}
 }

--- a/internal/pkg/service/buffer/api/gen/buffer/service.go
+++ b/internal/pkg/service/buffer/api/gen/buffer/service.go
@@ -23,38 +23,38 @@ import (
 // A service for continuously importing data to Keboola storage.
 type Service interface {
 	// Redirect to /v1.
-	APIRootIndex(dependencies.PublicRequestScope) (err error)
+	APIRootIndex(context.Context, dependencies.PublicRequestScope) (err error)
 	// List API name and link to documentation.
-	APIVersionIndex(dependencies.PublicRequestScope) (res *ServiceDetail, err error)
+	APIVersionIndex(context.Context, dependencies.PublicRequestScope) (res *ServiceDetail, err error)
 	// HealthCheck implements HealthCheck.
-	HealthCheck(dependencies.PublicRequestScope) (res string, err error)
+	HealthCheck(context.Context, dependencies.PublicRequestScope) (res string, err error)
 	// Create a new receiver for a given project
-	CreateReceiver(dependencies.ProjectRequestScope, *CreateReceiverPayload) (res *Task, err error)
+	CreateReceiver(context.Context, dependencies.ProjectRequestScope, *CreateReceiverPayload) (res *Task, err error)
 	// Update a receiver export.
-	UpdateReceiver(dependencies.ProjectRequestScope, *UpdateReceiverPayload) (res *Receiver, err error)
+	UpdateReceiver(context.Context, dependencies.ProjectRequestScope, *UpdateReceiverPayload) (res *Receiver, err error)
 	// List all receivers for a given project.
-	ListReceivers(dependencies.ProjectRequestScope, *ListReceiversPayload) (res *ReceiversList, err error)
+	ListReceivers(context.Context, dependencies.ProjectRequestScope, *ListReceiversPayload) (res *ReceiversList, err error)
 	// Get the configuration of a receiver.
-	GetReceiver(dependencies.ProjectRequestScope, *GetReceiverPayload) (res *Receiver, err error)
+	GetReceiver(context.Context, dependencies.ProjectRequestScope, *GetReceiverPayload) (res *Receiver, err error)
 	// Delete a receiver.
-	DeleteReceiver(dependencies.ProjectRequestScope, *DeleteReceiverPayload) (err error)
+	DeleteReceiver(context.Context, dependencies.ProjectRequestScope, *DeleteReceiverPayload) (err error)
 	// Each export uses its own token scoped to the target bucket, this endpoint
 	// refreshes all of those tokens.
-	RefreshReceiverTokens(dependencies.ProjectRequestScope, *RefreshReceiverTokensPayload) (res *Receiver, err error)
+	RefreshReceiverTokens(context.Context, dependencies.ProjectRequestScope, *RefreshReceiverTokensPayload) (res *Receiver, err error)
 	// Create a new export for an existing receiver.
-	CreateExport(dependencies.ProjectRequestScope, *CreateExportPayload) (res *Task, err error)
+	CreateExport(context.Context, dependencies.ProjectRequestScope, *CreateExportPayload) (res *Task, err error)
 	// Get the configuration of an export.
-	GetExport(dependencies.ProjectRequestScope, *GetExportPayload) (res *Export, err error)
+	GetExport(context.Context, dependencies.ProjectRequestScope, *GetExportPayload) (res *Export, err error)
 	// List all exports for a given receiver.
-	ListExports(dependencies.ProjectRequestScope, *ListExportsPayload) (res *ExportsList, err error)
+	ListExports(context.Context, dependencies.ProjectRequestScope, *ListExportsPayload) (res *ExportsList, err error)
 	// Update a receiver export.
-	UpdateExport(dependencies.ProjectRequestScope, *UpdateExportPayload) (res *Task, err error)
+	UpdateExport(context.Context, dependencies.ProjectRequestScope, *UpdateExportPayload) (res *Task, err error)
 	// Delete a receiver export.
-	DeleteExport(dependencies.ProjectRequestScope, *DeleteExportPayload) (err error)
+	DeleteExport(context.Context, dependencies.ProjectRequestScope, *DeleteExportPayload) (err error)
 	// Upload data into the receiver.
-	Import(dependencies.PublicRequestScope, *ImportPayload, io.ReadCloser) (err error)
+	Import(context.Context, dependencies.PublicRequestScope, *ImportPayload, io.ReadCloser) (err error)
 	// Get details of a task.
-	GetTask(dependencies.ProjectRequestScope, *GetTaskPayload) (res *Task, err error)
+	GetTask(context.Context, dependencies.ProjectRequestScope, *GetTaskPayload) (res *Task, err error)
 }
 
 // Auther defines the authorization functions to be implemented by the service.

--- a/internal/pkg/service/buffer/api/service/export.go
+++ b/internal/pkg/service/buffer/api/service/export.go
@@ -22,8 +22,8 @@ const (
 	exportUpdateTaskType = "export.update"
 )
 
-func (s *service) CreateExport(d dependencies.ProjectRequestScope, payload *buffer.CreateExportPayload) (res *buffer.Task, err error) {
-	ctx, str := d.RequestCtx(), d.Store()
+func (s *service) CreateExport(ctx context.Context, d dependencies.ProjectRequestScope, payload *buffer.CreateExportPayload) (res *buffer.Task, err error) {
+	str := d.Store()
 
 	receiverKey := key.ReceiverKey{ProjectID: d.ProjectID(), ReceiverID: payload.ReceiverID}
 	export, err := s.mapper.CreateExportModel(
@@ -89,7 +89,7 @@ func (s *service) CreateExport(d dependencies.ProjectRequestScope, payload *buff
 	return s.mapper.TaskPayload(t), nil
 }
 
-func (s *service) UpdateExport(d dependencies.ProjectRequestScope, payload *buffer.UpdateExportPayload) (res *buffer.Task, err error) {
+func (s *service) UpdateExport(ctx context.Context, d dependencies.ProjectRequestScope, payload *buffer.UpdateExportPayload) (res *buffer.Task, err error) {
 	receiverKey := key.ReceiverKey{ProjectID: d.ProjectID(), ReceiverID: payload.ReceiverID}
 	exportKey := key.ExportKey{ReceiverKey: receiverKey, ExportID: payload.ExportID}
 
@@ -143,12 +143,10 @@ func (s *service) UpdateExport(d dependencies.ProjectRequestScope, payload *buff
 	return s.mapper.TaskPayload(t), nil
 }
 
-func (s *service) GetExport(d dependencies.ProjectRequestScope, payload *buffer.GetExportPayload) (r *buffer.Export, err error) {
-	ctx, str := d.RequestCtx(), d.Store()
-
+func (s *service) GetExport(ctx context.Context, d dependencies.ProjectRequestScope, payload *buffer.GetExportPayload) (r *buffer.Export, err error) {
 	receiverKey := key.ReceiverKey{ProjectID: d.ProjectID(), ReceiverID: payload.ReceiverID}
 	exportKey := key.ExportKey{ReceiverKey: receiverKey, ExportID: payload.ExportID}
-	export, err := str.GetExport(ctx, exportKey)
+	export, err := d.Store().GetExport(ctx, exportKey)
 	if err != nil {
 		return nil, err
 	}
@@ -156,11 +154,9 @@ func (s *service) GetExport(d dependencies.ProjectRequestScope, payload *buffer.
 	return s.mapper.ExportPayload(export), nil
 }
 
-func (s *service) ListExports(d dependencies.ProjectRequestScope, payload *buffer.ListExportsPayload) (r *buffer.ExportsList, err error) {
-	ctx, str := d.RequestCtx(), d.Store()
-
+func (s *service) ListExports(ctx context.Context, d dependencies.ProjectRequestScope, payload *buffer.ListExportsPayload) (r *buffer.ExportsList, err error) {
 	receiverKey := key.ReceiverKey{ProjectID: d.ProjectID(), ReceiverID: payload.ReceiverID}
-	exports, err := str.ListExports(ctx, receiverKey)
+	exports, err := d.Store().ListExports(ctx, receiverKey)
 	if err != nil {
 		return nil, err
 	}
@@ -168,12 +164,10 @@ func (s *service) ListExports(d dependencies.ProjectRequestScope, payload *buffe
 	return &buffer.ExportsList{Exports: s.mapper.ExportsPayload(exports)}, nil
 }
 
-func (s *service) DeleteExport(d dependencies.ProjectRequestScope, payload *buffer.DeleteExportPayload) (err error) {
-	ctx, str := d.RequestCtx(), d.Store()
-
+func (s *service) DeleteExport(ctx context.Context, d dependencies.ProjectRequestScope, payload *buffer.DeleteExportPayload) (err error) {
 	receiverKey := key.ReceiverKey{ProjectID: d.ProjectID(), ReceiverID: payload.ReceiverID}
 	exportKey := key.ExportKey{ReceiverKey: receiverKey, ExportID: payload.ExportID}
-	return str.DeleteExport(ctx, exportKey)
+	return d.Store().DeleteExport(ctx, exportKey)
 }
 
 func (s *service) createResourcesForExport(ctx context.Context, d dependencies.ProjectRequestScope, rb rollback.Builder, export *model.Export) error {

--- a/internal/pkg/service/buffer/api/service/import.go
+++ b/internal/pkg/service/buffer/api/service/import.go
@@ -1,6 +1,7 @@
 package service
 
 import (
+	"context"
 	"io"
 
 	"github.com/keboola/keboola-as-code/internal/pkg/service/buffer/api/gen/buffer"
@@ -8,8 +9,7 @@ import (
 	"github.com/keboola/keboola-as-code/internal/pkg/service/buffer/store/key"
 )
 
-func (s *service) Import(d dependencies.PublicRequestScope, payload *buffer.ImportPayload, bodyReader io.ReadCloser) (err error) {
-	ctx := d.RequestCtx()
+func (s *service) Import(ctx context.Context, d dependencies.PublicRequestScope, payload *buffer.ImportPayload, bodyReader io.ReadCloser) (err error) {
 	receiverKey := key.ReceiverKey{ProjectID: payload.ProjectID, ReceiverID: payload.ReceiverID}
 	return s.importer.CreateRecord(ctx, d, receiverKey, payload.Secret, bodyReader)
 }

--- a/internal/pkg/service/buffer/api/service/service.go
+++ b/internal/pkg/service/buffer/api/service/service.go
@@ -1,6 +1,8 @@
 package service
 
 import (
+	"context"
+
 	"github.com/benbjohnson/clock"
 
 	"github.com/keboola/keboola-as-code/internal/pkg/log"
@@ -31,12 +33,12 @@ func New(d dependencies.APIScope) buffer.Service {
 	}
 }
 
-func (s *service) APIRootIndex(dependencies.PublicRequestScope) (err error) {
+func (s *service) APIRootIndex(context.Context, dependencies.PublicRequestScope) (err error) {
 	// Redirect / -> /v1
 	return nil
 }
 
-func (s *service) APIVersionIndex(dependencies.PublicRequestScope) (res *buffer.ServiceDetail, err error) {
+func (s *service) APIVersionIndex(context.Context, dependencies.PublicRequestScope) (res *buffer.ServiceDetail, err error) {
 	res = &buffer.ServiceDetail{
 		API:           "buffer",
 		Documentation: "https://buffer.keboola.com/v1/documentation",
@@ -44,6 +46,6 @@ func (s *service) APIVersionIndex(dependencies.PublicRequestScope) (res *buffer.
 	return res, nil
 }
 
-func (s *service) HealthCheck(dependencies.PublicRequestScope) (res string, err error) {
+func (s *service) HealthCheck(context.Context, dependencies.PublicRequestScope) (res string, err error) {
 	return "OK", nil
 }

--- a/internal/pkg/service/buffer/api/service/task.go
+++ b/internal/pkg/service/buffer/api/service/task.go
@@ -1,15 +1,15 @@
 package service
 
 import (
+	"context"
+
 	"github.com/keboola/keboola-as-code/internal/pkg/service/buffer/api/gen/buffer"
 	"github.com/keboola/keboola-as-code/internal/pkg/service/buffer/dependencies"
 	"github.com/keboola/keboola-as-code/internal/pkg/service/common/task"
 )
 
-func (s *service) GetTask(d dependencies.ProjectRequestScope, payload *buffer.GetTaskPayload) (res *buffer.Task, err error) {
-	ctx, str := d.RequestCtx(), d.Store()
-
-	t, err := str.GetTask(ctx, task.Key{
+func (s *service) GetTask(ctx context.Context, d dependencies.ProjectRequestScope, payload *buffer.GetTaskPayload) (res *buffer.Task, err error) {
+	t, err := d.Store().GetTask(ctx, task.Key{
 		ProjectID: d.ProjectID(),
 		TaskID:    payload.TaskID,
 	})

--- a/internal/pkg/service/buffer/api/service/token.go
+++ b/internal/pkg/service/buffer/api/service/token.go
@@ -1,14 +1,16 @@
 package service
 
 import (
+	"context"
+
 	"github.com/keboola/keboola-as-code/internal/pkg/service/buffer/api/gen/buffer"
 	"github.com/keboola/keboola-as-code/internal/pkg/service/buffer/dependencies"
 	"github.com/keboola/keboola-as-code/internal/pkg/service/buffer/store/key"
 	"github.com/keboola/keboola-as-code/internal/pkg/service/common/rollback"
 )
 
-func (s *service) RefreshReceiverTokens(d dependencies.ProjectRequestScope, payload *buffer.RefreshReceiverTokensPayload) (res *buffer.Receiver, err error) {
-	ctx, str := d.RequestCtx(), d.Store()
+func (s *service) RefreshReceiverTokens(ctx context.Context, d dependencies.ProjectRequestScope, payload *buffer.RefreshReceiverTokensPayload) (res *buffer.Receiver, err error) {
+	str := d.Store()
 
 	rb := rollback.New(s.logger)
 	defer rb.InvokeIfErr(ctx, &err)
@@ -27,5 +29,5 @@ func (s *service) RefreshReceiverTokens(d dependencies.ProjectRequestScope, payl
 		return nil, err
 	}
 
-	return s.GetReceiver(d, &buffer.GetReceiverPayload{ReceiverID: payload.ReceiverID})
+	return s.GetReceiver(ctx, d, &buffer.GetReceiverPayload{ReceiverID: payload.ReceiverID})
 }

--- a/internal/pkg/service/buffer/cleanup/node_test.go
+++ b/internal/pkg/service/buffer/cleanup/node_test.go
@@ -21,6 +21,7 @@ import (
 	"github.com/keboola/keboola-as-code/internal/pkg/service/common/utctime"
 	"github.com/keboola/keboola-as-code/internal/pkg/utils/errors"
 	"github.com/keboola/keboola-as-code/internal/pkg/utils/etcdhelper"
+	"github.com/keboola/keboola-as-code/internal/pkg/utils/strhelper"
 )
 
 func TestCleanup(t *testing.T) {
@@ -177,7 +178,7 @@ func TestCleanup(t *testing.T) {
 [task][1000/github/receiver.cleanup/%s]INFO  task succeeded (%s): receiver "1000/github" has been cleaned
 [task][1000/github/receiver.cleanup/%s]DEBUG  lock released "runtime/lock/task/1000/github/receiver.cleanup"
 %A
-`, mock.DebugLogger().AllMessages())
+`, strhelper.FilterLines(`^\[task|cleanup\]`, mock.DebugLogger().AllMessages()))
 
 	// Check keys
 	etcdhelper.AssertKVsString(t, client, `

--- a/internal/pkg/service/buffer/worker/service/cleanup_test.go
+++ b/internal/pkg/service/buffer/worker/service/cleanup_test.go
@@ -23,7 +23,6 @@ import (
 	"github.com/keboola/keboola-as-code/internal/pkg/utils/errors"
 	"github.com/keboola/keboola-as-code/internal/pkg/utils/etcdhelper"
 	"github.com/keboola/keboola-as-code/internal/pkg/utils/strhelper"
-	"github.com/keboola/keboola-as-code/internal/pkg/utils/testhelper"
 	"github.com/keboola/keboola-as-code/internal/pkg/utils/testproject"
 )
 
@@ -104,7 +103,6 @@ func TestCleanup(t *testing.T) {
 	assert.NoError(t, store.SwapFile(ctx, &oldFile, &oldSlice, export1.OpenedFile, export1.OpenedSlice))
 
 	// Create nodes
-	workerMock.DebugLogger().ConnectTo(testhelper.VerboseStdout())
 	_, err = service.New(workerScp)
 	assert.NoError(t, err)
 

--- a/internal/pkg/service/buffer/worker/service/slice_retry_test.go
+++ b/internal/pkg/service/buffer/worker/service/slice_retry_test.go
@@ -23,7 +23,6 @@ import (
 	"github.com/keboola/keboola-as-code/internal/pkg/utils/errors"
 	"github.com/keboola/keboola-as-code/internal/pkg/utils/etcdhelper"
 	"github.com/keboola/keboola-as-code/internal/pkg/utils/strhelper"
-	"github.com/keboola/keboola-as-code/internal/pkg/utils/testhelper"
 )
 
 type notRetryableError struct {
@@ -100,7 +99,6 @@ func TestRetryFailedUploadsTask(t *testing.T) {
 		),
 		append(opts, dependencies.WithUniqueID("my-worker"))...,
 	)
-	workerMock.DebugLogger().ConnectTo(testhelper.VerboseStdout())
 	_, err := service.New(workerScp)
 	assert.NoError(t, err)
 

--- a/internal/pkg/service/common/dependencies/dependencies.go
+++ b/internal/pkg/service/common/dependencies/dependencies.go
@@ -113,7 +113,6 @@ type ProjectScope interface {
 
 // RequestInfo dependencies provides information about received HTTP request.
 type RequestInfo interface {
-	RequestCtx() context.Context
 	RequestID() string
 	RequestHeader() http.Header
 	RequestClientIP() net.IP

--- a/internal/pkg/service/common/dependencies/mocked.go
+++ b/internal/pkg/service/common/dependencies/mocked.go
@@ -28,6 +28,7 @@ import (
 	"github.com/keboola/keboola-as-code/internal/pkg/utils/errors"
 	"github.com/keboola/keboola-as-code/internal/pkg/utils/etcdhelper"
 	"github.com/keboola/keboola-as-code/internal/pkg/utils/testapi"
+	"github.com/keboola/keboola-as-code/internal/pkg/utils/testhelper"
 	"github.com/keboola/keboola-as-code/internal/pkg/utils/testproject"
 )
 
@@ -213,7 +214,6 @@ func newMockedConfig(t *testing.T, opts []MockedOption) *MockedConfig {
 		ctx:         context.Background(),
 		clock:       clock.New(),
 		telemetry:   telemetry.NewForTest(t),
-		debugLogger: log.NewDebugLogger(),
 		useRealAPIs: false,
 		services: keboola.Services{
 			{ID: "encryption", URL: "https://encryption.mocked.transport.http"},
@@ -240,6 +240,11 @@ func newMockedConfig(t *testing.T, opts []MockedOption) *MockedConfig {
 	// Apply options
 	for _, opt := range opts {
 		opt(cfg)
+	}
+
+	if cfg.debugLogger == nil {
+		cfg.debugLogger = log.NewDebugLogger()
+		cfg.debugLogger.ConnectTo(testhelper.VerboseStdout())
 	}
 
 	return cfg

--- a/internal/pkg/service/common/dependencies/project_test.go
+++ b/internal/pkg/service/common/dependencies/project_test.go
@@ -1,6 +1,7 @@
 package dependencies
 
 import (
+	"context"
 	"net/http"
 	"testing"
 
@@ -13,7 +14,7 @@ func TestNewProjectDeps_MasterTokenRequiredError(t *testing.T) {
 	t.Parallel()
 	d := NewMocked(t)
 	token := keboola.Token{IsMaster: false}
-	_, err := newProjectScope(d.RequestCtx(), d, token)
+	_, err := newProjectScope(context.Background(), d, token)
 	assert.Error(t, err)
 	assert.Equal(t, "a master token of a project administrator is required", err.Error())
 	assert.Equal(t, http.StatusUnauthorized, err.(goaHttp.Statuser).StatusCode())

--- a/internal/pkg/service/common/dependencies/requestinfo.go
+++ b/internal/pkg/service/common/dependencies/requestinfo.go
@@ -1,7 +1,6 @@
 package dependencies
 
 import (
-	"context"
 	"net"
 	"net/http"
 
@@ -28,11 +27,6 @@ func (v *requestInfo) check() {
 	if v == nil {
 		panic(errors.New("dependencies request info scope is not initialized"))
 	}
-}
-
-func (v *requestInfo) RequestCtx() context.Context {
-	v.check()
-	return v.request.Context()
 }
 
 func (v *requestInfo) RequestID() string {

--- a/internal/pkg/service/common/distribution/node_test.go
+++ b/internal/pkg/service/common/distribution/node_test.go
@@ -19,7 +19,6 @@ import (
 	"github.com/keboola/keboola-as-code/internal/pkg/service/common/servicectx"
 	"github.com/keboola/keboola-as-code/internal/pkg/utils/errors"
 	"github.com/keboola/keboola-as-code/internal/pkg/utils/etcdhelper"
-	"github.com/keboola/keboola-as-code/internal/pkg/utils/testhelper"
 )
 
 func TestNodesDiscovery(t *testing.T) {
@@ -323,6 +322,5 @@ func createDeps(t *testing.T, clk clock.Clock, logs io.Writer, etcdCredentials e
 	if logs != nil {
 		d.DebugLogger().ConnectTo(logs)
 	}
-	d.DebugLogger().ConnectTo(testhelper.VerboseStdout())
 	return d
 }

--- a/internal/pkg/service/common/errors/statuscode.go
+++ b/internal/pkg/service/common/errors/statuscode.go
@@ -38,6 +38,11 @@ func HTTPCodeFrom(err error) int {
 		return StatusClientClosedRequest
 	}
 
+	// Handle request timeout
+	if errors.Is(err, context.DeadlineExceeded) {
+		return http.StatusRequestTimeout
+	}
+
 	return http.StatusInternalServerError
 }
 

--- a/internal/pkg/service/common/errors/statuscode_test.go
+++ b/internal/pkg/service/common/errors/statuscode_test.go
@@ -14,7 +14,7 @@ import (
 func TestHTTPCodeFrom(t *testing.T) {
 	t.Parallel()
 	assert.Equal(t, StatusClientClosedRequest, HTTPCodeFrom(context.Canceled))
-	assert.Equal(t, http.StatusInternalServerError, HTTPCodeFrom(context.DeadlineExceeded))
+	assert.Equal(t, http.StatusRequestTimeout, HTTPCodeFrom(context.DeadlineExceeded))
 	assert.Equal(t, http.StatusInternalServerError, HTTPCodeFrom(errors.New("some error")))
 	assert.Equal(t, http.StatusConflict, HTTPCodeFrom(NewResourceAlreadyExistsError("<what>", "<key>", "<in>")))
 	assert.Equal(t, http.StatusBadRequest, HTTPCodeFrom(NewBadRequestError(errors.New("message"))))

--- a/internal/pkg/service/common/goaextension/dependencies/dependencies.go
+++ b/internal/pkg/service/common/goaextension/dependencies/dependencies.go
@@ -30,7 +30,7 @@ func RegisterPlugin(pkgPath string) {
 					case "service":
 						// Add dependencies to the service interface, instead of context (it is included in dependencies)
 						search := `{{ .VarName }}(context.Context`
-						replace := `{{ .VarName }}(
+						replace := `{{ .VarName }}(context.Context, 
 {{- $authFound := false}}
 {{- range .Requirements }}
 	{{- range .Schemes }}
@@ -77,11 +77,11 @@ dependencies.PublicRequestScope
 	`
 						s.Source = strings.ReplaceAll(s.Source, search, replace)
 
-						// Add dependencies to the service method call, instead of context (it is included in dependencies)
+						// Add dependencies to the service method call
 						s.Source = strings.ReplaceAll(
 							s.Source,
 							"s.{{ .VarName }}(ctx",
-							"s.{{ .VarName }}(deps",
+							"s.{{ .VarName }}(ctx, deps",
 						)
 					}
 				}

--- a/internal/pkg/service/common/httpserver/httpserver.go
+++ b/internal/pkg/service/common/httpserver/httpserver.go
@@ -12,6 +12,7 @@ import (
 )
 
 const (
+	requestTimeout          = 30 * time.Second
 	readHeaderTimeout       = 10 * time.Second
 	gracefulShutdownTimeout = 30 * time.Second
 )
@@ -34,6 +35,7 @@ func Start(d dependencies, cfg Config) error {
 	com.Muxer.Use(middleware.OpenTelemetryExtractRoute())
 	handler := middleware.Wrap(
 		com.Muxer,
+		middleware.ContextTimout(requestTimeout),
 		middleware.RequestInfo(),
 		middleware.Filter(middlewareCfg),
 		middleware.Logger(logger),

--- a/internal/pkg/service/common/httpserver/middleware/timeout.go
+++ b/internal/pkg/service/common/httpserver/middleware/timeout.go
@@ -1,0 +1,17 @@
+package middleware
+
+import (
+	"context"
+	"net/http"
+	"time"
+)
+
+func ContextTimout(timeout time.Duration) Middleware {
+	return func(next http.Handler) http.Handler {
+		return http.HandlerFunc(func(w http.ResponseWriter, req *http.Request) {
+			ctx, cancel := context.WithTimeout(req.Context(), timeout)
+			next.ServeHTTP(w, req.WithContext(ctx))
+			cancel()
+		})
+	}
+}

--- a/internal/pkg/service/common/task/node_test.go
+++ b/internal/pkg/service/common/task/node_test.go
@@ -26,7 +26,6 @@ import (
 	"github.com/keboola/keboola-as-code/internal/pkg/utils/errors"
 	"github.com/keboola/keboola-as-code/internal/pkg/utils/etcdhelper"
 	"github.com/keboola/keboola-as-code/internal/pkg/utils/ioutil"
-	"github.com/keboola/keboola-as-code/internal/pkg/utils/testhelper"
 )
 
 func TestSuccessfulTask(t *testing.T) {
@@ -764,7 +763,6 @@ func createDeps(t *testing.T, etcdCredentials etcdclient.Credentials, logs io.Wr
 	})
 
 	// Connect logs output
-	d.DebugLogger().ConnectTo(testhelper.VerboseStdout())
 	if logs != nil {
 		d.DebugLogger().ConnectTo(logs)
 	}

--- a/internal/pkg/service/templates/api/config/config.go
+++ b/internal/pkg/service/templates/api/config/config.go
@@ -43,6 +43,29 @@ type Repositories []model.TemplateRepository
 
 type Option func(c *Config)
 
+func DefaultRepositories() Repositories {
+	return Repositories{
+		{
+			Type: model.RepositoryTypeGit,
+			Name: "keboola",
+			URL:  "https://github.com/keboola/keboola-as-code-templates.git",
+			Ref:  "main",
+		},
+		{
+			Type: model.RepositoryTypeGit,
+			Name: "keboola-beta",
+			URL:  "https://github.com/keboola/keboola-as-code-templates.git",
+			Ref:  "beta",
+		},
+		{
+			Type: model.RepositoryTypeGit,
+			Name: "keboola-dev",
+			URL:  "https://github.com/keboola/keboola-as-code-templates.git",
+			Ref:  "dev",
+		},
+	}
+}
+
 func NewConfig() Config {
 	return Config{
 		DebugLog:             false,
@@ -60,29 +83,10 @@ func NewConfig() Config {
 			Username:  "",
 			Password:  "",
 		},
-		EtcdConnectTimeout: 30 * time.Second, // longer default timeout, the etcd could be started at the same time as the API
-		UniqueID:           "",
-		PublicAddress:      nil,
-		Repositories: []model.TemplateRepository{
-			{
-				Type: model.RepositoryTypeGit,
-				Name: "keboola",
-				URL:  "https://github.com/keboola/keboola-as-code-templates.git",
-				Ref:  "main",
-			},
-			{
-				Type: model.RepositoryTypeGit,
-				Name: "keboola-beta",
-				URL:  "https://github.com/keboola/keboola-as-code-templates.git",
-				Ref:  "beta",
-			},
-			{
-				Type: model.RepositoryTypeGit,
-				Name: "keboola-dev",
-				URL:  "https://github.com/keboola/keboola-as-code-templates.git",
-				Ref:  "dev",
-			},
-		},
+		EtcdConnectTimeout:   30 * time.Second, // longer default timeout, the etcd could be started at the same time as the API
+		UniqueID:             "",
+		PublicAddress:        nil,
+		Repositories:         DefaultRepositories(),
 		TasksCleanup:         true,
 		TasksCleanupInterval: DefaultCleanupInterval,
 	}
@@ -153,6 +157,12 @@ func (c Config) Apply(ops ...Option) Config {
 		o(&c)
 	}
 	return c
+}
+
+func WithDefaultRepositories(v []model.TemplateRepository) Option {
+	return func(c *Config) {
+		c.Repositories = v
+	}
 }
 
 func WithCleanup(v bool) Option {

--- a/internal/pkg/service/templates/api/gen/templates/endpoints.go
+++ b/internal/pkg/service/templates/api/gen/templates/endpoints.go
@@ -94,7 +94,7 @@ func (e *Endpoints) Use(m func(goa.Endpoint) goa.Endpoint) {
 func NewAPIRootIndexEndpoint(s Service) goa.Endpoint {
 	return func(ctx context.Context, req interface{}) (interface{}, error) {
 		deps := ctx.Value(dependencies.PublicRequestScopeCtxKey).(dependencies.PublicRequestScope)
-		return nil, s.APIRootIndex(deps)
+		return nil, s.APIRootIndex(ctx, deps)
 	}
 }
 
@@ -103,7 +103,7 @@ func NewAPIRootIndexEndpoint(s Service) goa.Endpoint {
 func NewAPIVersionIndexEndpoint(s Service) goa.Endpoint {
 	return func(ctx context.Context, req interface{}) (interface{}, error) {
 		deps := ctx.Value(dependencies.PublicRequestScopeCtxKey).(dependencies.PublicRequestScope)
-		return s.APIVersionIndex(deps)
+		return s.APIVersionIndex(ctx, deps)
 	}
 }
 
@@ -112,7 +112,7 @@ func NewAPIVersionIndexEndpoint(s Service) goa.Endpoint {
 func NewHealthCheckEndpoint(s Service) goa.Endpoint {
 	return func(ctx context.Context, req interface{}) (interface{}, error) {
 		deps := ctx.Value(dependencies.PublicRequestScopeCtxKey).(dependencies.PublicRequestScope)
-		return s.HealthCheck(deps)
+		return s.HealthCheck(ctx, deps)
 	}
 }
 
@@ -132,7 +132,7 @@ func NewRepositoriesIndexEndpoint(s Service, authAPIKeyFn security.AuthAPIKeyFun
 			return nil, err
 		}
 		deps := ctx.Value(dependencies.ProjectRequestScopeCtxKey).(dependencies.ProjectRequestScope)
-		return s.RepositoriesIndex(deps, p)
+		return s.RepositoriesIndex(ctx, deps, p)
 	}
 }
 
@@ -152,7 +152,7 @@ func NewRepositoryIndexEndpoint(s Service, authAPIKeyFn security.AuthAPIKeyFunc)
 			return nil, err
 		}
 		deps := ctx.Value(dependencies.ProjectRequestScopeCtxKey).(dependencies.ProjectRequestScope)
-		return s.RepositoryIndex(deps, p)
+		return s.RepositoryIndex(ctx, deps, p)
 	}
 }
 
@@ -172,7 +172,7 @@ func NewTemplatesIndexEndpoint(s Service, authAPIKeyFn security.AuthAPIKeyFunc) 
 			return nil, err
 		}
 		deps := ctx.Value(dependencies.ProjectRequestScopeCtxKey).(dependencies.ProjectRequestScope)
-		return s.TemplatesIndex(deps, p)
+		return s.TemplatesIndex(ctx, deps, p)
 	}
 }
 
@@ -192,7 +192,7 @@ func NewTemplateIndexEndpoint(s Service, authAPIKeyFn security.AuthAPIKeyFunc) g
 			return nil, err
 		}
 		deps := ctx.Value(dependencies.ProjectRequestScopeCtxKey).(dependencies.ProjectRequestScope)
-		return s.TemplateIndex(deps, p)
+		return s.TemplateIndex(ctx, deps, p)
 	}
 }
 
@@ -212,7 +212,7 @@ func NewVersionIndexEndpoint(s Service, authAPIKeyFn security.AuthAPIKeyFunc) go
 			return nil, err
 		}
 		deps := ctx.Value(dependencies.ProjectRequestScopeCtxKey).(dependencies.ProjectRequestScope)
-		return s.VersionIndex(deps, p)
+		return s.VersionIndex(ctx, deps, p)
 	}
 }
 
@@ -232,7 +232,7 @@ func NewInputsIndexEndpoint(s Service, authAPIKeyFn security.AuthAPIKeyFunc) goa
 			return nil, err
 		}
 		deps := ctx.Value(dependencies.ProjectRequestScopeCtxKey).(dependencies.ProjectRequestScope)
-		return s.InputsIndex(deps, p)
+		return s.InputsIndex(ctx, deps, p)
 	}
 }
 
@@ -252,7 +252,7 @@ func NewValidateInputsEndpoint(s Service, authAPIKeyFn security.AuthAPIKeyFunc) 
 			return nil, err
 		}
 		deps := ctx.Value(dependencies.ProjectRequestScopeCtxKey).(dependencies.ProjectRequestScope)
-		return s.ValidateInputs(deps, p)
+		return s.ValidateInputs(ctx, deps, p)
 	}
 }
 
@@ -272,7 +272,7 @@ func NewUseTemplateVersionEndpoint(s Service, authAPIKeyFn security.AuthAPIKeyFu
 			return nil, err
 		}
 		deps := ctx.Value(dependencies.ProjectRequestScopeCtxKey).(dependencies.ProjectRequestScope)
-		return s.UseTemplateVersion(deps, p)
+		return s.UseTemplateVersion(ctx, deps, p)
 	}
 }
 
@@ -292,7 +292,7 @@ func NewInstancesIndexEndpoint(s Service, authAPIKeyFn security.AuthAPIKeyFunc) 
 			return nil, err
 		}
 		deps := ctx.Value(dependencies.ProjectRequestScopeCtxKey).(dependencies.ProjectRequestScope)
-		return s.InstancesIndex(deps, p)
+		return s.InstancesIndex(ctx, deps, p)
 	}
 }
 
@@ -312,7 +312,7 @@ func NewInstanceIndexEndpoint(s Service, authAPIKeyFn security.AuthAPIKeyFunc) g
 			return nil, err
 		}
 		deps := ctx.Value(dependencies.ProjectRequestScopeCtxKey).(dependencies.ProjectRequestScope)
-		return s.InstanceIndex(deps, p)
+		return s.InstanceIndex(ctx, deps, p)
 	}
 }
 
@@ -332,7 +332,7 @@ func NewUpdateInstanceEndpoint(s Service, authAPIKeyFn security.AuthAPIKeyFunc) 
 			return nil, err
 		}
 		deps := ctx.Value(dependencies.ProjectRequestScopeCtxKey).(dependencies.ProjectRequestScope)
-		return s.UpdateInstance(deps, p)
+		return s.UpdateInstance(ctx, deps, p)
 	}
 }
 
@@ -352,7 +352,7 @@ func NewDeleteInstanceEndpoint(s Service, authAPIKeyFn security.AuthAPIKeyFunc) 
 			return nil, err
 		}
 		deps := ctx.Value(dependencies.ProjectRequestScopeCtxKey).(dependencies.ProjectRequestScope)
-		return nil, s.DeleteInstance(deps, p)
+		return nil, s.DeleteInstance(ctx, deps, p)
 	}
 }
 
@@ -372,7 +372,7 @@ func NewUpgradeInstanceEndpoint(s Service, authAPIKeyFn security.AuthAPIKeyFunc)
 			return nil, err
 		}
 		deps := ctx.Value(dependencies.ProjectRequestScopeCtxKey).(dependencies.ProjectRequestScope)
-		return s.UpgradeInstance(deps, p)
+		return s.UpgradeInstance(ctx, deps, p)
 	}
 }
 
@@ -392,7 +392,7 @@ func NewUpgradeInstanceInputsIndexEndpoint(s Service, authAPIKeyFn security.Auth
 			return nil, err
 		}
 		deps := ctx.Value(dependencies.ProjectRequestScopeCtxKey).(dependencies.ProjectRequestScope)
-		return s.UpgradeInstanceInputsIndex(deps, p)
+		return s.UpgradeInstanceInputsIndex(ctx, deps, p)
 	}
 }
 
@@ -412,7 +412,7 @@ func NewUpgradeInstanceValidateInputsEndpoint(s Service, authAPIKeyFn security.A
 			return nil, err
 		}
 		deps := ctx.Value(dependencies.ProjectRequestScopeCtxKey).(dependencies.ProjectRequestScope)
-		return s.UpgradeInstanceValidateInputs(deps, p)
+		return s.UpgradeInstanceValidateInputs(ctx, deps, p)
 	}
 }
 
@@ -432,6 +432,6 @@ func NewGetTaskEndpoint(s Service, authAPIKeyFn security.AuthAPIKeyFunc) goa.End
 			return nil, err
 		}
 		deps := ctx.Value(dependencies.ProjectRequestScopeCtxKey).(dependencies.ProjectRequestScope)
-		return s.GetTask(deps, p)
+		return s.GetTask(ctx, deps, p)
 	}
 }

--- a/internal/pkg/service/templates/api/gen/templates/service.go
+++ b/internal/pkg/service/templates/api/gen/templates/service.go
@@ -19,46 +19,46 @@ import (
 // Service for applying templates to Keboola projects.
 type Service interface {
 	// Redirect to /v1.
-	APIRootIndex(dependencies.PublicRequestScope) (err error)
+	APIRootIndex(context.Context, dependencies.PublicRequestScope) (err error)
 	// List API name and link to documentation.
-	APIVersionIndex(dependencies.PublicRequestScope) (res *ServiceDetail, err error)
+	APIVersionIndex(context.Context, dependencies.PublicRequestScope) (res *ServiceDetail, err error)
 	// HealthCheck implements HealthCheck.
-	HealthCheck(dependencies.PublicRequestScope) (res string, err error)
+	HealthCheck(context.Context, dependencies.PublicRequestScope) (res string, err error)
 	// List all template repositories defined in the project.
-	RepositoriesIndex(dependencies.ProjectRequestScope, *RepositoriesIndexPayload) (res *Repositories, err error)
+	RepositoriesIndex(context.Context, dependencies.ProjectRequestScope, *RepositoriesIndexPayload) (res *Repositories, err error)
 	// Get details of specified repository. Use "keboola" for default Keboola
 	// repository.
-	RepositoryIndex(dependencies.ProjectRequestScope, *RepositoryIndexPayload) (res *Repository, err error)
+	RepositoryIndex(context.Context, dependencies.ProjectRequestScope, *RepositoryIndexPayload) (res *Repository, err error)
 	// List all templates  defined in the repository.
-	TemplatesIndex(dependencies.ProjectRequestScope, *TemplatesIndexPayload) (res *Templates, err error)
+	TemplatesIndex(context.Context, dependencies.ProjectRequestScope, *TemplatesIndexPayload) (res *Templates, err error)
 	// Get detail and versions of specified template.
-	TemplateIndex(dependencies.ProjectRequestScope, *TemplateIndexPayload) (res *TemplateDetail, err error)
+	TemplateIndex(context.Context, dependencies.ProjectRequestScope, *TemplateIndexPayload) (res *TemplateDetail, err error)
 	// Get details of specified template version.
-	VersionIndex(dependencies.ProjectRequestScope, *VersionIndexPayload) (res *VersionDetailExtended, err error)
+	VersionIndex(context.Context, dependencies.ProjectRequestScope, *VersionIndexPayload) (res *VersionDetailExtended, err error)
 	// Get inputs for the "use" API call.
-	InputsIndex(dependencies.ProjectRequestScope, *InputsIndexPayload) (res *Inputs, err error)
+	InputsIndex(context.Context, dependencies.ProjectRequestScope, *InputsIndexPayload) (res *Inputs, err error)
 	// Validate inputs for the "use" API call.
 	// Only configured steps should be send.
-	ValidateInputs(dependencies.ProjectRequestScope, *ValidateInputsPayload) (res *ValidationResult, err error)
+	ValidateInputs(context.Context, dependencies.ProjectRequestScope, *ValidateInputsPayload) (res *ValidationResult, err error)
 	// Validate inputs and use template in the branch.
 	// Only configured steps should be send.
-	UseTemplateVersion(dependencies.ProjectRequestScope, *UseTemplateVersionPayload) (res *Task, err error)
+	UseTemplateVersion(context.Context, dependencies.ProjectRequestScope, *UseTemplateVersionPayload) (res *Task, err error)
 	// InstancesIndex implements InstancesIndex.
-	InstancesIndex(dependencies.ProjectRequestScope, *InstancesIndexPayload) (res *Instances, err error)
+	InstancesIndex(context.Context, dependencies.ProjectRequestScope, *InstancesIndexPayload) (res *Instances, err error)
 	// InstanceIndex implements InstanceIndex.
-	InstanceIndex(dependencies.ProjectRequestScope, *InstanceIndexPayload) (res *InstanceDetail, err error)
+	InstanceIndex(context.Context, dependencies.ProjectRequestScope, *InstanceIndexPayload) (res *InstanceDetail, err error)
 	// UpdateInstance implements UpdateInstance.
-	UpdateInstance(dependencies.ProjectRequestScope, *UpdateInstancePayload) (res *InstanceDetail, err error)
+	UpdateInstance(context.Context, dependencies.ProjectRequestScope, *UpdateInstancePayload) (res *InstanceDetail, err error)
 	// DeleteInstance implements DeleteInstance.
-	DeleteInstance(dependencies.ProjectRequestScope, *DeleteInstancePayload) (err error)
+	DeleteInstance(context.Context, dependencies.ProjectRequestScope, *DeleteInstancePayload) (err error)
 	// UpgradeInstance implements UpgradeInstance.
-	UpgradeInstance(dependencies.ProjectRequestScope, *UpgradeInstancePayload) (res *Task, err error)
+	UpgradeInstance(context.Context, dependencies.ProjectRequestScope, *UpgradeInstancePayload) (res *Task, err error)
 	// UpgradeInstanceInputsIndex implements UpgradeInstanceInputsIndex.
-	UpgradeInstanceInputsIndex(dependencies.ProjectRequestScope, *UpgradeInstanceInputsIndexPayload) (res *Inputs, err error)
+	UpgradeInstanceInputsIndex(context.Context, dependencies.ProjectRequestScope, *UpgradeInstanceInputsIndexPayload) (res *Inputs, err error)
 	// UpgradeInstanceValidateInputs implements UpgradeInstanceValidateInputs.
-	UpgradeInstanceValidateInputs(dependencies.ProjectRequestScope, *UpgradeInstanceValidateInputsPayload) (res *ValidationResult, err error)
+	UpgradeInstanceValidateInputs(context.Context, dependencies.ProjectRequestScope, *UpgradeInstanceValidateInputsPayload) (res *ValidationResult, err error)
 	// Get details of a task.
-	GetTask(dependencies.ProjectRequestScope, *GetTaskPayload) (res *Task, err error)
+	GetTask(context.Context, dependencies.ProjectRequestScope, *GetTaskPayload) (res *Task, err error)
 }
 
 // Auther defines the authorization functions to be implemented by the service.

--- a/internal/pkg/service/templates/api/service/mapper.go
+++ b/internal/pkg/service/templates/api/service/mapper.go
@@ -92,7 +92,7 @@ func RepositoriesResponse(ctx context.Context, d dependencies.ProjectRequestScop
 
 	out = &Repositories{}
 	for _, repoRef := range d.ProjectRepositories().All() {
-		repo, err := repositoryInst(d, repoRef.Name)
+		repo, err := repositoryInst(ctx, d, repoRef.Name)
 		if err != nil {
 			return nil, err
 		}
@@ -491,7 +491,7 @@ func InstanceResponse(ctx context.Context, d dependencies.ProjectRequestScope, p
 }
 
 func instanceVersionDetail(ctx context.Context, d dependencies.ProjectRequestScope, instance *model.TemplateInstance) *VersionDetail {
-	repo, tmplRecord, err := templateRecord(d, instance.RepositoryName, instance.TemplateID)
+	repo, tmplRecord, err := templateRecord(ctx, d, instance.RepositoryName, instance.TemplateID)
 	if err != nil {
 		return nil
 	}

--- a/internal/pkg/service/templates/api/service/service.go
+++ b/internal/pkg/service/templates/api/service/service.go
@@ -499,7 +499,7 @@ func (s *service) UpgradeInstanceValidateInputs(ctx context.Context, d dependenc
 }
 
 func (s *service) GetTask(ctx context.Context, d dependencies.ProjectRequestScope, payload *GetTaskPayload) (res *Task, err error) {
-	ctx, str := ctx, d.Store()
+	str := d.Store()
 
 	t, err := str.GetTask(ctx, task.Key{
 		ProjectID: d.ProjectID(),

--- a/internal/pkg/service/templates/api/service/service.go
+++ b/internal/pkg/service/templates/api/service/service.go
@@ -48,12 +48,12 @@ type service struct {
 	mapper *Mapper
 }
 
-func New(d dependencies.APIScope) (Service, error) {
-	if err := StartComponentsCron(d.Process().Ctx(), d); err != nil {
+func New(ctx context.Context, d dependencies.APIScope) (Service, error) {
+	if err := StartComponentsCron(ctx, d); err != nil {
 		return nil, err
 	}
 
-	if err := StartRepositoriesPullCron(d.Process().Ctx(), d); err != nil {
+	if err := StartRepositoriesPullCron(ctx, d); err != nil {
 		return nil, err
 	}
 
@@ -97,12 +97,12 @@ func New(d dependencies.APIScope) (Service, error) {
 	return s, nil
 }
 
-func (s *service) APIRootIndex(dependencies.PublicRequestScope) (err error) {
+func (s *service) APIRootIndex(context.Context, dependencies.PublicRequestScope) (err error) {
 	// Redirect / -> /v1
 	return nil
 }
 
-func (s *service) APIVersionIndex(dependencies.PublicRequestScope) (res *ServiceDetail, err error) {
+func (s *service) APIVersionIndex(context.Context, dependencies.PublicRequestScope) (res *ServiceDetail, err error) {
 	url := *s.deps.APIConfig().PublicAddress
 	url.Path = path.Join(url.Path, "v1/documentation")
 	res = &ServiceDetail{
@@ -112,56 +112,56 @@ func (s *service) APIVersionIndex(dependencies.PublicRequestScope) (res *Service
 	return res, nil
 }
 
-func (s *service) HealthCheck(dependencies.PublicRequestScope) (res string, err error) {
+func (s *service) HealthCheck(context.Context, dependencies.PublicRequestScope) (res string, err error) {
 	return "OK", nil
 }
 
-func (s *service) RepositoriesIndex(d dependencies.ProjectRequestScope, _ *RepositoriesIndexPayload) (res *Repositories, err error) {
-	return RepositoriesResponse(d.RequestCtx(), d)
+func (s *service) RepositoriesIndex(ctx context.Context, d dependencies.ProjectRequestScope, _ *RepositoriesIndexPayload) (res *Repositories, err error) {
+	return RepositoriesResponse(ctx, d)
 }
 
-func (s *service) RepositoryIndex(d dependencies.ProjectRequestScope, payload *RepositoryIndexPayload) (res *Repository, err error) {
-	repo, err := repositoryInst(d, payload.Repository)
+func (s *service) RepositoryIndex(ctx context.Context, d dependencies.ProjectRequestScope, payload *RepositoryIndexPayload) (res *Repository, err error) {
+	repo, err := repositoryInst(ctx, d, payload.Repository)
 	if err != nil {
 		return nil, err
 	}
-	return RepositoryResponse(d.RequestCtx(), d, repo), nil
+	return RepositoryResponse(ctx, d, repo), nil
 }
 
-func (s *service) TemplatesIndex(d dependencies.ProjectRequestScope, payload *TemplatesIndexPayload) (res *Templates, err error) {
-	repo, err := repositoryInst(d, payload.Repository)
+func (s *service) TemplatesIndex(ctx context.Context, d dependencies.ProjectRequestScope, payload *TemplatesIndexPayload) (res *Templates, err error) {
+	repo, err := repositoryInst(ctx, d, payload.Repository)
 	if err != nil {
 		return nil, err
 	}
-	return TemplatesResponse(d.RequestCtx(), d, repo, repo.Templates())
+	return TemplatesResponse(ctx, d, repo, repo.Templates())
 }
 
-func (s *service) TemplateIndex(d dependencies.ProjectRequestScope, payload *TemplateIndexPayload) (res *TemplateDetail, err error) {
-	repo, tmplRecord, err := templateRecord(d, payload.Repository, payload.Template)
+func (s *service) TemplateIndex(ctx context.Context, d dependencies.ProjectRequestScope, payload *TemplateIndexPayload) (res *TemplateDetail, err error) {
+	repo, tmplRecord, err := templateRecord(ctx, d, payload.Repository, payload.Template)
 	if err != nil {
 		return nil, err
 	}
-	return TemplateDetailResponse(d.RequestCtx(), d, repo, tmplRecord)
+	return TemplateDetailResponse(ctx, d, repo, tmplRecord)
 }
 
-func (s *service) VersionIndex(d dependencies.ProjectRequestScope, payload *VersionIndexPayload) (res *VersionDetailExtended, err error) {
-	repo, tmpl, err := getTemplateVersion(d, payload.Repository, payload.Template, payload.Version)
+func (s *service) VersionIndex(ctx context.Context, d dependencies.ProjectRequestScope, payload *VersionIndexPayload) (res *VersionDetailExtended, err error) {
+	repo, tmpl, err := getTemplateVersion(ctx, d, payload.Repository, payload.Template, payload.Version)
 	if err != nil {
 		return nil, err
 	}
-	return VersionDetailExtendedResponse(d.RequestCtx(), d, repo, tmpl)
+	return VersionDetailExtendedResponse(ctx, d, repo, tmpl)
 }
 
-func (s *service) InputsIndex(d dependencies.ProjectRequestScope, payload *InputsIndexPayload) (res *Inputs, err error) {
-	_, tmpl, err := getTemplateVersion(d, payload.Repository, payload.Template, payload.Version)
+func (s *service) InputsIndex(ctx context.Context, d dependencies.ProjectRequestScope, payload *InputsIndexPayload) (res *Inputs, err error) {
+	_, tmpl, err := getTemplateVersion(ctx, d, payload.Repository, payload.Template, payload.Version)
 	if err != nil {
 		return nil, err
 	}
-	return InputsResponse(d.RequestCtx(), d, tmpl.Inputs().ToExtended()), nil
+	return InputsResponse(ctx, d, tmpl.Inputs().ToExtended()), nil
 }
 
-func (s *service) ValidateInputs(d dependencies.ProjectRequestScope, payload *ValidateInputsPayload) (res *ValidationResult, err error) {
-	_, tmpl, err := getTemplateVersion(d, payload.Repository, payload.Template, payload.Version)
+func (s *service) ValidateInputs(ctx context.Context, d dependencies.ProjectRequestScope, payload *ValidateInputsPayload) (res *ValidationResult, err error) {
+	_, tmpl, err := getTemplateVersion(ctx, d, payload.Repository, payload.Template, payload.Version)
 	if err != nil {
 		return nil, err
 	}
@@ -171,9 +171,9 @@ func (s *service) ValidateInputs(d dependencies.ProjectRequestScope, payload *Va
 	return result, err
 }
 
-func (s *service) UseTemplateVersion(d dependencies.ProjectRequestScope, payload *UseTemplateVersionPayload) (res *Task, err error) {
+func (s *service) UseTemplateVersion(ctx context.Context, d dependencies.ProjectRequestScope, payload *UseTemplateVersionPayload) (res *Task, err error) {
 	// Lock project
-	if unlockFn, err := tryLockProject(d); err != nil {
+	if unlockFn, err := tryLockProject(ctx, d); err != nil {
 		return nil, err
 	} else {
 		defer unlockFn()
@@ -184,13 +184,13 @@ func (s *service) UseTemplateVersion(d dependencies.ProjectRequestScope, payload
 	//   Since I did not manage to complete the refactoring - separation of remote and local state.
 	//   A virtual FS and fake manifest is created to make it work.
 
-	branchKey, err := getBranch(d, payload.Branch)
+	branchKey, err := getBranch(ctx, d, payload.Branch)
 	if err != nil {
 		return nil, err
 	}
 
 	// Get template
-	_, tmpl, err := getTemplateVersion(d, payload.Repository, payload.Template, payload.Version)
+	_, tmpl, err := getTemplateVersion(ctx, d, payload.Repository, payload.Template, payload.Version)
 	if err != nil {
 		return nil, err
 	}
@@ -271,8 +271,8 @@ func (s *service) UseTemplateVersion(d dependencies.ProjectRequestScope, payload
 	return s.mapper.TaskPayload(t), nil
 }
 
-func (s *service) InstancesIndex(d dependencies.ProjectRequestScope, payload *InstancesIndexPayload) (res *Instances, err error) {
-	branchKey, err := getBranch(d, payload.Branch)
+func (s *service) InstancesIndex(ctx context.Context, d dependencies.ProjectRequestScope, payload *InstancesIndexPayload) (res *Instances, err error) {
+	branchKey, err := getBranch(ctx, d, payload.Branch)
 	if err != nil {
 		return nil, err
 	}
@@ -285,7 +285,7 @@ func (s *service) InstancesIndex(d dependencies.ProjectRequestScope, payload *In
 
 	// Only one branch
 	m.Filter().SetAllowedBranches(model.AllowedBranches{model.AllowedBranch(cast.ToString(branchKey.ID))})
-	prj := project.NewWithManifest(d.RequestCtx(), fs, m)
+	prj := project.NewWithManifest(ctx, fs, m)
 
 	// Load project state
 	prjState, err := prj.LoadState(loadState.Options{LoadRemoteState: true}, d)
@@ -293,14 +293,14 @@ func (s *service) InstancesIndex(d dependencies.ProjectRequestScope, payload *In
 		return nil, err
 	}
 
-	return InstancesResponse(d.RequestCtx(), d, prjState, branchKey)
+	return InstancesResponse(ctx, d, prjState, branchKey)
 }
 
-func (s *service) InstanceIndex(d dependencies.ProjectRequestScope, payload *InstanceIndexPayload) (res *InstanceDetail, err error) {
-	_, span := d.Telemetry().Tracer().Start(d.RequestCtx(), "api.server.templates.service.InstanceIndex")
+func (s *service) InstanceIndex(ctx context.Context, d dependencies.ProjectRequestScope, payload *InstanceIndexPayload) (res *InstanceDetail, err error) {
+	_, span := d.Telemetry().Tracer().Start(ctx, "api.server.templates.service.InstanceIndex")
 	defer span.End(&err)
 
-	branchKey, err := getBranch(d, payload.Branch)
+	branchKey, err := getBranch(ctx, d, payload.Branch)
 	if err != nil {
 		return nil, err
 	}
@@ -313,26 +313,26 @@ func (s *service) InstanceIndex(d dependencies.ProjectRequestScope, payload *Ins
 
 	// Only one branch
 	m.Filter().SetAllowedBranches(model.AllowedBranches{model.AllowedBranch(cast.ToString(branchKey.ID))})
-	prj := project.NewWithManifest(d.RequestCtx(), fs, m)
+	prj := project.NewWithManifest(ctx, fs, m)
 
 	// Load project state
 	prjState, err := prj.LoadState(loadState.Options{LoadRemoteState: true}, d)
 	if err != nil {
 		return nil, err
 	}
-	return InstanceResponse(d.RequestCtx(), d, prjState, branchKey, payload.InstanceID)
+	return InstanceResponse(ctx, d, prjState, branchKey, payload.InstanceID)
 }
 
-func (s *service) UpdateInstance(d dependencies.ProjectRequestScope, payload *UpdateInstancePayload) (res *InstanceDetail, err error) {
+func (s *service) UpdateInstance(ctx context.Context, d dependencies.ProjectRequestScope, payload *UpdateInstancePayload) (res *InstanceDetail, err error) {
 	// Lock project
-	if unlockFn, err := tryLockProject(d); err != nil {
+	if unlockFn, err := tryLockProject(ctx, d); err != nil {
 		return nil, err
 	} else {
 		defer unlockFn()
 	}
 
 	// Get instance
-	prjState, branchKey, instance, err := getTemplateInstance(d, payload.Branch, payload.InstanceID, true)
+	prjState, branchKey, instance, err := getTemplateInstance(ctx, d, payload.Branch, payload.InstanceID, true)
 	if err != nil {
 		return nil, err
 	}
@@ -343,30 +343,30 @@ func (s *service) UpdateInstance(d dependencies.ProjectRequestScope, payload *Up
 		NewName:  payload.Name,
 	}
 
-	err = renameInst.Run(d.RequestCtx(), prjState, opts, d)
+	err = renameInst.Run(ctx, prjState, opts, d)
 	if err != nil {
 		return nil, err
 	}
 
 	// Push changes
 	changeDesc := fmt.Sprintf("Rename template instance %s", payload.InstanceID)
-	if err := push.Run(d.RequestCtx(), prjState, push.Options{ChangeDescription: changeDesc, AllowRemoteDelete: true, DryRun: false, SkipValidation: true}, d); err != nil {
+	if err := push.Run(ctx, prjState, push.Options{ChangeDescription: changeDesc, AllowRemoteDelete: true, DryRun: false, SkipValidation: true}, d); err != nil {
 		return nil, err
 	}
 
-	return InstanceResponse(d.RequestCtx(), d, prjState, branchKey, payload.InstanceID)
+	return InstanceResponse(ctx, d, prjState, branchKey, payload.InstanceID)
 }
 
-func (s *service) DeleteInstance(d dependencies.ProjectRequestScope, payload *DeleteInstancePayload) error {
+func (s *service) DeleteInstance(ctx context.Context, d dependencies.ProjectRequestScope, payload *DeleteInstancePayload) error {
 	// Lock project
-	if unlockFn, err := tryLockProject(d); err != nil {
+	if unlockFn, err := tryLockProject(ctx, d); err != nil {
 		return err
 	} else {
 		defer unlockFn()
 	}
 
 	// Get instance
-	prjState, branchKey, _, err := getTemplateInstance(d, payload.Branch, payload.InstanceID, true)
+	prjState, branchKey, _, err := getTemplateInstance(ctx, d, payload.Branch, payload.InstanceID, true)
 	if err != nil {
 		return err
 	}
@@ -377,36 +377,36 @@ func (s *service) DeleteInstance(d dependencies.ProjectRequestScope, payload *De
 		DryRun:   false,
 		Instance: payload.InstanceID,
 	}
-	err = deleteTemplate.Run(d.RequestCtx(), prjState, deleteOpts, d)
+	err = deleteTemplate.Run(ctx, prjState, deleteOpts, d)
 	if err != nil {
 		return err
 	}
 
 	// Push changes
 	changeDesc := fmt.Sprintf("Delete template instance %s", payload.InstanceID)
-	if err := push.Run(d.RequestCtx(), prjState, push.Options{ChangeDescription: changeDesc, AllowRemoteDelete: true, DryRun: false, SkipValidation: true}, d); err != nil {
+	if err := push.Run(ctx, prjState, push.Options{ChangeDescription: changeDesc, AllowRemoteDelete: true, DryRun: false, SkipValidation: true}, d); err != nil {
 		return err
 	}
 
 	return nil
 }
 
-func (s *service) UpgradeInstance(d dependencies.ProjectRequestScope, payload *UpgradeInstancePayload) (res *Task, err error) {
+func (s *service) UpgradeInstance(ctx context.Context, d dependencies.ProjectRequestScope, payload *UpgradeInstancePayload) (res *Task, err error) {
 	// Lock project
-	if unlockFn, err := tryLockProject(d); err != nil {
+	if unlockFn, err := tryLockProject(ctx, d); err != nil {
 		return nil, err
 	} else {
 		defer unlockFn()
 	}
 
 	// Get instance
-	prjState, branchKey, instance, err := getTemplateInstance(d, payload.Branch, payload.InstanceID, true)
+	prjState, branchKey, instance, err := getTemplateInstance(ctx, d, payload.Branch, payload.InstanceID, true)
 	if err != nil {
 		return nil, err
 	}
 
 	// Get template
-	_, tmpl, err := getTemplateVersion(d, instance.RepositoryName, instance.TemplateID, payload.Version)
+	_, tmpl, err := getTemplateVersion(ctx, d, instance.RepositoryName, instance.TemplateID, payload.Version)
 	if err != nil {
 		return nil, err
 	}
@@ -464,32 +464,32 @@ func (s *service) UpgradeInstance(d dependencies.ProjectRequestScope, payload *U
 	return s.mapper.TaskPayload(t), nil
 }
 
-func (s *service) UpgradeInstanceInputsIndex(d dependencies.ProjectRequestScope, payload *UpgradeInstanceInputsIndexPayload) (res *Inputs, err error) {
+func (s *service) UpgradeInstanceInputsIndex(ctx context.Context, d dependencies.ProjectRequestScope, payload *UpgradeInstanceInputsIndexPayload) (res *Inputs, err error) {
 	// Get instance
-	prjState, branchKey, instance, err := getTemplateInstance(d, payload.Branch, payload.InstanceID, true)
+	prjState, branchKey, instance, err := getTemplateInstance(ctx, d, payload.Branch, payload.InstanceID, true)
 	if err != nil {
 		return nil, err
 	}
 
 	// Get template
-	_, tmpl, err := getTemplateVersion(d, instance.RepositoryName, instance.TemplateID, payload.Version)
+	_, tmpl, err := getTemplateVersion(ctx, d, instance.RepositoryName, instance.TemplateID, payload.Version)
 	if err != nil {
 		return nil, err
 	}
 
 	// Generate response
-	return UpgradeInstanceInputsResponse(d.RequestCtx(), d, prjState, branchKey, instance, tmpl), nil
+	return UpgradeInstanceInputsResponse(ctx, d, prjState, branchKey, instance, tmpl), nil
 }
 
-func (s *service) UpgradeInstanceValidateInputs(d dependencies.ProjectRequestScope, payload *UpgradeInstanceValidateInputsPayload) (res *ValidationResult, err error) {
+func (s *service) UpgradeInstanceValidateInputs(ctx context.Context, d dependencies.ProjectRequestScope, payload *UpgradeInstanceValidateInputsPayload) (res *ValidationResult, err error) {
 	// Get instance
-	_, _, instance, err := getTemplateInstance(d, payload.Branch, payload.InstanceID, false)
+	_, _, instance, err := getTemplateInstance(ctx, d, payload.Branch, payload.InstanceID, false)
 	if err != nil {
 		return nil, err
 	}
 
 	// Validate the inputs as in the use operation
-	return s.ValidateInputs(d, &ValidateInputsPayload{
+	return s.ValidateInputs(ctx, d, &ValidateInputsPayload{
 		Repository:      instance.RepositoryName,
 		Template:        instance.TemplateID,
 		Version:         payload.Version,
@@ -498,8 +498,8 @@ func (s *service) UpgradeInstanceValidateInputs(d dependencies.ProjectRequestSco
 	})
 }
 
-func (s *service) GetTask(d dependencies.ProjectRequestScope, payload *GetTaskPayload) (res *Task, err error) {
-	ctx, str := d.RequestCtx(), d.Store()
+func (s *service) GetTask(ctx context.Context, d dependencies.ProjectRequestScope, payload *GetTaskPayload) (res *Task, err error) {
+	ctx, str := ctx, d.Store()
 
 	t, err := str.GetTask(ctx, task.Key{
 		ProjectID: d.ProjectID(),
@@ -523,7 +523,7 @@ func repositoryRef(d dependencies.ProjectRequestScope, name string) (model.Templ
 	}
 }
 
-func repositoryInst(d dependencies.ProjectRequestScope, repoName string) (*repository.Repository, error) {
+func repositoryInst(ctx context.Context, d dependencies.ProjectRequestScope, repoName string) (*repository.Repository, error) {
 	// Get repository ref
 	repoRef, err := repositoryRef(d, repoName)
 	if err != nil {
@@ -531,16 +531,16 @@ func repositoryInst(d dependencies.ProjectRequestScope, repoName string) (*repos
 	}
 
 	// Get repository
-	repo, err := d.TemplateRepository(d.RequestCtx(), repoRef)
+	repo, err := d.TemplateRepository(ctx, repoRef)
 	if err != nil {
 		return nil, err
 	}
 	return repo, nil
 }
 
-func templateRecord(d dependencies.ProjectRequestScope, repoName, templateID string) (*repository.Repository, *repository.TemplateRecord, error) {
+func templateRecord(ctx context.Context, d dependencies.ProjectRequestScope, repoName, templateID string) (*repository.Repository, *repository.TemplateRecord, error) {
 	// Get repository
-	repo, err := repositoryInst(d, repoName)
+	repo, err := repositoryInst(ctx, d, repoName)
 	if err != nil {
 		return nil, nil, err
 	}
@@ -556,9 +556,9 @@ func templateRecord(d dependencies.ProjectRequestScope, repoName, templateID str
 	return repo, &tmpl, nil
 }
 
-func getTemplateVersion(d dependencies.ProjectRequestScope, repoName, templateID, versionStr string) (*repository.Repository, *template.Template, error) {
+func getTemplateVersion(ctx context.Context, d dependencies.ProjectRequestScope, repoName, templateID, versionStr string) (*repository.Repository, *template.Template, error) {
 	// Get repo
-	repo, err := repositoryInst(d, repoName)
+	repo, err := repositoryInst(ctx, d, repoName)
 	if err != nil {
 		return nil, nil, err
 	}
@@ -591,7 +591,7 @@ func getTemplateVersion(d dependencies.ProjectRequestScope, repoName, templateID
 	}
 
 	// Get template version
-	tmpl, err := d.Template(d.RequestCtx(), model.NewTemplateRef(repo.Definition(), templateID, semVersion.Original()))
+	tmpl, err := d.Template(ctx, model.NewTemplateRef(repo.Definition(), templateID, semVersion.Original()))
 	if err != nil {
 		if errors.As(err, &manifest.TemplateNotFoundError{}) {
 			return nil, nil, &GenericError{
@@ -611,7 +611,7 @@ func getTemplateVersion(d dependencies.ProjectRequestScope, repoName, templateID
 	return repo, tmpl, nil
 }
 
-func getBranch(d dependencies.ProjectRequestScope, branchDef string) (model.BranchKey, error) {
+func getBranch(ctx context.Context, d dependencies.ProjectRequestScope, branchDef string) (model.BranchKey, error) {
 	// Get Keboola API
 	api := d.KeboolaProjectAPI()
 
@@ -619,7 +619,7 @@ func getBranch(d dependencies.ProjectRequestScope, branchDef string) (model.Bran
 	var targetBranch model.BranchKey
 	if branchDef == "default" {
 		// Use main branch
-		if v, err := api.GetDefaultBranchRequest().Send(d.RequestCtx()); err != nil {
+		if v, err := api.GetDefaultBranchRequest().Send(ctx); err != nil {
 			return targetBranch, err
 		} else {
 			targetBranch.ID = v.ID
@@ -627,7 +627,7 @@ func getBranch(d dependencies.ProjectRequestScope, branchDef string) (model.Bran
 	} else if branchID, err := strconv.Atoi(branchDef); err != nil {
 		// Branch ID must be numeric
 		return targetBranch, NewBadRequestError(errors.Errorf(`branch ID "%s" is not numeric`, branchDef))
-	} else if _, err := api.GetBranchRequest(keboola.BranchKey{ID: keboola.BranchID(branchID)}).Send(d.RequestCtx()); err != nil {
+	} else if _, err := api.GetBranchRequest(keboola.BranchKey{ID: keboola.BranchID(branchID)}).Send(ctx); err != nil {
 		// Branch not found
 		return targetBranch, NewResourceNotFoundError("branch", strconv.Itoa(branchID), "project")
 	} else {
@@ -638,12 +638,12 @@ func getBranch(d dependencies.ProjectRequestScope, branchDef string) (model.Bran
 	return targetBranch, nil
 }
 
-func getTemplateInstance(d dependencies.ProjectRequestScope, branchDef, instanceId string, loadConfigs bool) (*project.State, model.BranchKey, *model.TemplateInstance, error) {
+func getTemplateInstance(ctx context.Context, d dependencies.ProjectRequestScope, branchDef, instanceId string, loadConfigs bool) (*project.State, model.BranchKey, *model.TemplateInstance, error) {
 	// Note:
 	//   Waits for separation of remote and local state.
 	//   A virtual FS and fake manifest are created to make it work.
 
-	branchKey, err := getBranch(d, branchDef)
+	branchKey, err := getBranch(ctx, d, branchDef)
 	if err != nil {
 		return nil, branchKey, nil, err
 	}
@@ -660,7 +660,7 @@ func getTemplateInstance(d dependencies.ProjectRequestScope, branchDef, instance
 	} else {
 		m.Filter().SetAllowedKeys([]model.Key{branchKey})
 	}
-	prj := project.NewWithManifest(d.RequestCtx(), fs, m)
+	prj := project.NewWithManifest(ctx, fs, m)
 
 	// Load project state
 	prjState, err := prj.LoadState(loadState.Options{LoadRemoteState: true}, d)
@@ -682,16 +682,15 @@ func getTemplateInstance(d dependencies.ProjectRequestScope, branchDef, instance
 			Message: fmt.Sprintf(`Instance "%s" not found in branch "%d".`, instanceId, branchKey.ID),
 		}
 	}
-
 	return prjState, branchKey, instance, nil
 }
 
 // tryLockProject.
-func tryLockProject(d dependencies.ProjectRequestScope) (dependencies.UnlockFn, error) {
+func tryLockProject(ctx context.Context, d dependencies.ProjectRequestScope) (dependencies.UnlockFn, error) {
 	d.Logger().Infof(`requested lock for project "%d"`, d.ProjectID())
 
 	// Try lock
-	locked, unlockFn := d.ProjectLocker().TryLock(d.RequestCtx(), fmt.Sprintf("project-%d", d.ProjectID()))
+	locked, unlockFn := d.ProjectLocker().TryLock(ctx, fmt.Sprintf("project-%d", d.ProjectID()))
 	if !locked {
 		d.Logger().Infof(`project "%d" is locked by another request`, d.ProjectID())
 		return nil, &ProjectLockedError{

--- a/internal/pkg/service/templates/dependencies/mocked.go
+++ b/internal/pkg/service/templates/dependencies/mocked.go
@@ -1,11 +1,19 @@
 package dependencies
 
 import (
+	"fmt"
 	"net/url"
+	"os"
+	"path/filepath"
+	"reflect"
 	"testing"
 
+	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 
+	"github.com/keboola/keboola-as-code/internal/pkg/filesystem"
+	"github.com/keboola/keboola-as-code/internal/pkg/filesystem/aferofs"
+	"github.com/keboola/keboola-as-code/internal/pkg/model"
 	"github.com/keboola/keboola-as-code/internal/pkg/service/common/dependencies"
 	"github.com/keboola/keboola-as-code/internal/pkg/service/templates/api/config"
 )
@@ -19,8 +27,20 @@ func NewMockedAPIScope(t *testing.T, cfg config.Config, opts ...dependencies.Moc
 	var err error
 	cfg.StorageAPIHost = mocked.StorageAPIHost()
 	cfg.PublicAddress, err = url.Parse("https://templates.keboola.local")
-	cfg.Etcd = mocked.TestEtcdCredentials()
 	require.NoError(t, err)
+	cfg.Etcd = mocked.TestEtcdCredentials()
+
+	// Prepare test repository with templates, instead of default repositories, to prevent loading of all production templates.
+	if reflect.DeepEqual(cfg.Repositories, config.DefaultRepositories()) {
+		tmpDir := t.TempDir()
+		assert.NoError(t, aferofs.CopyFs2Fs(nil, filesystem.Join("git_test", "repository"), nil, tmpDir))
+		assert.NoError(t, os.Rename(filepath.Join(tmpDir, ".gittest"), filepath.Join(tmpDir, ".git"))) // nolint:forbidigo
+		cfg.Repositories = []model.TemplateRepository{{
+			Type: model.RepositoryTypeGit, Name: "keboola", URL: fmt.Sprintf("file://%s", tmpDir), Ref: "main",
+		}}
+	}
+
+	// Validate config
 	require.NoError(t, cfg.Validate())
 
 	apiScp, err := newAPIScope(mocked.TestContext(), mocked, cfg)

--- a/internal/pkg/service/templates/dependencies/reqproject.go
+++ b/internal/pkg/service/templates/dependencies/reqproject.go
@@ -92,6 +92,7 @@ func (v *projectRequestScope) TemplateRepository(ctx context.Context, definition
 	if err != nil {
 		return nil, err
 	}
+
 	return repo.Unwrap(), nil
 }
 

--- a/internal/pkg/template/repository/manager/manager.go
+++ b/internal/pkg/template/repository/manager/manager.go
@@ -5,7 +5,7 @@
 //   - Default repositories are preloaded in New by Manager.Repository method.
 //   - Manager.Repository creates a new CachedRepository by newCachedRepository function.
 //   - newCachedRepository function preloads all templates by CachedRepository.loadAllTemplates method.
-//   - Manager.Repository calls CachedRepository.markInUse method for every request.
+//   - Manager.Repository calls CachedRepository.lock method for every request.
 //   - After the request is finished, it must call provided UnlockFn.
 //   - Manager.Update is called periodically, it calls CachedRepository.update.
 //   - If there has been a change in the underlying git repository, then CachedRepository.update will return an updated copy of the repository.
@@ -120,7 +120,7 @@ func (m *Manager) Repository(ctx context.Context, ref model.TemplateRepository) 
 
 	// Prevented cleaning of the repository if it is outdated but still in use by some API request.
 	// UnlockFn must be called when the repository is no longer used.
-	unlockFn := cachedRepo.markInUse()
+	unlockFn := cachedRepo.lock()
 	return cachedRepo, unlockFn, nil
 }
 


### PR DESCRIPTION
Jira: https://keboola.atlassian.net/browse/PSGO-229

Changes:
- Remove `RequestCtx()` from dependencies, it is an anti-patern.

------

### Intro

- V Go mozes riesit jednoducho paralelne tasky, napr. cely HTTP server.
- No musis nejake vediet povedat ako dana paralelna uloha (`goroutine`):
  - vznikla
  - vediet ju ukoncit
  - ziskat nejak parent span, celkovo vediet "kontext" v ktorom kode bezi.
- V PHP to obycajne neriesis, kedze kontext programu je kontext jedneho requestu.
  - DD tak moze pouzit na podobny ucel nejake globalne premenne, alebo staticku class-u.
- V Go na to sluzi `context.Context` zo standardnej kniznice.
   - Vies nim ukonci operaciu: `context.WithCancel`, `context.WithTimeout` ....
       -  `goroutine` nevies killnut externe, musi sa ukoncit sama, a to prave tak, ze kontroluje `<-ctx.Done()`.
        - Ina alternativa je iba ukonci cely program, tj. ked skonci `main`, tak sa killnu aj vsetky goroutines.
        - Je to super v tom, ze program/goroutine ma definovane body kde skonci a nestane sa to napr. v polovici nejakeho `for` cyklu (ak nechces).
        - Viac k teme: https://www.sohamkamani.com/golang/context-cancellation-and-values/
   - Cez context si mozes odovzdavat optional hodnoty napr. logger, tracer ... `context.WithValue` ...
      - Prakticky su to nieco ako globalne premenne, s tou vyhodou ze nie su globalne :) 
      - Tj. je to dobre testovatelne.
      - Hodi sa to na veci, ktore su optional (span tracer, request ID, debug flag), tj. kod ide aj bez toho, ale nerobi nejake pomocne operacie.
- Programator by si mal `context` medzi volaniami odovzdavat (ak ho potrebuju, typicky nejake dlhsie trvajuce ulohy).
**- Je anti-patern si `ctx context.Context` niekde ulozit (do struktury) a potom si ho vytiahnut.**
   - Velmi jednoducho sa tak da dopustit chyby a prerusit napojenie jednodlivych celkov.
   - Viac je to vysvetlene tu: [Prefer contexts passed as arguments](https://go.dev/blog/context-and-structs)
- My to to v kode mame takto nespravne na niektorych miestach.
  - Najviac sa pouziva `RequestCtx`, ktory je ulozeny v dependencies.
  - Toho sa v tomto PR chcem zbavit, kedze to moze sposobovat tazko debugovatelne chyby.
  - Tj. nieco sa napr. neukonci/neodomkne, lebo sa tam predal zly kontext.
- Namiesto `d.RequestCtx()` sa pouzije `ctx` ziskany ako argument funkcie/metody.