### PR TITLE
Add configuration for page size, use serializable reads

### DIFF
--- a/internal/pkg/service/buffer/config/worker.go
+++ b/internal/pkg/service/buffer/config/worker.go
@@ -42,6 +42,7 @@ type WorkerConfig struct {
 	RetryFailedFiles        bool             `mapstructure:"enable-retry-failed-files" usage:"Enable retry for failed files."`
 	TasksCleanup            bool             `mapstructure:"tasks-cleanup-enabled" usage:"Enable periodical tasks cleanup functionality."`
 	TasksCleanupInterval    time.Duration    `mapstructure:"tasks-cleanup-interval" usage:"How often will old tasks be deleted."`
+	ReaderPageSize          int              `mapstructure:"reader-page-size" usage:"Page size of etcd range queries."`
 }
 
 func NewWorkerConfig() WorkerConfig {
@@ -66,6 +67,7 @@ func NewWorkerConfig() WorkerConfig {
 		RetryFailedFiles:     true,
 		TasksCleanup:         true,
 		TasksCleanupInterval: DefaultCleanupInterval,
+		ReaderPageSize:       100,
 	}
 }
 

--- a/internal/pkg/service/buffer/worker/service/slice_reader.go
+++ b/internal/pkg/service/buffer/worker/service/slice_reader.go
@@ -17,7 +17,7 @@ import (
 	"github.com/keboola/keboola-as-code/internal/pkg/utils/errors"
 )
 
-func newRecordsReader(ctx context.Context, logger log.Logger, client *etcd.Client, schema *schema.Schema, slice model.Slice, receivedStats statistics.Value, uploadStats *statistics.AfterUpload) io.Reader {
+func newRecordsReader(ctx context.Context, logger log.Logger, client *etcd.Client, schema *schema.Schema, slice model.Slice, receivedStats statistics.Value, uploadStats *statistics.AfterUpload, pageSize int) io.Reader {
 	out, in := io.Pipe()
 	go func() {
 		var err error
@@ -37,7 +37,6 @@ func newRecordsReader(ctx context.Context, logger log.Logger, client *etcd.Clien
 		// It is guaranteed that new records are not added to the prefix, and existing ones are not changed.
 		// Therefore, the WithFromSameRev(false) is used.
 		// This also prevents ErrCompacted, because we are not requesting a specific version.
-		pageSize := 100
 		records := schema.Records().InSlice(slice.SliceKey)
 		itr := records.GetAll(iterator.WithPageSize(pageSize), iterator.WithFromSameRev(false)).Do(ctx, client)
 		for itr.Next() {

--- a/internal/pkg/service/buffer/worker/service/slice_reader.go
+++ b/internal/pkg/service/buffer/worker/service/slice_reader.go
@@ -38,7 +38,13 @@ func newRecordsReader(ctx context.Context, logger log.Logger, client *etcd.Clien
 		// Therefore, the WithFromSameRev(false) is used.
 		// This also prevents ErrCompacted, because we are not requesting a specific version.
 		records := schema.Records().InSlice(slice.SliceKey)
-		itr := records.GetAll(iterator.WithPageSize(pageSize), iterator.WithFromSameRev(false)).Do(ctx, client)
+		itr := records.
+			GetAll(
+				iterator.WithPageSize(pageSize),
+				iterator.WithFromSameRev(false),
+				iterator.WithSerializable(),
+			).
+			Do(ctx, client)
 		for itr.Next() {
 			row := itr.Value().Value
 			row = bytes.ReplaceAll(row, idPlaceholder, []byte(strconv.FormatUint(id, 10)))

--- a/internal/pkg/service/buffer/worker/service/slice_reader_test.go
+++ b/internal/pkg/service/buffer/worker/service/slice_reader_test.go
@@ -58,7 +58,7 @@ func TestRecordsReader(t *testing.T) {
 	// Read all
 	// start := time.Now()
 	// t.Logf(`read start: %s`, start)
-	reader := newRecordsReader(ctx, logger, client, sm, slice, receivedStats, &uploadStats)
+	reader := newRecordsReader(ctx, logger, client, sm, slice, receivedStats, &uploadStats, 100)
 	rSize, err := io.Copy(io.Discard, reader)
 	assert.NoError(t, err)
 	assert.Equal(t, (recordSize * datasize.ByteSize(recordsCount)).String(), datasize.ByteSize(rSize).String())

--- a/internal/pkg/service/buffer/worker/service/slice_upload.go
+++ b/internal/pkg/service/buffer/worker/service/slice_upload.go
@@ -117,7 +117,7 @@ func (s *Service) uploadSlices(d dependencies) <-chan error {
 
 				// Upload slice, set statistics
 				uploadStats := statistics.AfterUpload{}
-				reader := newRecordsReader(ctx, s.logger, s.etcdClient, s.schema, slice, stats.Total, &uploadStats)
+				reader := newRecordsReader(ctx, s.logger, s.etcdClient, s.schema, slice, stats.Total, &uploadStats, s.config.ReaderPageSize)
 				if err := fileManager.UploadSlice(ctx, &slice, reader, &uploadStats); err != nil {
 					return task.ErrResult(errors.Errorf(`file upload failed: %w`, err))
 				}

--- a/internal/pkg/service/common/etcdop/iterator/iterator_typed.go
+++ b/internal/pkg/service/common/etcdop/iterator/iterator_typed.go
@@ -47,7 +47,7 @@ func (v *ForEachOpT[T]) Op(ctx context.Context) (etcd.Op, error) {
 	// Other pages are loaded within MapResponse method, see below.
 	// Iterator always load next pages WithRevision,
 	// so all results, from all pages, are from the same revision.
-	return firstPageOp(v.def.prefix, v.def.end, v.def.pageSize, v.def.revision).Op(ctx)
+	return getPageOp(v.def.prefix, v.def.end, v.def.pageSize, v.def.revision, v.def.serializable).Op(ctx)
 }
 
 func (v *ForEachOpT[T]) MapResponse(ctx context.Context, response op.Response) (result any, err error) {


### PR DESCRIPTION
Jira: https://keboola.atlassian.net/browse/PSGO-278

Changes:
- The page size when loading records from etcd when uploading to S3 is configurable.
- Default value remains same = `100`.