### PR TITLE
DataApps: rename /apps -> /app

### DIFF
--- a/internal/pkg/fixtures/local/empty-branch/.keboola/manifest.json
+++ b/internal/pkg/fixtures/local/empty-branch/.keboola/manifest.json
@@ -22,7 +22,7 @@
     "sharedCodeConfigRow": "codes/{config_row_name}",
     "variablesConfig": "variables",
     "variablesValuesRow": "values/{config_row_name}",
-    "dataAppConfig": "apps/{component_id}/{config_name}"
+    "dataAppConfig": "app/{component_id}/{config_name}"
   },
   "branches": [
     {

--- a/internal/pkg/fixtures/local/minimal/.keboola/manifest.json
+++ b/internal/pkg/fixtures/local/minimal/.keboola/manifest.json
@@ -22,7 +22,7 @@
     "sharedCodeConfigRow": "codes/{config_row_name}",
     "variablesConfig": "variables",
     "variablesValuesRow": "values/{config_row_name}",
-    "dataAppConfig": "apps/{component_id}/{config_name}"
+    "dataAppConfig": "app/{component_id}/{config_name}"
   },
   "branches": [
     {

--- a/internal/pkg/naming/generator_test.go
+++ b/internal/pkg/naming/generator_test.go
@@ -234,7 +234,7 @@ func TestNamingDefaultTemplate(t *testing.T) {
 	// DataAppConfig values
 	assert.Equal(
 		t,
-		"my-branch/apps/keboola.data-apps/456-some-data-app",
+		"my-branch/app/keboola.data-apps/456-some-data-app",
 		g.ConfigPath(
 			"my-branch",
 			&keboola.Component{

--- a/internal/pkg/naming/template.go
+++ b/internal/pkg/naming/template.go
@@ -72,7 +72,7 @@ func ForTemplate() Template {
 		SharedCodeConfigRow: "codes/{config_row_id}",
 		VariablesConfig:     "variables",
 		VariablesValuesRow:  "values/{config_row_id}",
-		DataAppConfig:       "apps/{component_id}/{config_name}",
+		DataAppConfig:       "app/{component_id}/{config_name}",
 	}
 }
 
@@ -86,7 +86,7 @@ func TemplateWithoutIds() Template {
 		SharedCodeConfigRow: "codes/{config_row_name}",
 		VariablesConfig:     "variables",
 		VariablesValuesRow:  "values/{config_row_name}",
-		DataAppConfig:       "apps/{component_id}/{config_name}",
+		DataAppConfig:       "app/{component_id}/{config_name}",
 	}
 }
 
@@ -100,6 +100,6 @@ func TemplateWithIds() Template {
 		SharedCodeConfigRow: "codes/{config_row_id}-{config_row_name}",
 		VariablesConfig:     "variables",
 		VariablesValuesRow:  "values/{config_row_id}-{config_row_name}",
-		DataAppConfig:       "apps/{component_id}/{config_id}-{config_name}",
+		DataAppConfig:       "app/{component_id}/{config_id}-{config_name}",
 	}
 }

--- a/internal/pkg/project/manifest/manifest_test.go
+++ b/internal/pkg/project/manifest/manifest_test.go
@@ -203,7 +203,7 @@ func minimalJSON() string {
     "sharedCodeConfigRow": "codes/{config_row_id}-{config_row_name}",
     "variablesConfig": "variables",
     "variablesValuesRow": "values/{config_row_id}-{config_row_name}",
-    "dataAppConfig": "apps/{component_id}/{config_id}-{config_name}"
+    "dataAppConfig": "app/{component_id}/{config_id}-{config_name}"
   },
   "allowedBranches": [
     "*"
@@ -246,7 +246,7 @@ func fullJSON() string {
     "sharedCodeConfigRow": "codes/{config_row_name}",
     "variablesConfig": "variables",
     "variablesValuesRow": "values/{config_row_name}",
-    "dataAppConfig": "apps/{component_id}/{config_name}"
+    "dataAppConfig": "app/{component_id}/{config_name}"
   },
   "allowedBranches": [
     "foo",

--- a/test/cli/create/branch/in/.keboola/manifest.json
+++ b/test/cli/create/branch/in/.keboola/manifest.json
@@ -14,7 +14,7 @@
     "sharedCodeConfigRow": "codes/{config_row_name}",
     "variablesConfig": "variables",
     "variablesValuesRow": "values/{config_row_name}",
-    "dataAppConfig": "apps/{component_id}/{config_name}"
+    "dataAppConfig": "app/{component_id}/{config_name}"
   },
   "allowedBranches": [
     "__main__"

--- a/test/cli/create/branch/out/.keboola/manifest.json
+++ b/test/cli/create/branch/out/.keboola/manifest.json
@@ -14,7 +14,7 @@
     "sharedCodeConfigRow": "codes/{config_row_name}",
     "variablesConfig": "variables",
     "variablesValuesRow": "values/{config_row_name}",
-    "dataAppConfig": "apps/{component_id}/{config_name}"
+    "dataAppConfig": "app/{component_id}/{config_name}"
   },
   "allowedBranches": [
     "__main__",

--- a/test/cli/create/config-orchestrator/in/.keboola/manifest.json
+++ b/test/cli/create/config-orchestrator/in/.keboola/manifest.json
@@ -14,7 +14,7 @@
     "sharedCodeConfigRow": "codes/{config_row_name}",
     "variablesConfig": "variables",
     "variablesValuesRow": "values/{config_row_name}",
-    "dataAppConfig": "apps/{component_id}/{config_name}"
+    "dataAppConfig": "app/{component_id}/{config_name}"
   },
   "allowedBranches": [
     "__all__"

--- a/test/cli/create/config-orchestrator/out/.keboola/manifest.json
+++ b/test/cli/create/config-orchestrator/out/.keboola/manifest.json
@@ -14,7 +14,7 @@
     "sharedCodeConfigRow": "codes/{config_row_name}",
     "variablesConfig": "variables",
     "variablesValuesRow": "values/{config_row_name}",
-    "dataAppConfig": "apps/{component_id}/{config_name}"
+    "dataAppConfig": "app/{component_id}/{config_name}"
   },
   "allowedBranches": [
     "__all__"

--- a/test/cli/create/config-row/in/.keboola/manifest.json
+++ b/test/cli/create/config-row/in/.keboola/manifest.json
@@ -14,7 +14,7 @@
     "sharedCodeConfigRow": "codes/{config_row_name}",
     "variablesConfig": "variables",
     "variablesValuesRow": "values/{config_row_name}",
-    "dataAppConfig": "apps/{component_id}/{config_name}"
+    "dataAppConfig": "app/{component_id}/{config_name}"
   },
   "allowedBranches": [
     "__all__"

--- a/test/cli/create/config-row/out/.keboola/manifest.json
+++ b/test/cli/create/config-row/out/.keboola/manifest.json
@@ -14,7 +14,7 @@
     "sharedCodeConfigRow": "codes/{config_row_name}",
     "variablesConfig": "variables",
     "variablesValuesRow": "values/{config_row_name}",
-    "dataAppConfig": "apps/{component_id}/{config_name}"
+    "dataAppConfig": "app/{component_id}/{config_name}"
   },
   "allowedBranches": [
     "__all__"

--- a/test/cli/create/config-transformation/in/.keboola/manifest.json
+++ b/test/cli/create/config-transformation/in/.keboola/manifest.json
@@ -14,7 +14,7 @@
     "sharedCodeConfigRow": "codes/{config_row_name}",
     "variablesConfig": "variables",
     "variablesValuesRow": "values/{config_row_name}",
-    "dataAppConfig": "apps/{component_id}/{config_name}"
+    "dataAppConfig": "app/{component_id}/{config_name}"
   },
   "allowedBranches": [
     "__all__"

--- a/test/cli/create/config-transformation/out/.keboola/manifest.json
+++ b/test/cli/create/config-transformation/out/.keboola/manifest.json
@@ -14,7 +14,7 @@
     "sharedCodeConfigRow": "codes/{config_row_name}",
     "variablesConfig": "variables",
     "variablesValuesRow": "values/{config_row_name}",
-    "dataAppConfig": "apps/{component_id}/{config_name}"
+    "dataAppConfig": "app/{component_id}/{config_name}"
   },
   "allowedBranches": [
     "__all__"

--- a/test/cli/create/config/in/.keboola/manifest.json
+++ b/test/cli/create/config/in/.keboola/manifest.json
@@ -14,7 +14,7 @@
     "sharedCodeConfigRow": "codes/{config_row_name}",
     "variablesConfig": "variables",
     "variablesValuesRow": "values/{config_row_name}",
-    "dataAppConfig": "apps/{component_id}/{config_name}"
+    "dataAppConfig": "app/{component_id}/{config_name}"
   },
   "allowedBranches": [
     "__all__"

--- a/test/cli/create/config/out/.keboola/manifest.json
+++ b/test/cli/create/config/out/.keboola/manifest.json
@@ -14,7 +14,7 @@
     "sharedCodeConfigRow": "codes/{config_row_name}",
     "variablesConfig": "variables",
     "variablesValuesRow": "values/{config_row_name}",
-    "dataAppConfig": "apps/{component_id}/{config_name}"
+    "dataAppConfig": "app/{component_id}/{config_name}"
   },
   "allowedBranches": [
     "__all__"

--- a/test/cli/diff/kbcdir-ignore/in/.keboola/manifest.json
+++ b/test/cli/diff/kbcdir-ignore/in/.keboola/manifest.json
@@ -14,7 +14,7 @@
     "sharedCodeConfigRow": "codes/{config_row_name}",
     "variablesConfig": "variables",
     "variablesValuesRow": "values/{config_row_name}",
-    "dataAppConfig": "apps/{component_id}/{config_name}"
+    "dataAppConfig": "app/{component_id}/{config_name}"
   },
   "allowedBranches": [
     "__all__"

--- a/test/cli/diff/kbcdir-ignore/out/.keboola/manifest.json
+++ b/test/cli/diff/kbcdir-ignore/out/.keboola/manifest.json
@@ -14,7 +14,7 @@
     "sharedCodeConfigRow": "codes/{config_row_name}",
     "variablesConfig": "variables",
     "variablesValuesRow": "values/{config_row_name}",
-    "dataAppConfig": "apps/{component_id}/{config_name}"
+    "dataAppConfig": "app/{component_id}/{config_name}"
   },
   "allowedBranches": [
     "__all__"

--- a/test/cli/diff/no-changed/in/.keboola/manifest.json
+++ b/test/cli/diff/no-changed/in/.keboola/manifest.json
@@ -14,7 +14,7 @@
     "sharedCodeConfigRow": "codes/{config_row_name}",
     "variablesConfig": "variables",
     "variablesValuesRow": "values/{config_row_name}",
-    "dataAppConfig": "apps/{component_id}/{config_name}"
+    "dataAppConfig": "app/{component_id}/{config_name}"
   },
   "allowedBranches": [
     "__all__"

--- a/test/cli/diff/no-changed/out/.keboola/manifest.json
+++ b/test/cli/diff/no-changed/out/.keboola/manifest.json
@@ -14,7 +14,7 @@
     "sharedCodeConfigRow": "codes/{config_row_name}",
     "variablesConfig": "variables",
     "variablesValuesRow": "values/{config_row_name}",
-    "dataAppConfig": "apps/{component_id}/{config_name}"
+    "dataAppConfig": "app/{component_id}/{config_name}"
   },
   "allowedBranches": [
     "__all__"

--- a/test/cli/diff/no-difference/in/.keboola/manifest.json
+++ b/test/cli/diff/no-difference/in/.keboola/manifest.json
@@ -14,7 +14,7 @@
     "sharedCodeConfigRow": "codes/{config_row_name}",
     "variablesConfig": "variables",
     "variablesValuesRow": "values/{config_row_name}",
-    "dataAppConfig": "apps/{component_id}/{config_name}"
+    "dataAppConfig": "app/{component_id}/{config_name}"
   },
   "allowedBranches": [
     "__all__"

--- a/test/cli/diff/no-difference/out/.keboola/manifest.json
+++ b/test/cli/diff/no-difference/out/.keboola/manifest.json
@@ -14,7 +14,7 @@
     "sharedCodeConfigRow": "codes/{config_row_name}",
     "variablesConfig": "variables",
     "variablesValuesRow": "values/{config_row_name}",
-    "dataAppConfig": "apps/{component_id}/{config_name}"
+    "dataAppConfig": "app/{component_id}/{config_name}"
   },
   "allowedBranches": [
     "__all__"

--- a/test/cli/diff/variables/in/.keboola/manifest.json
+++ b/test/cli/diff/variables/in/.keboola/manifest.json
@@ -13,7 +13,7 @@
     "sharedCodeConfigRow": "codes/{config_row_name}",
     "variablesConfig": "variables",
     "variablesValuesRow": "values/{config_row_name}",
-    "dataAppConfig": "apps/{component_id}/{config_name}"
+    "dataAppConfig": "app/{component_id}/{config_name}"
   },
   "allowedBranches": [
     "__all__"

--- a/test/cli/diff/variables/out/.keboola/manifest.json
+++ b/test/cli/diff/variables/out/.keboola/manifest.json
@@ -13,7 +13,7 @@
     "sharedCodeConfigRow": "codes/{config_row_name}",
     "variablesConfig": "variables",
     "variablesValuesRow": "values/{config_row_name}",
-    "dataAppConfig": "apps/{component_id}/{config_name}"
+    "dataAppConfig": "app/{component_id}/{config_name}"
   },
   "allowedBranches": [
     "__all__"

--- a/test/cli/diff/with-details/in/.keboola/manifest.json
+++ b/test/cli/diff/with-details/in/.keboola/manifest.json
@@ -14,7 +14,7 @@
     "sharedCodeConfigRow": "codes/{config_row_name}",
     "variablesConfig": "variables",
     "variablesValuesRow": "values/{config_row_name}",
-    "dataAppConfig": "apps/{component_id}/{config_name}"
+    "dataAppConfig": "app/{component_id}/{config_name}"
   },
   "allowedBranches": [
     "__all__"

--- a/test/cli/diff/with-details/out/.keboola/manifest.json
+++ b/test/cli/diff/with-details/out/.keboola/manifest.json
@@ -14,7 +14,7 @@
     "sharedCodeConfigRow": "codes/{config_row_name}",
     "variablesConfig": "variables",
     "variablesValuesRow": "values/{config_row_name}",
-    "dataAppConfig": "apps/{component_id}/{config_name}"
+    "dataAppConfig": "app/{component_id}/{config_name}"
   },
   "allowedBranches": [
     "__all__"

--- a/test/cli/diff/without-details/in/.keboola/manifest.json
+++ b/test/cli/diff/without-details/in/.keboola/manifest.json
@@ -14,7 +14,7 @@
     "sharedCodeConfigRow": "codes/{config_row_name}",
     "variablesConfig": "variables",
     "variablesValuesRow": "values/{config_row_name}",
-    "dataAppConfig": "apps/{component_id}/{config_name}"
+    "dataAppConfig": "app/{component_id}/{config_name}"
   },
   "allowedBranches": [
     "__all__"

--- a/test/cli/diff/without-details/out/.keboola/manifest.json
+++ b/test/cli/diff/without-details/out/.keboola/manifest.json
@@ -14,7 +14,7 @@
     "sharedCodeConfigRow": "codes/{config_row_name}",
     "variablesConfig": "variables",
     "variablesValuesRow": "values/{config_row_name}",
-    "dataAppConfig": "apps/{component_id}/{config_name}"
+    "dataAppConfig": "app/{component_id}/{config_name}"
   },
   "allowedBranches": [
     "__all__"

--- a/test/cli/encrypt/dry-run/in/.keboola/manifest.json
+++ b/test/cli/encrypt/dry-run/in/.keboola/manifest.json
@@ -14,7 +14,7 @@
     "sharedCodeConfigRow": "codes/{config_row_name}",
     "variablesConfig": "variables",
     "variablesValuesRow": "values/{config_row_name}",
-    "dataAppConfig": "apps/{component_id}/{config_name}"
+    "dataAppConfig": "app/{component_id}/{config_name}"
   },
   "allowedBranches": [
     "__all__"

--- a/test/cli/encrypt/dry-run/out/.keboola/manifest.json
+++ b/test/cli/encrypt/dry-run/out/.keboola/manifest.json
@@ -14,7 +14,7 @@
     "sharedCodeConfigRow": "codes/{config_row_name}",
     "variablesConfig": "variables",
     "variablesValuesRow": "values/{config_row_name}",
-    "dataAppConfig": "apps/{component_id}/{config_name}"
+    "dataAppConfig": "app/{component_id}/{config_name}"
   },
   "allowedBranches": [
     "__all__"

--- a/test/cli/encrypt/no-change/in/.keboola/manifest.json
+++ b/test/cli/encrypt/no-change/in/.keboola/manifest.json
@@ -14,7 +14,7 @@
     "sharedCodeConfigRow": "codes/{config_row_name}",
     "variablesConfig": "variables",
     "variablesValuesRow": "values/{config_row_name}",
-    "dataAppConfig": "apps/{component_id}/{config_name}"
+    "dataAppConfig": "app/{component_id}/{config_name}"
   },
   "allowedBranches": [
     "__all__"

--- a/test/cli/encrypt/no-change/out/.keboola/manifest.json
+++ b/test/cli/encrypt/no-change/out/.keboola/manifest.json
@@ -14,7 +14,7 @@
     "sharedCodeConfigRow": "codes/{config_row_name}",
     "variablesConfig": "variables",
     "variablesValuesRow": "values/{config_row_name}",
-    "dataAppConfig": "apps/{component_id}/{config_name}"
+    "dataAppConfig": "app/{component_id}/{config_name}"
   },
   "allowedBranches": [
     "__all__"

--- a/test/cli/encrypt/ok/in/.keboola/manifest.json
+++ b/test/cli/encrypt/ok/in/.keboola/manifest.json
@@ -14,7 +14,7 @@
     "sharedCodeConfigRow": "codes/{config_row_name}",
     "variablesConfig": "variables",
     "variablesValuesRow": "values/{config_row_name}",
-    "dataAppConfig": "apps/{component_id}/{config_name}"
+    "dataAppConfig": "app/{component_id}/{config_name}"
   },
   "allowedBranches": [
     "*"

--- a/test/cli/encrypt/ok/out/.keboola/manifest.json
+++ b/test/cli/encrypt/ok/out/.keboola/manifest.json
@@ -14,7 +14,7 @@
     "sharedCodeConfigRow": "codes/{config_row_name}",
     "variablesConfig": "variables",
     "variablesValuesRow": "values/{config_row_name}",
-    "dataAppConfig": "apps/{component_id}/{config_name}"
+    "dataAppConfig": "app/{component_id}/{config_name}"
   },
   "allowedBranches": [
     "*"

--- a/test/cli/fix-paths/defaultbucket/in/.keboola/manifest.json
+++ b/test/cli/fix-paths/defaultbucket/in/.keboola/manifest.json
@@ -14,7 +14,7 @@
     "sharedCodeConfigRow": "codes/{config_row_name}",
     "variablesConfig": "variables",
     "variablesValuesRow": "values/{config_row_name}",
-    "dataAppConfig": "apps/{component_id}/{config_name}"
+    "dataAppConfig": "app/{component_id}/{config_name}"
   },
   "allowedBranches": [
     "__all__"

--- a/test/cli/fix-paths/defaultbucket/out/.keboola/manifest.json
+++ b/test/cli/fix-paths/defaultbucket/out/.keboola/manifest.json
@@ -14,7 +14,7 @@
     "sharedCodeConfigRow": "codes/{config_row_name}",
     "variablesConfig": "variables",
     "variablesValuesRow": "values/{config_row_name}",
-    "dataAppConfig": "apps/{component_id}/{config_name}"
+    "dataAppConfig": "app/{component_id}/{config_name}"
   },
   "allowedBranches": [
     "__all__"

--- a/test/cli/fix-paths/dry-run/in/.keboola/manifest.json
+++ b/test/cli/fix-paths/dry-run/in/.keboola/manifest.json
@@ -14,7 +14,7 @@
     "sharedCodeConfigRow": "codes/{config_row_name}",
     "variablesConfig": "variables",
     "variablesValuesRow": "values/{config_row_name}",
-    "dataAppConfig": "apps/{component_id}/{config_name}"
+    "dataAppConfig": "app/{component_id}/{config_name}"
   },
   "allowedBranches": [
     "__all__"

--- a/test/cli/fix-paths/dry-run/out/.keboola/manifest.json
+++ b/test/cli/fix-paths/dry-run/out/.keboola/manifest.json
@@ -14,7 +14,7 @@
     "sharedCodeConfigRow": "codes/{config_row_name}",
     "variablesConfig": "variables",
     "variablesValuesRow": "values/{config_row_name}",
-    "dataAppConfig": "apps/{component_id}/{config_name}"
+    "dataAppConfig": "app/{component_id}/{config_name}"
   },
   "allowedBranches": [
     "__all__"

--- a/test/cli/fix-paths/ok/in/.keboola/manifest.json
+++ b/test/cli/fix-paths/ok/in/.keboola/manifest.json
@@ -14,7 +14,7 @@
     "sharedCodeConfigRow": "codes/{config_row_name}",
     "variablesConfig": "variables",
     "variablesValuesRow": "values/{config_row_name}",
-    "dataAppConfig": "apps/{component_id}/{config_name}"
+    "dataAppConfig": "app/{component_id}/{config_name}"
   },
   "allowedBranches": [
     "__all__"

--- a/test/cli/fix-paths/ok/out/.keboola/manifest.json
+++ b/test/cli/fix-paths/ok/out/.keboola/manifest.json
@@ -14,7 +14,7 @@
     "sharedCodeConfigRow": "codes/{config_row_name}",
     "variablesConfig": "variables",
     "variablesValuesRow": "values/{config_row_name}",
-    "dataAppConfig": "apps/{component_id}/{config_name}"
+    "dataAppConfig": "app/{component_id}/{config_name}"
   },
   "allowedBranches": [
     "__all__"

--- a/test/cli/fix-paths/orchestrator-task/in/.keboola/manifest.json
+++ b/test/cli/fix-paths/orchestrator-task/in/.keboola/manifest.json
@@ -14,7 +14,7 @@
     "sharedCodeConfigRow": "codes/{config_row_name}",
     "variablesConfig": "variables",
     "variablesValuesRow": "values/{config_row_name}",
-    "dataAppConfig": "apps/{component_id}/{config_name}"
+    "dataAppConfig": "app/{component_id}/{config_name}"
   },
   "allowedBranches": [
     "__all__"

--- a/test/cli/fix-paths/orchestrator-task/out/.keboola/manifest.json
+++ b/test/cli/fix-paths/orchestrator-task/out/.keboola/manifest.json
@@ -14,7 +14,7 @@
     "sharedCodeConfigRow": "codes/{config_row_name}",
     "variablesConfig": "variables",
     "variablesValuesRow": "values/{config_row_name}",
-    "dataAppConfig": "apps/{component_id}/{config_name}"
+    "dataAppConfig": "app/{component_id}/{config_name}"
   },
   "allowedBranches": [
     "__all__"

--- a/test/cli/fix-paths/orchestrator/in/.keboola/manifest.json
+++ b/test/cli/fix-paths/orchestrator/in/.keboola/manifest.json
@@ -14,7 +14,7 @@
     "sharedCodeConfigRow": "codes/{config_row_name}",
     "variablesConfig": "variables",
     "variablesValuesRow": "values/{config_row_name}",
-    "dataAppConfig": "apps/{component_id}/{config_name}"
+    "dataAppConfig": "app/{component_id}/{config_name}"
   },
   "allowedBranches": [
     "__all__"

--- a/test/cli/fix-paths/orchestrator/out/.keboola/manifest.json
+++ b/test/cli/fix-paths/orchestrator/out/.keboola/manifest.json
@@ -14,7 +14,7 @@
     "sharedCodeConfigRow": "codes/{config_row_name}",
     "variablesConfig": "variables",
     "variablesValuesRow": "values/{config_row_name}",
-    "dataAppConfig": "apps/{component_id}/{config_name}"
+    "dataAppConfig": "app/{component_id}/{config_name}"
   },
   "allowedBranches": [
     "__all__"

--- a/test/cli/fix-paths/shared-code/in/.keboola/manifest.json
+++ b/test/cli/fix-paths/shared-code/in/.keboola/manifest.json
@@ -14,7 +14,7 @@
     "sharedCodeConfigRow": "codes/{config_row_name}",
     "variablesConfig": "variables",
     "variablesValuesRow": "values/{config_row_name}",
-    "dataAppConfig": "apps/{component_id}/{config_name}"
+    "dataAppConfig": "app/{component_id}/{config_name}"
   },
   "allowedBranches": [
     "__all__"

--- a/test/cli/fix-paths/shared-code/out/.keboola/manifest.json
+++ b/test/cli/fix-paths/shared-code/out/.keboola/manifest.json
@@ -14,7 +14,7 @@
     "sharedCodeConfigRow": "codes/{config_row_name}",
     "variablesConfig": "variables",
     "variablesValuesRow": "values/{config_row_name}",
-    "dataAppConfig": "apps/{component_id}/{config_name}"
+    "dataAppConfig": "app/{component_id}/{config_name}"
   },
   "allowedBranches": [
     "__all__"

--- a/test/cli/persist/dry-run/in/.keboola/manifest.json
+++ b/test/cli/persist/dry-run/in/.keboola/manifest.json
@@ -14,7 +14,7 @@
     "sharedCodeConfigRow": "codes/{config_row_name}",
     "variablesConfig": "variables",
     "variablesValuesRow": "values/{config_row_name}",
-    "dataAppConfig": "apps/{component_id}/{config_name}"
+    "dataAppConfig": "app/{component_id}/{config_name}"
   },
   "allowedBranches": [
     "__all__"

--- a/test/cli/persist/dry-run/out/.keboola/manifest.json
+++ b/test/cli/persist/dry-run/out/.keboola/manifest.json
@@ -14,7 +14,7 @@
     "sharedCodeConfigRow": "codes/{config_row_name}",
     "variablesConfig": "variables",
     "variablesValuesRow": "values/{config_row_name}",
-    "dataAppConfig": "apps/{component_id}/{config_name}"
+    "dataAppConfig": "app/{component_id}/{config_name}"
   },
   "allowedBranches": [
     "__all__"

--- a/test/cli/persist/invalid-state/in/.keboola/manifest.json
+++ b/test/cli/persist/invalid-state/in/.keboola/manifest.json
@@ -14,7 +14,7 @@
     "sharedCodeConfigRow": "codes/{config_row_name}",
     "variablesConfig": "variables",
     "variablesValuesRow": "values/{config_row_name}",
-    "dataAppConfig": "apps/{component_id}/{config_name}"
+    "dataAppConfig": "app/{component_id}/{config_name}"
   },
   "allowedBranches": [
     "__all__"

--- a/test/cli/persist/invalid-state/out/.keboola/manifest.json
+++ b/test/cli/persist/invalid-state/out/.keboola/manifest.json
@@ -14,7 +14,7 @@
     "sharedCodeConfigRow": "codes/{config_row_name}",
     "variablesConfig": "variables",
     "variablesValuesRow": "values/{config_row_name}",
-    "dataAppConfig": "apps/{component_id}/{config_name}"
+    "dataAppConfig": "app/{component_id}/{config_name}"
   },
   "allowedBranches": [
     "__all__"

--- a/test/cli/persist/no-change/in/.keboola/manifest.json
+++ b/test/cli/persist/no-change/in/.keboola/manifest.json
@@ -14,7 +14,7 @@
     "sharedCodeConfigRow": "codes/{config_row_name}",
     "variablesConfig": "variables",
     "variablesValuesRow": "values/{config_row_name}",
-    "dataAppConfig": "apps/{component_id}/{config_name}"
+    "dataAppConfig": "app/{component_id}/{config_name}"
   },
   "allowedBranches": [
     "__all__"

--- a/test/cli/persist/no-change/out/.keboola/manifest.json
+++ b/test/cli/persist/no-change/out/.keboola/manifest.json
@@ -14,7 +14,7 @@
     "sharedCodeConfigRow": "codes/{config_row_name}",
     "variablesConfig": "variables",
     "variablesValuesRow": "values/{config_row_name}",
-    "dataAppConfig": "apps/{component_id}/{config_name}"
+    "dataAppConfig": "app/{component_id}/{config_name}"
   },
   "allowedBranches": [
     "__all__"

--- a/test/cli/persist/ok/in/.keboola/manifest.json
+++ b/test/cli/persist/ok/in/.keboola/manifest.json
@@ -14,7 +14,7 @@
     "sharedCodeConfigRow": "codes/{config_row_name}",
     "variablesConfig": "variables",
     "variablesValuesRow": "values/{config_row_name}",
-    "dataAppConfig": "apps/{component_id}/{config_name}"
+    "dataAppConfig": "app/{component_id}/{config_name}"
   },
   "allowedBranches": [
     "__all__"

--- a/test/cli/persist/ok/out/.keboola/manifest.json
+++ b/test/cli/persist/ok/out/.keboola/manifest.json
@@ -14,7 +14,7 @@
     "sharedCodeConfigRow": "codes/{config_row_name}",
     "variablesConfig": "variables",
     "variablesValuesRow": "values/{config_row_name}",
-    "dataAppConfig": "apps/{component_id}/{config_name}"
+    "dataAppConfig": "app/{component_id}/{config_name}"
   },
   "allowedBranches": [
     "__all__"

--- a/test/cli/project-init/ok-interactive/out/.keboola/manifest.json
+++ b/test/cli/project-init/ok-interactive/out/.keboola/manifest.json
@@ -14,7 +14,7 @@
     "sharedCodeConfigRow": "codes/{config_row_name}",
     "variablesConfig": "variables",
     "variablesValuesRow": "values/{config_row_name}",
-    "dataAppConfig": "apps/{component_id}/{config_name}"
+    "dataAppConfig": "app/{component_id}/{config_name}"
   },
   "allowedBranches": [
     "__all__"

--- a/test/cli/project-init/ok/out/.keboola/manifest.json
+++ b/test/cli/project-init/ok/out/.keboola/manifest.json
@@ -14,7 +14,7 @@
     "sharedCodeConfigRow": "codes/{config_row_name}",
     "variablesConfig": "variables",
     "variablesValuesRow": "values/{config_row_name}",
-    "dataAppConfig": "apps/{component_id}/{config_name}"
+    "dataAppConfig": "app/{component_id}/{config_name}"
   },
   "allowedBranches": [
     "__all__"

--- a/test/cli/project-init/update-dot-files/out/.keboola/manifest.json
+++ b/test/cli/project-init/update-dot-files/out/.keboola/manifest.json
@@ -14,7 +14,7 @@
     "sharedCodeConfigRow": "codes/{config_row_name}",
     "variablesConfig": "variables",
     "variablesValuesRow": "values/{config_row_name}",
-    "dataAppConfig": "apps/{component_id}/{config_name}"
+    "dataAppConfig": "app/{component_id}/{config_name}"
   },
   "allowedBranches": [
     "__all__"

--- a/test/cli/pull/add/in/.keboola/manifest.json
+++ b/test/cli/pull/add/in/.keboola/manifest.json
@@ -14,7 +14,7 @@
     "sharedCodeConfigRow": "codes/{config_row_name}",
     "variablesConfig": "variables",
     "variablesValuesRow": "values/{config_row_name}",
-    "dataAppConfig": "apps/{component_id}/{config_name}"
+    "dataAppConfig": "app/{component_id}/{config_name}"
   },
   "allowedBranches": [
     "__all__"

--- a/test/cli/pull/add/out/.keboola/manifest.json
+++ b/test/cli/pull/add/out/.keboola/manifest.json
@@ -14,7 +14,7 @@
     "sharedCodeConfigRow": "codes/{config_row_name}",
     "variablesConfig": "variables",
     "variablesValuesRow": "values/{config_row_name}",
-    "dataAppConfig": "apps/{component_id}/{config_name}"
+    "dataAppConfig": "app/{component_id}/{config_name}"
   },
   "allowedBranches": [
     "__all__"

--- a/test/cli/pull/changed/in/.keboola/manifest.json
+++ b/test/cli/pull/changed/in/.keboola/manifest.json
@@ -14,7 +14,7 @@
     "sharedCodeConfigRow": "codes/{config_row_name}",
     "variablesConfig": "variables",
     "variablesValuesRow": "values/{config_row_name}",
-    "dataAppConfig": "apps/{component_id}/{config_name}"
+    "dataAppConfig": "app/{component_id}/{config_name}"
   },
   "allowedBranches": [
     "__all__"

--- a/test/cli/pull/changed/out/.keboola/manifest.json
+++ b/test/cli/pull/changed/out/.keboola/manifest.json
@@ -14,7 +14,7 @@
     "sharedCodeConfigRow": "codes/{config_row_name}",
     "variablesConfig": "variables",
     "variablesValuesRow": "values/{config_row_name}",
-    "dataAppConfig": "apps/{component_id}/{config_name}"
+    "dataAppConfig": "app/{component_id}/{config_name}"
   },
   "allowedBranches": [
     "__all__"

--- a/test/cli/pull/config-name-diacritics/in/.keboola/manifest.json
+++ b/test/cli/pull/config-name-diacritics/in/.keboola/manifest.json
@@ -14,7 +14,7 @@
     "sharedCodeConfigRow": "codes/{config_row_name}",
     "variablesConfig": "variables",
     "variablesValuesRow": "values/{config_row_name}",
-    "dataAppConfig": "apps/{component_id}/{config_name}"
+    "dataAppConfig": "app/{component_id}/{config_name}"
   },
   "allowedBranches": [
     "__all__"

--- a/test/cli/pull/config-name-diacritics/out/.keboola/manifest.json
+++ b/test/cli/pull/config-name-diacritics/out/.keboola/manifest.json
@@ -14,7 +14,7 @@
     "sharedCodeConfigRow": "codes/{config_row_name}",
     "variablesConfig": "variables",
     "variablesValuesRow": "values/{config_row_name}",
-    "dataAppConfig": "apps/{component_id}/{config_name}"
+    "dataAppConfig": "app/{component_id}/{config_name}"
   },
   "allowedBranches": [
     "__all__"

--- a/test/cli/pull/delete-all/in/.keboola/manifest.json
+++ b/test/cli/pull/delete-all/in/.keboola/manifest.json
@@ -14,7 +14,7 @@
     "sharedCodeConfigRow": "codes/{config_row_name}",
     "variablesConfig": "variables",
     "variablesValuesRow": "values/{config_row_name}",
-    "dataAppConfig": "apps/{component_id}/{config_name}"
+    "dataAppConfig": "app/{component_id}/{config_name}"
   },
   "allowedBranches": [
     "__all__"

--- a/test/cli/pull/delete-all/out/.keboola/manifest.json
+++ b/test/cli/pull/delete-all/out/.keboola/manifest.json
@@ -14,7 +14,7 @@
     "sharedCodeConfigRow": "codes/{config_row_name}",
     "variablesConfig": "variables",
     "variablesValuesRow": "values/{config_row_name}",
-    "dataAppConfig": "apps/{component_id}/{config_name}"
+    "dataAppConfig": "app/{component_id}/{config_name}"
   },
   "allowedBranches": [
     "__all__"

--- a/test/cli/pull/delete/in/.keboola/manifest.json
+++ b/test/cli/pull/delete/in/.keboola/manifest.json
@@ -14,7 +14,7 @@
     "sharedCodeConfigRow": "codes/{config_row_name}",
     "variablesConfig": "variables",
     "variablesValuesRow": "values/{config_row_name}",
-    "dataAppConfig": "apps/{component_id}/{config_name}"
+    "dataAppConfig": "app/{component_id}/{config_name}"
   },
   "allowedBranches": [
     "__all__"

--- a/test/cli/pull/delete/out/.keboola/manifest.json
+++ b/test/cli/pull/delete/out/.keboola/manifest.json
@@ -14,7 +14,7 @@
     "sharedCodeConfigRow": "codes/{config_row_name}",
     "variablesConfig": "variables",
     "variablesValuesRow": "values/{config_row_name}",
-    "dataAppConfig": "apps/{component_id}/{config_name}"
+    "dataAppConfig": "app/{component_id}/{config_name}"
   },
   "allowedBranches": [
     "__all__"

--- a/test/cli/pull/dry-run/in/.keboola/manifest.json
+++ b/test/cli/pull/dry-run/in/.keboola/manifest.json
@@ -14,7 +14,7 @@
     "sharedCodeConfigRow": "codes/{config_row_name}",
     "variablesConfig": "variables",
     "variablesValuesRow": "values/{config_row_name}",
-    "dataAppConfig": "apps/{component_id}/{config_name}"
+    "dataAppConfig": "app/{component_id}/{config_name}"
   },
   "allowedBranches": [
     "__all__"

--- a/test/cli/pull/dry-run/out/.keboola/manifest.json
+++ b/test/cli/pull/dry-run/out/.keboola/manifest.json
@@ -14,7 +14,7 @@
     "sharedCodeConfigRow": "codes/{config_row_name}",
     "variablesConfig": "variables",
     "variablesValuesRow": "values/{config_row_name}",
-    "dataAppConfig": "apps/{component_id}/{config_name}"
+    "dataAppConfig": "app/{component_id}/{config_name}"
   },
   "allowedBranches": [
     "__all__"

--- a/test/cli/pull/empty-transformation/in/.keboola/manifest.json
+++ b/test/cli/pull/empty-transformation/in/.keboola/manifest.json
@@ -14,7 +14,7 @@
     "sharedCodeConfigRow": "codes/{config_row_name}",
     "variablesConfig": "variables",
     "variablesValuesRow": "values/{config_row_name}",
-    "dataAppConfig": "apps/{component_id}/{config_name}"
+    "dataAppConfig": "app/{component_id}/{config_name}"
   },
   "allowedBranches": [
     "__all__"

--- a/test/cli/pull/empty-transformation/out/.keboola/manifest.json
+++ b/test/cli/pull/empty-transformation/out/.keboola/manifest.json
@@ -14,7 +14,7 @@
     "sharedCodeConfigRow": "codes/{config_row_name}",
     "variablesConfig": "variables",
     "variablesValuesRow": "values/{config_row_name}",
-    "dataAppConfig": "apps/{component_id}/{config_name}"
+    "dataAppConfig": "app/{component_id}/{config_name}"
   },
   "allowedBranches": [
     "__all__"

--- a/test/cli/pull/force-invalid-local-state/in/.keboola/manifest.json
+++ b/test/cli/pull/force-invalid-local-state/in/.keboola/manifest.json
@@ -14,7 +14,7 @@
     "sharedCodeConfigRow": "codes/{config_row_name}",
     "variablesConfig": "variables",
     "variablesValuesRow": "values/{config_row_name}",
-    "dataAppConfig": "apps/{component_id}/{config_name}"
+    "dataAppConfig": "app/{component_id}/{config_name}"
   },
   "allowedBranches": [
     "__all__"

--- a/test/cli/pull/force-invalid-local-state/out/.keboola/manifest.json
+++ b/test/cli/pull/force-invalid-local-state/out/.keboola/manifest.json
@@ -14,7 +14,7 @@
     "sharedCodeConfigRow": "codes/{config_row_name}",
     "variablesConfig": "variables",
     "variablesValuesRow": "values/{config_row_name}",
-    "dataAppConfig": "apps/{component_id}/{config_name}"
+    "dataAppConfig": "app/{component_id}/{config_name}"
   },
   "allowedBranches": [
     "__all__"

--- a/test/cli/pull/force-invalid-manifest/in/.keboola/manifest.json
+++ b/test/cli/pull/force-invalid-manifest/in/.keboola/manifest.json
@@ -14,7 +14,7 @@
     "sharedCodeConfigRow": "codes/{config_row_name}",
     "variablesConfig": "variables",
     "variablesValuesRow": "values/{config_row_name}",
-    "dataAppConfig": "apps/{component_id}/{config_name}"
+    "dataAppConfig": "app/{component_id}/{config_name}"
   },
   "allowedBranches": [
     "__main__"

--- a/test/cli/pull/force-invalid-manifest/out/.keboola/manifest.json
+++ b/test/cli/pull/force-invalid-manifest/out/.keboola/manifest.json
@@ -14,7 +14,7 @@
     "sharedCodeConfigRow": "codes/{config_row_name}",
     "variablesConfig": "variables",
     "variablesValuesRow": "values/{config_row_name}",
-    "dataAppConfig": "apps/{component_id}/{config_name}"
+    "dataAppConfig": "app/{component_id}/{config_name}"
   },
   "allowedBranches": [
     "__main__"

--- a/test/cli/pull/force-missing-directory/in/.keboola/manifest.json
+++ b/test/cli/pull/force-missing-directory/in/.keboola/manifest.json
@@ -14,7 +14,7 @@
     "sharedCodeConfigRow": "codes/{config_row_name}",
     "variablesConfig": "variables",
     "variablesValuesRow": "values/{config_row_name}",
-    "dataAppConfig": "apps/{component_id}/{config_name}"
+    "dataAppConfig": "app/{component_id}/{config_name}"
   },
   "allowedBranches": [
     "__main__"

--- a/test/cli/pull/force-missing-directory/out/.keboola/manifest.json
+++ b/test/cli/pull/force-missing-directory/out/.keboola/manifest.json
@@ -14,7 +14,7 @@
     "sharedCodeConfigRow": "codes/{config_row_name}",
     "variablesConfig": "variables",
     "variablesValuesRow": "values/{config_row_name}",
-    "dataAppConfig": "apps/{component_id}/{config_name}"
+    "dataAppConfig": "app/{component_id}/{config_name}"
   },
   "allowedBranches": [
     "__main__"

--- a/test/cli/pull/ignored-components/in/.keboola/manifest.json
+++ b/test/cli/pull/ignored-components/in/.keboola/manifest.json
@@ -14,7 +14,7 @@
     "sharedCodeConfigRow": "codes/{config_row_name}",
     "variablesConfig": "variables",
     "variablesValuesRow": "values/{config_row_name}",
-    "dataAppConfig": "apps/{component_id}/{config_name}"
+    "dataAppConfig": "app/{component_id}/{config_name}"
   },
   "allowedBranches": [
     "__all__"

--- a/test/cli/pull/ignored-components/out/.keboola/manifest.json
+++ b/test/cli/pull/ignored-components/out/.keboola/manifest.json
@@ -14,7 +14,7 @@
     "sharedCodeConfigRow": "codes/{config_row_name}",
     "variablesConfig": "variables",
     "variablesValuesRow": "values/{config_row_name}",
-    "dataAppConfig": "apps/{component_id}/{config_name}"
+    "dataAppConfig": "app/{component_id}/{config_name}"
   },
   "allowedBranches": [
     "__all__"

--- a/test/cli/pull/im-default-bucket-missing-row/in/.keboola/manifest.json
+++ b/test/cli/pull/im-default-bucket-missing-row/in/.keboola/manifest.json
@@ -14,7 +14,7 @@
     "sharedCodeConfigRow": "codes/{config_row_name}",
     "variablesConfig": "variables",
     "variablesValuesRow": "values/{config_row_name}",
-    "dataAppConfig": "apps/{component_id}/{config_name}"
+    "dataAppConfig": "app/{component_id}/{config_name}"
   },
   "allowedBranches": [
     "__all__"

--- a/test/cli/pull/im-default-bucket-missing-row/out/.keboola/manifest.json
+++ b/test/cli/pull/im-default-bucket-missing-row/out/.keboola/manifest.json
@@ -14,7 +14,7 @@
     "sharedCodeConfigRow": "codes/{config_row_name}",
     "variablesConfig": "variables",
     "variablesValuesRow": "values/{config_row_name}",
-    "dataAppConfig": "apps/{component_id}/{config_name}"
+    "dataAppConfig": "app/{component_id}/{config_name}"
   },
   "allowedBranches": [
     "__all__"

--- a/test/cli/pull/im-default-bucket-missing/in/.keboola/manifest.json
+++ b/test/cli/pull/im-default-bucket-missing/in/.keboola/manifest.json
@@ -14,7 +14,7 @@
     "sharedCodeConfigRow": "codes/{config_row_name}",
     "variablesConfig": "variables",
     "variablesValuesRow": "values/{config_row_name}",
-    "dataAppConfig": "apps/{component_id}/{config_name}"
+    "dataAppConfig": "app/{component_id}/{config_name}"
   },
   "allowedBranches": [
     "__all__"

--- a/test/cli/pull/im-default-bucket-missing/out/.keboola/manifest.json
+++ b/test/cli/pull/im-default-bucket-missing/out/.keboola/manifest.json
@@ -14,7 +14,7 @@
     "sharedCodeConfigRow": "codes/{config_row_name}",
     "variablesConfig": "variables",
     "variablesValuesRow": "values/{config_row_name}",
-    "dataAppConfig": "apps/{component_id}/{config_name}"
+    "dataAppConfig": "app/{component_id}/{config_name}"
   },
   "allowedBranches": [
     "__all__"

--- a/test/cli/pull/im-default-bucket-row/in/.keboola/manifest.json
+++ b/test/cli/pull/im-default-bucket-row/in/.keboola/manifest.json
@@ -14,7 +14,7 @@
     "sharedCodeConfigRow": "codes/{config_row_name}",
     "variablesConfig": "variables",
     "variablesValuesRow": "values/{config_row_name}",
-    "dataAppConfig": "apps/{component_id}/{config_name}"
+    "dataAppConfig": "app/{component_id}/{config_name}"
   },
   "allowedBranches": [
     "__all__"

--- a/test/cli/pull/im-default-bucket-row/out/.keboola/manifest.json
+++ b/test/cli/pull/im-default-bucket-row/out/.keboola/manifest.json
@@ -14,7 +14,7 @@
     "sharedCodeConfigRow": "codes/{config_row_name}",
     "variablesConfig": "variables",
     "variablesValuesRow": "values/{config_row_name}",
-    "dataAppConfig": "apps/{component_id}/{config_name}"
+    "dataAppConfig": "app/{component_id}/{config_name}"
   },
   "allowedBranches": [
     "__all__"

--- a/test/cli/pull/im-default-bucket/in/.keboola/manifest.json
+++ b/test/cli/pull/im-default-bucket/in/.keboola/manifest.json
@@ -14,7 +14,7 @@
     "sharedCodeConfigRow": "codes/{config_row_name}",
     "variablesConfig": "variables",
     "variablesValuesRow": "values/{config_row_name}",
-    "dataAppConfig": "apps/{component_id}/{config_name}"
+    "dataAppConfig": "app/{component_id}/{config_name}"
   },
   "allowedBranches": [
     "__all__"

--- a/test/cli/pull/im-default-bucket/out/.keboola/manifest.json
+++ b/test/cli/pull/im-default-bucket/out/.keboola/manifest.json
@@ -14,7 +14,7 @@
     "sharedCodeConfigRow": "codes/{config_row_name}",
     "variablesConfig": "variables",
     "variablesValuesRow": "values/{config_row_name}",
-    "dataAppConfig": "apps/{component_id}/{config_name}"
+    "dataAppConfig": "app/{component_id}/{config_name}"
   },
   "allowedBranches": [
     "__all__"

--- a/test/cli/pull/invalid-local-state/in/.keboola/manifest.json
+++ b/test/cli/pull/invalid-local-state/in/.keboola/manifest.json
@@ -14,7 +14,7 @@
     "sharedCodeConfigRow": "codes/{config_row_name}",
     "variablesConfig": "variables",
     "variablesValuesRow": "values/{config_row_name}",
-    "dataAppConfig": "apps/{component_id}/{config_name}"
+    "dataAppConfig": "app/{component_id}/{config_name}"
   },
   "allowedBranches": [
     "__all__"

--- a/test/cli/pull/invalid-local-state/out/.keboola/manifest.json
+++ b/test/cli/pull/invalid-local-state/out/.keboola/manifest.json
@@ -14,7 +14,7 @@
     "sharedCodeConfigRow": "codes/{config_row_name}",
     "variablesConfig": "variables",
     "variablesValuesRow": "values/{config_row_name}",
-    "dataAppConfig": "apps/{component_id}/{config_name}"
+    "dataAppConfig": "app/{component_id}/{config_name}"
   },
   "allowedBranches": [
     "__all__"

--- a/test/cli/pull/invalid-manifest/in/.keboola/manifest.json
+++ b/test/cli/pull/invalid-manifest/in/.keboola/manifest.json
@@ -14,7 +14,7 @@
     "sharedCodeConfigRow": "codes/{config_row_name}",
     "variablesConfig": "variables",
     "variablesValuesRow": "values/{config_row_name}",
-    "dataAppConfig": "apps/{component_id}/{config_name}"
+    "dataAppConfig": "app/{component_id}/{config_name}"
   },
   "allowedBranches": [
     "__main__"

--- a/test/cli/pull/invalid-manifest/out/.keboola/manifest.json
+++ b/test/cli/pull/invalid-manifest/out/.keboola/manifest.json
@@ -14,7 +14,7 @@
     "sharedCodeConfigRow": "codes/{config_row_name}",
     "variablesConfig": "variables",
     "variablesValuesRow": "values/{config_row_name}",
-    "dataAppConfig": "apps/{component_id}/{config_name}"
+    "dataAppConfig": "app/{component_id}/{config_name}"
   },
   "allowedBranches": [
     "__main__"

--- a/test/cli/pull/invalid-remote-state/in/.keboola/manifest.json
+++ b/test/cli/pull/invalid-remote-state/in/.keboola/manifest.json
@@ -14,7 +14,7 @@
     "sharedCodeConfigRow": "codes/{config_row_name}",
     "variablesConfig": "variables",
     "variablesValuesRow": "values/{config_row_name}",
-    "dataAppConfig": "apps/{component_id}/{config_name}"
+    "dataAppConfig": "app/{component_id}/{config_name}"
   },
   "allowedBranches": [
     "__all__"

--- a/test/cli/pull/invalid-remote-state/out/.keboola/manifest.json
+++ b/test/cli/pull/invalid-remote-state/out/.keboola/manifest.json
@@ -14,7 +14,7 @@
     "sharedCodeConfigRow": "codes/{config_row_name}",
     "variablesConfig": "variables",
     "variablesValuesRow": "values/{config_row_name}",
-    "dataAppConfig": "apps/{component_id}/{config_name}"
+    "dataAppConfig": "app/{component_id}/{config_name}"
   },
   "allowedBranches": [
     "__all__"

--- a/test/cli/pull/metadata/in/.keboola/manifest.json
+++ b/test/cli/pull/metadata/in/.keboola/manifest.json
@@ -14,7 +14,7 @@
     "sharedCodeConfigRow": "codes/{config_row_name}",
     "variablesConfig": "variables",
     "variablesValuesRow": "values/{config_row_name}",
-    "dataAppConfig": "apps/{component_id}/{config_name}"
+    "dataAppConfig": "app/{component_id}/{config_name}"
   },
   "allowedBranches": [
     "__all__"

--- a/test/cli/pull/metadata/out/.keboola/manifest.json
+++ b/test/cli/pull/metadata/out/.keboola/manifest.json
@@ -14,7 +14,7 @@
     "sharedCodeConfigRow": "codes/{config_row_name}",
     "variablesConfig": "variables",
     "variablesValuesRow": "values/{config_row_name}",
-    "dataAppConfig": "apps/{component_id}/{config_name}"
+    "dataAppConfig": "app/{component_id}/{config_name}"
   },
   "allowedBranches": [
     "__all__"

--- a/test/cli/pull/missing-directory/in/.keboola/manifest.json
+++ b/test/cli/pull/missing-directory/in/.keboola/manifest.json
@@ -14,7 +14,7 @@
     "sharedCodeConfigRow": "codes/{config_row_name}",
     "variablesConfig": "variables",
     "variablesValuesRow": "values/{config_row_name}",
-    "dataAppConfig": "apps/{component_id}/{config_name}"
+    "dataAppConfig": "app/{component_id}/{config_name}"
   },
   "allowedBranches": [
     "__all__"

--- a/test/cli/pull/missing-directory/out/.keboola/manifest.json
+++ b/test/cli/pull/missing-directory/out/.keboola/manifest.json
@@ -14,7 +14,7 @@
     "sharedCodeConfigRow": "codes/{config_row_name}",
     "variablesConfig": "variables",
     "variablesValuesRow": "values/{config_row_name}",
-    "dataAppConfig": "apps/{component_id}/{config_name}"
+    "dataAppConfig": "app/{component_id}/{config_name}"
   },
   "allowedBranches": [
     "__all__"

--- a/test/cli/pull/missing-relations/in/.keboola/manifest.json
+++ b/test/cli/pull/missing-relations/in/.keboola/manifest.json
@@ -14,7 +14,7 @@
     "sharedCodeConfigRow": "codes/{config_row_name}",
     "variablesConfig": "variables",
     "variablesValuesRow": "values/{config_row_name}",
-    "dataAppConfig": "apps/{component_id}/{config_name}"
+    "dataAppConfig": "app/{component_id}/{config_name}"
   },
   "allowedBranches": [
     "__all__"

--- a/test/cli/pull/missing-relations/out/.keboola/manifest.json
+++ b/test/cli/pull/missing-relations/out/.keboola/manifest.json
@@ -14,7 +14,7 @@
     "sharedCodeConfigRow": "codes/{config_row_name}",
     "variablesConfig": "variables",
     "variablesValuesRow": "values/{config_row_name}",
-    "dataAppConfig": "apps/{component_id}/{config_name}"
+    "dataAppConfig": "app/{component_id}/{config_name}"
   },
   "allowedBranches": [
     "__all__"

--- a/test/cli/pull/no-difference/in/.keboola/manifest.json
+++ b/test/cli/pull/no-difference/in/.keboola/manifest.json
@@ -14,7 +14,7 @@
     "sharedCodeConfigRow": "codes/{config_row_name}",
     "variablesConfig": "variables",
     "variablesValuesRow": "values/{config_row_name}",
-    "dataAppConfig": "apps/{component_id}/{config_name}"
+    "dataAppConfig": "app/{component_id}/{config_name}"
   },
   "allowedBranches": [
     "__all__"

--- a/test/cli/pull/no-difference/out/.keboola/manifest.json
+++ b/test/cli/pull/no-difference/out/.keboola/manifest.json
@@ -14,7 +14,7 @@
     "sharedCodeConfigRow": "codes/{config_row_name}",
     "variablesConfig": "variables",
     "variablesValuesRow": "values/{config_row_name}",
-    "dataAppConfig": "apps/{component_id}/{config_name}"
+    "dataAppConfig": "app/{component_id}/{config_name}"
   },
   "allowedBranches": [
     "__all__"

--- a/test/cli/pull/ok/in/.keboola/manifest.json
+++ b/test/cli/pull/ok/in/.keboola/manifest.json
@@ -14,7 +14,7 @@
     "sharedCodeConfigRow": "codes/{config_row_name}",
     "variablesConfig": "variables",
     "variablesValuesRow": "values/{config_row_name}",
-    "dataAppConfig": "apps/{component_id}/{config_name}"
+    "dataAppConfig": "app/{component_id}/{config_name}"
   },
   "allowedBranches": [
     "__all__"

--- a/test/cli/pull/ok/out/.keboola/manifest.json
+++ b/test/cli/pull/ok/out/.keboola/manifest.json
@@ -14,7 +14,7 @@
     "sharedCodeConfigRow": "codes/{config_row_name}",
     "variablesConfig": "variables",
     "variablesValuesRow": "values/{config_row_name}",
-    "dataAppConfig": "apps/{component_id}/{config_name}"
+    "dataAppConfig": "app/{component_id}/{config_name}"
   },
   "allowedBranches": [
     "__all__"

--- a/test/cli/pull/only-allowed-branch/in/.keboola/manifest.json
+++ b/test/cli/pull/only-allowed-branch/in/.keboola/manifest.json
@@ -14,7 +14,7 @@
     "sharedCodeConfigRow": "codes/{config_row_name}",
     "variablesConfig": "variables",
     "variablesValuesRow": "values/{config_row_name}",
-    "dataAppConfig": "apps/{component_id}/{config_name}"
+    "dataAppConfig": "app/{component_id}/{config_name}"
   },
   "allowedBranches": [
     "fo*"

--- a/test/cli/pull/only-allowed-branch/out/.keboola/manifest.json
+++ b/test/cli/pull/only-allowed-branch/out/.keboola/manifest.json
@@ -14,7 +14,7 @@
     "sharedCodeConfigRow": "codes/{config_row_name}",
     "variablesConfig": "variables",
     "variablesValuesRow": "values/{config_row_name}",
-    "dataAppConfig": "apps/{component_id}/{config_name}"
+    "dataAppConfig": "app/{component_id}/{config_name}"
   },
   "allowedBranches": [
     "fo*"

--- a/test/cli/pull/orchestrator-partial/in/.keboola/manifest.json
+++ b/test/cli/pull/orchestrator-partial/in/.keboola/manifest.json
@@ -14,7 +14,7 @@
     "sharedCodeConfigRow": "codes/{config_row_name}",
     "variablesConfig": "variables",
     "variablesValuesRow": "values/{config_row_name}",
-    "dataAppConfig": "apps/{component_id}/{config_name}"
+    "dataAppConfig": "app/{component_id}/{config_name}"
   },
   "allowedBranches": [
     "__all__"

--- a/test/cli/pull/orchestrator-partial/out/.keboola/manifest.json
+++ b/test/cli/pull/orchestrator-partial/out/.keboola/manifest.json
@@ -14,7 +14,7 @@
     "sharedCodeConfigRow": "codes/{config_row_name}",
     "variablesConfig": "variables",
     "variablesValuesRow": "values/{config_row_name}",
-    "dataAppConfig": "apps/{component_id}/{config_name}"
+    "dataAppConfig": "app/{component_id}/{config_name}"
   },
   "allowedBranches": [
     "__all__"

--- a/test/cli/pull/orchestrator/in/.keboola/manifest.json
+++ b/test/cli/pull/orchestrator/in/.keboola/manifest.json
@@ -14,7 +14,7 @@
     "sharedCodeConfigRow": "codes/{config_row_name}",
     "variablesConfig": "variables",
     "variablesValuesRow": "values/{config_row_name}",
-    "dataAppConfig": "apps/{component_id}/{config_name}"
+    "dataAppConfig": "app/{component_id}/{config_name}"
   },
   "allowedBranches": [
     "__all__"

--- a/test/cli/pull/orchestrator/out/.keboola/manifest.json
+++ b/test/cli/pull/orchestrator/out/.keboola/manifest.json
@@ -14,7 +14,7 @@
     "sharedCodeConfigRow": "codes/{config_row_name}",
     "variablesConfig": "variables",
     "variablesValuesRow": "values/{config_row_name}",
-    "dataAppConfig": "apps/{component_id}/{config_name}"
+    "dataAppConfig": "app/{component_id}/{config_name}"
   },
   "allowedBranches": [
     "__all__"

--- a/test/cli/pull/rows-without-name/in/.keboola/manifest.json
+++ b/test/cli/pull/rows-without-name/in/.keboola/manifest.json
@@ -14,7 +14,7 @@
     "sharedCodeConfigRow": "codes/{config_row_name}",
     "variablesConfig": "variables",
     "variablesValuesRow": "values/{config_row_name}",
-    "dataAppConfig": "apps/{component_id}/{config_name}"
+    "dataAppConfig": "app/{component_id}/{config_name}"
   },
   "allowedBranches": [
     "__all__"

--- a/test/cli/pull/rows-without-name/out/.keboola/manifest.json
+++ b/test/cli/pull/rows-without-name/out/.keboola/manifest.json
@@ -14,7 +14,7 @@
     "sharedCodeConfigRow": "codes/{config_row_name}",
     "variablesConfig": "variables",
     "variablesValuesRow": "values/{config_row_name}",
-    "dataAppConfig": "apps/{component_id}/{config_name}"
+    "dataAppConfig": "app/{component_id}/{config_name}"
   },
   "allowedBranches": [
     "__all__"

--- a/test/cli/pull/scheduler/in/.keboola/manifest.json
+++ b/test/cli/pull/scheduler/in/.keboola/manifest.json
@@ -14,7 +14,7 @@
     "sharedCodeConfigRow": "codes/{config_row_name}",
     "variablesConfig": "variables",
     "variablesValuesRow": "values/{config_row_name}",
-    "dataAppConfig": "apps/{component_id}/{config_name}"
+    "dataAppConfig": "app/{component_id}/{config_name}"
   },
   "allowedBranches": [
     "__all__"

--- a/test/cli/pull/scheduler/out/.keboola/manifest.json
+++ b/test/cli/pull/scheduler/out/.keboola/manifest.json
@@ -14,7 +14,7 @@
     "sharedCodeConfigRow": "codes/{config_row_name}",
     "variablesConfig": "variables",
     "variablesValuesRow": "values/{config_row_name}",
-    "dataAppConfig": "apps/{component_id}/{config_name}"
+    "dataAppConfig": "app/{component_id}/{config_name}"
   },
   "allowedBranches": [
     "__all__"

--- a/test/cli/pull/variables-add-relation/in/.keboola/manifest.json
+++ b/test/cli/pull/variables-add-relation/in/.keboola/manifest.json
@@ -14,7 +14,7 @@
     "sharedCodeConfigRow": "codes/{config_row_name}",
     "variablesConfig": "variables",
     "variablesValuesRow": "values/{config_row_name}",
-    "dataAppConfig": "apps/{component_id}/{config_name}"
+    "dataAppConfig": "app/{component_id}/{config_name}"
   },
   "allowedBranches": [
     "__all__"

--- a/test/cli/pull/variables-add-relation/out/.keboola/manifest.json
+++ b/test/cli/pull/variables-add-relation/out/.keboola/manifest.json
@@ -14,7 +14,7 @@
     "sharedCodeConfigRow": "codes/{config_row_name}",
     "variablesConfig": "variables",
     "variablesValuesRow": "values/{config_row_name}",
-    "dataAppConfig": "apps/{component_id}/{config_name}"
+    "dataAppConfig": "app/{component_id}/{config_name}"
   },
   "allowedBranches": [
     "__all__"

--- a/test/cli/pull/variables-rm-parent/in/.keboola/manifest.json
+++ b/test/cli/pull/variables-rm-parent/in/.keboola/manifest.json
@@ -14,7 +14,7 @@
     "sharedCodeConfigRow": "codes/{config_row_name}",
     "variablesConfig": "variables",
     "variablesValuesRow": "values/{config_row_name}",
-    "dataAppConfig": "apps/{component_id}/{config_name}"
+    "dataAppConfig": "app/{component_id}/{config_name}"
   },
   "allowedBranches": [
     "__all__"

--- a/test/cli/pull/variables-rm-parent/out/.keboola/manifest.json
+++ b/test/cli/pull/variables-rm-parent/out/.keboola/manifest.json
@@ -14,7 +14,7 @@
     "sharedCodeConfigRow": "codes/{config_row_name}",
     "variablesConfig": "variables",
     "variablesValuesRow": "values/{config_row_name}",
-    "dataAppConfig": "apps/{component_id}/{config_name}"
+    "dataAppConfig": "app/{component_id}/{config_name}"
   },
   "allowedBranches": [
     "__all__"

--- a/test/cli/pull/variables-rm-relation/in/.keboola/manifest.json
+++ b/test/cli/pull/variables-rm-relation/in/.keboola/manifest.json
@@ -14,7 +14,7 @@
     "sharedCodeConfigRow": "codes/{config_row_name}",
     "variablesConfig": "variables",
     "variablesValuesRow": "values/{config_row_name}",
-    "dataAppConfig": "apps/{component_id}/{config_name}"
+    "dataAppConfig": "app/{component_id}/{config_name}"
   },
   "allowedBranches": [
     "__all__"

--- a/test/cli/pull/variables-rm-relation/out/.keboola/manifest.json
+++ b/test/cli/pull/variables-rm-relation/out/.keboola/manifest.json
@@ -14,7 +14,7 @@
     "sharedCodeConfigRow": "codes/{config_row_name}",
     "variablesConfig": "variables",
     "variablesValuesRow": "values/{config_row_name}",
-    "dataAppConfig": "apps/{component_id}/{config_name}"
+    "dataAppConfig": "app/{component_id}/{config_name}"
   },
   "allowedBranches": [
     "__all__"

--- a/test/cli/pull/variables-used-twice/in/.keboola/manifest.json
+++ b/test/cli/pull/variables-used-twice/in/.keboola/manifest.json
@@ -14,7 +14,7 @@
     "sharedCodeConfigRow": "codes/{config_row_name}",
     "variablesConfig": "variables",
     "variablesValuesRow": "values/{config_row_name}",
-    "dataAppConfig": "apps/{component_id}/{config_name}"
+    "dataAppConfig": "app/{component_id}/{config_name}"
   },
   "allowedBranches": [
     "__all__"

--- a/test/cli/pull/variables-used-twice/out/.keboola/manifest.json
+++ b/test/cli/pull/variables-used-twice/out/.keboola/manifest.json
@@ -14,7 +14,7 @@
     "sharedCodeConfigRow": "codes/{config_row_name}",
     "variablesConfig": "variables",
     "variablesValuesRow": "values/{config_row_name}",
-    "dataAppConfig": "apps/{component_id}/{config_name}"
+    "dataAppConfig": "app/{component_id}/{config_name}"
   },
   "allowedBranches": [
     "__all__"

--- a/test/cli/pull/variables/in/.keboola/manifest.json
+++ b/test/cli/pull/variables/in/.keboola/manifest.json
@@ -14,7 +14,7 @@
     "sharedCodeConfigRow": "codes/{config_row_name}",
     "variablesConfig": "variables",
     "variablesValuesRow": "values/{config_row_name}",
-    "dataAppConfig": "apps/{component_id}/{config_name}"
+    "dataAppConfig": "app/{component_id}/{config_name}"
   },
   "allowedBranches": [
     "__all__"

--- a/test/cli/pull/variables/out/.keboola/manifest.json
+++ b/test/cli/pull/variables/out/.keboola/manifest.json
@@ -14,7 +14,7 @@
     "sharedCodeConfigRow": "codes/{config_row_name}",
     "variablesConfig": "variables",
     "variablesValuesRow": "values/{config_row_name}",
-    "dataAppConfig": "apps/{component_id}/{config_name}"
+    "dataAppConfig": "app/{component_id}/{config_name}"
   },
   "allowedBranches": [
     "__all__"

--- a/test/cli/push/delete-branch-dev-force/in/.keboola/manifest.json
+++ b/test/cli/push/delete-branch-dev-force/in/.keboola/manifest.json
@@ -14,7 +14,7 @@
     "sharedCodeConfigRow": "codes/{config_row_name}",
     "variablesConfig": "variables",
     "variablesValuesRow": "values/{config_row_name}",
-    "dataAppConfig": "apps/{component_id}/{config_name}"
+    "dataAppConfig": "app/{component_id}/{config_name}"
   },
   "allowedBranches": [
     "__all__"

--- a/test/cli/push/delete-branch-dev-force/out/.keboola/manifest.json
+++ b/test/cli/push/delete-branch-dev-force/out/.keboola/manifest.json
@@ -14,7 +14,7 @@
     "sharedCodeConfigRow": "codes/{config_row_name}",
     "variablesConfig": "variables",
     "variablesValuesRow": "values/{config_row_name}",
-    "dataAppConfig": "apps/{component_id}/{config_name}"
+    "dataAppConfig": "app/{component_id}/{config_name}"
   },
   "allowedBranches": [
     "__all__"

--- a/test/cli/push/delete-branch-dev/in/.keboola/manifest.json
+++ b/test/cli/push/delete-branch-dev/in/.keboola/manifest.json
@@ -14,7 +14,7 @@
     "sharedCodeConfigRow": "codes/{config_row_name}",
     "variablesConfig": "variables",
     "variablesValuesRow": "values/{config_row_name}",
-    "dataAppConfig": "apps/{component_id}/{config_name}"
+    "dataAppConfig": "app/{component_id}/{config_name}"
   },
   "allowedBranches": [
     "__all__"

--- a/test/cli/push/delete-branch-dev/out/.keboola/manifest.json
+++ b/test/cli/push/delete-branch-dev/out/.keboola/manifest.json
@@ -14,7 +14,7 @@
     "sharedCodeConfigRow": "codes/{config_row_name}",
     "variablesConfig": "variables",
     "variablesValuesRow": "values/{config_row_name}",
-    "dataAppConfig": "apps/{component_id}/{config_name}"
+    "dataAppConfig": "app/{component_id}/{config_name}"
   },
   "allowedBranches": [
     "__all__"

--- a/test/cli/push/delete-branch-main/in/.keboola/manifest.json
+++ b/test/cli/push/delete-branch-main/in/.keboola/manifest.json
@@ -14,7 +14,7 @@
     "sharedCodeConfigRow": "codes/{config_row_name}",
     "variablesConfig": "variables",
     "variablesValuesRow": "values/{config_row_name}",
-    "dataAppConfig": "apps/{component_id}/{config_name}"
+    "dataAppConfig": "app/{component_id}/{config_name}"
   },
   "allowedBranches": [
     "__all__"

--- a/test/cli/push/delete-branch-main/out/.keboola/manifest.json
+++ b/test/cli/push/delete-branch-main/out/.keboola/manifest.json
@@ -14,7 +14,7 @@
     "sharedCodeConfigRow": "codes/{config_row_name}",
     "variablesConfig": "variables",
     "variablesValuesRow": "values/{config_row_name}",
-    "dataAppConfig": "apps/{component_id}/{config_name}"
+    "dataAppConfig": "app/{component_id}/{config_name}"
   },
   "allowedBranches": [
     "__all__"

--- a/test/cli/push/delete-config-dev-force/in/.keboola/manifest.json
+++ b/test/cli/push/delete-config-dev-force/in/.keboola/manifest.json
@@ -14,7 +14,7 @@
     "sharedCodeConfigRow": "codes/{config_row_name}",
     "variablesConfig": "variables",
     "variablesValuesRow": "values/{config_row_name}",
-    "dataAppConfig": "apps/{component_id}/{config_name}"
+    "dataAppConfig": "app/{component_id}/{config_name}"
   },
   "allowedBranches": [
     "__all__"

--- a/test/cli/push/delete-config-dev-force/out/.keboola/manifest.json
+++ b/test/cli/push/delete-config-dev-force/out/.keboola/manifest.json
@@ -14,7 +14,7 @@
     "sharedCodeConfigRow": "codes/{config_row_name}",
     "variablesConfig": "variables",
     "variablesValuesRow": "values/{config_row_name}",
-    "dataAppConfig": "apps/{component_id}/{config_name}"
+    "dataAppConfig": "app/{component_id}/{config_name}"
   },
   "allowedBranches": [
     "__all__"

--- a/test/cli/push/delete-config-main-force/in/.keboola/manifest.json
+++ b/test/cli/push/delete-config-main-force/in/.keboola/manifest.json
@@ -14,7 +14,7 @@
     "sharedCodeConfigRow": "codes/{config_row_name}",
     "variablesConfig": "variables",
     "variablesValuesRow": "values/{config_row_name}",
-    "dataAppConfig": "apps/{component_id}/{config_name}"
+    "dataAppConfig": "app/{component_id}/{config_name}"
   },
   "allowedBranches": [
     "__all__"

--- a/test/cli/push/delete-config-main-force/out/.keboola/manifest.json
+++ b/test/cli/push/delete-config-main-force/out/.keboola/manifest.json
@@ -14,7 +14,7 @@
     "sharedCodeConfigRow": "codes/{config_row_name}",
     "variablesConfig": "variables",
     "variablesValuesRow": "values/{config_row_name}",
-    "dataAppConfig": "apps/{component_id}/{config_name}"
+    "dataAppConfig": "app/{component_id}/{config_name}"
   },
   "allowedBranches": [
     "__all__"

--- a/test/cli/push/delete-config-main/in/.keboola/manifest.json
+++ b/test/cli/push/delete-config-main/in/.keboola/manifest.json
@@ -14,7 +14,7 @@
     "sharedCodeConfigRow": "codes/{config_row_name}",
     "variablesConfig": "variables",
     "variablesValuesRow": "values/{config_row_name}",
-    "dataAppConfig": "apps/{component_id}/{config_name}"
+    "dataAppConfig": "app/{component_id}/{config_name}"
   },
   "allowedBranches": [
     "__all__"

--- a/test/cli/push/delete-config-main/out/.keboola/manifest.json
+++ b/test/cli/push/delete-config-main/out/.keboola/manifest.json
@@ -14,7 +14,7 @@
     "sharedCodeConfigRow": "codes/{config_row_name}",
     "variablesConfig": "variables",
     "variablesValuesRow": "values/{config_row_name}",
-    "dataAppConfig": "apps/{component_id}/{config_name}"
+    "dataAppConfig": "app/{component_id}/{config_name}"
   },
   "allowedBranches": [
     "__all__"

--- a/test/cli/push/delete-config-row-dev-force/in/.keboola/manifest.json
+++ b/test/cli/push/delete-config-row-dev-force/in/.keboola/manifest.json
@@ -14,7 +14,7 @@
     "sharedCodeConfigRow": "codes/{config_row_name}",
     "variablesConfig": "variables",
     "variablesValuesRow": "values/{config_row_name}",
-    "dataAppConfig": "apps/{component_id}/{config_name}"
+    "dataAppConfig": "app/{component_id}/{config_name}"
   },
   "allowedBranches": [
     "__all__"

--- a/test/cli/push/delete-config-row-dev-force/out/.keboola/manifest.json
+++ b/test/cli/push/delete-config-row-dev-force/out/.keboola/manifest.json
@@ -14,7 +14,7 @@
     "sharedCodeConfigRow": "codes/{config_row_name}",
     "variablesConfig": "variables",
     "variablesValuesRow": "values/{config_row_name}",
-    "dataAppConfig": "apps/{component_id}/{config_name}"
+    "dataAppConfig": "app/{component_id}/{config_name}"
   },
   "allowedBranches": [
     "__all__"

--- a/test/cli/push/delete-config-row-main-force/in/.keboola/manifest.json
+++ b/test/cli/push/delete-config-row-main-force/in/.keboola/manifest.json
@@ -14,7 +14,7 @@
     "sharedCodeConfigRow": "codes/{config_row_name}",
     "variablesConfig": "variables",
     "variablesValuesRow": "values/{config_row_name}",
-    "dataAppConfig": "apps/{component_id}/{config_name}"
+    "dataAppConfig": "app/{component_id}/{config_name}"
   },
   "allowedBranches": [
     "__all__"

--- a/test/cli/push/delete-config-row-main-force/out/.keboola/manifest.json
+++ b/test/cli/push/delete-config-row-main-force/out/.keboola/manifest.json
@@ -14,7 +14,7 @@
     "sharedCodeConfigRow": "codes/{config_row_name}",
     "variablesConfig": "variables",
     "variablesValuesRow": "values/{config_row_name}",
-    "dataAppConfig": "apps/{component_id}/{config_name}"
+    "dataAppConfig": "app/{component_id}/{config_name}"
   },
   "allowedBranches": [
     "__all__"

--- a/test/cli/push/delete-config-row-main/in/.keboola/manifest.json
+++ b/test/cli/push/delete-config-row-main/in/.keboola/manifest.json
@@ -14,7 +14,7 @@
     "sharedCodeConfigRow": "codes/{config_row_name}",
     "variablesConfig": "variables",
     "variablesValuesRow": "values/{config_row_name}",
-    "dataAppConfig": "apps/{component_id}/{config_name}"
+    "dataAppConfig": "app/{component_id}/{config_name}"
   },
   "allowedBranches": [
     "__all__"

--- a/test/cli/push/delete-config-row-main/out/.keboola/manifest.json
+++ b/test/cli/push/delete-config-row-main/out/.keboola/manifest.json
@@ -14,7 +14,7 @@
     "sharedCodeConfigRow": "codes/{config_row_name}",
     "variablesConfig": "variables",
     "variablesValuesRow": "values/{config_row_name}",
-    "dataAppConfig": "apps/{component_id}/{config_name}"
+    "dataAppConfig": "app/{component_id}/{config_name}"
   },
   "allowedBranches": [
     "__all__"

--- a/test/cli/push/dry-run/in/.keboola/manifest.json
+++ b/test/cli/push/dry-run/in/.keboola/manifest.json
@@ -14,7 +14,7 @@
     "sharedCodeConfigRow": "codes/{config_row_name}",
     "variablesConfig": "variables",
     "variablesValuesRow": "values/{config_row_name}",
-    "dataAppConfig": "apps/{component_id}/{config_name}"
+    "dataAppConfig": "app/{component_id}/{config_name}"
   },
   "allowedBranches": [
     "__all__"

--- a/test/cli/push/dry-run/out/.keboola/manifest.json
+++ b/test/cli/push/dry-run/out/.keboola/manifest.json
@@ -14,7 +14,7 @@
     "sharedCodeConfigRow": "codes/{config_row_name}",
     "variablesConfig": "variables",
     "variablesValuesRow": "values/{config_row_name}",
-    "dataAppConfig": "apps/{component_id}/{config_name}"
+    "dataAppConfig": "app/{component_id}/{config_name}"
   },
   "allowedBranches": [
     "__all__"

--- a/test/cli/push/im-default-bucket-missing-row/in/.keboola/manifest.json
+++ b/test/cli/push/im-default-bucket-missing-row/in/.keboola/manifest.json
@@ -14,7 +14,7 @@
     "sharedCodeConfigRow": "codes/{config_row_name}",
     "variablesConfig": "variables",
     "variablesValuesRow": "values/{config_row_name}",
-    "dataAppConfig": "apps/{component_id}/{config_name}"
+    "dataAppConfig": "app/{component_id}/{config_name}"
   },
   "allowedBranches": [
     "__all__"

--- a/test/cli/push/im-default-bucket-missing-row/out/.keboola/manifest.json
+++ b/test/cli/push/im-default-bucket-missing-row/out/.keboola/manifest.json
@@ -14,7 +14,7 @@
     "sharedCodeConfigRow": "codes/{config_row_name}",
     "variablesConfig": "variables",
     "variablesValuesRow": "values/{config_row_name}",
-    "dataAppConfig": "apps/{component_id}/{config_name}"
+    "dataAppConfig": "app/{component_id}/{config_name}"
   },
   "allowedBranches": [
     "__all__"

--- a/test/cli/push/im-default-bucket-missing/in/.keboola/manifest.json
+++ b/test/cli/push/im-default-bucket-missing/in/.keboola/manifest.json
@@ -14,7 +14,7 @@
     "sharedCodeConfigRow": "codes/{config_row_name}",
     "variablesConfig": "variables",
     "variablesValuesRow": "values/{config_row_name}",
-    "dataAppConfig": "apps/{component_id}/{config_name}"
+    "dataAppConfig": "app/{component_id}/{config_name}"
   },
   "allowedBranches": [
     "__all__"

--- a/test/cli/push/im-default-bucket-missing/out/.keboola/manifest.json
+++ b/test/cli/push/im-default-bucket-missing/out/.keboola/manifest.json
@@ -14,7 +14,7 @@
     "sharedCodeConfigRow": "codes/{config_row_name}",
     "variablesConfig": "variables",
     "variablesValuesRow": "values/{config_row_name}",
-    "dataAppConfig": "apps/{component_id}/{config_name}"
+    "dataAppConfig": "app/{component_id}/{config_name}"
   },
   "allowedBranches": [
     "__all__"

--- a/test/cli/push/im-default-bucket-row/in/.keboola/manifest.json
+++ b/test/cli/push/im-default-bucket-row/in/.keboola/manifest.json
@@ -14,7 +14,7 @@
     "sharedCodeConfigRow": "codes/{config_row_name}",
     "variablesConfig": "variables",
     "variablesValuesRow": "values/{config_row_name}",
-    "dataAppConfig": "apps/{component_id}/{config_name}"
+    "dataAppConfig": "app/{component_id}/{config_name}"
   },
   "allowedBranches": [
     "__all__"

--- a/test/cli/push/im-default-bucket-row/out/.keboola/manifest.json
+++ b/test/cli/push/im-default-bucket-row/out/.keboola/manifest.json
@@ -14,7 +14,7 @@
     "sharedCodeConfigRow": "codes/{config_row_name}",
     "variablesConfig": "variables",
     "variablesValuesRow": "values/{config_row_name}",
-    "dataAppConfig": "apps/{component_id}/{config_name}"
+    "dataAppConfig": "app/{component_id}/{config_name}"
   },
   "allowedBranches": [
     "__all__"

--- a/test/cli/push/im-default-bucket/in/.keboola/manifest.json
+++ b/test/cli/push/im-default-bucket/in/.keboola/manifest.json
@@ -14,7 +14,7 @@
     "sharedCodeConfigRow": "codes/{config_row_name}",
     "variablesConfig": "variables",
     "variablesValuesRow": "values/{config_row_name}",
-    "dataAppConfig": "apps/{component_id}/{config_name}"
+    "dataAppConfig": "app/{component_id}/{config_name}"
   },
   "allowedBranches": [
     "__all__"

--- a/test/cli/push/im-default-bucket/out/.keboola/manifest.json
+++ b/test/cli/push/im-default-bucket/out/.keboola/manifest.json
@@ -14,7 +14,7 @@
     "sharedCodeConfigRow": "codes/{config_row_name}",
     "variablesConfig": "variables",
     "variablesValuesRow": "values/{config_row_name}",
-    "dataAppConfig": "apps/{component_id}/{config_name}"
+    "dataAppConfig": "app/{component_id}/{config_name}"
   },
   "allowedBranches": [
     "__all__"

--- a/test/cli/push/invalid-local-state/in/.keboola/manifest.json
+++ b/test/cli/push/invalid-local-state/in/.keboola/manifest.json
@@ -14,7 +14,7 @@
     "sharedCodeConfigRow": "codes/{config_row_name}",
     "variablesConfig": "variables",
     "variablesValuesRow": "values/{config_row_name}",
-    "dataAppConfig": "apps/{component_id}/{config_name}"
+    "dataAppConfig": "app/{component_id}/{config_name}"
   },
   "allowedBranches": [
     "__all__"

--- a/test/cli/push/invalid-local-state/out/.keboola/manifest.json
+++ b/test/cli/push/invalid-local-state/out/.keboola/manifest.json
@@ -14,7 +14,7 @@
     "sharedCodeConfigRow": "codes/{config_row_name}",
     "variablesConfig": "variables",
     "variablesValuesRow": "values/{config_row_name}",
-    "dataAppConfig": "apps/{component_id}/{config_name}"
+    "dataAppConfig": "app/{component_id}/{config_name}"
   },
   "allowedBranches": [
     "__all__"

--- a/test/cli/push/metadata-empty/in/.keboola/manifest.json
+++ b/test/cli/push/metadata-empty/in/.keboola/manifest.json
@@ -14,7 +14,7 @@
     "sharedCodeConfigRow": "codes/{config_row_name}",
     "variablesConfig": "variables",
     "variablesValuesRow": "values/{config_row_name}",
-    "dataAppConfig": "apps/{component_id}/{config_name}"
+    "dataAppConfig": "app/{component_id}/{config_name}"
   },
   "allowedBranches": [
     "__all__"

--- a/test/cli/push/metadata-empty/out/.keboola/manifest.json
+++ b/test/cli/push/metadata-empty/out/.keboola/manifest.json
@@ -14,7 +14,7 @@
     "sharedCodeConfigRow": "codes/{config_row_name}",
     "variablesConfig": "variables",
     "variablesValuesRow": "values/{config_row_name}",
-    "dataAppConfig": "apps/{component_id}/{config_name}"
+    "dataAppConfig": "app/{component_id}/{config_name}"
   },
   "allowedBranches": [
     "__all__"

--- a/test/cli/push/metadata/in/.keboola/manifest.json
+++ b/test/cli/push/metadata/in/.keboola/manifest.json
@@ -14,7 +14,7 @@
     "sharedCodeConfigRow": "codes/{config_row_name}",
     "variablesConfig": "variables",
     "variablesValuesRow": "values/{config_row_name}",
-    "dataAppConfig": "apps/{component_id}/{config_name}"
+    "dataAppConfig": "app/{component_id}/{config_name}"
   },
   "allowedBranches": [
     "__all__"

--- a/test/cli/push/metadata/out/.keboola/manifest.json
+++ b/test/cli/push/metadata/out/.keboola/manifest.json
@@ -14,7 +14,7 @@
     "sharedCodeConfigRow": "codes/{config_row_name}",
     "variablesConfig": "variables",
     "variablesValuesRow": "values/{config_row_name}",
-    "dataAppConfig": "apps/{component_id}/{config_name}"
+    "dataAppConfig": "app/{component_id}/{config_name}"
   },
   "allowedBranches": [
     "__all__"

--- a/test/cli/push/new-config-and-row/in/.keboola/manifest.json
+++ b/test/cli/push/new-config-and-row/in/.keboola/manifest.json
@@ -14,7 +14,7 @@
     "sharedCodeConfigRow": "codes/{config_row_name}",
     "variablesConfig": "variables",
     "variablesValuesRow": "values/{config_row_name}",
-    "dataAppConfig": "apps/{component_id}/{config_name}"
+    "dataAppConfig": "app/{component_id}/{config_name}"
   },
   "allowedBranches": [
     "__all__"

--- a/test/cli/push/new-config-and-row/out/.keboola/manifest.json
+++ b/test/cli/push/new-config-and-row/out/.keboola/manifest.json
@@ -14,7 +14,7 @@
     "sharedCodeConfigRow": "codes/{config_row_name}",
     "variablesConfig": "variables",
     "variablesValuesRow": "values/{config_row_name}",
-    "dataAppConfig": "apps/{component_id}/{config_name}"
+    "dataAppConfig": "app/{component_id}/{config_name}"
   },
   "allowedBranches": [
     "__all__"

--- a/test/cli/push/ok/in/.keboola/manifest.json
+++ b/test/cli/push/ok/in/.keboola/manifest.json
@@ -14,7 +14,7 @@
     "sharedCodeConfigRow": "codes/{config_row_name}",
     "variablesConfig": "variables",
     "variablesValuesRow": "values/{config_row_name}",
-    "dataAppConfig": "apps/{component_id}/{config_name}"
+    "dataAppConfig": "app/{component_id}/{config_name}"
   },
   "allowedBranches": [
     "__all__"

--- a/test/cli/push/ok/out/.keboola/manifest.json
+++ b/test/cli/push/ok/out/.keboola/manifest.json
@@ -14,7 +14,7 @@
     "sharedCodeConfigRow": "codes/{config_row_name}",
     "variablesConfig": "variables",
     "variablesValuesRow": "values/{config_row_name}",
-    "dataAppConfig": "apps/{component_id}/{config_name}"
+    "dataAppConfig": "app/{component_id}/{config_name}"
   },
   "allowedBranches": [
     "__all__"

--- a/test/cli/push/only-allowed-branch/in/.keboola/manifest.json
+++ b/test/cli/push/only-allowed-branch/in/.keboola/manifest.json
@@ -14,7 +14,7 @@
     "sharedCodeConfigRow": "codes/{config_row_name}",
     "variablesConfig": "variables",
     "variablesValuesRow": "values/{config_row_name}",
-    "dataAppConfig": "apps/{component_id}/{config_name}"
+    "dataAppConfig": "app/{component_id}/{config_name}"
   },
   "allowedBranches": [
     "main"

--- a/test/cli/push/only-allowed-branch/out/.keboola/manifest.json
+++ b/test/cli/push/only-allowed-branch/out/.keboola/manifest.json
@@ -14,7 +14,7 @@
     "sharedCodeConfigRow": "codes/{config_row_name}",
     "variablesConfig": "variables",
     "variablesValuesRow": "values/{config_row_name}",
-    "dataAppConfig": "apps/{component_id}/{config_name}"
+    "dataAppConfig": "app/{component_id}/{config_name}"
   },
   "allowedBranches": [
     "main"

--- a/test/cli/push/orchestrator-partial/in/.keboola/manifest.json
+++ b/test/cli/push/orchestrator-partial/in/.keboola/manifest.json
@@ -14,7 +14,7 @@
     "sharedCodeConfigRow": "codes/{config_row_name}",
     "variablesConfig": "variables",
     "variablesValuesRow": "values/{config_row_name}",
-    "dataAppConfig": "apps/{component_id}/{config_name}"
+    "dataAppConfig": "app/{component_id}/{config_name}"
   },
   "allowedBranches": [
     "__all__"

--- a/test/cli/push/orchestrator-partial/out/.keboola/manifest.json
+++ b/test/cli/push/orchestrator-partial/out/.keboola/manifest.json
@@ -14,7 +14,7 @@
     "sharedCodeConfigRow": "codes/{config_row_name}",
     "variablesConfig": "variables",
     "variablesValuesRow": "values/{config_row_name}",
-    "dataAppConfig": "apps/{component_id}/{config_name}"
+    "dataAppConfig": "app/{component_id}/{config_name}"
   },
   "allowedBranches": [
     "__all__"

--- a/test/cli/push/orchestrator/in/.keboola/manifest.json
+++ b/test/cli/push/orchestrator/in/.keboola/manifest.json
@@ -14,7 +14,7 @@
     "sharedCodeConfigRow": "codes/{config_row_name}",
     "variablesConfig": "variables",
     "variablesValuesRow": "values/{config_row_name}",
-    "dataAppConfig": "apps/{component_id}/{config_name}"
+    "dataAppConfig": "app/{component_id}/{config_name}"
   },
   "allowedBranches": [
     "__all__"

--- a/test/cli/push/orchestrator/out/.keboola/manifest.json
+++ b/test/cli/push/orchestrator/out/.keboola/manifest.json
@@ -14,7 +14,7 @@
     "sharedCodeConfigRow": "codes/{config_row_name}",
     "variablesConfig": "variables",
     "variablesValuesRow": "values/{config_row_name}",
-    "dataAppConfig": "apps/{component_id}/{config_name}"
+    "dataAppConfig": "app/{component_id}/{config_name}"
   },
   "allowedBranches": [
     "__all__"

--- a/test/cli/push/scheduler-dev-branch/in/.keboola/manifest.json
+++ b/test/cli/push/scheduler-dev-branch/in/.keboola/manifest.json
@@ -14,7 +14,7 @@
     "sharedCodeConfigRow": "codes/{config_row_name}",
     "variablesConfig": "variables",
     "variablesValuesRow": "values/{config_row_name}",
-    "dataAppConfig": "apps/{component_id}/{config_name}"
+    "dataAppConfig": "app/{component_id}/{config_name}"
   },
   "allowedBranches": [
     "__all__"

--- a/test/cli/push/scheduler-dev-branch/out/.keboola/manifest.json
+++ b/test/cli/push/scheduler-dev-branch/out/.keboola/manifest.json
@@ -14,7 +14,7 @@
     "sharedCodeConfigRow": "codes/{config_row_name}",
     "variablesConfig": "variables",
     "variablesValuesRow": "values/{config_row_name}",
-    "dataAppConfig": "apps/{component_id}/{config_name}"
+    "dataAppConfig": "app/{component_id}/{config_name}"
   },
   "allowedBranches": [
     "__all__"

--- a/test/cli/push/scheduler/in/.keboola/manifest.json
+++ b/test/cli/push/scheduler/in/.keboola/manifest.json
@@ -14,7 +14,7 @@
     "sharedCodeConfigRow": "codes/{config_row_name}",
     "variablesConfig": "variables",
     "variablesValuesRow": "values/{config_row_name}",
-    "dataAppConfig": "apps/{component_id}/{config_name}"
+    "dataAppConfig": "app/{component_id}/{config_name}"
   },
   "allowedBranches": [
     "__all__"

--- a/test/cli/push/scheduler/out/.keboola/manifest.json
+++ b/test/cli/push/scheduler/out/.keboola/manifest.json
@@ -14,7 +14,7 @@
     "sharedCodeConfigRow": "codes/{config_row_name}",
     "variablesConfig": "variables",
     "variablesValuesRow": "values/{config_row_name}",
-    "dataAppConfig": "apps/{component_id}/{config_name}"
+    "dataAppConfig": "app/{component_id}/{config_name}"
   },
   "allowedBranches": [
     "__all__"

--- a/test/cli/push/shared-code-with-vars/in/.keboola/manifest.json
+++ b/test/cli/push/shared-code-with-vars/in/.keboola/manifest.json
@@ -13,7 +13,7 @@
     "sharedCodeConfigRow": "codes/{config_row_name}",
     "variablesConfig": "variables",
     "variablesValuesRow": "values/{config_row_name}",
-    "dataAppConfig": "apps/{component_id}/{config_name}"
+    "dataAppConfig": "app/{component_id}/{config_name}"
   },
   "allowedBranches": [
     "__all__"

--- a/test/cli/push/shared-code-with-vars/out/.keboola/manifest.json
+++ b/test/cli/push/shared-code-with-vars/out/.keboola/manifest.json
@@ -13,7 +13,7 @@
     "sharedCodeConfigRow": "codes/{config_row_name}",
     "variablesConfig": "variables",
     "variablesValuesRow": "values/{config_row_name}",
-    "dataAppConfig": "apps/{component_id}/{config_name}"
+    "dataAppConfig": "app/{component_id}/{config_name}"
   },
   "allowedBranches": [
     "__all__"

--- a/test/cli/push/transformation/in/.keboola/manifest.json
+++ b/test/cli/push/transformation/in/.keboola/manifest.json
@@ -14,7 +14,7 @@
     "sharedCodeConfigRow": "codes/{config_row_name}",
     "variablesConfig": "variables",
     "variablesValuesRow": "values/{config_row_name}",
-    "dataAppConfig": "apps/{component_id}/{config_name}"
+    "dataAppConfig": "app/{component_id}/{config_name}"
   },
   "allowedBranches": [
     "__all__"

--- a/test/cli/push/transformation/out/.keboola/manifest.json
+++ b/test/cli/push/transformation/out/.keboola/manifest.json
@@ -14,7 +14,7 @@
     "sharedCodeConfigRow": "codes/{config_row_name}",
     "variablesConfig": "variables",
     "variablesValuesRow": "values/{config_row_name}",
-    "dataAppConfig": "apps/{component_id}/{config_name}"
+    "dataAppConfig": "app/{component_id}/{config_name}"
   },
   "allowedBranches": [
     "__all__"

--- a/test/cli/push/update-branch/in/.keboola/manifest.json
+++ b/test/cli/push/update-branch/in/.keboola/manifest.json
@@ -14,7 +14,7 @@
     "sharedCodeConfigRow": "codes/{config_row_name}",
     "variablesConfig": "variables",
     "variablesValuesRow": "values/{config_row_name}",
-    "dataAppConfig": "apps/{component_id}/{config_name}"
+    "dataAppConfig": "app/{component_id}/{config_name}"
   },
   "allowedBranches": [
     "__all__"

--- a/test/cli/push/update-branch/out/.keboola/manifest.json
+++ b/test/cli/push/update-branch/out/.keboola/manifest.json
@@ -14,7 +14,7 @@
     "sharedCodeConfigRow": "codes/{config_row_name}",
     "variablesConfig": "variables",
     "variablesValuesRow": "values/{config_row_name}",
-    "dataAppConfig": "apps/{component_id}/{config_name}"
+    "dataAppConfig": "app/{component_id}/{config_name}"
   },
   "allowedBranches": [
     "__all__"

--- a/test/cli/push/update-config-row/in/.keboola/manifest.json
+++ b/test/cli/push/update-config-row/in/.keboola/manifest.json
@@ -14,7 +14,7 @@
     "sharedCodeConfigRow": "codes/{config_row_name}",
     "variablesConfig": "variables",
     "variablesValuesRow": "values/{config_row_name}",
-    "dataAppConfig": "apps/{component_id}/{config_name}"
+    "dataAppConfig": "app/{component_id}/{config_name}"
   },
   "allowedBranches": [
     "__all__"

--- a/test/cli/push/update-config-row/out/.keboola/manifest.json
+++ b/test/cli/push/update-config-row/out/.keboola/manifest.json
@@ -14,7 +14,7 @@
     "sharedCodeConfigRow": "codes/{config_row_name}",
     "variablesConfig": "variables",
     "variablesValuesRow": "values/{config_row_name}",
-    "dataAppConfig": "apps/{component_id}/{config_name}"
+    "dataAppConfig": "app/{component_id}/{config_name}"
   },
   "allowedBranches": [
     "__all__"

--- a/test/cli/push/update-config/in/.keboola/manifest.json
+++ b/test/cli/push/update-config/in/.keboola/manifest.json
@@ -14,7 +14,7 @@
     "sharedCodeConfigRow": "codes/{config_row_name}",
     "variablesConfig": "variables",
     "variablesValuesRow": "values/{config_row_name}",
-    "dataAppConfig": "apps/{component_id}/{config_name}"
+    "dataAppConfig": "app/{component_id}/{config_name}"
   },
   "allowedBranches": [
     "__all__"

--- a/test/cli/push/update-config/out/.keboola/manifest.json
+++ b/test/cli/push/update-config/out/.keboola/manifest.json
@@ -14,7 +14,7 @@
     "sharedCodeConfigRow": "codes/{config_row_name}",
     "variablesConfig": "variables",
     "variablesValuesRow": "values/{config_row_name}",
-    "dataAppConfig": "apps/{component_id}/{config_name}"
+    "dataAppConfig": "app/{component_id}/{config_name}"
   },
   "allowedBranches": [
     "__all__"

--- a/test/cli/push/variables-add-relation/in/.keboola/manifest.json
+++ b/test/cli/push/variables-add-relation/in/.keboola/manifest.json
@@ -13,7 +13,7 @@
     "sharedCodeConfigRow": "codes/{config_row_name}",
     "variablesConfig": "variables",
     "variablesValuesRow": "values/{config_row_name}",
-    "dataAppConfig": "apps/{component_id}/{config_name}"
+    "dataAppConfig": "app/{component_id}/{config_name}"
   },
   "allowedBranches": [
     "__all__"

--- a/test/cli/push/variables-add-relation/out/.keboola/manifest.json
+++ b/test/cli/push/variables-add-relation/out/.keboola/manifest.json
@@ -13,7 +13,7 @@
     "sharedCodeConfigRow": "codes/{config_row_name}",
     "variablesConfig": "variables",
     "variablesValuesRow": "values/{config_row_name}",
-    "dataAppConfig": "apps/{component_id}/{config_name}"
+    "dataAppConfig": "app/{component_id}/{config_name}"
   },
   "allowedBranches": [
     "__all__"

--- a/test/cli/push/variables-rm-relation/in/.keboola/manifest.json
+++ b/test/cli/push/variables-rm-relation/in/.keboola/manifest.json
@@ -14,7 +14,7 @@
     "sharedCodeConfigRow": "codes/{config_row_name}",
     "variablesConfig": "variables",
     "variablesValuesRow": "values/{config_row_name}",
-    "dataAppConfig": "apps/{component_id}/{config_name}"
+    "dataAppConfig": "app/{component_id}/{config_name}"
   },
   "allowedBranches": [
     "__all__"

--- a/test/cli/push/variables-rm-relation/out/.keboola/manifest.json
+++ b/test/cli/push/variables-rm-relation/out/.keboola/manifest.json
@@ -14,7 +14,7 @@
     "sharedCodeConfigRow": "codes/{config_row_name}",
     "variablesConfig": "variables",
     "variablesValuesRow": "values/{config_row_name}",
-    "dataAppConfig": "apps/{component_id}/{config_name}"
+    "dataAppConfig": "app/{component_id}/{config_name}"
   },
   "allowedBranches": [
     "__all__"

--- a/test/cli/template-delete/complex/in/.keboola/manifest.json
+++ b/test/cli/template-delete/complex/in/.keboola/manifest.json
@@ -14,7 +14,7 @@
     "sharedCodeConfigRow": "codes/{config_row_name}",
     "variablesConfig": "variables",
     "variablesValuesRow": "values/{config_row_name}",
-    "dataAppConfig": "apps/{component_id}/{config_name}"
+    "dataAppConfig": "app/{component_id}/{config_name}"
   },
   "allowedBranches": [
     "__all__"

--- a/test/cli/template-delete/complex/out/.keboola/manifest.json
+++ b/test/cli/template-delete/complex/out/.keboola/manifest.json
@@ -14,7 +14,7 @@
     "sharedCodeConfigRow": "codes/{config_row_name}",
     "variablesConfig": "variables",
     "variablesValuesRow": "values/{config_row_name}",
-    "dataAppConfig": "apps/{component_id}/{config_name}"
+    "dataAppConfig": "app/{component_id}/{config_name}"
   },
   "allowedBranches": [
     "__all__"

--- a/test/cli/template-delete/orchestrator-schedule/in/.keboola/manifest.json
+++ b/test/cli/template-delete/orchestrator-schedule/in/.keboola/manifest.json
@@ -14,7 +14,7 @@
     "sharedCodeConfigRow": "codes/{config_row_name}",
     "variablesConfig": "variables",
     "variablesValuesRow": "values/{config_row_name}",
-    "dataAppConfig": "apps/{component_id}/{config_name}"
+    "dataAppConfig": "app/{component_id}/{config_name}"
   },
   "allowedBranches": [
     "__all__"

--- a/test/cli/template-delete/orchestrator-schedule/out/.keboola/manifest.json
+++ b/test/cli/template-delete/orchestrator-schedule/out/.keboola/manifest.json
@@ -14,7 +14,7 @@
     "sharedCodeConfigRow": "codes/{config_row_name}",
     "variablesConfig": "variables",
     "variablesValuesRow": "values/{config_row_name}",
-    "dataAppConfig": "apps/{component_id}/{config_name}"
+    "dataAppConfig": "app/{component_id}/{config_name}"
   },
   "allowedBranches": [
     "__all__"

--- a/test/cli/template-instance-list/list/in/.keboola/manifest.json
+++ b/test/cli/template-instance-list/list/in/.keboola/manifest.json
@@ -14,7 +14,7 @@
     "sharedCodeConfigRow": "codes/{config_row_name}",
     "variablesConfig": "variables",
     "variablesValuesRow": "values/{config_row_name}",
-    "dataAppConfig": "apps/{component_id}/{config_name}"
+    "dataAppConfig": "app/{component_id}/{config_name}"
   },
   "allowedBranches": [
     "__all__"

--- a/test/cli/template-instance-list/list/out/.keboola/manifest.json
+++ b/test/cli/template-instance-list/list/out/.keboola/manifest.json
@@ -14,7 +14,7 @@
     "sharedCodeConfigRow": "codes/{config_row_name}",
     "variablesConfig": "variables",
     "variablesValuesRow": "values/{config_row_name}",
-    "dataAppConfig": "apps/{component_id}/{config_name}"
+    "dataAppConfig": "app/{component_id}/{config_name}"
   },
   "allowedBranches": [
     "__all__"

--- a/test/cli/template-rename/ok/in/.keboola/manifest.json
+++ b/test/cli/template-rename/ok/in/.keboola/manifest.json
@@ -14,7 +14,7 @@
     "sharedCodeConfigRow": "codes/{config_row_name}",
     "variablesConfig": "variables",
     "variablesValuesRow": "values/{config_row_name}",
-    "dataAppConfig": "apps/{component_id}/{config_name}"
+    "dataAppConfig": "app/{component_id}/{config_name}"
   },
   "allowedBranches": [
     "__all__"

--- a/test/cli/template-rename/ok/out/.keboola/manifest.json
+++ b/test/cli/template-rename/ok/out/.keboola/manifest.json
@@ -14,7 +14,7 @@
     "sharedCodeConfigRow": "codes/{config_row_name}",
     "variablesConfig": "variables",
     "variablesValuesRow": "values/{config_row_name}",
-    "dataAppConfig": "apps/{component_id}/{config_name}"
+    "dataAppConfig": "app/{component_id}/{config_name}"
   },
   "allowedBranches": [
     "__all__"

--- a/test/cli/template-test-create/create/out/my-template/v0/tests/one/expected-out/.keboola/manifest.json
+++ b/test/cli/template-test-create/create/out/my-template/v0/tests/one/expected-out/.keboola/manifest.json
@@ -14,7 +14,7 @@
     "sharedCodeConfigRow": "codes/{config_row_name}",
     "variablesConfig": "variables",
     "variablesValuesRow": "values/{config_row_name}",
-    "dataAppConfig": "apps/{component_id}/{config_name}"
+    "dataAppConfig": "app/{component_id}/{config_name}"
   },
   "allowedBranches": [
     "*"

--- a/test/cli/template-test-run/local-all/in/my-template/v0/tests/one/expected-out/.keboola/manifest.json
+++ b/test/cli/template-test-run/local-all/in/my-template/v0/tests/one/expected-out/.keboola/manifest.json
@@ -14,7 +14,7 @@
     "sharedCodeConfigRow": "codes/{config_row_name}",
     "variablesConfig": "variables",
     "variablesValuesRow": "values/{config_row_name}",
-    "dataAppConfig": "apps/{component_id}/{config_name}"
+    "dataAppConfig": "app/{component_id}/{config_name}"
   },
   "allowedBranches": [
     "*"

--- a/test/cli/template-test-run/local-all/in/template-2/v2/tests/one/expected-out/.keboola/manifest.json
+++ b/test/cli/template-test-run/local-all/in/template-2/v2/tests/one/expected-out/.keboola/manifest.json
@@ -14,7 +14,7 @@
     "sharedCodeConfigRow": "codes/{config_row_name}",
     "variablesConfig": "variables",
     "variablesValuesRow": "values/{config_row_name}",
-    "dataAppConfig": "apps/{component_id}/{config_name}"
+    "dataAppConfig": "app/{component_id}/{config_name}"
   },
   "allowedBranches": [
     "*"

--- a/test/cli/template-test-run/local-all/out/my-template/v0/tests/one/expected-out/.keboola/manifest.json
+++ b/test/cli/template-test-run/local-all/out/my-template/v0/tests/one/expected-out/.keboola/manifest.json
@@ -14,7 +14,7 @@
     "sharedCodeConfigRow": "codes/{config_row_name}",
     "variablesConfig": "variables",
     "variablesValuesRow": "values/{config_row_name}",
-    "dataAppConfig": "apps/{component_id}/{config_name}"
+    "dataAppConfig": "app/{component_id}/{config_name}"
   },
   "allowedBranches": [
     "*"

--- a/test/cli/template-test-run/local-all/out/template-2/v2/tests/one/expected-out/.keboola/manifest.json
+++ b/test/cli/template-test-run/local-all/out/template-2/v2/tests/one/expected-out/.keboola/manifest.json
@@ -14,7 +14,7 @@
     "sharedCodeConfigRow": "codes/{config_row_name}",
     "variablesConfig": "variables",
     "variablesValuesRow": "values/{config_row_name}",
-    "dataAppConfig": "apps/{component_id}/{config_name}"
+    "dataAppConfig": "app/{component_id}/{config_name}"
   },
   "allowedBranches": [
     "*"

--- a/test/cli/template-test-run/local-fail-missing-env/in/my-template/v0/tests/one/expected-out/.keboola/manifest.json
+++ b/test/cli/template-test-run/local-fail-missing-env/in/my-template/v0/tests/one/expected-out/.keboola/manifest.json
@@ -14,7 +14,7 @@
     "sharedCodeConfigRow": "codes/{config_row_name}",
     "variablesConfig": "variables",
     "variablesValuesRow": "values/{config_row_name}",
-    "dataAppConfig": "apps/{component_id}/{config_name}"
+    "dataAppConfig": "app/{component_id}/{config_name}"
   },
   "allowedBranches": [
     "*"

--- a/test/cli/template-test-run/local-fail-missing-env/out/my-template/v0/tests/one/expected-out/.keboola/manifest.json
+++ b/test/cli/template-test-run/local-fail-missing-env/out/my-template/v0/tests/one/expected-out/.keboola/manifest.json
@@ -14,7 +14,7 @@
     "sharedCodeConfigRow": "codes/{config_row_name}",
     "variablesConfig": "variables",
     "variablesValuesRow": "values/{config_row_name}",
-    "dataAppConfig": "apps/{component_id}/{config_name}"
+    "dataAppConfig": "app/{component_id}/{config_name}"
   },
   "allowedBranches": [
     "*"

--- a/test/cli/template-test-run/local-one/in/my-template/v0/tests/one/expected-out/.keboola/manifest.json
+++ b/test/cli/template-test-run/local-one/in/my-template/v0/tests/one/expected-out/.keboola/manifest.json
@@ -14,7 +14,7 @@
     "sharedCodeConfigRow": "codes/{config_row_name}",
     "variablesConfig": "variables",
     "variablesValuesRow": "values/{config_row_name}",
-    "dataAppConfig": "apps/{component_id}/{config_name}"
+    "dataAppConfig": "app/{component_id}/{config_name}"
   },
   "allowedBranches": [
     "*"

--- a/test/cli/template-test-run/local-one/in/my-template/v0/tests/two/expected-out/.keboola/manifest.json
+++ b/test/cli/template-test-run/local-one/in/my-template/v0/tests/two/expected-out/.keboola/manifest.json
@@ -14,7 +14,7 @@
     "sharedCodeConfigRow": "codes/{config_row_name}",
     "variablesConfig": "variables",
     "variablesValuesRow": "values/{config_row_name}",
-    "dataAppConfig": "apps/{component_id}/{config_name}"
+    "dataAppConfig": "app/{component_id}/{config_name}"
   },
   "allowedBranches": [
     "*"

--- a/test/cli/template-test-run/local-one/out/my-template/v0/tests/one/expected-out/.keboola/manifest.json
+++ b/test/cli/template-test-run/local-one/out/my-template/v0/tests/one/expected-out/.keboola/manifest.json
@@ -14,7 +14,7 @@
     "sharedCodeConfigRow": "codes/{config_row_name}",
     "variablesConfig": "variables",
     "variablesValuesRow": "values/{config_row_name}",
-    "dataAppConfig": "apps/{component_id}/{config_name}"
+    "dataAppConfig": "app/{component_id}/{config_name}"
   },
   "allowedBranches": [
     "*"

--- a/test/cli/template-test-run/local-one/out/my-template/v0/tests/two/expected-out/.keboola/manifest.json
+++ b/test/cli/template-test-run/local-one/out/my-template/v0/tests/two/expected-out/.keboola/manifest.json
@@ -14,7 +14,7 @@
     "sharedCodeConfigRow": "codes/{config_row_name}",
     "variablesConfig": "variables",
     "variablesValuesRow": "values/{config_row_name}",
-    "dataAppConfig": "apps/{component_id}/{config_name}"
+    "dataAppConfig": "app/{component_id}/{config_name}"
   },
   "allowedBranches": [
     "*"

--- a/test/cli/template-test-run/remote-fail/in/my-template/v0/tests/one/expected-out/.keboola/manifest.json
+++ b/test/cli/template-test-run/remote-fail/in/my-template/v0/tests/one/expected-out/.keboola/manifest.json
@@ -14,7 +14,7 @@
     "sharedCodeConfigRow": "codes/{config_row_name}",
     "variablesConfig": "variables",
     "variablesValuesRow": "values/{config_row_name}",
-    "dataAppConfig": "apps/{component_id}/{config_name}"
+    "dataAppConfig": "app/{component_id}/{config_name}"
   },
   "allowedBranches": [
     "*"

--- a/test/cli/template-test-run/remote-fail/out/my-template/v0/tests/one/expected-out/.keboola/manifest.json
+++ b/test/cli/template-test-run/remote-fail/out/my-template/v0/tests/one/expected-out/.keboola/manifest.json
@@ -14,7 +14,7 @@
     "sharedCodeConfigRow": "codes/{config_row_name}",
     "variablesConfig": "variables",
     "variablesValuesRow": "values/{config_row_name}",
-    "dataAppConfig": "apps/{component_id}/{config_name}"
+    "dataAppConfig": "app/{component_id}/{config_name}"
   },
   "allowedBranches": [
     "*"

--- a/test/cli/template-test-run/remote-ok/in/my-template/v0/tests/one/expected-out/.keboola/manifest.json
+++ b/test/cli/template-test-run/remote-ok/in/my-template/v0/tests/one/expected-out/.keboola/manifest.json
@@ -14,7 +14,7 @@
     "sharedCodeConfigRow": "codes/{config_row_name}",
     "variablesConfig": "variables",
     "variablesValuesRow": "values/{config_row_name}",
-    "dataAppConfig": "apps/{component_id}/{config_name}"
+    "dataAppConfig": "app/{component_id}/{config_name}"
   },
   "allowedBranches": [
     "*"

--- a/test/cli/template-test-run/remote-ok/out/my-template/v0/tests/one/expected-out/.keboola/manifest.json
+++ b/test/cli/template-test-run/remote-ok/out/my-template/v0/tests/one/expected-out/.keboola/manifest.json
@@ -14,7 +14,7 @@
     "sharedCodeConfigRow": "codes/{config_row_name}",
     "variablesConfig": "variables",
     "variablesValuesRow": "values/{config_row_name}",
-    "dataAppConfig": "apps/{component_id}/{config_name}"
+    "dataAppConfig": "app/{component_id}/{config_name}"
   },
   "allowedBranches": [
     "*"

--- a/test/cli/template-upgrade/complex/in/project/.keboola/manifest.json
+++ b/test/cli/template-upgrade/complex/in/project/.keboola/manifest.json
@@ -14,7 +14,7 @@
     "sharedCodeConfigRow": "codes/{config_row_name}",
     "variablesConfig": "variables",
     "variablesValuesRow": "values/{config_row_name}",
-    "dataAppConfig": "apps/{component_id}/{config_name}"
+    "dataAppConfig": "app/{component_id}/{config_name}"
   },
   "allowedBranches": [
     "__all__"

--- a/test/cli/template-upgrade/complex/out/project/.keboola/manifest.json
+++ b/test/cli/template-upgrade/complex/out/project/.keboola/manifest.json
@@ -14,7 +14,7 @@
     "sharedCodeConfigRow": "codes/{config_row_name}",
     "variablesConfig": "variables",
     "variablesValuesRow": "values/{config_row_name}",
-    "dataAppConfig": "apps/{component_id}/{config_name}"
+    "dataAppConfig": "app/{component_id}/{config_name}"
   },
   "allowedBranches": [
     "__all__"

--- a/test/cli/template-use/common-dir/in/project/.keboola/manifest.json
+++ b/test/cli/template-use/common-dir/in/project/.keboola/manifest.json
@@ -14,7 +14,7 @@
     "sharedCodeConfigRow": "codes/{config_row_name}",
     "variablesConfig": "variables",
     "variablesValuesRow": "values/{config_row_name}",
-    "dataAppConfig": "apps/{component_id}/{config_name}"
+    "dataAppConfig": "app/{component_id}/{config_name}"
   },
   "allowedBranches": [
     "__all__"

--- a/test/cli/template-use/common-dir/out/project/.keboola/manifest.json
+++ b/test/cli/template-use/common-dir/out/project/.keboola/manifest.json
@@ -14,7 +14,7 @@
     "sharedCodeConfigRow": "codes/{config_row_name}",
     "variablesConfig": "variables",
     "variablesValuesRow": "values/{config_row_name}",
-    "dataAppConfig": "apps/{component_id}/{config_name}"
+    "dataAppConfig": "app/{component_id}/{config_name}"
   },
   "allowedBranches": [
     "__all__"

--- a/test/cli/template-use/complex/in/project/.keboola/manifest.json
+++ b/test/cli/template-use/complex/in/project/.keboola/manifest.json
@@ -14,7 +14,7 @@
     "sharedCodeConfigRow": "codes/{config_row_name}",
     "variablesConfig": "variables",
     "variablesValuesRow": "values/{config_row_name}",
-    "dataAppConfig": "apps/{component_id}/{config_name}"
+    "dataAppConfig": "app/{component_id}/{config_name}"
   },
   "allowedBranches": [
     "__all__"

--- a/test/cli/template-use/complex/out/project/.keboola/manifest.json
+++ b/test/cli/template-use/complex/out/project/.keboola/manifest.json
@@ -14,7 +14,7 @@
     "sharedCodeConfigRow": "codes/{config_row_name}",
     "variablesConfig": "variables",
     "variablesValuesRow": "values/{config_row_name}",
-    "dataAppConfig": "apps/{component_id}/{config_name}"
+    "dataAppConfig": "app/{component_id}/{config_name}"
   },
   "allowedBranches": [
     "__all__"

--- a/test/cli/template-use/default-version/in/project/.keboola/manifest.json
+++ b/test/cli/template-use/default-version/in/project/.keboola/manifest.json
@@ -14,7 +14,7 @@
     "sharedCodeConfigRow": "codes/{config_row_name}",
     "variablesConfig": "variables",
     "variablesValuesRow": "values/{config_row_name}",
-    "dataAppConfig": "apps/{component_id}/{config_name}"
+    "dataAppConfig": "app/{component_id}/{config_name}"
   },
   "allowedBranches": [
     "__all__"

--- a/test/cli/template-use/default-version/out/project/.keboola/manifest.json
+++ b/test/cli/template-use/default-version/out/project/.keboola/manifest.json
@@ -14,7 +14,7 @@
     "sharedCodeConfigRow": "codes/{config_row_name}",
     "variablesConfig": "variables",
     "variablesValuesRow": "values/{config_row_name}",
-    "dataAppConfig": "apps/{component_id}/{config_name}"
+    "dataAppConfig": "app/{component_id}/{config_name}"
   },
   "allowedBranches": [
     "__all__"

--- a/test/cli/template-use/inputs-file-not-found/in/project/.keboola/manifest.json
+++ b/test/cli/template-use/inputs-file-not-found/in/project/.keboola/manifest.json
@@ -14,7 +14,7 @@
     "sharedCodeConfigRow": "codes/{config_row_name}",
     "variablesConfig": "variables",
     "variablesValuesRow": "values/{config_row_name}",
-    "dataAppConfig": "apps/{component_id}/{config_name}"
+    "dataAppConfig": "app/{component_id}/{config_name}"
   },
   "allowedBranches": [
     "__all__"

--- a/test/cli/template-use/inputs-file-not-found/out/project/.keboola/manifest.json
+++ b/test/cli/template-use/inputs-file-not-found/out/project/.keboola/manifest.json
@@ -14,7 +14,7 @@
     "sharedCodeConfigRow": "codes/{config_row_name}",
     "variablesConfig": "variables",
     "variablesValuesRow": "values/{config_row_name}",
-    "dataAppConfig": "apps/{component_id}/{config_name}"
+    "dataAppConfig": "app/{component_id}/{config_name}"
   },
   "allowedBranches": [
     "__all__"

--- a/test/cli/template-use/inputs-file/in/project/.keboola/manifest.json
+++ b/test/cli/template-use/inputs-file/in/project/.keboola/manifest.json
@@ -14,7 +14,7 @@
     "sharedCodeConfigRow": "codes/{config_row_name}",
     "variablesConfig": "variables",
     "variablesValuesRow": "values/{config_row_name}",
-    "dataAppConfig": "apps/{component_id}/{config_name}"
+    "dataAppConfig": "app/{component_id}/{config_name}"
   },
   "allowedBranches": [
     "__all__"

--- a/test/cli/template-use/inputs-file/out/project/.keboola/manifest.json
+++ b/test/cli/template-use/inputs-file/out/project/.keboola/manifest.json
@@ -14,7 +14,7 @@
     "sharedCodeConfigRow": "codes/{config_row_name}",
     "variablesConfig": "variables",
     "variablesValuesRow": "values/{config_row_name}",
-    "dataAppConfig": "apps/{component_id}/{config_name}"
+    "dataAppConfig": "app/{component_id}/{config_name}"
   },
   "allowedBranches": [
     "__all__"

--- a/test/cli/template-use/inputs-types/in/project/.keboola/manifest.json
+++ b/test/cli/template-use/inputs-types/in/project/.keboola/manifest.json
@@ -14,7 +14,7 @@
     "sharedCodeConfigRow": "codes/{config_row_name}",
     "variablesConfig": "variables",
     "variablesValuesRow": "values/{config_row_name}",
-    "dataAppConfig": "apps/{component_id}/{config_name}"
+    "dataAppConfig": "app/{component_id}/{config_name}"
   },
   "allowedBranches": [
     "__all__"

--- a/test/cli/template-use/inputs-types/out/project/.keboola/manifest.json
+++ b/test/cli/template-use/inputs-types/out/project/.keboola/manifest.json
@@ -14,7 +14,7 @@
     "sharedCodeConfigRow": "codes/{config_row_name}",
     "variablesConfig": "variables",
     "variablesValuesRow": "values/{config_row_name}",
-    "dataAppConfig": "apps/{component_id}/{config_name}"
+    "dataAppConfig": "app/{component_id}/{config_name}"
   },
   "allowedBranches": [
     "__all__"

--- a/test/cli/template-use/invalid-template/in/project/.keboola/manifest.json
+++ b/test/cli/template-use/invalid-template/in/project/.keboola/manifest.json
@@ -14,7 +14,7 @@
     "sharedCodeConfigRow": "codes/{config_row_name}",
     "variablesConfig": "variables",
     "variablesValuesRow": "values/{config_row_name}",
-    "dataAppConfig": "apps/{component_id}/{config_name}"
+    "dataAppConfig": "app/{component_id}/{config_name}"
   },
   "allowedBranches": [
     "__all__"

--- a/test/cli/template-use/invalid-template/out/project/.keboola/manifest.json
+++ b/test/cli/template-use/invalid-template/out/project/.keboola/manifest.json
@@ -14,7 +14,7 @@
     "sharedCodeConfigRow": "codes/{config_row_name}",
     "variablesConfig": "variables",
     "variablesValuesRow": "values/{config_row_name}",
-    "dataAppConfig": "apps/{component_id}/{config_name}"
+    "dataAppConfig": "app/{component_id}/{config_name}"
   },
   "allowedBranches": [
     "__all__"

--- a/test/cli/template-use/steps-at-least-one/in/project/.keboola/manifest.json
+++ b/test/cli/template-use/steps-at-least-one/in/project/.keboola/manifest.json
@@ -14,7 +14,7 @@
     "sharedCodeConfigRow": "codes/{config_row_name}",
     "variablesConfig": "variables",
     "variablesValuesRow": "values/{config_row_name}",
-    "dataAppConfig": "apps/{component_id}/{config_name}"
+    "dataAppConfig": "app/{component_id}/{config_name}"
   },
   "allowedBranches": [
     "__all__"

--- a/test/cli/template-use/steps-at-least-one/out/project/.keboola/manifest.json
+++ b/test/cli/template-use/steps-at-least-one/out/project/.keboola/manifest.json
@@ -14,7 +14,7 @@
     "sharedCodeConfigRow": "codes/{config_row_name}",
     "variablesConfig": "variables",
     "variablesValuesRow": "values/{config_row_name}",
-    "dataAppConfig": "apps/{component_id}/{config_name}"
+    "dataAppConfig": "app/{component_id}/{config_name}"
   },
   "allowedBranches": [
     "__all__"

--- a/test/cli/template-use/steps-required-error-2/in/project/.keboola/manifest.json
+++ b/test/cli/template-use/steps-required-error-2/in/project/.keboola/manifest.json
@@ -14,7 +14,7 @@
     "sharedCodeConfigRow": "codes/{config_row_name}",
     "variablesConfig": "variables",
     "variablesValuesRow": "values/{config_row_name}",
-    "dataAppConfig": "apps/{component_id}/{config_name}"
+    "dataAppConfig": "app/{component_id}/{config_name}"
   },
   "allowedBranches": [
     "__all__"

--- a/test/cli/template-use/steps-required-error-2/out/project/.keboola/manifest.json
+++ b/test/cli/template-use/steps-required-error-2/out/project/.keboola/manifest.json
@@ -14,7 +14,7 @@
     "sharedCodeConfigRow": "codes/{config_row_name}",
     "variablesConfig": "variables",
     "variablesValuesRow": "values/{config_row_name}",
-    "dataAppConfig": "apps/{component_id}/{config_name}"
+    "dataAppConfig": "app/{component_id}/{config_name}"
   },
   "allowedBranches": [
     "__all__"

--- a/test/cli/template-use/steps-required-error/in/project/.keboola/manifest.json
+++ b/test/cli/template-use/steps-required-error/in/project/.keboola/manifest.json
@@ -14,7 +14,7 @@
     "sharedCodeConfigRow": "codes/{config_row_name}",
     "variablesConfig": "variables",
     "variablesValuesRow": "values/{config_row_name}",
-    "dataAppConfig": "apps/{component_id}/{config_name}"
+    "dataAppConfig": "app/{component_id}/{config_name}"
   },
   "allowedBranches": [
     "__all__"

--- a/test/cli/template-use/steps-required-error/out/project/.keboola/manifest.json
+++ b/test/cli/template-use/steps-required-error/out/project/.keboola/manifest.json
@@ -14,7 +14,7 @@
     "sharedCodeConfigRow": "codes/{config_row_name}",
     "variablesConfig": "variables",
     "variablesValuesRow": "values/{config_row_name}",
-    "dataAppConfig": "apps/{component_id}/{config_name}"
+    "dataAppConfig": "app/{component_id}/{config_name}"
   },
   "allowedBranches": [
     "__all__"

--- a/test/cli/template-use/steps/in/project/.keboola/manifest.json
+++ b/test/cli/template-use/steps/in/project/.keboola/manifest.json
@@ -14,7 +14,7 @@
     "sharedCodeConfigRow": "codes/{config_row_name}",
     "variablesConfig": "variables",
     "variablesValuesRow": "values/{config_row_name}",
-    "dataAppConfig": "apps/{component_id}/{config_name}"
+    "dataAppConfig": "app/{component_id}/{config_name}"
   },
   "allowedBranches": [
     "__all__"

--- a/test/cli/template-use/steps/out/project/.keboola/manifest.json
+++ b/test/cli/template-use/steps/out/project/.keboola/manifest.json
@@ -14,7 +14,7 @@
     "sharedCodeConfigRow": "codes/{config_row_name}",
     "variablesConfig": "variables",
     "variablesValuesRow": "values/{config_row_name}",
-    "dataAppConfig": "apps/{component_id}/{config_name}"
+    "dataAppConfig": "app/{component_id}/{config_name}"
   },
   "allowedBranches": [
     "__all__"

--- a/test/cli/validate/dir-error/in/.keboola/manifest.json
+++ b/test/cli/validate/dir-error/in/.keboola/manifest.json
@@ -14,7 +14,7 @@
     "sharedCodeConfigRow": "codes/{config_row_name}",
     "variablesConfig": "variables",
     "variablesValuesRow": "values/{config_row_name}",
-    "dataAppConfig": "apps/{component_id}/{config_name}"
+    "dataAppConfig": "app/{component_id}/{config_name}"
   },
   "allowedBranches": [
     "__all__"

--- a/test/cli/validate/dir-error/out/.keboola/manifest.json
+++ b/test/cli/validate/dir-error/out/.keboola/manifest.json
@@ -14,7 +14,7 @@
     "sharedCodeConfigRow": "codes/{config_row_name}",
     "variablesConfig": "variables",
     "variablesValuesRow": "values/{config_row_name}",
-    "dataAppConfig": "apps/{component_id}/{config_name}"
+    "dataAppConfig": "app/{component_id}/{config_name}"
   },
   "allowedBranches": [
     "__all__"

--- a/test/cli/validate/dir-ok/in/.keboola/manifest.json
+++ b/test/cli/validate/dir-ok/in/.keboola/manifest.json
@@ -14,7 +14,7 @@
     "sharedCodeConfigRow": "codes/{config_row_name}",
     "variablesConfig": "variables",
     "variablesValuesRow": "values/{config_row_name}",
-    "dataAppConfig": "apps/{component_id}/{config_name}"
+    "dataAppConfig": "app/{component_id}/{config_name}"
   },
   "allowedBranches": [
     "__all__"

--- a/test/cli/validate/dir-ok/out/.keboola/manifest.json
+++ b/test/cli/validate/dir-ok/out/.keboola/manifest.json
@@ -14,7 +14,7 @@
     "sharedCodeConfigRow": "codes/{config_row_name}",
     "variablesConfig": "variables",
     "variablesValuesRow": "values/{config_row_name}",
-    "dataAppConfig": "apps/{component_id}/{config_name}"
+    "dataAppConfig": "app/{component_id}/{config_name}"
   },
   "allowedBranches": [
     "__all__"

--- a/test/cli/validate/skip-empty-config/in/.keboola/manifest.json
+++ b/test/cli/validate/skip-empty-config/in/.keboola/manifest.json
@@ -14,7 +14,7 @@
     "sharedCodeConfigRow": "codes/{config_row_name}",
     "variablesConfig": "variables",
     "variablesValuesRow": "values/{config_row_name}",
-    "dataAppConfig": "apps/{component_id}/{config_name}"
+    "dataAppConfig": "app/{component_id}/{config_name}"
   },
   "allowedBranches": [
     "__all__"

--- a/test/cli/validate/skip-empty-config/out/.keboola/manifest.json
+++ b/test/cli/validate/skip-empty-config/out/.keboola/manifest.json
@@ -14,7 +14,7 @@
     "sharedCodeConfigRow": "codes/{config_row_name}",
     "variablesConfig": "variables",
     "variablesValuesRow": "values/{config_row_name}",
-    "dataAppConfig": "apps/{component_id}/{config_name}"
+    "dataAppConfig": "app/{component_id}/{config_name}"
   },
   "allowedBranches": [
     "__all__"

--- a/test/cli/version/warning/in/.keboola/manifest.json
+++ b/test/cli/version/warning/in/.keboola/manifest.json
@@ -14,7 +14,7 @@
     "sharedCodeConfigRow": "codes/{config_row_name}",
     "variablesConfig": "variables",
     "variablesValuesRow": "values/{config_row_name}",
-    "dataAppConfig": "apps/{component_id}/{config_name}"
+    "dataAppConfig": "app/{component_id}/{config_name}"
   },
   "allowedBranches": [
     "__all__"

--- a/test/cli/version/warning/out/.keboola/manifest.json
+++ b/test/cli/version/warning/out/.keboola/manifest.json
@@ -14,7 +14,7 @@
     "sharedCodeConfigRow": "codes/{config_row_name}",
     "variablesConfig": "variables",
     "variablesValuesRow": "values/{config_row_name}",
-    "dataAppConfig": "apps/{component_id}/{config_name}"
+    "dataAppConfig": "app/{component_id}/{config_name}"
   },
   "allowedBranches": [
     "__all__"


### PR DESCRIPTION
Jira: https://keboola.atlassian.net/browse/PSGO-249

Changes:
- Use `app` instead of `apps` as directory name, to match naming style of other directories at the same level.
![image](https://github.com/keboola/keboola-as-code/assets/19371734/30ede833-7f8b-4784-814e-1cab88e46f46)


