### PR TITLE
Add push images to GCP GAR

### DIFF
--- a/.github/actions/push-image-aws-azure-gcp/action.yml
+++ b/.github/actions/push-image-aws-azure-gcp/action.yml
@@ -1,5 +1,5 @@
-name: 'Push image to Amazon ECR and Azure ACR'
-description: 'Push image to Amazon ECR and Azure ACR'
+name: 'Push image to Amazon ECR, Azure ACR and GCP GAR'
+description: 'Push image to Amazon ECR, Azure ACR and GCP GAR'
 inputs:
   imageName:
     description: Name of the image
@@ -15,6 +15,18 @@ inputs:
     required: true
   ecrPushRole:
     description: Amazon ECR push role
+    required: true
+  gcpRegistry:
+    description: GCP Artifact Registry root URL
+    required: true
+  gcpRepository:
+    description: GCP Repository name
+    required: true
+  gcpIdentityProvider:
+    description: GCP Identity Provider for OIDC integration
+    required: true
+  gcpServiceAccount:
+    description: GCP Service Account for OIDC integration
     required: true
   acrRegistry:
     description: Azure ACR registry
@@ -48,6 +60,32 @@ runs:
         TAG: ${{ inputs.imageTag }}
         REGISTRY: ${{ steps.login-ecr.outputs.registry }}
         REPOSITORY: ${{ inputs.ecrRepository }}
+      run: |
+        docker tag $IMAGE:$TAG $REGISTRY/$REPOSITORY:$TAG
+        docker push $REGISTRY/$REPOSITORY:$TAG
+
+    - name: Authenticate to GCP
+      uses: google-github-actions/auth@v1
+      with:
+        token_format: access_token
+        create_credentials_file: true
+        workload_identity_provider: ${{ inputs.gcpIdentityProvider }}
+        service_account: ${{ inputs.gcpServiceAccount }}
+
+    - name: Login to GCP GAR
+      uses: docker/login-action@v1
+      with:
+        registry: ${{ inputs.gcpRegistry }}
+        username: oauth2accesstoken
+        password: ${{ steps.auth.outputs.access_token }}
+
+    - name: Push image to GCP GAR
+      shell: bash
+      env:
+        IMAGE: ${{ inputs.imageName }}
+        TAG: ${{ inputs.imageTag }}
+        REGISTRY: ${{ inputs.gcpRegistry }}
+        REPOSITORY: ${{ inputs.gcpRepository }}
       run: |
         docker tag $IMAGE:$TAG $REGISTRY/$REPOSITORY:$TAG
         docker push $REGISTRY/$REPOSITORY:$TAG

--- a/.github/workflows/release-service-buffer.yml
+++ b/.github/workflows/release-service-buffer.yml
@@ -22,7 +22,7 @@ env:
   API_IMAGE_NAME: "keboola/buffer-api"
   API_ECR_REPOSITORY: "keboola/buffer-api"
   API_ECR_PUSH_ROLE: "arn:aws:iam::968984773589:role/kbc-ecr-BufferApiPushRole-8SI5TUN6TV99"
-  API_GCP_REPOSITORY: "keboola-prod-artifacts/buffer-api"
+  API_GCP_REPOSITORY: "keboola-prod-artifacts/keboola-as-code/buffer-api"
   API_ACR_REPOSITORY: "buffer-api"
   API_ACR_USERNAME: "buffer-api-push"
 
@@ -30,7 +30,7 @@ env:
   WORKER_IMAGE_NAME: "keboola/buffer-worker"
   WORKER_ECR_REPOSITORY: "keboola/buffer-worker"
   WORKER_ECR_PUSH_ROLE: "arn:aws:iam::968984773589:role/kbc-ecr-BufferWorkerPushRole-15AMFOJ64KHB9"
-  WORKER_GCP_REPOSITORY: "keboola-prod-artifacts/buffer-worker"
+  WORKER_GCP_REPOSITORY: "keboola-prod-artifacts/keboola-as-code/buffer-worker"
   WORKER_ACR_REPOSITORY: "buffer-worker"
   WORKER_ACR_USERNAME: "buffer-worker-push"
 

--- a/.github/workflows/release-service-buffer.yml
+++ b/.github/workflows/release-service-buffer.yml
@@ -14,11 +14,15 @@ env:
   IMAGE_TAG: ${{ github.ref_name }}
   ECR_REGION: "us-east-1"
   ACR_REGISTRY: "keboola.azurecr.io"
+  GCP_REGISTRY: "us-central1-docker.pkg.dev"
+  GCP_IDENTITY_PROVIDER: "projects/keboola-prod-artifacts/locations/global/workloadIdentityPools/github/providers/github"
+  GCP_SERVICE_ACCOUNT: "keboola-as-code-ci-push@keboola-prod-artifacts.iam.gserviceaccount.com"
 
   # API image
   API_IMAGE_NAME: "keboola/buffer-api"
   API_ECR_REPOSITORY: "keboola/buffer-api"
   API_ECR_PUSH_ROLE: "arn:aws:iam::968984773589:role/kbc-ecr-BufferApiPushRole-8SI5TUN6TV99"
+  API_GCP_REPOSITORY: "keboola-prod-artifacts/buffer-api"
   API_ACR_REPOSITORY: "buffer-api"
   API_ACR_USERNAME: "buffer-api-push"
 
@@ -26,6 +30,7 @@ env:
   WORKER_IMAGE_NAME: "keboola/buffer-worker"
   WORKER_ECR_REPOSITORY: "keboola/buffer-worker"
   WORKER_ECR_PUSH_ROLE: "arn:aws:iam::968984773589:role/kbc-ecr-BufferWorkerPushRole-15AMFOJ64KHB9"
+  WORKER_GCP_REPOSITORY: "keboola-prod-artifacts/buffer-worker"
   WORKER_ACR_REPOSITORY: "buffer-worker"
   WORKER_ACR_USERNAME: "buffer-worker-push"
 
@@ -85,27 +90,35 @@ jobs:
           context: .
           file: provisioning/buffer/docker/worker/Dockerfile
 
-      - name: Push API image to Amazon ECR and Azure ACR
-        uses: ./.github/actions/push-image-aws-azure
+      - name: Push API image to Amazon ECR, Azure ACR and GCP GAR
+        uses: ./.github/actions/push-image-aws-azure-gcp
         with:
           imageName: ${{ env.API_IMAGE_NAME }}
           imageTag: ${{ env.IMAGE_TAG }}
           ecrRegion: ${{ env.ECR_REGION }}
           ecrRepository: ${{ env.API_ECR_REPOSITORY }}
           ecrPushRole: ${{ env.API_ECR_PUSH_ROLE }}
+          gcpRegistry: ${{ env.GCP_REGISTRY }}
+          gcpRepository: ${{ env.API_GCP_REPOSITORY }}
+          gcpIdentityProvider: ${{ env.GCP_IDENTITY_PROVIDER }}
+          gcpServiceAccount: ${{ env.GCP_SERVICE_ACCOUNT }}
           acrRegistry: ${{ env.ACR_REGISTRY }}
           acrRepository: ${{ env.API_ACR_REPOSITORY }}
           acrUsername: ${{ env.API_ACR_USERNAME }}
           acrPassword: ${{ secrets.BUFFER_API_ACR_PASSWORD }}
 
-      - name: Push Worker image to Amazon ECR and Azure ACR
-        uses: ./.github/actions/push-image-aws-azure
+      - name: Push Worker image to Amazon ECR, Azure ACR and GCP GAR
+        uses: ./.github/actions/push-image-aws-azure-gcp
         with:
           imageName: ${{ env.WORKER_IMAGE_NAME }}
           imageTag: ${{ env.IMAGE_TAG }}
           ecrRegion: ${{ env.ECR_REGION }}
           ecrRepository: ${{ env.WORKER_ECR_REPOSITORY }}
           ecrPushRole: ${{ env.WORKER_ECR_PUSH_ROLE }}
+          gcpRegistry: ${{ env.GCP_REGISTRY }}
+          gcpRepository: ${{ env.WORKER_GCP_REPOSITORY }}
+          gcpIdentityProvider: ${{ env.GCP_IDENTITY_PROVIDER }}
+          gcpServiceAccount: ${{ env.GCP_SERVICE_ACCOUNT }}
           acrRegistry: ${{ env.ACR_REGISTRY }}
           acrRepository: ${{ env.WORKER_ACR_REPOSITORY }}
           acrUsername: ${{ env.WORKER_ACR_USERNAME }}

--- a/.github/workflows/release-service-templates.yml
+++ b/.github/workflows/release-service-templates.yml
@@ -16,6 +16,10 @@ env:
   ECR_REGION: "us-east-1"
   ECR_REPOSITORY: "keboola/templates-api"
   ECR_PUSH_ROLE: "arn:aws:iam::968984773589:role/kbc-ecr-TemplatesApiPushRole-1HHHR3LGXWRZN"
+  GCP_REGISTRY: "us-central1-docker.pkg.dev"
+  GCP_REPOSITORY: "keboola-prod-artifacts/templates-api"
+  GCP_IDENTITY_PROVIDER: "projects/keboola-prod-artifacts/locations/global/workloadIdentityPools/github/providers/github"
+  GCP_SERVICE_ACCOUNT: "keboola-as-code-ci-push@keboola-prod-artifacts.iam.gserviceaccount.com"
   ACR_REPOSITORY: "templates-api"
   ACR_REGISTRY: "keboola.azurecr.io"
   ACR_USERNAME: "templates-api-push"
@@ -68,14 +72,18 @@ jobs:
           context: .
           file: provisioning/templates-api/docker/Dockerfile
 
-      - name: Push image to Amazon ECR and Azure ACR
-        uses: ./.github/actions/push-image-aws-azure
+      - name: Push image to Amazon ECR, Azure ACR and GCP GAR
+        uses: ./.github/actions/push-image-aws-azure-gcp
         with:
           imageName: ${{ env.IMAGE_NAME }}
           imageTag: ${{ env.IMAGE_TAG }}
           ecrRegion: ${{ env.ECR_REGION }}
           ecrRepository: ${{ env.ECR_REPOSITORY }}
           ecrPushRole: ${{ env.ECR_PUSH_ROLE }}
+          gcpRegistry: ${{ env.GCP_REGISTRY }}
+          gcpRepository: ${{ env.GCP_REPOSITORY }}
+          gcpIdentityProvider: ${{ env.GCP_IDENTITY_PROVIDER }}
+          gcpServiceAccount: ${{ env.GCP_SERVICE_ACCOUNT }}
           acrRepository: ${{ env.ACR_REPOSITORY }}
           acrRegistry: ${{ env.ACR_REGISTRY }}
           acrUsername: ${{ env.ACR_USERNAME }}

--- a/.github/workflows/release-service-templates.yml
+++ b/.github/workflows/release-service-templates.yml
@@ -17,7 +17,7 @@ env:
   ECR_REPOSITORY: "keboola/templates-api"
   ECR_PUSH_ROLE: "arn:aws:iam::968984773589:role/kbc-ecr-TemplatesApiPushRole-1HHHR3LGXWRZN"
   GCP_REGISTRY: "us-central1-docker.pkg.dev"
-  GCP_REPOSITORY: "keboola-prod-artifacts/templates-api"
+  GCP_REPOSITORY: "keboola-prod-artifacts/keboola-as-code/templates-api"
   GCP_IDENTITY_PROVIDER: "projects/keboola-prod-artifacts/locations/global/workloadIdentityPools/github/providers/github"
   GCP_SERVICE_ACCOUNT: "keboola-as-code-ci-push@keboola-prod-artifacts.iam.gserviceaccount.com"
   ACR_REPOSITORY: "templates-api"


### PR DESCRIPTION
Fixes https://keboola.atlassian.net/browse/GCP-79

Repository bylo přidané zde https://github.com/keboola/infrastructure/pull/1382, návod jsem v confluence aktualizoval https://keboola.atlassian.net/wiki/spaces/ENGG/pages/3022323758/GCP+Centralized+images+repository+GAR#GitHub-Actions-with-OIDC

Bohužel release neumožňuje pushnout testovací tag, nejspíš to zde zatím nebylo potřeba. Takže nemám jak otestovat, že push funguje. @michaljurecko dává ti smysl zde přidat něco jako:
```
on:
  push:
    tags:
      - 'buffer-v**'
      - 'test-v**'
```

Nebo počkáme na další release?

Ještě pak moc nevím proč padnul tento check https://github.com/keboola/keboola-as-code/actions/runs/5741779787/job/15562576240, ale nejspíš to bude nějaký haluz.