### PR TITLE
etcd defragmentation: increase command timeout from 5s -> 60s

### DIFF
--- a/provisioning/common/etcd/values.yaml
+++ b/provisioning/common/etcd/values.yaml
@@ -202,7 +202,7 @@ extraDeploy:
                       
                       # Common flags
                       read -r -a flags <<<"$(etcdctl_auth_flags)"
-                      cmd="etcdctl ${flags[@]}"
+                      cmd="etcdctl --command-timeout=60s ${flags[@]}"
                       
                       # Sequentially run defragmentation for each node
                       for (( index=0; index<$ETCD_REPLICAS; index++ )); do


### PR DESCRIPTION
Jira: https://keboola.atlassian.net/browse/PSGO-277
Slack: https://keboolaglobal.slack.com/archives/C054DF6DZ1B/p1691499379058189?thread_ts=1691490147.199709&cid=C054DF6DZ1B

Changes:
- Increased command timeout to `60s`, default value is `5s`.