### PR TITLE
Add storage/compression packages

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -24,7 +24,7 @@ require (
 	github.com/fatih/color v1.15.0
 	github.com/go-playground/locales v0.14.1
 	github.com/go-playground/universal-translator v0.18.1
-	github.com/go-playground/validator/v10 v10.14.0
+	github.com/go-playground/validator/v10 v10.15.1
 	github.com/go-resty/resty/v2 v2.7.0
 	github.com/google/go-cmp v0.5.9
 	github.com/google/go-jsonnet v0.19.1
@@ -34,6 +34,8 @@ require (
 	github.com/jpillora/longestcommon v0.0.0-20161227235612-adb9d91ee629
 	github.com/keboola/go-client v1.16.5
 	github.com/keboola/go-utils v0.8.1
+	github.com/klauspost/compress v1.16.3
+	github.com/klauspost/pgzip v1.2.6
 	github.com/kylelemons/godebug v1.1.0
 	github.com/lafikl/consistent v0.0.0-20220512074542-bdd3606bfc3e
 	github.com/lestrrat-go/strftime v1.0.6

--- a/go.sum
+++ b/go.sum
@@ -1081,8 +1081,8 @@ github.com/go-playground/universal-translator v0.18.1 h1:Bcnm0ZwsGyWbCzImXv+pAJn
 github.com/go-playground/universal-translator v0.18.1/go.mod h1:xekY+UJKNuX9WP91TpwSH2VMlDf28Uj24BCp08ZFTUY=
 github.com/go-playground/validator/v10 v10.2.0/go.mod h1:uOYAAleCW8F/7oMFd6aG0GOhaH6EGOAJShg8Id5JGkI=
 github.com/go-playground/validator/v10 v10.4.1/go.mod h1:nlOn6nFhuKACm19sB/8EGNn9GlaMV7XkbRSipzJ0Ii4=
-github.com/go-playground/validator/v10 v10.14.0 h1:vgvQWe3XCz3gIeFDm/HnTIbj6UGmg/+t63MyGU2n5js=
-github.com/go-playground/validator/v10 v10.14.0/go.mod h1:9iXMNT7sEkjXb0I+enO7QXmzG6QCsPWY4zveKFVRSyU=
+github.com/go-playground/validator/v10 v10.15.1 h1:BSe8uhN+xQ4r5guV/ywQI4gO59C2raYcGffYWZEjZzM=
+github.com/go-playground/validator/v10 v10.15.1/go.mod h1:9iXMNT7sEkjXb0I+enO7QXmzG6QCsPWY4zveKFVRSyU=
 github.com/go-resty/resty/v2 v2.1.1-0.20191201195748-d7b97669fe48/go.mod h1:dZGr0i9PLlaaTD4H/hoZIDjQ+r6xq8mgbRzHZf7f2J8=
 github.com/go-resty/resty/v2 v2.7.0 h1:me+K9p3uhSmXtrBZ4k9jcEAfJmuC8IivWHwaLZwPrFY=
 github.com/go-resty/resty/v2 v2.7.0/go.mod h1:9PWDzw47qPphMRFfhsyk0NnSgvluHcljSMVIq3w7q0I=
@@ -1523,6 +1523,10 @@ github.com/klauspost/compress v1.11.13/go.mod h1:aoV0uJVorq1K+umq18yTdKaF57EivdY
 github.com/klauspost/compress v1.13.4/go.mod h1:8dP1Hq4DHOhN9w426knH3Rhby4rFm6D8eO+e+Dq5Gzg=
 github.com/klauspost/compress v1.13.6/go.mod h1:/3/Vjq9QcHkK5uEr5lBEmyoZ1iFhe47etQ6QUkpK6sk=
 github.com/klauspost/compress v1.15.1/go.mod h1:/3/Vjq9QcHkK5uEr5lBEmyoZ1iFhe47etQ6QUkpK6sk=
+github.com/klauspost/compress v1.16.3 h1:XuJt9zzcnaz6a16/OU53ZjWp/v7/42WcR5t2a0PcNQY=
+github.com/klauspost/compress v1.16.3/go.mod h1:ntbaceVETuRiXiv4DpjP66DpAtAGkEQskQzEyD//IeE=
+github.com/klauspost/pgzip v1.2.6 h1:8RXeL5crjEUFnR2/Sn6GJNWtSQ3Dk8pq4CL3jvdDyjU=
+github.com/klauspost/pgzip v1.2.6/go.mod h1:Ch1tH69qFZu15pkjo5kYi6mth2Zzwzt50oCQKQE9RUs=
 github.com/kolo/xmlrpc v0.0.0-20201022064351-38db28db192b/go.mod h1:pcaDhQK0/NJZEvtCO0qQPPropqV0sJOJ6YW7X+9kRwM=
 github.com/kolo/xmlrpc v0.0.0-20220921171641-a4b6fa1dd06b/go.mod h1:pcaDhQK0/NJZEvtCO0qQPPropqV0sJOJ6YW7X+9kRwM=
 github.com/konsorten/go-windows-terminal-sequences v1.0.1/go.mod h1:T0+1ngSBFLxvqU3pZ+m/2kptfBszLMUkC4ZK/EgS/cQ=

--- a/internal/pkg/service/buffer/storage/compression/compression.go
+++ b/internal/pkg/service/buffer/storage/compression/compression.go
@@ -1,0 +1,22 @@
+// Package compression provides configuration for compression and decompression for local and staging storage.
+// The Config structure provides options for different types and algorithms of compression.
+// Separate packages "writer" and "reader" provide compression and decompression, this package contains common code.
+package compression
+
+const (
+	TypeNone = Type("none")
+	TypeGZIP = Type("gzip")
+	TypeZSTD = Type("zstd")
+
+	DefaultGZIPImpl = GZIPImplParallel
+	// GZIPImplStandard - https://pkg.go.dev/compress/gzip
+	GZIPImplStandard = GZIPImplementation("standard")
+	// GZIPImplFast - https://pkg.go.dev/github.com/klauspost/compress/gzip
+	GZIPImplFast = GZIPImplementation("fast")
+	// GZIPImplParallel - https://pkg.go.dev/github.com/klauspost/pgzip
+	GZIPImplParallel = GZIPImplementation("parallel")
+)
+
+type GZIPImplementation string
+
+type Type string

--- a/internal/pkg/service/buffer/storage/compression/config.go
+++ b/internal/pkg/service/buffer/storage/compression/config.go
@@ -1,0 +1,67 @@
+package compression
+
+import (
+	"github.com/c2h5oh/datasize"
+	"runtime"
+)
+
+const (
+	DefaultGZIPLevel     = 6 // 1-9
+	DefaultGZIPBlockSize = datasize.MB
+
+	DefaultZSTDLevel      = 3 // 1-22
+	DefaultZSDTWindowSize = datasize.MB
+)
+
+// Config for compression writer and reader.
+type Config struct {
+	Type Type        `json:"type" mapstructure:"type" validate:"required,oneof=none gzip zstd"  usage:"Default GZIP compression type."`
+	GZIP *GZIPConfig `json:"gzip,omitempty" mapstructure:"gzip" validate:"excluded_unless=Type gzip,required_if=Type gzip"`
+	ZSTD *ZSTDConfig `json:"zstd,omitempty" mapstructure:"zstd" validate:"excluded_unless=Type zstd,required_if=Type zstd"`
+}
+
+type GZIPConfig struct {
+	Level       int                `json:"level" mapstructure:"level" validate:"min=1,max=9"  usage:"Default GZIP compression level."`
+	Impl        GZIPImplementation `json:"impl" mapstructure:"impl" validate:"required,oneof=standard fast parallel" usage:"Default GZIP implementation: standard, fast, parallel."`
+	BlockSize   datasize.ByteSize  `json:"blockSize" mapstructure:"block-size" validate:"required,min=16384,max=104857600" usage:"Default GZIP parallel block size."` //16kB-100MB
+	Concurrency int                `json:"concurrency" mapstructure:"concurrency" usage:"Default GZIP parallel concurrency, 0 = auto."`
+}
+
+type ZSTDConfig struct {
+	Level       int               `json:"level" mapstructure:"level" validate:"min=1,max=22" usage:"Default ZSTD compression level."`
+	WindowSize  datasize.ByteSize `json:"windowSize" mapstructure:"window-size" validate:"required,min=1024,max=536870912" usage:"Default ZSTD window size."` //1kB-512MB
+	Concurrency int               `json:"concurrency" mapstructure:"concurrency" usage:"Default ZSTD concurrency, 0 = auto"`
+}
+
+func DefaultConfig() Config {
+	return DefaultGZIPConfig()
+}
+
+func DefaultNoneConfig() Config {
+	return Config{
+		Type: TypeNone,
+	}
+}
+
+func DefaultGZIPConfig() Config {
+	return Config{
+		Type: TypeGZIP,
+		GZIP: &GZIPConfig{
+			Level:       DefaultGZIPLevel,
+			Impl:        DefaultGZIPImpl,
+			BlockSize:   DefaultGZIPBlockSize,
+			Concurrency: runtime.GOMAXPROCS(0),
+		},
+	}
+}
+
+func DefaultZSTDConfig() Config {
+	return Config{
+		Type: TypeZSTD,
+		ZSTD: &ZSTDConfig{
+			Level:       DefaultZSTDLevel,
+			WindowSize:  DefaultZSDTWindowSize,
+			Concurrency: runtime.GOMAXPROCS(0),
+		},
+	}
+}

--- a/internal/pkg/service/buffer/storage/compression/config_test.go
+++ b/internal/pkg/service/buffer/storage/compression/config_test.go
@@ -1,0 +1,249 @@
+package compression
+
+import (
+	"context"
+	"github.com/keboola/keboola-as-code/internal/pkg/validator"
+	"github.com/stretchr/testify/assert"
+	"strings"
+	"testing"
+)
+
+func TestConfig(t *testing.T) {
+	t.Parallel()
+
+	cases := []struct {
+		Name          string
+		ExpectedError string
+		Config        Config
+	}{
+		{
+			Name:          "empty",
+			ExpectedError: `"type" is a required field`,
+			Config:        Config{},
+		},
+		{
+			Name:          "invalid type",
+			ExpectedError: `"type" must be one of [none gzip zstd]`,
+			Config: Config{
+				Type: "foo",
+			},
+		},
+		{
+			Name:          "gzip: empty",
+			ExpectedError: "- \"gzip.level\" must be 1 or greater\n- \"gzip.impl\" is a required field\n- \"gzip.blockSize\" is a required field",
+			Config: Config{
+				Type: TypeGZIP,
+				GZIP: &GZIPConfig{},
+			},
+		},
+		{
+			Name:   "default  ok",
+			Config: DefaultConfig(),
+		},
+		{
+			Name: "none: ok",
+			Config: Config{
+				Type: TypeNone,
+			},
+		},
+		{
+			Name:   "none: default ok",
+			Config: DefaultNoneConfig(),
+		},
+		{
+			Name:          "none: unexpected gzip config",
+			ExpectedError: `"gzip" should not be set`,
+			Config: Config{
+				Type: TypeNone,
+				GZIP: &GZIPConfig{},
+			},
+		},
+		{
+			Name:          "none: unexpected zstd config",
+			ExpectedError: `"zstd" should not be set`,
+			Config: Config{
+				Type: TypeNone,
+				ZSTD: &ZSTDConfig{},
+			},
+		},
+		{
+			Name: "gzip: ok",
+			Config: Config{
+				Type: TypeGZIP,
+				GZIP: &GZIPConfig{
+					Level:       DefaultGZIPLevel,
+					Impl:        DefaultGZIPImpl,
+					BlockSize:   DefaultGZIPBlockSize,
+					Concurrency: 4,
+				},
+			},
+		},
+		{
+			Name:   "gzip: default ok",
+			Config: DefaultGZIPConfig(),
+		},
+		{
+			Name:          "gzip: level under min",
+			ExpectedError: `"gzip.level" must be 1 or greater`,
+			Config: Config{
+				Type: TypeGZIP,
+				GZIP: &GZIPConfig{
+					Level:     0,
+					Impl:      DefaultGZIPImpl,
+					BlockSize: DefaultGZIPBlockSize,
+				},
+			},
+		},
+		{
+			Name:          "gzip: level over max",
+			ExpectedError: `"gzip.level" must be 9 or less`,
+			Config: Config{
+				Type: TypeGZIP,
+				GZIP: &GZIPConfig{
+					Level:     10,
+					Impl:      DefaultGZIPImpl,
+					BlockSize: DefaultGZIPBlockSize,
+				},
+			},
+		},
+		{
+			Name:          "gzip: unexpected impl",
+			ExpectedError: `"gzip.impl" must be one of [standard fast parallel]`,
+			Config: Config{
+				Type: TypeGZIP,
+				GZIP: &GZIPConfig{
+					Level:     DefaultGZIPLevel,
+					Impl:      "foo",
+					BlockSize: DefaultGZIPBlockSize,
+				},
+			},
+		},
+		{
+			Name:          "gzip: block size under min",
+			ExpectedError: `"gzip.blockSize" must be 16,384 or greater`,
+			Config: Config{
+				Type: TypeGZIP,
+				GZIP: &GZIPConfig{
+					Level:     DefaultGZIPLevel,
+					Impl:      DefaultGZIPImpl,
+					BlockSize: 1,
+				},
+			},
+		},
+		{
+			Name:          "gzip: block size over max",
+			ExpectedError: `"gzip.blockSize" must be 104,857,600 or less`,
+			Config: Config{
+				Type: TypeGZIP,
+				GZIP: &GZIPConfig{
+					Level:     DefaultGZIPLevel,
+					Impl:      DefaultGZIPImpl,
+					BlockSize: 1000000000,
+				},
+			},
+		},
+		{
+			Name:          "gzip: unexpected zstd config",
+			ExpectedError: `"zstd" should not be set`,
+			Config: Config{
+				Type: TypeGZIP,
+				GZIP: &GZIPConfig{
+					Level:     DefaultGZIPLevel,
+					Impl:      DefaultGZIPImpl,
+					BlockSize: DefaultGZIPBlockSize,
+				},
+				ZSTD: &ZSTDConfig{},
+			},
+		},
+		{
+			Name: "zstd: ok",
+			Config: Config{
+				Type: TypeZSTD,
+				ZSTD: &ZSTDConfig{
+					Level:       DefaultGZIPLevel,
+					WindowSize:  DefaultZSDTWindowSize,
+					Concurrency: 4,
+				},
+			},
+		},
+		{
+			Name:   "zstd: default ok",
+			Config: DefaultZSTDConfig(),
+		},
+		{
+			Name:          "zstd: level under min",
+			ExpectedError: `"zstd.level" must be 1 or greater`,
+			Config: Config{
+				Type: TypeZSTD,
+				ZSTD: &ZSTDConfig{
+					Level:       0,
+					WindowSize:  DefaultZSDTWindowSize,
+					Concurrency: 4,
+				},
+			},
+		},
+		{
+			Name:          "zstd: level over max",
+			ExpectedError: `"zstd.level" must be 22 or less`,
+			Config: Config{
+				Type: TypeZSTD,
+				ZSTD: &ZSTDConfig{
+					Level:       100,
+					WindowSize:  DefaultZSDTWindowSize,
+					Concurrency: 4,
+				},
+			},
+		},
+		{
+			Name:          "zstd: window size under min",
+			ExpectedError: `"zstd.windowSize" must be 1,024 or greater`,
+			Config: Config{
+				Type: TypeZSTD,
+				ZSTD: &ZSTDConfig{
+					Level:       DefaultZSTDLevel,
+					WindowSize:  1,
+					Concurrency: 4,
+				},
+			},
+		},
+		{
+			Name:          "zstd: window size over max",
+			ExpectedError: `"zstd.windowSize" must be 536,870,912 or less`,
+			Config: Config{
+				Type: TypeZSTD,
+				ZSTD: &ZSTDConfig{
+					Level:       DefaultZSTDLevel,
+					WindowSize:  1000000000,
+					Concurrency: 4,
+				},
+			},
+		},
+		{
+			Name:          "zstd: unexpected gzip config",
+			ExpectedError: `"gzip" should not be set`,
+			Config: Config{
+				Type: TypeZSTD,
+				GZIP: &GZIPConfig{},
+				ZSTD: &ZSTDConfig{
+					Level:       DefaultGZIPLevel,
+					WindowSize:  DefaultZSDTWindowSize,
+					Concurrency: 4,
+				},
+			},
+		},
+	}
+
+	// Run test cases
+	ctx := context.Background()
+	val := validator.New()
+	for _, tc := range cases {
+		err := val.Validate(ctx, tc.Config)
+		if tc.ExpectedError == "" {
+			assert.NoError(t, err, tc.Name)
+		} else {
+			if assert.Error(t, err, tc.Name) {
+				assert.Equal(t, strings.TrimSpace(tc.ExpectedError), strings.TrimSpace(err.Error()), tc.Name)
+			}
+		}
+	}
+}

--- a/internal/pkg/service/buffer/storage/compression/filename.go
+++ b/internal/pkg/service/buffer/storage/compression/filename.go
@@ -1,0 +1,16 @@
+package compression
+
+import "github.com/keboola/keboola-as-code/internal/pkg/utils/errors"
+
+func Filename(base string, t Type) (string, error) {
+	switch t {
+	case TypeNone:
+		return base, nil
+	case TypeGZIP:
+		return base + ".gzip", nil
+	case TypeZSTD:
+		return base + ".zstd", nil
+	default:
+		return "", errors.Errorf(`unexpected compression type "%s"`, t)
+	}
+}

--- a/internal/pkg/service/buffer/storage/compression/filename_test.go
+++ b/internal/pkg/service/buffer/storage/compression/filename_test.go
@@ -1,0 +1,30 @@
+package compression
+
+import (
+	"github.com/stretchr/testify/assert"
+	"testing"
+)
+
+func TestFilename(t *testing.T) {
+	t.Parallel()
+
+	cases := []struct {
+		expected string
+		t        Type
+	}{
+		{"file.txt", TypeNone},
+		{"file.txt.gzip", TypeGZIP},
+		{"file.txt.zstd", TypeZSTD},
+		{"", "invalid"},
+	}
+
+	for _, tc := range cases {
+		filename, err := Filename("file.txt", tc.t)
+		if tc.expected == "" {
+			assert.Error(t, err)
+		} else {
+			assert.NoError(t, err)
+			assert.Equal(t, tc.expected, filename)
+		}
+	}
+}

--- a/internal/pkg/service/buffer/storage/compression/reader/reader.go
+++ b/internal/pkg/service/buffer/storage/compression/reader/reader.go
@@ -1,0 +1,59 @@
+// Package reader provides a configurable compression reader.
+package reader
+
+import (
+	"compress/gzip"
+	"github.com/keboola/keboola-as-code/internal/pkg/service/buffer/storage/compression"
+	"github.com/keboola/keboola-as-code/internal/pkg/utils/errors"
+	fastGzip "github.com/klauspost/compress/gzip"
+	"github.com/klauspost/compress/zstd"
+	"github.com/klauspost/pgzip"
+	"io"
+)
+
+// New wraps the specified reader with the compression reader.
+func New(r io.Reader, cfg compression.Config) (io.Reader, error) {
+	switch cfg.Type {
+	case compression.TypeNone:
+		return r, nil
+	case compression.TypeGZIP:
+		switch cfg.GZIP.Impl {
+		case compression.GZIPImplStandard:
+			return newGZIPReader(r)
+		case compression.GZIPImplFast:
+			return newFastGZIPReader(r)
+		case compression.GZIPImplParallel:
+			return newParallelGZIPReader(r)
+		default:
+			panic(errors.Errorf(`unexpected gzip implementation type "%s"`, cfg.GZIP.Impl))
+		}
+	case compression.TypeZSTD:
+		return newZstdReader(r, cfg)
+	default:
+		panic(errors.Errorf(`unexpected reader compression type "%s"`, cfg.Type))
+	}
+}
+
+func newGZIPReader(r io.Reader) (io.Reader, error) {
+	return gzip.NewReader(r)
+}
+
+func newFastGZIPReader(r io.Reader) (io.Reader, error) {
+	return fastGzip.NewReader(r)
+}
+
+func newParallelGZIPReader(r io.Reader) (io.Reader, error) {
+	out, err := pgzip.NewReader(r)
+	if err != nil {
+		return nil, errors.Errorf(`cannot create parallel gzip reader: %w`, err)
+	}
+
+	return out, nil
+}
+
+func newZstdReader(r io.Reader, cfg compression.Config) (io.Reader, error) {
+	return zstd.NewReader(
+		r,
+		zstd.WithDecoderConcurrency(cfg.ZSTD.Concurrency),
+	)
+}

--- a/internal/pkg/service/buffer/storage/compression/reader/reader_test.go
+++ b/internal/pkg/service/buffer/storage/compression/reader/reader_test.go
@@ -1,0 +1,164 @@
+package reader
+
+import (
+	"bytes"
+	"compress/gzip"
+	"crypto/md5"
+	"github.com/c2h5oh/datasize"
+	"github.com/keboola/keboola-as-code/internal/pkg/service/buffer/storage/compression"
+	"github.com/klauspost/compress/zstd"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	"io"
+	"math/rand"
+	"testing"
+	"time"
+)
+
+func TestReader(t *testing.T) {
+	t.Parallel()
+
+	// Encoders to compressed data before test
+	noneDecoder := func(t *testing.T, w io.Writer) io.Writer {
+		return w
+	}
+	gzipEncoder := func(t *testing.T, w io.Writer) io.Writer {
+		// The standard gzip implementation is used to encode data.
+		return gzip.NewWriter(w)
+	}
+	zstdEncoder := func(t *testing.T, w io.Writer) io.Writer {
+		r, err := zstd.NewWriter(w)
+		require.NoError(t, err)
+		return r
+	}
+
+	// Test cases
+	cases := []struct {
+		Name    string
+		Config  compression.Config
+		Encoder func(t *testing.T, w io.Writer) io.Writer
+	}{
+		{
+			Name:    "none",
+			Encoder: noneDecoder,
+			Config: compression.Config{
+				Type: compression.TypeNone,
+			},
+		},
+		{
+			Name:    "gzip.standard",
+			Encoder: gzipEncoder,
+			Config: compression.Config{
+				Type: compression.TypeGZIP,
+				GZIP: &compression.GZIPConfig{
+					Level: compression.DefaultGZIPLevel,
+					Impl:  compression.GZIPImplStandard, // <<<<<<<<
+				},
+			},
+		},
+		{
+			Name:    "gzip.fast",
+			Encoder: gzipEncoder,
+			Config: compression.Config{
+				Type: compression.TypeGZIP,
+				GZIP: &compression.GZIPConfig{
+					Level: compression.DefaultGZIPLevel,
+					Impl:  compression.GZIPImplFast, // <<<<<<<<
+				},
+			},
+		},
+		{
+			Name:    "gzip.parallel",
+			Encoder: gzipEncoder,
+			Config: compression.Config{
+				Type: compression.TypeGZIP,
+				GZIP: &compression.GZIPConfig{
+					Level:       compression.DefaultGZIPLevel,
+					Impl:        compression.GZIPImplParallel, // <<<<<<<<
+					Concurrency: 4,
+				},
+			},
+		},
+		{
+			Name:    "zstd",
+			Encoder: zstdEncoder,
+			Config: compression.Config{
+				Type: compression.TypeZSTD,
+				ZSTD: &compression.ZSTDConfig{
+					Level:       compression.DefaultZSTDLevel,
+					Concurrency: 4,
+				},
+			},
+		},
+	}
+
+	// Random data for compression
+	dataLen := 4 * datasize.MB
+	step := 100 * datasize.KB
+	data := make([]byte, dataLen.Bytes())
+	rnd := rand.New(rand.NewSource(time.Now().UnixMilli()))
+	n, err := rnd.Read(data)
+	assert.Equal(t, int(dataLen.Bytes()), n)
+	assert.NoError(t, err)
+
+	// The data is written 2x, in halves, to simulate reopen of the compressed file.
+	// Thus, it is checked that it is possible to continue compression after restarting the pod.
+	writePart := func(pos datasize.ByteSize, w io.Writer) {
+		var part []byte
+		if pos > dataLen-step {
+			part = data[pos:]
+		} else {
+			part = data[pos : pos+step]
+		}
+		n, err := w.Write(part)
+		assert.Equal(t, len(part), n)
+		assert.NoError(t, err)
+	}
+
+	// Run test cases in parallel
+	for _, tc := range cases {
+		tc := tc
+		t.Run(tc.Name, func(t *testing.T) {
+			t.Parallel()
+
+			var out bytes.Buffer
+			w := tc.Encoder(t, &out)
+
+			// Write the first half
+			pos := datasize.ByteSize(0)
+			for ; pos < dataLen/2; pos += step {
+				writePart(pos, w)
+			}
+
+			// Close the writer - simulate file close - some outage
+			if v, ok := w.(io.Closer); ok {
+				assert.NoError(t, v.Close())
+			}
+
+			// Reopen writer - simulates recovery from the outage
+			w = tc.Encoder(t, &out)
+
+			// Write the second half
+			for ; pos < dataLen; pos += step {
+				writePart(pos, w)
+			}
+
+			// Close the writer
+			if v, ok := w.(io.Closer); ok {
+				assert.NoError(t, v.Close())
+			}
+
+			// Create reader
+			r, err := New(&out, tc.Config)
+			require.NoError(t, err)
+
+			// Decode all
+			decoded, err := io.ReadAll(r)
+			assert.NoError(t, err)
+
+			// Compare md5 checksum, because assert library cannot diff such big data.
+			assert.NoError(t, err)
+			assert.Equal(t, md5.Sum(data), md5.Sum(decoded))
+		})
+	}
+}

--- a/internal/pkg/service/buffer/storage/compression/writer/writer.go
+++ b/internal/pkg/service/buffer/storage/compression/writer/writer.go
@@ -1,0 +1,76 @@
+// Package writer provides a configurable compression writer.
+package writer
+
+import (
+	"compress/gzip"
+	"github.com/keboola/keboola-as-code/internal/pkg/service/buffer/storage/compression"
+	"github.com/keboola/keboola-as-code/internal/pkg/utils/errors"
+	fastGzip "github.com/klauspost/compress/gzip"
+	"github.com/klauspost/compress/zstd"
+	"github.com/klauspost/pgzip"
+	"io"
+)
+
+// New wraps the specified writer with the compression writer.
+func New(w io.Writer, cfg compression.Config) (io.Writer, error) {
+	switch cfg.Type {
+	case compression.TypeNone:
+		return w, nil
+	case compression.TypeGZIP:
+		switch cfg.GZIP.Impl {
+		case compression.GZIPImplStandard:
+			return newGZIPWriter(w, cfg)
+		case compression.GZIPImplFast:
+			return newFastGZIPWriter(w, cfg)
+		case compression.GZIPImplParallel:
+			return newParallelGZIPWriter(w, cfg)
+		default:
+			panic(errors.Errorf(`unexpected gzip implementation type "%s"`, cfg.GZIP.Impl))
+		}
+	case compression.TypeZSTD:
+		return newZstdWriter(w, cfg)
+	default:
+		panic(errors.Errorf(`unexpected writer compression type "%s"`, cfg.Type))
+	}
+}
+
+func newGZIPWriter(w io.Writer, cfg compression.Config) (io.Writer, error) {
+	return gzip.NewWriterLevel(w, cfg.GZIP.Level)
+}
+
+func newFastGZIPWriter(w io.Writer, cfg compression.Config) (io.Writer, error) {
+	return fastGzip.NewWriterLevel(w, cfg.GZIP.Level)
+}
+
+func newParallelGZIPWriter(w io.Writer, cfg compression.Config) (io.Writer, error) {
+	bSize, bCount := cfg.GZIP.BlockSize, cfg.GZIP.Concurrency
+
+	out, err := pgzip.NewWriterLevel(w, cfg.GZIP.Level)
+	if err != nil {
+		return nil, errors.Errorf(`cannot create parallel gzip writer: %w`, err)
+	}
+
+	err = out.SetConcurrency(int(cfg.GZIP.BlockSize.Bytes()), cfg.GZIP.Concurrency)
+	if err != nil {
+		return nil, errors.Errorf(`cannot set parallel gzip concurrency, size=%s, count=%d: %w`, bSize, bCount, err)
+	}
+
+	return out, nil
+}
+
+func newZstdWriter(w io.Writer, cfg compression.Config) (io.Writer, error) {
+	return zstd.NewWriter(
+		w,
+		zstd.WithEncoderLevel(zstd.EncoderLevel(cfg.ZSTD.Level)),
+		zstd.WithEncoderConcurrency(cfg.ZSTD.Concurrency),
+		zstd.WithWindowSize(nextPowOf2(int(cfg.ZSTD.WindowSize.Bytes()))),
+	)
+}
+
+func nextPowOf2(n int) int {
+	k := 1
+	for k < n {
+		k = k << 1
+	}
+	return k
+}

--- a/internal/pkg/service/buffer/storage/compression/writer/writer_test.go
+++ b/internal/pkg/service/buffer/storage/compression/writer/writer_test.go
@@ -1,0 +1,165 @@
+package writer
+
+import (
+	"bytes"
+	"compress/gzip"
+	"crypto/md5"
+	"github.com/c2h5oh/datasize"
+	"github.com/keboola/keboola-as-code/internal/pkg/service/buffer/storage/compression"
+	"github.com/klauspost/compress/zstd"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	"io"
+	"math/rand"
+	"testing"
+	"time"
+)
+
+func TestWriter(t *testing.T) {
+	t.Parallel()
+
+	// Decoders to validate compressed data
+	noneDecoder := func(t *testing.T, r io.Reader) io.Reader {
+		return r
+	}
+	gzipDecoder := func(t *testing.T, r io.Reader) io.Reader {
+		// The standard gzip implementation is used to decode data.
+		r, err := gzip.NewReader(r)
+		require.NoError(t, err)
+		return r
+	}
+	zstdDecoder := func(t *testing.T, r io.Reader) io.Reader {
+		r, err := zstd.NewReader(r)
+		require.NoError(t, err)
+		return r
+	}
+
+	// Test cases
+	cases := []struct {
+		Name    string
+		Config  compression.Config
+		Decoder func(t *testing.T, r io.Reader) io.Reader
+	}{
+		{
+			Name:    "none",
+			Decoder: noneDecoder,
+			Config: compression.Config{
+				Type: compression.TypeNone,
+			},
+		},
+		{
+			Name:    "gzip.standard",
+			Decoder: gzipDecoder,
+			Config: compression.Config{
+				Type: compression.TypeGZIP,
+				GZIP: &compression.GZIPConfig{
+					Level: compression.DefaultGZIPLevel,
+					Impl:  compression.GZIPImplStandard, // <<<<<<<<
+				},
+			},
+		},
+		{
+			Name:    "gzip.fast",
+			Decoder: gzipDecoder,
+			Config: compression.Config{
+				Type: compression.TypeGZIP,
+				GZIP: &compression.GZIPConfig{
+					Level: compression.DefaultGZIPLevel,
+					Impl:  compression.GZIPImplFast, // <<<<<<<<
+				},
+			},
+		},
+		{
+			Name:    "gzip.parallel",
+			Decoder: gzipDecoder,
+			Config: compression.Config{
+				Type: compression.TypeGZIP,
+				GZIP: &compression.GZIPConfig{
+					Level:       compression.DefaultGZIPLevel,
+					Impl:        compression.GZIPImplParallel, // <<<<<<<<
+					BlockSize:   compression.DefaultGZIPBlockSize,
+					Concurrency: 4,
+				},
+			},
+		},
+		{
+			Name:    "zstd",
+			Decoder: zstdDecoder,
+			Config: compression.Config{
+				Type: compression.TypeZSTD,
+				ZSTD: &compression.ZSTDConfig{
+					Level:       compression.DefaultZSTDLevel,
+					WindowSize:  compression.DefaultZSDTWindowSize,
+					Concurrency: 4,
+				},
+			},
+		},
+	}
+
+	// Random data for compression
+	// The data is written 2x, in halves, to simulate reopen of the file when writing.
+	dataLen := 4 * datasize.MB
+	step := 100 * datasize.KB
+	data := make([]byte, dataLen.Bytes())
+	rnd := rand.New(rand.NewSource(time.Now().UnixMilli()))
+	n, err := rnd.Read(data)
+	assert.Equal(t, int(dataLen.Bytes()), n)
+	assert.NoError(t, err)
+
+	// The data is written 2x, in halves, to simulate reopen of the compressed file.
+	// Thus, it is checked that it is possible to continue compression after restarting the pod.
+	writePart := func(pos datasize.ByteSize, w io.Writer) {
+		var part []byte
+		if pos > dataLen-step {
+			part = data[pos:]
+		} else {
+			part = data[pos : pos+step]
+		}
+		n, err := w.Write(part)
+		assert.Equal(t, len(part), n)
+		assert.NoError(t, err)
+	}
+
+	// Run test cases in parallel
+	for _, tc := range cases {
+		tc := tc
+		t.Run(tc.Name, func(t *testing.T) {
+			t.Parallel()
+
+			var out bytes.Buffer
+			w, err := New(&out, tc.Config)
+			require.NoError(t, err)
+
+			// Write the first half
+			pos := datasize.ByteSize(0)
+			for ; pos < dataLen/2; pos += step {
+				writePart(pos, w)
+			}
+
+			// Close the writer - simulate file close - some outage
+			if v, ok := w.(io.Closer); ok {
+				assert.NoError(t, v.Close())
+			}
+
+			// Reopen writer - simulates recovery from the outage
+			w, err = New(&out, tc.Config)
+			require.NoError(t, err)
+
+			// Write the second half
+			for ; pos < dataLen; pos += step {
+				writePart(pos, w)
+			}
+
+			// Close the writer
+			if v, ok := w.(io.Closer); ok {
+				assert.NoError(t, v.Close())
+			}
+
+			// Decode written data and compare.
+			// Compare md5 checksum, because assert library cannot diff such big data.
+			decoded, err := io.ReadAll(tc.Decoder(t, &out))
+			assert.NoError(t, err)
+			assert.Equal(t, md5.Sum(data), md5.Sum(decoded))
+		})
+	}
+}

--- a/internal/pkg/validator/custom.go
+++ b/internal/pkg/validator/custom.go
@@ -17,6 +17,9 @@ import (
 
 func (v *wrapper) registerCustomMessages() {
 	v.registerErrorMessage("required_if", "{0} is a required field")
+	v.registerErrorMessage("required_unless", "{0} is a required field")
+	v.registerErrorMessage("excluded_if", "{0} should not be set")
+	v.registerErrorMessage("excluded_unless", "{0} should not be set")
 }
 
 func (v *wrapper) registerCustomRules() {


### PR DESCRIPTION
Jira: https://keboola.atlassian.net/browse/PSGO-285

Changes:
- Added compression writer and reader.

----------------

Coverage nie je `100%`, takzo by sa simulovali chyby v jednotlivych implementaciach kompresie - a ani to nema zmysel.
Tj. ze by si zapisal nejake data, ale nepodarilo sa ich komprimovat.

![image](https://github.com/keboola/keboola-as-code/assets/19371734/d76a9606-8738-4c37-9877-82fee00ee8ef)


-----------------

- Komentare sa snazim davat priamo do kodu.
- Updatol som validator, lebo tam bol nejaky bug + pridal som nejake custom messages, lebo by defalt tam bolo iba `is invalid`.
- Doteraz sme robili kompresiu pred uploadom do S3, teraz budu komprimovane subory priamo na disku.
  - Kompresiu budu poskytovat pkgs z tohto PRs.
  - Budu mozne rozne moznosti, by default to bude GZIP -> disk ... a bez zmeny priamo upload do staging storage.