### PR TITLE
Limit number of quota exceeded errors

### DIFF
--- a/internal/pkg/service/buffer/api/receive/importer.go
+++ b/internal/pkg/service/buffer/api/receive/importer.go
@@ -34,7 +34,7 @@ type Importer struct {
 	watcher        *watcher.APINode
 	statsCollector *statistics.CollectorNode
 	statsCache     *statistics.CacheNode
-	quota          *quota.Quota
+	quota          *quota.Checker
 }
 
 type dependencies interface {
@@ -97,7 +97,7 @@ func (i *Importer) CreateRecord(ctx context.Context, d requestDeps, receiverKey 
 
 	// Check whether the size of records that one receiver can buffer in etcd has not been exceeded.
 	if err := i.quota.Check(receiverKey); err != nil {
-		return NewInsufficientStorageError(err)
+		return err
 	}
 
 	//  ReadBody, its length is limited.

--- a/internal/pkg/service/buffer/api/receive/quota/quota_test.go
+++ b/internal/pkg/service/buffer/api/receive/quota/quota_test.go
@@ -1,0 +1,82 @@
+package quota_test
+
+import (
+	"context"
+	"strings"
+	"sync"
+	"testing"
+	"time"
+
+	"github.com/c2h5oh/datasize"
+	"github.com/stretchr/testify/assert"
+
+	"github.com/keboola/keboola-as-code/internal/pkg/service/buffer/api/receive/quota"
+	"github.com/keboola/keboola-as-code/internal/pkg/service/buffer/config"
+	"github.com/keboola/keboola-as-code/internal/pkg/service/buffer/dependencies"
+	"github.com/keboola/keboola-as-code/internal/pkg/service/buffer/store/key"
+	"github.com/keboola/keboola-as-code/internal/pkg/service/common/errors"
+)
+
+func TestQuota_Check(t *testing.T) {
+	t.Parallel()
+	wg := &sync.WaitGroup{}
+	defer wg.Wait()
+	ctx, cancel := context.WithCancel(context.Background())
+	defer cancel()
+
+	// Prepare some keys
+	now := time.Now()
+	receiverKey := key.ReceiverKey{ProjectID: 123, ReceiverID: "my-receiver"}
+	exportKey1 := key.ExportKey{ReceiverKey: receiverKey, ExportID: "my-export-1"}
+	file1Key := key.FileKey{ExportKey: exportKey1, FileID: key.FileID(now.Add(10 * time.Second))}
+	slice1Key := key.SliceKey{FileKey: file1Key, SliceID: key.SliceID(now.Add(20 * time.Second))}
+	exportKey2 := key.ExportKey{ReceiverKey: receiverKey, ExportID: "my-export-2"}
+	file2Key := key.FileKey{ExportKey: exportKey2, FileID: key.FileID(now.Add(30 * time.Second))}
+	slice2Key := key.SliceKey{FileKey: file2Key, SliceID: key.SliceID(now.Add(40 * time.Second))}
+
+	limit := 1000 * datasize.KB
+	cfg := config.NewAPIConfig()
+	cfg.ReceiverBufferSize = limit
+
+	apiScope, mock := dependencies.NewMockedAPIScope(t, cfg)
+	logger := mock.DebugLogger()
+	statsCollector := apiScope.StatsCollector()
+	quoteChecker := quota.New(ctx, wg, apiScope)
+
+	notifyReceivedData := func(sliceKey key.SliceKey, recordSize datasize.ByteSize) {
+		statsCollector.Notify(sliceKey, recordSize, 123)
+		<-statsCollector.Sync(ctx)
+		assert.Eventually(t, func() bool {
+			return strings.Contains(logger.AllMessages(), "[stats-cache]DEBUG  synced to revision")
+		}, 5*time.Second, 100*time.Millisecond)
+		logger.Truncate()
+		quoteChecker.ClearCache()
+	}
+
+	// No data, no error
+	assert.NoError(t, quoteChecker.Check(receiverKey))
+
+	// Received some data under limit: 600kB < 1000kB limit, no error
+	notifyReceivedData(slice1Key, 600*datasize.KB)
+	assert.NoError(t, quoteChecker.Check(receiverKey))
+
+	// Received some data over limit: 1200kB > 1000kB limit, error
+	notifyReceivedData(slice2Key, 600*datasize.KB)
+	err := quoteChecker.Check(receiverKey)
+	if assert.Error(t, err) {
+		assert.Equal(t, `no free space in the buffer: receiver "my-receiver" has "1.2 MB" buffered for upload, limit is "1000.0 KB"`, err.Error())
+		errValue, ok := err.(errors.WithErrorLogEnabled)
+		assert.True(t, ok)
+		// Error is logged only once per quote.MinErrorLogInterval
+		assert.True(t, errValue.ErrorLogEnabled())
+	}
+
+	// Error is not logged on second error
+	err = quoteChecker.Check(receiverKey)
+	if assert.Error(t, err) {
+		assert.Equal(t, `no free space in the buffer: receiver "my-receiver" has "1.2 MB" buffered for upload, limit is "1000.0 KB"`, err.Error())
+		errValue, ok := err.(errors.WithErrorLogEnabled)
+		assert.True(t, ok)
+		assert.False(t, errValue.ErrorLogEnabled())
+	}
+}

--- a/internal/pkg/service/buffer/cleanup/node_test.go
+++ b/internal/pkg/service/buffer/cleanup/node_test.go
@@ -170,15 +170,12 @@ func TestCleanup(t *testing.T) {
 	wildcards.Assert(t, `
 [task][1000/github/receiver.cleanup/%s]INFO  started task
 [task][1000/github/receiver.cleanup/%s]DEBUG  lock acquired "runtime/lock/task/1000/github/receiver.cleanup"
-[cleanup]INFO  started "1" receiver cleanup tasks
-%A
 [task][1000/github/receiver.cleanup/%s]DEBUG  deleted slice "1000/github/first/2006-01-02T08:04:05.000Z"
 [task][1000/github/receiver.cleanup/%s]DEBUG  deleted file "1000/github/first/2006-01-02T08:04:05.000Z"
 [task][1000/github/receiver.cleanup/%s]INFO  deleted "1" files, "1" slices, "1" records
 [task][1000/github/receiver.cleanup/%s]INFO  task succeeded (%s): receiver "1000/github" has been cleaned
 [task][1000/github/receiver.cleanup/%s]DEBUG  lock released "runtime/lock/task/1000/github/receiver.cleanup"
-%A
-`, strhelper.FilterLines(`^\[task|cleanup\]`, mock.DebugLogger().AllMessages()))
+`, strhelper.FilterLines(`^\[task\]\[1000/`, mock.DebugLogger().AllMessages()))
 
 	// Check keys
 	etcdhelper.AssertKVsString(t, client, `

--- a/internal/pkg/service/buffer/statistics/cache/cache.go
+++ b/internal/pkg/service/buffer/statistics/cache/cache.go
@@ -155,6 +155,7 @@ func watchOpenedSlices(ctx context.Context, wg *sync.WaitGroup, n *Node) <-chan 
 						panic(errors.Errorf(`unexpected event type "%v"`, event.Type))
 					}
 				}
+				n.logger.Debugf(`synced to revision %d`, header.Revision)
 			})
 		}).
 		StartConsumer(wg)

--- a/internal/pkg/service/common/errors/error.go
+++ b/internal/pkg/service/common/errors/error.go
@@ -1,4 +1,4 @@
-// Package error provides common errors for all services.
+// Package errors provides common errors for all services.
 package errors
 
 type WithStatusCode interface {
@@ -20,4 +20,8 @@ type WithExceptionID interface {
 
 type WithLogMessage interface {
 	ErrorLogMessage() string
+}
+
+type WithErrorLogEnabled interface {
+	ErrorLogEnabled() bool
 }

--- a/internal/pkg/service/common/errors/insufficientstorage.go
+++ b/internal/pkg/service/common/errors/insufficientstorage.go
@@ -5,11 +5,12 @@ import (
 )
 
 type InsufficientStorageError struct {
+	log bool
 	err error
 }
 
-func NewInsufficientStorageError(err error) InsufficientStorageError {
-	return InsufficientStorageError{err: err}
+func NewInsufficientStorageError(log bool, err error) InsufficientStorageError {
+	return InsufficientStorageError{log: log, err: err}
 }
 
 func (InsufficientStorageError) ErrorName() string {
@@ -26,4 +27,8 @@ func (e InsufficientStorageError) Error() string {
 
 func (e InsufficientStorageError) ErrorUserMessage() string {
 	return e.Error()
+}
+
+func (e InsufficientStorageError) ErrorLogEnabled() bool {
+	return e.log
 }

--- a/internal/pkg/service/common/errors/statuscode_test.go
+++ b/internal/pkg/service/common/errors/statuscode_test.go
@@ -19,7 +19,7 @@ func TestHTTPCodeFrom(t *testing.T) {
 	assert.Equal(t, http.StatusConflict, HTTPCodeFrom(NewResourceAlreadyExistsError("<what>", "<key>", "<in>")))
 	assert.Equal(t, http.StatusBadRequest, HTTPCodeFrom(NewBadRequestError(errors.New("message"))))
 	assert.Equal(t, http.StatusNotFound, HTTPCodeFrom(NewEndpointNotFoundError(&url.URL{Host: "host.local"})))
-	assert.Equal(t, http.StatusInsufficientStorage, HTTPCodeFrom(NewInsufficientStorageError(errors.New("message"))))
+	assert.Equal(t, http.StatusInsufficientStorage, HTTPCodeFrom(NewInsufficientStorageError(false, errors.New("message"))))
 	assert.Equal(t, http.StatusInternalServerError, HTTPCodeFrom(NewNotImplementedError()))
 	assert.Equal(t, http.StatusRequestEntityTooLarge, HTTPCodeFrom(NewPayloadTooLargeError(errors.New("message"))))
 	assert.Equal(t, http.StatusNotFound, HTTPCodeFrom(NewResourceNotFoundError("<what>", "<key>", "<in>")))

--- a/internal/pkg/service/common/httpserver/components.go
+++ b/internal/pkg/service/common/httpserver/components.go
@@ -20,6 +20,9 @@ type Components struct {
 func newComponents(cfg Config, logger log.Logger) Components {
 	errorWr := NewErrorWriter(logger, cfg.ErrorNamePrefix, cfg.ExceptionIDPrefix)
 	errFmt := func(ctx context.Context, err error) goaHTTP.Statuser {
+		if v, ok := err.(errors.WithStatusCode); ok { //nolint:errorlint
+			return v
+		}
 		return errors.WrapWithStatusCode(err, errors.HTTPCodeFrom(err))
 	}
 	return Components{

--- a/internal/pkg/service/common/httpserver/error.go
+++ b/internal/pkg/service/common/httpserver/error.go
@@ -94,11 +94,14 @@ func (wr *ErrorWriter) WriteOrErr(ctx context.Context, w http.ResponseWriter, er
 	response.Message = errors.Format(errForResponse, errors.FormatAsSentences())
 
 	// Log error
-	logger := wr.logger.AddPrefix(fmt.Sprintf("[http][requestId=%s]", requestID))
-	if response.StatusCode > 499 {
-		logger.Error(errorLogMessage(err, response))
-	} else {
-		logger.Info(errorLogMessage(err, response))
+	var logEnabledProvider WithErrorLogEnabled
+	if !errors.As(err, &logEnabledProvider) || logEnabledProvider.ErrorLogEnabled() {
+		logger := wr.logger.AddPrefix(fmt.Sprintf("[http][requestId=%s]", requestID))
+		if response.StatusCode > 499 {
+			logger.Error(errorLogMessage(err, response))
+		} else {
+			logger.Info(errorLogMessage(err, response))
+		}
 	}
 
 	// Write response


### PR DESCRIPTION
Jira: https://keboola.atlassian.net/browse/PSGO-234

Changes:
- `no space in the buffer` error is logged only once per 5min, per receiver and API node.
   - This will limit unnecessary logging at each import.
-----------------

V produkcii sa teraz dost casto deje chyba, `no space in the buffer`.
- V tom pripade neprijmame dalsie imports, aby sa nezaplnila cela DB.
- Pricinu chyboveho stavu riesim v inych taskoch.
- Tu riesim aby sa to nelogovalo tisicky krat za sekundu, ale iba raz za 5 min.
   - Pre OK stavy to je uz vyriesene (access log pre `import` je vypnuty).
   - Ale pre chybove stavy to vyriesene este nebolo.