### PR TITLE
Tune etcd parameters

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -77,6 +77,7 @@ services:
       ETCD_LISTEN_CLIENT_URLS: "http://0.0.0.0:2379"
       ETCD_LISTEN_PEER_URLS: "http://0.0.0.0:2380"
       ETCD_DISABLE_STORE_MEMBER_ID: "true"
+      ETCD_QUOTA_BACKEND_BYTES: "21474836480" # 20GB
   k6:
     volumes:
       - ./scripts:/scripts

--- a/provisioning/buffer/kubernetes/templates/etcd.yaml
+++ b/provisioning/buffer/kubernetes/templates/etcd.yaml
@@ -8,6 +8,17 @@ resources:
   limits:
     memory: "2000Mi"
 
+extraEnvVars:
+  # Set max DB size to 80GB
+  # 8GB is the recommended maximum, but we want to test how it works for our use-case.
+  # It's better to let it slow down than stop working at all.
+  - name: ETCD_QUOTA_BACKEND_BYTES
+    value: "85899345920"
+
+# Set disk size
+persistence:
+  size: 100Gi
+
 # Run defragmentation each 30 minutes
 defragmentation:
   cronjob:

--- a/provisioning/buffer/kubernetes/templates/etcd.yaml
+++ b/provisioning/buffer/kubernetes/templates/etcd.yaml
@@ -8,7 +8,7 @@ resources:
   limits:
     memory: "2000Mi"
 
-# Run defragmentation each 2 hours
+# Run defragmentation each 30 minutes
 defragmentation:
   cronjob:
-    schedule: "0 */2 * * *"
+    schedule: "*/30 * * * *"


### PR DESCRIPTION
Jira: https://keboola.atlassian.net/browse/PSGO-263

Changes:
- Defragmentation runs each 30 minutes, instead of 2 hours.
- DB size is `80GB` instad of `8GB`.