### PR TITLE
Add method to restart watch stream manually

### DIFF
--- a/internal/pkg/service/common/etcdop/consumer.go
+++ b/internal/pkg/service/common/etcdop/consumer.go
@@ -125,7 +125,7 @@ func (c WatchConsumer[E]) StartConsumer(wg *sync.WaitGroup) (initErr <-chan erro
 				// A fatal error (etcd ErrCompacted) occurred.
 				// It is not possible to continue watching, the operation must be restarted.
 				restart = true
-				c.logger.Warn(resp.RestartReason)
+				c.logger.Warn("restarted, ", resp.RestartReason)
 				if c.onRestarted != nil {
 					c.onRestarted(resp.RestartReason, resp.RestartDelay)
 				}

--- a/internal/pkg/service/common/etcdop/consumer_test.go
+++ b/internal/pkg/service/common/etcdop/consumer_test.go
@@ -116,7 +116,7 @@ INFO  ForEach: restart=false, events(1): create "my/prefix/key1"
 	wildcards.Assert(t, `
 WARN  watch error: etcdserver: mvcc: required revision has been compacted
 WARN  restarted, backoff delay %s, reason: watch error: etcdserver: mvcc: required revision has been compacted
-INFO  OnRestarted: restarted, backoff delay %s, reason: watch error: etcdserver: mvcc: required revision has been compacted
+INFO  OnRestarted: backoff delay %s, reason: watch error: etcdserver: mvcc: required revision has been compacted
 INFO  ForEach: restart=true, events(3): create "my/prefix/key1", create "my/prefix/key2", create "my/prefix/key3"
 `, logger.AllMessages())
 	logger.Truncate()

--- a/internal/pkg/service/common/etcdop/etcdop.go
+++ b/internal/pkg/service/common/etcdop/etcdop.go
@@ -27,8 +27,9 @@
 // - Prefix[T].GetAllAndWatch - get all KVs and then watch for updates, restart on a fatal error, values are deserialized to the type T.
 //
 // Watch layers:
-// - Prefix.Watch wraps low-level client.Watch
-// - Prefix.GetAllAndWatch calls wrapWatchWithRestart, Prefix.GetAll and Prefix.Watch
+// - Prefix.WatchWithoutRestart wraps low-level client.Watch
+// - Prefix.Watch calls wrapStreamWithRestart.
+// - Prefix.GetAllAndWatch calls wrapStreamWithRestart, Prefix.GetAll and Prefix.WatchWithoutRestart
 // - Prefix[T].Watch calls Prefix.Watch and Prefix[T].decodeChannel
 // - Prefix[T].GetAllAndWatch calls Prefix.GetAllAndWatch and Prefix[T].decodeChannel
 package etcdop

--- a/internal/pkg/service/common/etcdop/watch.go
+++ b/internal/pkg/service/common/etcdop/watch.go
@@ -6,6 +6,7 @@ import (
 	"fmt"
 	"sort"
 	"strconv"
+	"sync"
 	"time"
 
 	"github.com/cenkalti/backoff/v4"
@@ -47,23 +48,35 @@ type WatcherStatus struct {
 	Err error
 	// Created is used to indicate the creation of the watcher, it is emitted before the first event.
 	Created bool
-	// Restarted is used to indicate re-creation of the watcher, the following events are streamed from the beginning.
-	// It is used in case of a fatal error (etcd ErrCompacted) from which it is not possible to recover.
+	// Restarted is used to indicate re-creation of the watcher.
+	// Prefix.GetAllAndWatch and PrefixT.GetAllAndWatch watchers will stream all records again.
+	// Restart is triggered in case of a fatal error (such as ErrCompacted) from which it is not possible to recover.
+	// Restart can be triggerred also manually by RestartableWatchStream.Restart method.
 	Restarted     bool
 	RestartReason string
 	RestartDelay  time.Duration
 }
 
+// WatchStreamE streams events of the E type.
 type WatchStreamE[E any] struct {
 	channel chan WatchResponseE[E]
 	cancel  context.CancelFunc
 }
 
+// RestartableWatchStream is restarted on a fatal error, or manually by the Restart method.
+type RestartableWatchStream struct {
+	WatchStreamE[WatchEvent]
+	lock *sync.Mutex
+	sub  *WatchStreamE[WatchEvent]
+}
+
+// WatchStream for untyped prefix.
 type WatchStream = WatchStreamE[WatchEvent]
 
+// WatchResponse for untyped prefix.
 type WatchResponse = WatchResponseE[WatchEvent]
 
-// WatchResponseE wraps events of the type E.
+// WatchResponseE wraps events of the type E together with WatcherStatus.
 type WatchResponseE[E any] struct {
 	WatcherStatus
 	Events []E
@@ -94,14 +107,30 @@ func (s *WatchStreamE[E]) SetupConsumer(logger log.Logger) WatchConsumer[E] {
 	return newConsumer[E](logger, s)
 }
 
+// Restart cancels the current stream, so a new stream is created.
+func (s RestartableWatchStream) Restart() {
+	s.lock.Lock()
+	if s.sub != nil {
+		s.sub.cancel()
+		for range s.sub.channel {
+			// wait for the channel close
+		}
+	}
+	s.lock.Unlock()
+}
+
 // GetAllAndWatch loads all keys in the prefix by the iterator and then Watch for changes.
-//
-// If a fatal error occurs, the watcher is restarted.
-// The "restarted" event is emitted before the restart.
-// Then, the following events are streamed from the beginning.
-//
-// See WatchResponse for details.
-func (v Prefix) GetAllAndWatch(ctx context.Context, client *etcd.Client, opts ...etcd.OpOption) *WatchStream {
+//   - Connection of GetAll and Watch phase is atomic, the etcd.WithRev option is used.
+//   - If an error occurs during initialization, the operation is halted, it is signalized by the WatcherStatus.InitErr field.
+//   - After successful initialization, the WatcherStatus.Created = true event is emitted.
+//   - Recoverable errors are automatically retried in the background by the low-level etcd client.
+//   - If a fatal error occurs after initialization (such as ErrCompacted), the watcher is automatically restarted.
+//   - The retry mechanism uses exponential backoff for subsequent attempts.
+//   - When a restart occurs, the WatcherStatus.Restarted = true is emitted.
+//   - Then, the following events are streamed from the beginning.
+//   - Restart can be triggered also manually by the RestartableWatchStream.Restart method.
+//   - The operation can be cancelled using the context.
+func (v Prefix) GetAllAndWatch(ctx context.Context, client *etcd.Client, opts ...etcd.OpOption) *RestartableWatchStream {
 	return wrapStreamWithRestart(ctx, func(ctx context.Context) *WatchStream {
 		ctx, cancel := context.WithCancel(ctx)
 		stream := &WatchStream{channel: make(chan WatchResponse), cancel: cancel}
@@ -154,10 +183,16 @@ func (v Prefix) GetAllAndWatch(ctx context.Context, client *etcd.Client, opts ..
 	})
 }
 
-// Watch method wraps low-level etcd watcher and watch for changes in the prefix.
-// Operation can be cancelled by the context or a fatal error (etcd ErrCompacted).
-// Otherwise, Watch will retry on other recoverable errors forever until reconnected.
-func (v Prefix) Watch(ctx context.Context, client etcd.Watcher, opts ...etcd.OpOption) *WatchStream {
+// Watch method wraps the low-level etcd watcher to watch for changes in the prefix.
+//   - If an error occurs during initialization, the operation is halted, and it is signalized by the event.InitErr field.
+//   - After successful initialization, the WatcherStatus.Created = true event is emitted.
+//   - Recoverable errors are automatically retried in the background by the low-level etcd client.
+//   - If a fatal error occurs after initialization (such as etcd ErrCompacted), the watcher is automatically restarted.
+//   - The retry mechanism uses exponential backoff for subsequent attempts.
+//   - When a restart occurs, the WatcherStatus.Restarted = true is emitted.
+//   - Restart can be triggered also manually by the RestartableWatchStream.Restart method.
+//   - The operation can be cancelled using the context.
+func (v Prefix) Watch(ctx context.Context, client etcd.Watcher, opts ...etcd.OpOption) *RestartableWatchStream {
 	return wrapStreamWithRestart(ctx, func(ctx context.Context) *WatchStream {
 		return v.WatchWithoutRestart(ctx, client, opts...)
 	})
@@ -262,10 +297,13 @@ func (v Prefix) WatchWithoutRestart(ctx context.Context, client etcd.Watcher, op
 	return stream
 }
 
-func wrapStreamWithRestart(ctx context.Context, channelFactory func(ctx context.Context) *WatchStream) *WatchStream {
+// wrapStreamWithRestart continuously tries to restart the stream on fatal errors.
+// An exponential backoff is used between attempts.
+// The operation can be cancelled using the context.
+func wrapStreamWithRestart(ctx context.Context, channelFactory func(ctx context.Context) *WatchStream) *RestartableWatchStream {
 	b := backoff.WithContext(newWatchBackoff(), ctx)
 	ctx, cancel := context.WithCancel(ctx)
-	stream := &WatchStream{channel: make(chan WatchResponse), cancel: cancel}
+	stream := &RestartableWatchStream{WatchStreamE: WatchStream{channel: make(chan WatchResponse), cancel: cancel}, lock: &sync.Mutex{}}
 	go func() {
 		defer close(stream.channel)
 		defer cancel()
@@ -277,20 +315,49 @@ func wrapStreamWithRestart(ctx context.Context, channelFactory func(ctx context.
 
 		// The "restarted" event contains RestartReason - last error.
 		var lastErr error
+		var restart bool
+		var restartDelay time.Duration
 
 		for {
-			// The rawStream channel is closed by the context, so the context does not have to be checked here again.
-			rawStream := channelFactory(ctx)
-			for resp := range rawStream.channel {
+			// Is context done?
+			if ctx.Err() != nil {
+				return
+			}
+
+			// Store reference to the current stream, so it can be canceled/restarted
+			subStream := channelFactory(ctx)
+			stream.lock.Lock()
+			stream.sub = subStream
+			stream.lock.Unlock()
+
+			for resp := range subStream.channel {
+				// Emit "restarted" event before the first event after the restart
+				if restart {
+					var reason string
+					if lastErr == nil {
+						reason = "manual restart"
+					} else {
+						reason = fmt.Sprintf(`backoff delay %s, reason: %v`, restartDelay, lastErr)
+					}
+
+					rst := WatchResponse{}
+					rst.Restarted = true
+					rst.RestartReason = reason
+					rst.RestartDelay = restartDelay
+					stream.channel <- rst
+					lastErr = nil
+					restart = false
+				}
+
 				// Stop initialization phase after the first "created" event
 				if resp.Created {
-					b.Reset()
 					if init {
 						init = false
 						// Pass event to the stream.channel channel
 					} else {
-						// Create event can be emitted only once.
-						// The Restarted event has already been sent.
+						// Create event can be emitted only once, skip.
+						// Reset the backoff
+						b.Reset()
 						continue
 					}
 				}
@@ -326,26 +393,26 @@ func wrapStreamWithRestart(ctx context.Context, channelFactory func(ctx context.
 				stream.channel <- resp
 			}
 
-			// Underlying watcher has stopped, restart
-			delay := b.NextBackOff()
-			if delay == backoff.Stop {
-				return
-			}
+			// Restart is in progress
+			restart = true
 
-			// Wait before restart
-			select {
-			case <-ctx.Done():
-				return
-			case <-time.After(delay):
-				// continue
-			}
+			// Delay is applied only if the restart is caused by an error, not by the manual restart
+			var delay time.Duration
+			if lastErr != nil {
+				// Calculate delay
+				restartDelay = b.NextBackOff()
+				if restartDelay == backoff.Stop {
+					return
+				}
 
-			// Emit "restarted" event
-			resp := WatchResponse{}
-			resp.Restarted = true
-			resp.RestartReason = fmt.Sprintf(`restarted, backoff delay %s, reason: %s`, delay, lastErr)
-			resp.RestartDelay = delay
-			stream.channel <- resp
+				// Wait before restart
+				select {
+				case <-ctx.Done():
+					return
+				case <-time.After(delay):
+					// continue
+				}
+			}
 		}
 	}()
 

--- a/internal/pkg/service/common/etcdop/watch_test.go
+++ b/internal/pkg/service/common/etcdop/watch_test.go
@@ -8,6 +8,7 @@ import (
 	"time"
 
 	"github.com/cenkalti/backoff/v4"
+	"github.com/davecgh/go-spew/spew"
 	"github.com/keboola/go-utils/pkg/wildcards"
 	"github.com/stretchr/testify/assert"
 	"go.etcd.io/etcd/api/v3/mvccpb"
@@ -128,8 +129,8 @@ func TestPrefix_Watch(t *testing.T) {
 
 	// Channel should be closed by the context
 	cancel()
-	_, ok := <-ch
-	assert.False(t, ok)
+	resp, ok := <-ch
+	assert.False(t, ok, spew.Sdump(resp))
 }
 
 func TestPrefix_GetAllAndWatch(t *testing.T) {
@@ -266,8 +267,8 @@ func TestPrefix_GetAllAndWatch(t *testing.T) {
 
 	// Channel should be closed by the context
 	cancel()
-	_, ok := <-ch
-	assert.False(t, ok)
+	resp, ok := <-ch
+	assert.False(t, ok, spew.Sdump(resp))
 }
 
 // nolint:paralleltest // etcd integration tests cannot run in parallel, see integration.BeforeTestExternal
@@ -342,7 +343,7 @@ func TestPrefix_Watch_ErrCompacted(t *testing.T) {
 	// Expect "restarted" event
 	resp = <-ch
 	assert.True(t, resp.Restarted)
-	wildcards.Assert(t, "restarted, backoff delay %s, reason: watch error: etcdserver: mvcc: required revision has been compacted", resp.RestartReason)
+	wildcards.Assert(t, "backoff delay %s, reason: watch error: etcdserver: mvcc: required revision has been compacted", resp.RestartReason)
 
 	// After the restart, Watch is waiting for new events, put and expected the key
 	assert.NoError(t, pfx.Key("key04").Put(value).Do(ctx, testClient))
@@ -366,7 +367,7 @@ func TestPrefix_Watch_ErrCompacted(t *testing.T) {
 	assert.Equal(t, "watch error: etcdserver: mvcc: required revision has been compacted", resp.Err.Error())
 	resp = <-ch
 	assert.True(t, resp.Restarted)
-	wildcards.Assert(t, "restarted, backoff delay %s, reason: watch error: etcdserver: mvcc: required revision has been compacted", resp.RestartReason)
+	wildcards.Assert(t, "backoff delay %s, reason: watch error: etcdserver: mvcc: required revision has been compacted", resp.RestartReason)
 
 	// After the restart, Watch is streaming new events, put and receive the key
 	assert.NoError(t, pfx.Key("key07").Put(value).Do(ctx, testClient))
@@ -374,8 +375,8 @@ func TestPrefix_Watch_ErrCompacted(t *testing.T) {
 
 	// Channel should be closed by the context
 	cancel()
-	_, ok := <-ch
-	assert.False(t, ok)
+	resp, ok := <-ch
+	assert.False(t, ok, spew.Sdump(resp))
 }
 
 // nolint:paralleltest // etcd integration tests cannot run in parallel, see integration.BeforeTestExternal
@@ -450,7 +451,7 @@ func TestPrefix_GetAllAndWatch_ErrCompacted(t *testing.T) {
 	// Expect "restarted" event
 	resp = <-ch
 	assert.True(t, resp.Restarted)
-	wildcards.Assert(t, "restarted, backoff delay %s, reason: watch error: etcdserver: mvcc: required revision has been compacted", resp.RestartReason)
+	wildcards.Assert(t, "backoff delay %s, reason: watch error: etcdserver: mvcc: required revision has been compacted", resp.RestartReason)
 
 	// Read keys, watcher was restarted, it is now in the GetAll phase,
 	// so all keys are received at once
@@ -483,7 +484,7 @@ func TestPrefix_GetAllAndWatch_ErrCompacted(t *testing.T) {
 	assert.Equal(t, "watch error: etcdserver: mvcc: required revision has been compacted", resp.Err.Error())
 	resp = <-ch
 	assert.True(t, resp.Restarted)
-	wildcards.Assert(t, "restarted, backoff delay %s, reason: watch error: etcdserver: mvcc: required revision has been compacted", resp.RestartReason)
+	wildcards.Assert(t, "backoff delay %s, reason: watch error: etcdserver: mvcc: required revision has been compacted", resp.RestartReason)
 	resp = receive(6)
 	assert.Equal(t, []byte("my/prefix/key01"), resp.Events[0].Kv.Key)
 	assert.Equal(t, []byte("my/prefix/key02"), resp.Events[1].Kv.Key)
@@ -494,8 +495,8 @@ func TestPrefix_GetAllAndWatch_ErrCompacted(t *testing.T) {
 
 	// Channel should be closed by the context
 	cancel()
-	_, ok := <-ch
-	assert.False(t, ok)
+	resp, ok := <-ch
+	assert.False(t, ok, spew.Sdump(resp))
 }
 
 func TestWatchBackoff(t *testing.T) {

--- a/internal/pkg/service/common/etcdop/watch_test.go
+++ b/internal/pkg/service/common/etcdop/watch_test.go
@@ -28,7 +28,8 @@ func TestPrefix_Watch(t *testing.T) {
 	pfx := prefixForTest()
 
 	// Create watcher
-	ch := pfx.Watch(ctx, c)
+	stream := pfx.Watch(ctx, c)
+	ch := stream.Channel()
 
 	// Wait for watcher created event
 	assertDone(t, func() {
@@ -125,7 +126,8 @@ func TestPrefix_GetAllAndWatch(t *testing.T) {
 	assert.NoError(t, pfx.Key("key1").Put("foo1").Do(ctx, c))
 
 	// Create watcher
-	ch := pfx.GetAllAndWatch(ctx, c)
+	stream := pfx.GetAllAndWatch(ctx, c)
+	ch := stream.Channel()
 
 	// Wait for CREATE key1 event
 	assertDone(t, func() {
@@ -242,7 +244,8 @@ func TestPrefix_GetAllAndWatch_ErrCompacted(t *testing.T) {
 
 	// Create watcher
 	pfx := prefixForTest()
-	ch := pfx.GetAllAndWatch(ctx, watchClient)
+	stream := pfx.GetAllAndWatch(ctx, watchClient)
+	ch := stream.Channel()
 	receive := func(expectedLen int) WatchResponse {
 		resp, ok := <-ch
 		assert.True(t, ok)

--- a/internal/pkg/service/common/etcdop/watchmirror.go
+++ b/internal/pkg/service/common/etcdop/watchmirror.go
@@ -21,7 +21,7 @@ type Mirror[T any, V any] struct {
 
 type MirrorSetup[T any, V any] struct {
 	logger   log.Logger
-	stream   WatchStreamT[T]
+	stream   *WatchStreamT[T]
 	filter   func(t WatchEventT[T]) bool
 	mapKey   func(kv *op.KeyValue, value T) string
 	mapValue func(kv *op.KeyValue, value T) V
@@ -29,7 +29,7 @@ type MirrorSetup[T any, V any] struct {
 
 func SetupMirror[T any, V any](
 	logger log.Logger,
-	stream WatchStreamT[T],
+	stream *WatchStreamT[T],
 	mapKey func(kv *op.KeyValue, value T) string,
 	mapValue func(kv *op.KeyValue, value T) V,
 ) MirrorSetup[T, V] {

--- a/internal/pkg/service/common/etcdop/watchmirror.go
+++ b/internal/pkg/service/common/etcdop/watchmirror.go
@@ -21,7 +21,7 @@ type Mirror[T any, V any] struct {
 
 type MirrorSetup[T any, V any] struct {
 	logger   log.Logger
-	stream   *WatchStreamT[T]
+	stream   *RestartableWatchStreamT[T]
 	filter   func(t WatchEventT[T]) bool
 	mapKey   func(kv *op.KeyValue, value T) string
 	mapValue func(kv *op.KeyValue, value T) V
@@ -29,7 +29,7 @@ type MirrorSetup[T any, V any] struct {
 
 func SetupMirror[T any, V any](
 	logger log.Logger,
-	stream *WatchStreamT[T],
+	stream *RestartableWatchStreamT[T],
 	mapKey func(kv *op.KeyValue, value T) string,
 	mapValue func(kv *op.KeyValue, value T) V,
 ) MirrorSetup[T, V] {

--- a/internal/pkg/service/common/etcdop/watchtyped.go
+++ b/internal/pkg/service/common/etcdop/watchtyped.go
@@ -62,11 +62,10 @@ func (v PrefixT[T]) Watch(ctx context.Context, client etcd.Watcher, opts ...etcd
 
 // decodeChannel is used by Watch and GetAllAndWatch to decode raw data to typed data.
 func (v PrefixT[T]) decodeChannel(ctx context.Context, channelFactory func(ctx context.Context) *WatchStream) *WatchStreamT[T] {
-	stream := &WatchStreamT[T]{channel: make(chan WatchResponseE[WatchEventT[T]])}
+	ctx, cancel := context.WithCancel(ctx)
+	stream := &WatchStreamT[T]{channel: make(chan WatchResponseE[WatchEventT[T]]), cancel: cancel}
 	go func() {
 		defer close(stream.channel)
-
-		ctx, cancel := context.WithCancel(ctx)
 		defer cancel()
 
 		// Decode value, if an error occurs, send it through the channel.

--- a/internal/pkg/service/common/etcdop/watchtyped_test.go
+++ b/internal/pkg/service/common/etcdop/watchtyped_test.go
@@ -5,6 +5,7 @@ import (
 	"sync"
 	"testing"
 
+	"github.com/davecgh/go-spew/spew"
 	"github.com/stretchr/testify/assert"
 	"go.etcd.io/etcd/api/v3/mvccpb"
 	etcd "go.etcd.io/etcd/client/v3"
@@ -105,8 +106,8 @@ func TestPrefixT_Watch(t *testing.T) {
 
 	// Channel should be closed by the context
 	cancel()
-	_, ok := <-ch
-	assert.False(t, ok)
+	resp, ok := <-ch
+	assert.False(t, ok, spew.Sdump(resp))
 }
 
 func TestPrefixT_GetAllAndWatch(t *testing.T) {
@@ -232,8 +233,8 @@ func TestPrefixT_GetAllAndWatch(t *testing.T) {
 
 	// Channel should be closed by the context
 	cancel()
-	_, ok := <-ch
-	assert.False(t, ok)
+	resp, ok := <-ch
+	assert.False(t, ok, spew.Sdump(resp))
 }
 
 func clearResponseT(resp WatchResponseE[WatchEventT[fooType]]) WatchResponseE[WatchEventT[fooType]] {

--- a/internal/pkg/service/common/etcdop/watchtyped_test.go
+++ b/internal/pkg/service/common/etcdop/watchtyped_test.go
@@ -23,7 +23,8 @@ func TestPrefixT_Watch(t *testing.T) {
 	pfx := typedPrefixForTest()
 
 	// Create watcher
-	ch := pfx.Watch(ctx, c)
+	stream := pfx.Watch(ctx, c)
+	ch := stream.Channel()
 
 	// Wait for watcher created event
 	assertDone(t, func() {
@@ -122,7 +123,8 @@ func TestPrefixT_GetAllAndWatch(t *testing.T) {
 	assert.NoError(t, pfx.Key("key1").Put("foo1").Do(ctx, c))
 
 	// Create watcher
-	ch := pfx.GetAllAndWatch(ctx, c, etcd.WithPrevKV())
+	stream := pfx.GetAllAndWatch(ctx, c, etcd.WithPrevKV())
+	ch := stream.Channel()
 
 	// Wait for CREATE key1 event
 	assertDone(t, func() {


### PR DESCRIPTION
Part of: https://keboola.atlassian.net/browse/PSGO-246

Changes:
- To fix the `PSGO-246` bug, we need to be able to restart the stream.
- The stream is already restarted (re-created again) in case of fatal errors, but the possibility to do it manually was missing.
- This PR adds the `RestartableWatchStream.Restart()` method.

-----------

Okomentovane po commitoch.