### PR TITLE
Buffer - GCP Deploy

### DIFF
--- a/provisioning/buffer/gcp.sh
+++ b/provisioning/buffer/gcp.sh
@@ -41,4 +41,20 @@ echo $GKE_CLUSTER_NAME
 echo $GKE_CLUSTER_LOCATION
 
 gcloud auth login --cred-file=$GOOGLE_APPLICATION_CREDENTIALS
+
+echo "deb [signed-by=/usr/share/keyrings/cloud.google.gpg] https://packages.cloud.google.com/apt cloud-sdk main" | sudo tee -a /etc/apt/sources.list.d/google-cloud-sdk.list
+curl https://packages.cloud.google.com/apt/doc/apt-key.gpg | sudo apt-key --keyring /usr/share/keyrings/cloud.google.gpg add -
+sudo apt update
+sudo apt-get install google-cloud-sdk-gke-gcloud-auth-plugin
+
 gcloud container clusters get-credentials $GKE_CLUSTER_NAME --region $GKE_CLUSTER_LOCATION --project $GCP_PROJECT
+
+# Common part of the deploy
+export ETCD_STORAGE_CLASS_NAME=
+. ./common.sh
+
+# GCP specific part of the deploy
+# TODO
+
+# Wait for the rollout
+. ./wait.sh

--- a/provisioning/buffer/gcp.sh
+++ b/provisioning/buffer/gcp.sh
@@ -42,6 +42,7 @@ echo $GKE_CLUSTER_LOCATION
 
 gcloud auth login --cred-file=$GOOGLE_APPLICATION_CREDENTIALS
 
+# https://cloud.google.com/blog/products/containers-kubernetes/kubectl-auth-changes-in-gke
 echo "deb [signed-by=/usr/share/keyrings/cloud.google.gpg] https://packages.cloud.google.com/apt cloud-sdk main" | sudo tee -a /etc/apt/sources.list.d/google-cloud-sdk.list
 curl https://packages.cloud.google.com/apt/doc/apt-key.gpg | sudo apt-key --keyring /usr/share/keyrings/cloud.google.gpg add -
 sudo apt update
@@ -54,7 +55,8 @@ export ETCD_STORAGE_CLASS_NAME=
 . ./common.sh
 
 # GCP specific part of the deploy
-# TODO
+kubectl apply -f ./kubernetes/deploy/cloud/gcp/service.yaml
+kubectl apply -f ./kubernetes/deploy/cloud/gcp/ingress.yaml
 
 # Wait for the rollout
 . ./wait.sh

--- a/provisioning/buffer/gcp.sh
+++ b/provisioning/buffer/gcp.sh
@@ -1,0 +1,44 @@
+#!/usr/bin/env bash
+set -Eeuo pipefail
+
+terraform_output () {
+  terraform -chdir=./gcp output -raw $1
+}
+
+SCRIPT_PATH="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+cd "${SCRIPT_PATH}"
+
+
+if [ -n "${TF_INIT_ONLY:-}" ]; then
+  terraform init -no-color -backend=false
+  exit 0
+fi
+
+echo ""
+echo "Terraform backend configuration:"
+echo "bucket=${TERRAFORM_REMOTE_STATE_BUCKET}"
+echo ""
+
+terraform -chdir=./gcp  init -input=false -no-color \
+  -backend-config="bucket=${TERRAFORM_REMOTE_STATE_BUCKET}" \
+  -backend-config="prefix=keboola-as-code/buffer"
+
+echo "=> Validating configuration"
+terraform validate -no-color
+
+echo "=> Planning changes"
+terraform -chdir=./gcp plan -input=false -no-color  -out=terraform.tfplan \
+  -var "terraform_remote_state_bucket=${TERRAFORM_REMOTE_STATE_BUCKET}"
+
+echo "=> Applying changes"
+terraform -chdir=./gcp apply -no-color terraform.tfplan
+
+# Authorize to GKE
+GKE_CLUSTER_NAME=$(terraform_output main_gke_cluster_name)
+GKE_CLUSTER_LOCATION=$(terraform_output main_gke_cluster_location)
+
+echo $GKE_CLUSTER_NAME
+echo $GKE_CLUSTER_LOCATION
+
+gcloud auth login --cred-file=$GOOGLE_APPLICATION_CREDENTIALS
+gcloud container clusters get-credentials $GKE_CLUSTER_NAME --region $GKE_CLUSTER_LOCATION --project $GCP_PROJECT

--- a/provisioning/buffer/gcp/.gitignore
+++ b/provisioning/buffer/gcp/.gitignore
@@ -1,0 +1,38 @@
+# Local .terraform directories
+**/.terraform/*
+
+# .tfstate files
+*.tfstate
+*.tfstate.*
+
+# Crash log files
+crash.log
+
+# Exclude all .tfvars files, which are likely to contain sentitive data, such as
+# password, private keys, and other secrets. These should not be part of version
+# control as they are data points which are potentially sensitive and subject
+# to change depending on the environment.
+#
+*.tfvars
+
+# Ignore override files as they are usually used to override resources locally and so
+# are not checked in
+override.tf
+override.tf.json
+*_override.tf
+*_override.tf.json
+
+# Include override files you do wish to add to version control using negated pattern
+#
+# !example_override.tf
+
+# Include tfplan files to ignore the plan output of command: terraform plan -out=tfplan
+# example: *tfplan*
+
+# Ignore CLI configuration files
+.terraformrc
+terraform.rc
+
+terraform.tfplan
+
+.env

--- a/provisioning/buffer/gcp/.terraform.lock.hcl
+++ b/provisioning/buffer/gcp/.terraform.lock.hcl
@@ -1,0 +1,2 @@
+# This file is maintained automatically by "terraform init".
+# Manual edits may be lost in future updates.

--- a/provisioning/buffer/gcp/main.tf
+++ b/provisioning/buffer/gcp/main.tf
@@ -1,0 +1,22 @@
+terraform {
+  required_version = "~> 1.1"
+  backend "gcs" {}
+}
+
+# Read shared infrastructure outputs
+data "terraform_remote_state" "infrastructure" {
+  backend = "gcs"
+
+  config = {
+    bucket = var.terraform_remote_state_bucket
+    prefix = "infrastructure/output"
+  }
+}
+
+output "main_gke_cluster_name" {
+  value = data.terraform_remote_state.infrastructure.outputs.main_gke_cluster_name
+}
+
+output "main_gke_cluster_location" {
+  value = data.terraform_remote_state.infrastructure.outputs.main_gke_cluster_location
+}

--- a/provisioning/buffer/gcp/variables.tf
+++ b/provisioning/buffer/gcp/variables.tf
@@ -1,0 +1,3 @@
+variable "terraform_remote_state_bucket" {
+  type = string
+}

--- a/provisioning/buffer/kubernetes/build.sh
+++ b/provisioning/buffer/kubernetes/build.sh
@@ -39,6 +39,9 @@ fi
 if [[ "$CLOUD_PROVIDER" == "aws" ]]; then
   envsubst < templates/cloud/aws/service.yaml > deploy/cloud/aws/service.yaml
   envsubst < templates/cloud/aws/ingress.yaml > deploy/cloud/aws/ingress.yaml
+elif [[ "$CLOUD_PROVIDER" == "gcp" ]]; then
+  envsubst < templates/cloud/gcp/service.yaml > deploy/cloud/gcp/service.yaml
+  envsubst < templates/cloud/gcp/ingress.yaml > deploy/cloud/gcp/ingress.yaml
 elif [[ "$CLOUD_PROVIDER" == "azure" ]]; then
   envsubst < templates/cloud/azure/service.yaml > deploy/cloud/azure/service.yaml
 elif [[ "$CLOUD_PROVIDER" == "local" ]]; then

--- a/provisioning/buffer/kubernetes/deploy/cloud/gcp/.gitignore
+++ b/provisioning/buffer/kubernetes/deploy/cloud/gcp/.gitignore
@@ -1,0 +1,2 @@
+*
+!.gitignore

--- a/provisioning/buffer/kubernetes/templates/cloud/gcp/ingress.yaml
+++ b/provisioning/buffer/kubernetes/templates/cloud/gcp/ingress.yaml
@@ -1,0 +1,22 @@
+---
+apiVersion: networking.k8s.io/v1
+kind: Ingress
+metadata:
+  name: buffer-api
+  namespace: $NAMESPACE
+  labels:
+    app: buffer-api
+  annotations:
+    kubernetes.io/ingress.class: "nginx"
+spec:
+  rules:
+    - host: "buffer.${HOSTNAME_SUFFIX}"
+      http:
+        paths:
+          - backend:
+              service:
+                name: buffer-api
+                port:
+                  number: 80
+            path: /
+            pathType: Prefix

--- a/provisioning/buffer/kubernetes/templates/cloud/gcp/service.yaml
+++ b/provisioning/buffer/kubernetes/templates/cloud/gcp/service.yaml
@@ -1,0 +1,17 @@
+---
+kind: Service
+apiVersion: v1
+metadata:
+  name: buffer-api
+  namespace: $NAMESPACE
+  labels:
+    app: buffer-api
+spec:
+  type: ClusterIP
+  selector:
+    app: buffer-api
+  ports:
+    - port: 80
+      targetPort: 8000
+      protocol: TCP
+      name: http


### PR DESCRIPTION
FIXES https://keboola.atlassian.net/browse/GCP-186

 - GCP Deploy Buffer Service
 - Testing Release - https://dev.azure.com/keboola-prod/Keboola%20Connection%20GCP/_releaseProgress?_a=release-environment-logs&releaseId=379&environmentId=379
 - Terraformem se pouze získají  outputy ze sdílené infra a pak nasazuje standardními common manifesty. 
 - Prošel jsem akceptační testy https://keboola.atlassian.net/wiki/spaces/ENGG/pages/2947121200/Buffer+Acceptance+tests 
   -  Vytvořená a naimportovaná tabulka - https://connection.us-central1.gcp.keboola.dev/admin/projects/2/storage/in.c-test/buffer-test#data-sample 
- etcd:
<img width="1377" alt="image" src="https://github.com/keboola/keboola-as-code/assets/903531/f799f26c-e56e-45a6-bf4e-8257cbaecd01">
- Monitoring - https://app.datadoghq.eu/dashboard/n3c-jfd-8jm/buffer-service?tpl_var_env%5B0%5D=dev-keboola-gcp-us-central1
  - Přijde mi že nevidím custom APM metriky 
- APM - https://app.datadoghq.eu/apm/services/buffer-api/operations/http.server.request/resources?env=dev-keboola-gcp-us-central1