### PR TITLE
Preserve application instance ID when the template instance is upgraded

### DIFF
--- a/internal/pkg/fixtures/configs/from-template-data-app-with-id.json
+++ b/internal/pkg/fixtures/configs/from-template-data-app-with-id.json
@@ -1,0 +1,22 @@
+{
+  "componentId": "keboola.data-apps",
+  "name": "My Data App",
+  "description": "test fixture",
+  "changeDescription": "From template keboola/my-template-id/1.2.3",
+  "configuration": {
+    "parameters": {
+      "id": "123456",
+      "param1": "value1",
+      "param2": "value2"
+    }
+  },
+  "rows": [],
+  "metadata": {
+    "KBC.KAC.templates.configId": "{\"idInTemplate\":\"my-app\"}",
+    "KBC.KAC.templates.configInputs": "[{\"input\":\"data-app-param1\",\"key\":\"parameters.param1\"}]",
+    "KBC.KAC.templates.instanceId": "inst-001",
+    "KBC.KAC.templates.repository": "keboola",
+    "KBC.KAC.templates.templateId": "my-template-id"
+  },
+  "isDisabled": false
+}

--- a/internal/pkg/mapper/template/replacevalues/mapper.go
+++ b/internal/pkg/mapper/template/replacevalues/mapper.go
@@ -33,7 +33,7 @@ func (m *replaceKeysMapper) AfterRemoteOperation(_ context.Context, changes *mod
 }
 
 func (m *replaceKeysMapper) afterOperation(changes changes) error {
-	// Replace keys in the loaded remote objects
+	// Replace keys in the loaded objects
 	replaced := make(map[string]model.ObjectState)
 	errs := errors.NewMultiError()
 	for _, original := range changes.Loaded() {

--- a/internal/pkg/template/context/upgrade/context.go
+++ b/internal/pkg/template/context/upgrade/context.go
@@ -5,6 +5,7 @@ import (
 	"context"
 
 	"github.com/keboola/go-client/pkg/keboola"
+	"github.com/keboola/go-utils/pkg/orderedmap"
 
 	"github.com/keboola/keboola-as-code/internal/pkg/filesystem"
 	"github.com/keboola/keboola-as-code/internal/pkg/model"
@@ -13,6 +14,12 @@ import (
 	"github.com/keboola/keboola-as-code/internal/pkg/template"
 	"github.com/keboola/keboola-as-code/internal/pkg/template/context/use"
 )
+
+// dataAppInstanceIDContentPath contains path to the app instance ID in the configuration content.
+// There is no ID when creating the configuration.
+// The ID is set by the application deploy job after the application deployment.
+// The ID must be preserved when the template instance is upgraded.
+const dataAppInstanceIDContentPath = "parameters.id"
 
 // Context represents the process of the replacing values when upgrading a template instance.
 // It is similar and extends the use.Context.
@@ -33,6 +40,23 @@ func NewContext(ctx context.Context, templateRef model.TemplateRef, objectsRoot 
 		configs,
 		func(config *model.Config, idInTemplate keboola.ConfigID, _ []model.ConfigInputUsage) {
 			c.RegisterPlaceholder(idInTemplate, func(_ use.Placeholder, cb use.ResolveCallback) { cb(config.ID) })
+
+			// Preserve application instance ID when the template instance is upgraded.
+			if config.ComponentID == keboola.DataAppsComponentID {
+				appInstanceID, found1, _ := config.Content.GetNested(dataAppInstanceIDContentPath)
+				placeholder, found2 := c.Placeholders()[idInTemplate]
+				if found1 && found2 {
+					// Jsonnet template is evaluated to a temporary JSON with unique placeholders.
+					// Later, the placeholders in the JSON are replaced.
+					// This is because we do not know in advance how many new IDs we will need to generate.
+					// And generating them one by one would take a long time.
+					// We need to identify the application config in this temporary form.
+					key := config.ConfigKey
+					key.BranchID = 0
+					key.ID = placeholder.Value().(keboola.ConfigID)
+					c.ReplaceContentField(key, orderedmap.PathFromStr(dataAppInstanceIDContentPath), appInstanceID)
+				}
+			}
 		},
 		func(row *model.ConfigRow, idInTemplate keboola.RowID, _ []model.RowInputUsage) {
 			c.RegisterPlaceholder(idInTemplate, func(_ use.Placeholder, cb use.ResolveCallback) { cb(row.ID) })

--- a/internal/pkg/template/context/use/context.go
+++ b/internal/pkg/template/context/use/context.go
@@ -75,6 +75,10 @@ type Placeholder struct {
 	asValue  interface{} // eg. ConfigId, RowID, eg. ConfigId("<<~~placeholder:1~~>>)
 }
 
+func (v Placeholder) Value() any {
+	return v.asValue
+}
+
 type PlaceholderResolver func(p Placeholder, cb ResolveCallback)
 
 type ResolveCallback func(newID interface{})
@@ -151,6 +155,15 @@ func (c *Context) InstanceID() string {
 
 func (c *Context) JsonnetContext() *jsonnet.Context {
 	return c.jsonnetCtx
+}
+
+// ReplaceContentField sets nested value in config/row.Content ordered map.
+func (c *Context) ReplaceContentField(objectKey model.Key, fieldPath orderedmap.Path, replace any) {
+	c.replacements.AddContentField(objectKey, fieldPath, replace)
+}
+
+func (c *Context) Placeholders() PlaceholdersMap {
+	return c.placeholders
 }
 
 func (c *Context) Replacements() (*replacevalues.Values, error) {

--- a/test/templates/api/projects/instance-upgrade/expected-state.json
+++ b/test/templates/api/projects/instance-upgrade/expected-state.json
@@ -19,7 +19,8 @@
             "parameters": {
               "param1": "modified",
               "param2": "value2",
-              "param3": "value3"
+              "param3": "value3",
+              "id": "123456"
             }
           },
           "rows": [],

--- a/test/templates/api/projects/instance-upgrade/initial-state.json
+++ b/test/templates/api/projects/instance-upgrade/initial-state.json
@@ -11,7 +11,7 @@
       },
       "configs": [
         "from-template",
-        "from-template-data-app"
+        "from-template-data-app-with-id"
       ]
     }
   ]


### PR DESCRIPTION
Jira: https://keboola.atlassian.net/browse/PSGO-250

Changes:
- if the `componentId` == `keboola.data-apps`, the `parameters.id` is automatically copied on template instance upgrade.

----------------------

## Intro

Kratke intro ku vyhodnocovaniu sablon.

Sablony su zapisane ako Jsonnet, mame tam definovane nejake extra funkcie.

Niektore funkcie sluzia na definovanie ID, napr. `ConfigID`:
![image](https://github.com/keboola/keboola-as-code/assets/19371734/962b9fc4-d2d6-4434-867e-31b6f034a90a)

Pouziva sa to hlavne v `manifest.jsonnet`
- ale aj na prelinkovanie konfiguracii medzi sebou 
- ked jedna konfiguracia ma v sebe ID inej konfiguracie (napr. default bucket)

Jsonnet sablona moze mat v sebe podmienky a cykly.
- Je tu problem, ze dopredu nevieme kolko novych ID budeme potrebovat.
- Ked sa vytvara nova konfiguracia, pri `upgrade` sa ID nemeni.

Z toho dovodu to funguje takto:
- Z Jsonnet robime Json....
- Funkcia `ConfigID(foo)` vrati unikatny placeholder zviazany s hodnotou `foo`.
  - Realne to vyzera nejak takto; `<<~~placeholder:1~~>>`
- Ked sa cela sablona vyhodnoti, tak uz vieme, kolko novych ID (`tickets`) potrebujeme paralelne vygenerovat.
- Ako posledny krok vygenerujeme paralelne potrebny pocet `tickets` a nahradime placeholders za realne ID.
- Ak by sme vzdy generovali ID pri prvom pouziti `ConfigID(foo)`, tak by to velmi predlzilo aplikovanie vacsich sablon.
  - Takto je cas ~ konstantný.
  
Toto vysvetluje preto, lebo doplnenie ID apky sa deje prave v tom case, ked to mame ako JSON s placeholders.
