### PR TITLE
Catch user errors in tasks

### DIFF
--- a/internal/pkg/service/buffer/worker/service/conditions.go
+++ b/internal/pkg/service/buffer/worker/service/conditions.go
@@ -225,10 +225,10 @@ func (c *checker) swapFile(fileKey key.FileKey, reason string) (err error) {
 			return context.WithTimeout(context.Background(), time.Minute)
 		},
 		Operation: func(ctx context.Context, logger log.Logger) task.Result {
-			c.logger.Infof(`closing file "%s": %s`, fileKey, reason)
+			logger.Infof(`closing file "%s": %s`, fileKey, reason)
 
 			err := func() (err error) {
-				rb := rollback.New(c.logger)
+				rb := rollback.New(logger)
 				defer rb.InvokeIfErr(ctx, &err)
 
 				// Get export
@@ -289,10 +289,10 @@ func (c *checker) swapSlice(sliceKey key.SliceKey, reason string) (err error) {
 			return context.WithTimeout(context.Background(), time.Minute)
 		},
 		Operation: func(ctx context.Context, logger log.Logger) task.Result {
-			c.logger.Infof(`closing slice "%s": %s`, sliceKey, reason)
+			logger.Infof(`closing slice "%s": %s`, sliceKey, reason)
 
 			err := func() (err error) {
-				rb := rollback.New(c.logger)
+				rb := rollback.New(logger)
 				defer rb.InvokeIfErr(ctx, &err)
 
 				// Get export

--- a/internal/pkg/service/buffer/worker/service/conditions.go
+++ b/internal/pkg/service/buffer/worker/service/conditions.go
@@ -3,29 +3,21 @@ package service
 import (
 	"context"
 	"fmt"
-	"strings"
 	"sync"
 	"time"
 
-	"github.com/keboola/go-client/pkg/keboola"
 	etcd "go.etcd.io/etcd/client/v3"
 
 	"github.com/keboola/keboola-as-code/internal/pkg/log"
-	"github.com/keboola/keboola-as-code/internal/pkg/service/buffer/storage/file"
 	"github.com/keboola/keboola-as-code/internal/pkg/service/buffer/store/key"
 	"github.com/keboola/keboola-as-code/internal/pkg/service/buffer/store/model"
 	"github.com/keboola/keboola-as-code/internal/pkg/service/common/etcdop"
-	"github.com/keboola/keboola-as-code/internal/pkg/service/common/rollback"
-	"github.com/keboola/keboola-as-code/internal/pkg/service/common/task"
 	"github.com/keboola/keboola-as-code/internal/pkg/utils/errors"
 )
 
 const (
 	// MinimalCredentialsExpiration which triggers the import.
 	MinimalCredentialsExpiration = time.Hour
-
-	fileSwapTaskType  = "file.swap"
-	sliceSwapTaskType = "slice.swap"
 )
 
 type checker struct {
@@ -207,121 +199,6 @@ func (c *checker) startTicker(ctx context.Context, wg *sync.WaitGroup) {
 			}
 		}
 	}()
-}
-
-func (c *checker) swapFile(fileKey key.FileKey, reason string) (err error) {
-	return c.tasks.StartTaskOrErr(task.Config{
-		Type: fileSwapTaskType,
-		Key: task.Key{
-			ProjectID: fileKey.ProjectID,
-			TaskID: task.ID(strings.Join([]string{
-				fileKey.ReceiverID.String(),
-				fileKey.ExportID.String(),
-				fileKey.FileID.String(),
-				fileSwapTaskType,
-			}, "/")),
-		},
-		Context: func() (context.Context, context.CancelFunc) {
-			return context.WithTimeout(context.Background(), time.Minute)
-		},
-		Operation: func(ctx context.Context, logger log.Logger) task.Result {
-			logger.Infof(`closing file "%s": %s`, fileKey, reason)
-
-			err := func() (err error) {
-				rb := rollback.New(logger)
-				defer rb.InvokeIfErr(ctx, &err)
-
-				// Get export
-				export, err := c.store.GetExport(ctx, fileKey.ExportKey)
-				if err != nil {
-					return errors.Errorf(`cannot close file "%s": %w`, fileKey.String(), err)
-				}
-
-				oldFile := export.OpenedFile
-				if oldFile.FileKey != fileKey {
-					return errors.Errorf(`cannot close file "%s": unexpected export opened file "%s"`, fileKey.String(), oldFile.FileKey)
-				}
-
-				oldSlice := export.OpenedSlice
-				if oldSlice.FileKey != fileKey {
-					return errors.Errorf(`cannot close file "%s": unexpected export opened slice "%s"`, fileKey.String(), oldFile.FileKey)
-				}
-
-				api, err := keboola.NewAPI(ctx, c.storageAPIHost, keboola.WithClient(&c.httpClient), keboola.WithToken(export.Token.Token))
-				if err != nil {
-					return err
-				}
-				files := file.NewManager(c.clock, api, nil)
-
-				if err := files.CreateFileForExport(ctx, rb, &export); err != nil {
-					return errors.Errorf(`cannot close file "%s": cannot create new file: %w`, fileKey.String(), err)
-				}
-
-				if err := c.store.SwapFile(ctx, &oldFile, &oldSlice, export.OpenedFile, export.OpenedSlice); err != nil {
-					return errors.Errorf(`cannot close file "%s": cannot swap old and new file: %w`, fileKey.String(), err)
-				}
-
-				return nil
-			}()
-			if err != nil {
-				return task.ErrResult(err)
-			}
-
-			return task.OkResult("new file created, the old is closing")
-		},
-	})
-}
-
-func (c *checker) swapSlice(sliceKey key.SliceKey, reason string) (err error) {
-	return c.tasks.StartTaskOrErr(task.Config{
-		Type: sliceSwapTaskType,
-		Key: task.Key{
-			ProjectID: sliceKey.ProjectID,
-			TaskID: task.ID(strings.Join([]string{
-				sliceKey.ReceiverID.String(),
-				sliceKey.ExportID.String(),
-				sliceKey.FileID.String(),
-				sliceKey.SliceID.String(),
-				sliceSwapTaskType,
-			}, "/")),
-		},
-		Context: func() (context.Context, context.CancelFunc) {
-			return context.WithTimeout(context.Background(), time.Minute)
-		},
-		Operation: func(ctx context.Context, logger log.Logger) task.Result {
-			logger.Infof(`closing slice "%s": %s`, sliceKey, reason)
-
-			err := func() (err error) {
-				rb := rollback.New(logger)
-				defer rb.InvokeIfErr(ctx, &err)
-
-				// Get export
-				export, err := c.store.GetExport(ctx, sliceKey.ExportKey)
-				if err != nil {
-					return errors.Errorf(`cannot close slice "%s": %w`, sliceKey.String(), err)
-				}
-
-				oldSlice := export.OpenedSlice
-				if oldSlice.SliceKey != sliceKey {
-					return errors.Errorf(`cannot close slice "%s": unexpected export opened slice "%s"`, sliceKey.String(), oldSlice.FileKey)
-				}
-
-				export.OpenedSlice = model.NewSlice(oldSlice.FileKey, c.clock.Now(), oldSlice.Mapping, oldSlice.Number+1, oldSlice.StorageResource)
-				if newSlice, err := c.store.SwapSlice(ctx, &oldSlice); err == nil {
-					export.OpenedSlice = newSlice
-				} else {
-					return errors.Errorf(`cannot close slice "%s": cannot swap old and new slice: %w`, sliceKey.String(), err)
-				}
-
-				return nil
-			}()
-			if err != nil {
-				return task.ErrResult(err)
-			}
-
-			return task.OkResult("new slice created, the old is closing")
-		},
-	})
 }
 
 func getCredentialsExpiration(slice model.Slice) time.Time {

--- a/internal/pkg/service/buffer/worker/service/error.go
+++ b/internal/pkg/service/buffer/worker/service/error.go
@@ -1,0 +1,31 @@
+package service
+
+import (
+	"github.com/keboola/go-client/pkg/keboola"
+
+	"github.com/keboola/keboola-as-code/internal/pkg/service/common/task"
+	"github.com/keboola/keboola-as-code/internal/pkg/utils/errors"
+)
+
+// checkAndWrapUserError checks the error with isUserError function.
+// If the error is a user error, then the error is wrapped using task.WrapUserError function.
+func checkAndWrapUserError(errPtr *error) {
+	if errPtr == nil || *errPtr == nil {
+		return
+	}
+
+	if err := *errPtr; isUserError(err) {
+		*errPtr = task.WrapUserError(err)
+	}
+}
+
+// isUserError returns true if the error is a user error, not an app error.
+// For example "storage.invalidToken" error need a user action and cannot be handled by the app code.
+func isUserError(err error) bool {
+	var storageAPIErr *keboola.StorageError
+	if errors.As(err, &storageAPIErr) && storageAPIErr.ErrCode == "storage.tokenInvalid" {
+		return true
+	}
+
+	return false
+}

--- a/internal/pkg/service/buffer/worker/service/file_close.go
+++ b/internal/pkg/service/buffer/worker/service/file_close.go
@@ -52,7 +52,9 @@ func (s *Service) closeFiles(slicesWatcher *activeSlicesWatcher, d dependencies)
 			return context.WithTimeout(context.Background(), 2*time.Minute)
 		},
 		TaskFactory: func(event etcdop.WatchEventT[model.File]) task.Fn {
-			return func(ctx context.Context, logger log.Logger) task.Result {
+			return func(ctx context.Context, logger log.Logger) (result task.Result) {
+				defer checkAndWrapUserError(&result.Error)
+
 				// Wait until all slices are uploaded
 				file := event.Value
 				if err := slicesWatcher.WaitUntilAllSlicesUploaded(ctx, logger, file.FileKey); err != nil {

--- a/internal/pkg/service/buffer/worker/service/file_import.go
+++ b/internal/pkg/service/buffer/worker/service/file_import.go
@@ -61,6 +61,7 @@ func (s *Service) importFiles(d dependencies) <-chan error {
 				fileRes := event.Value
 
 				// Handle error
+				defer checkAndWrapUserError(&result.Error)
 				defer func() {
 					if result.IsError() {
 						ctx, cancel := context.WithTimeout(context.Background(), fileMarkAsFailedTimeout)

--- a/internal/pkg/service/buffer/worker/service/file_import.go
+++ b/internal/pkg/service/buffer/worker/service/file_import.go
@@ -66,7 +66,7 @@ func (s *Service) importFiles(d dependencies) <-chan error {
 						ctx, cancel := context.WithTimeout(context.Background(), fileMarkAsFailedTimeout)
 						defer cancel()
 						retryAt := calculateFileRetryTime(&fileRes, s.clock.Now())
-						result = result.WithError(errors.Errorf(`file import failed: %w, import will be retried after "%s"`, result.Error(), retryAt))
+						result = result.WithError(errors.Errorf(`file import failed: %w, import will be retried after "%s"`, result.Error, retryAt))
 						if err := s.store.MarkFileImportFailed(ctx, &fileRes); err != nil {
 							s.logger.Errorf(`cannot mark the file "%s" as failed: %s`, fileRes.FileKey, err)
 						}

--- a/internal/pkg/service/buffer/worker/service/file_retry.go
+++ b/internal/pkg/service/buffer/worker/service/file_retry.go
@@ -61,7 +61,9 @@ func (s *Service) retryFailedImports(d dependencies) <-chan error {
 			return context.WithTimeout(context.Background(), time.Minute)
 		},
 		TaskFactory: func(event etcdop.WatchEventT[model.File]) task.Fn {
-			return func(ctx context.Context, logger log.Logger) task.Result {
+			return func(ctx context.Context, logger log.Logger) (result task.Result) {
+				defer checkAndWrapUserError(&result.Error)
+
 				file := event.Value
 				file.StorageJob = nil
 				if err := s.store.ScheduleFileForRetry(ctx, &file); err != nil {

--- a/internal/pkg/service/buffer/worker/service/file_swap.go
+++ b/internal/pkg/service/buffer/worker/service/file_swap.go
@@ -1,0 +1,83 @@
+package service
+
+import (
+	"context"
+	"strings"
+	"time"
+
+	"github.com/keboola/go-client/pkg/keboola"
+
+	"github.com/keboola/keboola-as-code/internal/pkg/log"
+	"github.com/keboola/keboola-as-code/internal/pkg/service/buffer/storage/file"
+	"github.com/keboola/keboola-as-code/internal/pkg/service/buffer/store/key"
+	"github.com/keboola/keboola-as-code/internal/pkg/service/common/rollback"
+	"github.com/keboola/keboola-as-code/internal/pkg/service/common/task"
+	"github.com/keboola/keboola-as-code/internal/pkg/utils/errors"
+)
+
+const (
+	fileSwapTaskType = "file.swap"
+)
+
+func (s *Service) swapFile(fileKey key.FileKey, reason string) (err error) {
+	return s.tasks.StartTaskOrErr(task.Config{
+		Type: fileSwapTaskType,
+		Key: task.Key{
+			ProjectID: fileKey.ProjectID,
+			TaskID: task.ID(strings.Join([]string{
+				fileKey.ReceiverID.String(),
+				fileKey.ExportID.String(),
+				fileKey.FileID.String(),
+				fileSwapTaskType,
+			}, "/")),
+		},
+		Context: func() (context.Context, context.CancelFunc) {
+			return context.WithTimeout(context.Background(), time.Minute)
+		},
+		Operation: func(ctx context.Context, logger log.Logger) task.Result {
+			logger.Infof(`closing file "%s": %s`, fileKey, reason)
+
+			err := func() (err error) {
+				rb := rollback.New(logger)
+				defer rb.InvokeIfErr(ctx, &err)
+
+				// Get export
+				export, err := s.store.GetExport(ctx, fileKey.ExportKey)
+				if err != nil {
+					return errors.Errorf(`cannot close file "%s": %w`, fileKey.String(), err)
+				}
+
+				oldFile := export.OpenedFile
+				if oldFile.FileKey != fileKey {
+					return errors.Errorf(`cannot close file "%s": unexpected export opened file "%s"`, fileKey.String(), oldFile.FileKey)
+				}
+
+				oldSlice := export.OpenedSlice
+				if oldSlice.FileKey != fileKey {
+					return errors.Errorf(`cannot close file "%s": unexpected export opened slice "%s"`, fileKey.String(), oldFile.FileKey)
+				}
+
+				api, err := keboola.NewAPI(ctx, s.storageAPIHost, keboola.WithClient(&s.httpClient), keboola.WithToken(export.Token.Token))
+				if err != nil {
+					return err
+				}
+				files := file.NewManager(s.clock, api, nil)
+
+				if err := files.CreateFileForExport(ctx, rb, &export); err != nil {
+					return errors.Errorf(`cannot close file "%s": cannot create new file: %w`, fileKey.String(), err)
+				}
+
+				if err := s.store.SwapFile(ctx, &oldFile, &oldSlice, export.OpenedFile, export.OpenedSlice); err != nil {
+					return errors.Errorf(`cannot close file "%s": cannot swap old and new file: %w`, fileKey.String(), err)
+				}
+
+				return nil
+			}()
+			if err != nil {
+				return task.ErrResult(err)
+			}
+
+			return task.OkResult("new file created, the old is closing")
+		},
+	})
+}

--- a/internal/pkg/service/buffer/worker/service/file_swap.go
+++ b/internal/pkg/service/buffer/worker/service/file_swap.go
@@ -35,10 +35,12 @@ func (s *Service) swapFile(fileKey key.FileKey, reason string) (err error) {
 			return context.WithTimeout(context.Background(), time.Minute)
 		},
 		Operation: func(ctx context.Context, logger log.Logger) (result task.Result) {
-			logger.Infof(`closing file "%s": %s`, fileKey, reason)
+			defer checkAndWrapUserError(&result.Error)
 
 			rb := rollback.New(logger)
 			defer rb.InvokeIfErr(ctx, &result.Error)
+
+			logger.Infof(`closing file "%s": %s`, fileKey, reason)
 
 			// Get export
 			export, err := s.store.GetExport(ctx, fileKey.ExportKey)

--- a/internal/pkg/service/buffer/worker/service/slice_close.go
+++ b/internal/pkg/service/buffer/worker/service/slice_close.go
@@ -52,7 +52,9 @@ func (s *Service) closeSlices(d dependencies) <-chan error {
 			return context.WithTimeout(s.ctx, 2*time.Minute)
 		},
 		TaskFactory: func(event etcdop.WatchEventT[model.Slice]) task.Fn {
-			return func(ctx context.Context, logger log.Logger) task.Result {
+			return func(ctx context.Context, logger log.Logger) (result task.Result) {
+				defer checkAndWrapUserError(&result.Error)
+
 				// Wait until all API nodes switch to a new slice.
 				waitCtx, waitCancel := context.WithTimeout(ctx, time.Minute)
 				defer waitCancel()

--- a/internal/pkg/service/buffer/worker/service/slice_retry.go
+++ b/internal/pkg/service/buffer/worker/service/slice_retry.go
@@ -61,7 +61,9 @@ func (s *Service) retryFailedUploads(d dependencies) <-chan error {
 			return fmt.Sprintf(`Slice.RetryAfter condition not met, now: "%s", needed: "%s"`, now, needed), false
 		},
 		TaskFactory: func(event etcdop.WatchEventT[model.Slice]) task.Fn {
-			return func(ctx context.Context, logger log.Logger) task.Result {
+			return func(ctx context.Context, logger log.Logger) (result task.Result) {
+				defer checkAndWrapUserError(&result.Error)
+
 				slice := event.Value
 				if err := s.store.ScheduleSliceForRetry(ctx, &slice); err != nil {
 					return task.ErrResult(err)

--- a/internal/pkg/service/buffer/worker/service/slice_swap.go
+++ b/internal/pkg/service/buffer/worker/service/slice_swap.go
@@ -33,7 +33,9 @@ func (s *Service) swapSlice(sliceKey key.SliceKey, reason string) (err error) {
 		Context: func() (context.Context, context.CancelFunc) {
 			return context.WithTimeout(context.Background(), time.Minute)
 		},
-		Operation: func(ctx context.Context, logger log.Logger) task.Result {
+		Operation: func(ctx context.Context, logger log.Logger) (result task.Result) {
+			defer checkAndWrapUserError(&result.Error)
+
 			logger.Infof(`closing slice "%s": %s`, sliceKey, reason)
 
 			err := func() (err error) {

--- a/internal/pkg/service/buffer/worker/service/slice_swap.go
+++ b/internal/pkg/service/buffer/worker/service/slice_swap.go
@@ -1,0 +1,70 @@
+package service
+
+import (
+	"context"
+	"strings"
+	"time"
+
+	"github.com/keboola/keboola-as-code/internal/pkg/log"
+	"github.com/keboola/keboola-as-code/internal/pkg/service/buffer/store/key"
+	"github.com/keboola/keboola-as-code/internal/pkg/service/buffer/store/model"
+	"github.com/keboola/keboola-as-code/internal/pkg/service/common/rollback"
+	"github.com/keboola/keboola-as-code/internal/pkg/service/common/task"
+	"github.com/keboola/keboola-as-code/internal/pkg/utils/errors"
+)
+
+const (
+	sliceSwapTaskType = "slice.swap"
+)
+
+func (s *Service) swapSlice(sliceKey key.SliceKey, reason string) (err error) {
+	return s.tasks.StartTaskOrErr(task.Config{
+		Type: sliceSwapTaskType,
+		Key: task.Key{
+			ProjectID: sliceKey.ProjectID,
+			TaskID: task.ID(strings.Join([]string{
+				sliceKey.ReceiverID.String(),
+				sliceKey.ExportID.String(),
+				sliceKey.FileID.String(),
+				sliceKey.SliceID.String(),
+				sliceSwapTaskType,
+			}, "/")),
+		},
+		Context: func() (context.Context, context.CancelFunc) {
+			return context.WithTimeout(context.Background(), time.Minute)
+		},
+		Operation: func(ctx context.Context, logger log.Logger) task.Result {
+			logger.Infof(`closing slice "%s": %s`, sliceKey, reason)
+
+			err := func() (err error) {
+				rb := rollback.New(logger)
+				defer rb.InvokeIfErr(ctx, &err)
+
+				// Get export
+				export, err := s.store.GetExport(ctx, sliceKey.ExportKey)
+				if err != nil {
+					return errors.Errorf(`cannot close slice "%s": %w`, sliceKey.String(), err)
+				}
+
+				oldSlice := export.OpenedSlice
+				if oldSlice.SliceKey != sliceKey {
+					return errors.Errorf(`cannot close slice "%s": unexpected export opened slice "%s"`, sliceKey.String(), oldSlice.FileKey)
+				}
+
+				export.OpenedSlice = model.NewSlice(oldSlice.FileKey, s.clock.Now(), oldSlice.Mapping, oldSlice.Number+1, oldSlice.StorageResource)
+				if newSlice, err := s.store.SwapSlice(ctx, &oldSlice); err == nil {
+					export.OpenedSlice = newSlice
+				} else {
+					return errors.Errorf(`cannot close slice "%s": cannot swap old and new slice: %w`, sliceKey.String(), err)
+				}
+
+				return nil
+			}()
+			if err != nil {
+				return task.ErrResult(err)
+			}
+
+			return task.OkResult("new slice created, the old is closing")
+		},
+	})
+}

--- a/internal/pkg/service/buffer/worker/service/slice_upload.go
+++ b/internal/pkg/service/buffer/worker/service/slice_upload.go
@@ -62,6 +62,7 @@ func (s *Service) uploadSlices(d dependencies) <-chan error {
 				slice := event.Value
 
 				// Handle error
+				defer checkAndWrapUserError(&result.Error)
 				defer func() {
 					if result.IsError() {
 						attempt := slice.RetryAttempt + 1

--- a/internal/pkg/service/buffer/worker/service/slice_upload.go
+++ b/internal/pkg/service/buffer/worker/service/slice_upload.go
@@ -68,7 +68,7 @@ func (s *Service) uploadSlices(d dependencies) <-chan error {
 						retryAfter := utctime.UTCTime(RetryAt(NewRetryBackoff(), s.clock.Now(), attempt))
 						slice.RetryAttempt = attempt
 						slice.RetryAfter = &retryAfter
-						result = result.WithError(errors.Errorf(`slice upload failed: %w, upload will be retried after "%s"`, result.Error(), slice.RetryAfter))
+						result = result.WithError(errors.Errorf(`slice upload failed: %w, upload will be retried after "%s"`, result.Error, slice.RetryAfter))
 						if err := s.store.MarkSliceUploadFailed(ctx, &slice); err != nil {
 							s.logger.Errorf(`cannot mark the slice "%s" as failed: %s`, slice.SliceKey, err)
 						}

--- a/internal/pkg/service/common/task/cleanup_test.go
+++ b/internal/pkg/service/common/task/cleanup_test.go
@@ -32,11 +32,15 @@ func TestCleanup(t *testing.T) {
 
 	etcdCredentials := etcdhelper.TmpNamespace(t)
 	client := etcdhelper.ClientForTest(t, etcdCredentials)
+	tel := newTestTelemetryWithFilter(t)
 
 	logs := ioutil.NewAtomicWriter()
-	node, d := createNode(t, etcdCredentials, logs, telemetry.NewForTest(t), "node1")
+	node, d := createNode(t, etcdCredentials, logs, tel, "node1")
+	logger := d.DebugLogger()
+	logger.Truncate()
+	tel.Reset()
+
 	taskPrefix := etcdop.NewTypedPrefix[task.Task](task.DefaultTaskEtcdPrefix, d.EtcdSerde())
-	tel := d.TestTelemetry()
 
 	// Add task without a finishedAt timestamp but too old - will be deleted
 	createdAtRaw, _ := time.Parse(time.RFC3339, "2006-01-02T15:04:05+07:00")

--- a/internal/pkg/service/common/task/cleanup_test.go
+++ b/internal/pkg/service/common/task/cleanup_test.go
@@ -217,8 +217,6 @@ task/_system_/tasks.cleanup/%s
 							Attributes: attribute.NewSet(
 								attribute.String("task_type", "tasks.cleanup"),
 								attribute.Bool("is_success", true),
-								attribute.Bool("is_application_error", false),
-								attribute.String("error_type", ""),
 							),
 						},
 					},

--- a/internal/pkg/service/common/task/error.go
+++ b/internal/pkg/service/common/task/error.go
@@ -1,0 +1,24 @@
+package task
+
+import "github.com/keboola/keboola-as-code/internal/pkg/utils/errors"
+
+// UserError marks the wrapped error as expected, so it will not be taken as an error in the metrics.
+// UserError is an error that could occur during normal operation.
+type UserError struct {
+	error
+}
+
+func (e UserError) Unwrap() error {
+	return e.error
+}
+
+// WrapUserError marks the error as the UserError, so it will not be taken as an error in the metrics.
+// UserError is an error that could occur during normal operation.
+func WrapUserError(err error) error {
+	return &UserError{error: err}
+}
+
+func isUserError(err error) bool {
+	var expectedErr *UserError
+	return errors.As(err, &expectedErr)
+}

--- a/internal/pkg/service/common/task/error_test.go
+++ b/internal/pkg/service/common/task/error_test.go
@@ -1,0 +1,15 @@
+package task
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+
+	"github.com/keboola/keboola-as-code/internal/pkg/utils/errors"
+)
+
+func TestUserError(t *testing.T) {
+	t.Parallel()
+	assert.False(t, isUserError(errors.New("some error")))
+	assert.True(t, isUserError(WrapUserError(errors.New("some error"))))
+}

--- a/internal/pkg/service/common/task/model.go
+++ b/internal/pkg/service/common/task/model.go
@@ -16,9 +16,11 @@ type Task struct {
 	Lock       etcdop.Key       `json:"lock" validate:"required"`
 	Result     string           `json:"result,omitempty"`
 	Error      string           `json:"error,omitempty"`
-	Outputs    map[string]any   `json:"outputs,omitempty"`
+	Outputs    Outputs          `json:"outputs,omitempty"`
 	Duration   *time.Duration   `json:"duration,omitempty"`
 }
+
+type Outputs map[string]any
 
 func (t *Task) IsProcessing() bool {
 	return t.FinishedAt == nil

--- a/internal/pkg/service/common/task/node.go
+++ b/internal/pkg/service/common/task/node.go
@@ -282,9 +282,9 @@ func (n *Node) runTask(logger log.Logger, task Task, cfg Config) (result Result,
 	// Update fields
 	task.FinishedAt = &finishedAt
 	task.Duration = &duration
+	task.Outputs = result.Outputs
 	if result.Error == nil {
 		task.Result = result.Result
-		task.Outputs = result.Outputs
 		if len(task.Outputs) > 0 {
 			logger.Infof(`task succeeded (%s): %s outputs: %s`, duration, task.Result, json.MustEncodeString(task.Outputs, false))
 		} else {
@@ -292,7 +292,6 @@ func (n *Node) runTask(logger log.Logger, task Task, cfg Config) (result Result,
 		}
 	} else {
 		task.Error = result.Error.Error()
-		task.Outputs = result.Outputs
 		if len(task.Outputs) > 0 {
 			logger.Warnf(`task failed (%s): %s outputs: %s`, duration, errors.Format(result.Error, errors.FormatWithStack()), json.MustEncodeString(task.Outputs, false))
 		} else {

--- a/internal/pkg/service/common/task/node.go
+++ b/internal/pkg/service/common/task/node.go
@@ -180,7 +180,7 @@ func (n *Node) RunTask(cfg Config) (t *Task, err error) {
 	}
 
 	// Handle error during task itself
-	return task, result.Error()
+	return task, result.Error
 }
 
 func (n *Node) prepareTask(cfg Config) (t *Task, fn runTaskFn, err error) {
@@ -256,7 +256,7 @@ func (n *Node) runTask(logger log.Logger, task Task, cfg Config) (result Result,
 	n.meters.running.Add(ctx, 1, metric.WithAttributes(meterStartAttrs(&task)...))
 
 	// Process results in defer to catch panic
-	defer span.End(&result.error)
+	defer span.End(&result.Error)
 
 	// Do operation
 	startTime := n.clock.Now()
@@ -265,7 +265,7 @@ func (n *Node) runTask(logger log.Logger, task Task, cfg Config) (result Result,
 			if panicErr := recover(); panicErr != nil {
 				err := errors.Errorf("panic: %s, stacktrace: %s", panicErr, string(debug.Stack()))
 				logger.Errorf(`task panic: %s`, err)
-				if result.error == nil {
+				if result.Error == nil {
 					result = ErrResult(err)
 				}
 			}
@@ -282,21 +282,21 @@ func (n *Node) runTask(logger log.Logger, task Task, cfg Config) (result Result,
 	// Update fields
 	task.FinishedAt = &finishedAt
 	task.Duration = &duration
-	if result.error == nil {
-		task.Result = result.result
-		task.Outputs = result.outputs
+	if result.Error == nil {
+		task.Result = result.Result
+		task.Outputs = result.Outputs
 		if len(task.Outputs) > 0 {
 			logger.Infof(`task succeeded (%s): %s outputs: %s`, duration, task.Result, json.MustEncodeString(task.Outputs, false))
 		} else {
 			logger.Infof(`task succeeded (%s): %s`, duration, task.Result)
 		}
 	} else {
-		task.Error = result.error.Error()
-		task.Outputs = result.outputs
+		task.Error = result.Error.Error()
+		task.Outputs = result.Outputs
 		if len(task.Outputs) > 0 {
-			logger.Warnf(`task failed (%s): %s outputs: %s`, duration, errors.Format(result.error, errors.FormatWithStack()), json.MustEncodeString(task.Outputs, false))
+			logger.Warnf(`task failed (%s): %s outputs: %s`, duration, errors.Format(result.Error, errors.FormatWithStack()), json.MustEncodeString(task.Outputs, false))
 		} else {
-			logger.Warnf(`task failed (%s): %s`, duration, errors.Format(result.error, errors.FormatWithStack()))
+			logger.Warnf(`task failed (%s): %s`, duration, errors.Format(result.Error, errors.FormatWithStack()))
 		}
 	}
 

--- a/internal/pkg/service/common/task/node_test.go
+++ b/internal/pkg/service/common/task/node_test.go
@@ -297,8 +297,6 @@ task/123/my-receiver/my-export/some.task/%s
 						Attributes: attribute.NewSet(
 							attribute.String("task_type", "some.task"),
 							attribute.Bool("is_success", true),
-							attribute.Bool("is_application_error", false),
-							attribute.String("error_type", ""),
 						),
 					},
 				},

--- a/internal/pkg/service/common/task/node_test.go
+++ b/internal/pkg/service/common/task/node_test.go
@@ -46,7 +46,7 @@ func TestSuccessfulTask(t *testing.T) {
 	}
 
 	logs := ioutil.NewAtomicWriter()
-	tel := telemetry.NewForTest(t)
+	tel := newTestTelemetryWithFilter(t)
 
 	// Create nodes
 	node1, _ := createNode(t, etcdCredentials, logs, tel, "node1")
@@ -320,8 +320,9 @@ func TestFailedTask(t *testing.T) {
 		ProjectID: 123,
 		TaskID:    task.ID("my-receiver/my-export/" + taskType),
 	}
+
 	logs := ioutil.NewAtomicWriter()
-	tel := telemetry.NewForTest(t)
+	tel := newTestTelemetryWithFilter(t)
 
 	// Create nodes
 	node1, _ := createNode(t, etcdCredentials, logs, tel, "node1")
@@ -643,12 +644,16 @@ func TestTaskTimeout(t *testing.T) {
 		ProjectID: 123,
 		TaskID:    task.ID("my-receiver/my-export/" + taskType),
 	}
-	tel := telemetry.NewForTest(t)
 
-	// Create node and start task
+	tel := newTestTelemetryWithFilter(t)
+
+	// Create node and
 	node1, d := createNode(t, etcdCredentials, nil, tel, "node1")
 	logger := d.DebugLogger()
+	logger.Truncate()
 	tel.Reset()
+
+	// Start task
 	_, err := node1.StartTask(task.Config{
 		Key:  tKey,
 		Type: taskType,
@@ -807,10 +812,11 @@ func TestWorkerNodeShutdownDuringTask(t *testing.T) {
 	}
 
 	logs := ioutil.NewAtomicWriter()
-	tel := telemetry.NewForTest(t)
+	tel := newTestTelemetryWithFilter(t)
 
 	// Create node
 	node1, d := createNode(t, etcdCredentials, logs, tel, "node1")
+	tel.Reset()
 	logs.Truncate()
 
 	// Start a task
@@ -891,6 +897,16 @@ task/123/my-receiver/my-export/some.task/%s
 `, logs.String())
 }
 
+func newTestTelemetryWithFilter(t *testing.T) telemetry.ForTest {
+	t.Helper()
+	return telemetry.
+		NewForTest(t).
+		SetSpanFilter(func(ctx context.Context, spanName string, opts ...trace.SpanStartOption) bool {
+			// Ignore etcd spans
+			return !strings.HasPrefix(spanName, "etcd")
+		})
+}
+
 func createNode(t *testing.T, etcdCredentials etcdclient.Credentials, logs io.Writer, tel telemetry.ForTest, nodeName string) (*task.Node, dependencies.Mocked) {
 	t.Helper()
 	d := createDeps(t, etcdCredentials, logs, tel, nodeName)
@@ -902,11 +918,6 @@ func createNode(t *testing.T, etcdCredentials etcdclient.Credentials, logs io.Wr
 
 func createDeps(t *testing.T, etcdCredentials etcdclient.Credentials, logs io.Writer, tel telemetry.ForTest, nodeName string) dependencies.Mocked {
 	t.Helper()
-
-	// Ignore etcd spans
-	tel.SetSpanFilter(func(ctx context.Context, spanName string, opts ...trace.SpanStartOption) bool {
-		return !strings.HasPrefix(spanName, "etcd")
-	})
 
 	d := dependencies.NewMocked(
 		t,

--- a/internal/pkg/service/common/task/result_test.go
+++ b/internal/pkg/service/common/task/result_test.go
@@ -11,17 +11,17 @@ import (
 func TestOkResult(t *testing.T) {
 	t.Parallel()
 	result := OkResult("task succeeded")
-	assert.Equal(t, Result{result: "task succeeded"}, result)
-	assert.Equal(t, "task succeeded", result.Result())
+	assert.Equal(t, Result{Result: "task succeeded"}, result)
+	assert.Equal(t, "task succeeded", result.Result)
 	assert.False(t, result.IsError())
-	assert.Nil(t, result.Error())
+	assert.Nil(t, result.Error)
 
 	// WithResult
 	result = result.WithResult("new message")
-	assert.Equal(t, Result{result: "new message"}, result)
-	assert.Equal(t, "new message", result.Result())
+	assert.Equal(t, Result{Result: "new message"}, result)
+	assert.Equal(t, "new message", result.Result)
 	assert.False(t, result.IsError())
-	assert.Nil(t, result.Error())
+	assert.Nil(t, result.Error)
 
 	// WithError
 	assert.PanicsWithError(t, `result type is "ok", not "error", it cannot be modified`, func() {
@@ -33,28 +33,28 @@ func TestOkResult_WithOutput(t *testing.T) {
 	t.Parallel()
 	result := OkResult("task succeeded").WithOutput("key1", 123).WithOutput("key2", "foo")
 	assert.Equal(t, Result{
-		result: "task succeeded",
-		outputs: map[string]any{
+		Result: "task succeeded",
+		Outputs: map[string]any{
 			"key1": 123,
 			"key2": "foo",
 		},
 	}, result)
-	assert.Equal(t, "task succeeded", result.Result())
+	assert.Equal(t, "task succeeded", result.Result)
 	assert.False(t, result.IsError())
-	assert.Nil(t, result.Error())
+	assert.Nil(t, result.Error)
 
 	// WithResult
 	result = result.WithResult("new message")
 	assert.Equal(t, Result{
-		result: "new message",
-		outputs: map[string]any{
+		Result: "new message",
+		Outputs: map[string]any{
 			"key1": 123,
 			"key2": "foo",
 		},
 	}, result)
-	assert.Equal(t, "new message", result.Result())
+	assert.Equal(t, "new message", result.Result)
 	assert.False(t, result.IsError())
-	assert.Nil(t, result.Error())
+	assert.Nil(t, result.Error)
 
 	// WithError
 	assert.PanicsWithError(t, `result type is "ok", not "error", it cannot be modified`, func() {
@@ -66,47 +66,16 @@ func TestErrResult(t *testing.T) {
 	t.Parallel()
 	err := errors.New("task failed")
 	result := ErrResult(err)
-	assert.Equal(t, Result{error: err, errorType: "other", applicationError: true}, result)
+	assert.Equal(t, Result{Error: err}, result)
 	assert.True(t, result.IsError())
-	assert.True(t, result.IsApplicationError())
-	assert.Equal(t, "other", result.ErrorType())
-	assert.Equal(t, err, result.Error())
+	assert.Equal(t, err, result.Error)
 
 	// WithError
 	err = errors.New("new error")
 	result = result.WithError(err)
-	assert.Equal(t, Result{error: err, errorType: "other", applicationError: true}, result)
+	assert.Equal(t, Result{Error: err}, result)
 	assert.True(t, result.IsError())
-	assert.True(t, result.IsApplicationError())
-	assert.Equal(t, "other", result.ErrorType())
-	assert.Equal(t, err, result.Error())
-
-	// WithResult
-	assert.PanicsWithError(t, `result type is "error", not "ok", it cannot be modified`, func() {
-		result.WithResult("msg")
-	})
-}
-
-func TestErrResult_UserError(t *testing.T) {
-	t.Parallel()
-	err := WrapUserError(errors.New("task failed"))
-	result := ErrResult(err)
-	assert.Equal(t, Result{error: err, errorType: "other", applicationError: false}, result)
-	assert.True(t, result.IsError())
-	assert.True(t, result.IsUserError())
-	assert.False(t, result.IsApplicationError())
-	assert.Equal(t, "other", result.ErrorType())
-	assert.Equal(t, err, result.Error())
-
-	// WithError
-	err = WrapUserError(errors.New("new error"))
-	result = result.WithError(err)
-	assert.Equal(t, Result{error: err, errorType: "other", applicationError: false}, result)
-	assert.True(t, result.IsError())
-	assert.True(t, result.IsUserError())
-	assert.False(t, result.IsApplicationError())
-	assert.Equal(t, "other", result.ErrorType())
-	assert.Equal(t, err, result.Error())
+	assert.Equal(t, err, result.Error)
 
 	// WithResult
 	assert.PanicsWithError(t, `result type is "error", not "ok", it cannot be modified`, func() {
@@ -119,38 +88,29 @@ func TestErrResult_WithOutput(t *testing.T) {
 	err := errors.New("task failed")
 	result := ErrResult(err).WithOutput("key1", 123).WithOutput("key2", "foo")
 	assert.Equal(t, Result{
-		error:            err,
-		errorType:        "other",
-		applicationError: true,
-		outputs: map[string]any{
+		Error: err,
+		Outputs: map[string]any{
 			"key1": 123,
 			"key2": "foo",
 		},
 	}, result)
-	assert.Equal(t, "", result.Result())
+	assert.Equal(t, "", result.Result)
 	assert.True(t, result.IsError())
-	assert.False(t, result.IsUserError())
-	assert.True(t, result.IsApplicationError())
-	assert.Equal(t, err, result.Error())
+	assert.Equal(t, err, result.Error)
 
 	// WithError
 	err = errors.New("new error")
 	result = result.WithError(err)
 	assert.Equal(t, Result{
-		error:            err,
-		errorType:        "other",
-		applicationError: true,
-		outputs: map[string]any{
+		Error: err,
+		Outputs: map[string]any{
 			"key1": 123,
 			"key2": "foo",
 		},
 	}, result)
-	assert.Equal(t, "", result.Result())
+	assert.Equal(t, "", result.Result)
 	assert.True(t, result.IsError())
-	assert.False(t, result.IsUserError())
-	assert.True(t, result.IsApplicationError())
-	assert.Equal(t, "other", result.ErrorType())
-	assert.Equal(t, err, result.Error())
+	assert.Equal(t, err, result.Error)
 
 	// WithResult
 	assert.PanicsWithError(t, `result type is "error", not "ok", it cannot be modified`, func() {

--- a/internal/pkg/service/common/task/trace.go
+++ b/internal/pkg/service/common/task/trace.go
@@ -32,8 +32,8 @@ func meterEndAttrs(task *Task, r Result) []attribute.KeyValue {
 	return []attribute.KeyValue{
 		attribute.String("task_type", task.Type),
 		attribute.Bool("is_success", task.IsSuccessful()),
-		attribute.Bool("is_application_error", r.IsApplicationError()),
-		attribute.String("error_type", r.ErrorType()),
+		attribute.Bool("is_application_error", !isUserError(r.Error)),
+		attribute.String("error_type", telemetry.ErrorType(r.Error)),
 	}
 }
 
@@ -67,9 +67,9 @@ func spanEndAttrs(task *Task, r Result) []attribute.KeyValue {
 	} else {
 		out = append(
 			out,
-			attribute.Bool("is_application_error", r.IsApplicationError()),
+			attribute.Bool("is_application_error", !isUserError(r.Error)),
 			attribute.String("error", task.Error),
-			attribute.String("error_type", r.ErrorType()),
+			attribute.String("error_type", telemetry.ErrorType(r.Error)),
 		)
 	}
 

--- a/internal/pkg/service/common/task/trace.go
+++ b/internal/pkg/service/common/task/trace.go
@@ -29,12 +29,17 @@ func meterStartAttrs(task *Task) []attribute.KeyValue {
 }
 
 func meterEndAttrs(task *Task, r Result) []attribute.KeyValue {
-	return []attribute.KeyValue{
+	out := []attribute.KeyValue{
 		attribute.String("task_type", task.Type),
 		attribute.Bool("is_success", task.IsSuccessful()),
-		attribute.Bool("is_application_error", !isUserError(r.Error)),
-		attribute.String("error_type", telemetry.ErrorType(r.Error)),
 	}
+	if r.IsError() {
+		out = append(out,
+			attribute.Bool("is_application_error", !isUserError(r.Error)),
+			attribute.String("error_type", telemetry.ErrorType(r.Error)),
+		)
+	}
+	return out
 }
 
 func spanStartAttrs(task *Task) []attribute.KeyValue {

--- a/internal/pkg/telemetry/fortest.go
+++ b/internal/pkg/telemetry/fortest.go
@@ -32,7 +32,7 @@ type ForTest interface {
 	TraceID(n int) trace.TraceID
 	SpanID(n int) trace.SpanID
 	Reset()
-	SetSpanFilter(f TestSpanFilter)
+	SetSpanFilter(f TestSpanFilter) ForTest
 	Spans(t *testing.T, opts ...TestSpanOption) tracetest.SpanStubs
 	Metrics(t *testing.T, opts ...TestMeterOption) []metricdata.Metrics
 	AssertSpans(t *testing.T, expectedSpans tracetest.SpanStubs, opts ...TestSpanOption)
@@ -135,9 +135,10 @@ func NewForTest(t *testing.T) ForTest {
 	}
 }
 
-func (v *forTest) SetSpanFilter(f TestSpanFilter) {
+func (v *forTest) SetSpanFilter(f TestSpanFilter) ForTest {
 	v.traceProvider.filter = f
 	v.Reset()
+	return v
 }
 
 func (v *forTest) TraceID(n int) trace.TraceID {

--- a/test/buffer/worker/002_slice_upload_test.go
+++ b/test/buffer/worker/002_slice_upload_test.go
@@ -23,8 +23,8 @@ func (ts *testSuite) test002SliceUpload() {
 	// Periodic condition checks have detected that the UPLOAD conditions for both slices/exports have been met.
 	ts.t.Logf("waiting for upload conditions check ...")
 	if ts.WaitForLogMessages(15*time.Second, `
-[worker-node-%d][bufferWorker][service][conditions]INFO closing slice "%s": count threshold met, received: 6 rows, threshold: 5 rows
-[worker-node-%d][bufferWorker][service][conditions]INFO closing slice "%s": count threshold met, received: 6 rows, threshold: 5 rows
+[worker-node-%d][bufferWorker][task][%s/slice.swap/%s]INFO closing slice "%s": count threshold met, received: 6 rows, threshold: 5 rows
+[worker-node-%d][bufferWorker][task][%s/slice.swap/%s]INFO closing slice "%s": count threshold met, received: 6 rows, threshold: 5 rows
 `) {
 		ts.t.Logf("upload conditions met")
 	}

--- a/test/buffer/worker/003_file_import_test.go
+++ b/test/buffer/worker/003_file_import_test.go
@@ -26,8 +26,8 @@ func (ts *testSuite) test003FileImport() {
 	// Periodic condition checks have detected that the IMPORT conditions for both files/exports have been met.
 	ts.t.Logf("waiting for import conditions check ...")
 	if ts.WaitForLogMessages(15*time.Second, `
-[worker-node-%d][bufferWorker][service][conditions]INFO closing file "%s": count threshold met, received: 10 rows, threshold: 10 rows
-[worker-node-%d][bufferWorker][service][conditions]INFO closing file "%s": count threshold met, received: 10 rows, threshold: 10 rows
+[worker-node-%d][bufferWorker][task][%s/file.swap/%s]INFO closing file "%s": count threshold met, received: 10 rows, threshold: 10 rows
+[worker-node-%d][bufferWorker][task][%s/file.swap/%s]INFO closing file "%s": count threshold met, received: 10 rows, threshold: 10 rows
 `) {
 		ts.t.Logf("import conditions met")
 	}


### PR DESCRIPTION
Jira: https://keboola.atlassian.net/browse/PSGO-129

Changes:
- Added ability to specify which errors are user errors in buffer tasks.
- Mark `storage.tokenInvalid` error as user error.

![image](https://github.com/keboola/keboola-as-code/assets/19371734/b953c134-10bb-4283-a8aa-435f5871b37f)
