### PR TITLE
Revert part of Add custom importer metrics

### DIFF
--- a/cmd/buffer-api/main.go
+++ b/cmd/buffer-api/main.go
@@ -111,6 +111,10 @@ func run() error {
 	// Create service.
 	svc := service.New(apiScp)
 
+	filterImportEndpoint := func(req *http.Request) bool {
+		return !strings.HasPrefix(req.URL.Path, "/v1/import/") || req.URL.RawQuery == "debug=true"
+	}
+
 	// Start HTTP server.
 	logger.Infof("starting Buffer API HTTP server, listen-address=%s", cfg.ListenAddress)
 	err = httpserver.Start(apiScp, httpserver.Config{
@@ -123,8 +127,11 @@ func run() error {
 			middleware.WithPropagators(propagation.TraceContext{}),
 			// Ignore health checks
 			middleware.WithFilter(func(req *http.Request) bool {
-				return req.URL.Path != "/health-check" && !strings.HasPrefix(req.URL.Path, "/v1/import/")
+				return req.URL.Path != "/health-check"
 			}),
+			// Filter out import endpoint traces and logs, but keep metrics
+			middleware.WithFilterTracing(filterImportEndpoint),
+			middleware.WithFilterAccessLog(filterImportEndpoint),
 		},
 		Mount: func(c httpserver.Components) {
 			// Create public request deps for each request


### PR DESCRIPTION
Part of: https://keboola.atlassian.net/browse/PSGO-241

Ako som v PR https://github.com/keboola/keboola-as-code/pull/1382 , v commite https://github.com/keboola/keboola-as-code/pull/1382/commits/e0308ae32e27754523969b628d5fb6a022168ca9 (hned hore) vypinal spolocne metriky pre import endpoint, tak mi nedoslo, ze je to hlupost. 

![image](https://github.com/keboola/keboola-as-code/assets/19371734/2128571c-e403-4744-8800-dd93700fc7a6)


Pridal som tam sice `import` metriky s `projectID`, ale tie nie su take rozsiahle, takze musim zachovat aj tie povodne (ktore su rozsiahlejsie, ale bez `projectID`). Iba pripominam, ze `projectID`, nemozem dat vsade, lebo by nam prudko stupol pocet custom metrics v DD a stalo nas to vela $$$.