### PR TITLE
Add storage/local/{reader,writer}.OpenVolume

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -26,6 +26,7 @@ require (
 	github.com/go-playground/universal-translator v0.18.1
 	github.com/go-playground/validator/v10 v10.15.1
 	github.com/go-resty/resty/v2 v2.7.0
+	github.com/gofrs/flock v0.8.1
 	github.com/google/go-cmp v0.5.9
 	github.com/google/go-jsonnet v0.19.1
 	github.com/google/shlex v0.0.0-20191202100458-e7afc7fbc510
@@ -186,7 +187,6 @@ require (
 	github.com/go-logr/logr v1.2.4 // indirect
 	github.com/go-logr/stdr v1.2.2 // indirect
 	github.com/go-openapi/inflect v0.19.0 // indirect
-	github.com/gofrs/flock v0.8.1 // indirect
 	github.com/gogo/protobuf v1.3.2 // indirect
 	github.com/golang-jwt/jwt/v4 v4.4.3 // indirect
 	github.com/golang/groupcache v0.0.0-20210331224755-41bb18bfe9da // indirect

--- a/internal/pkg/service/buffer/storage/local/reader/config.go
+++ b/internal/pkg/service/buffer/storage/local/reader/config.go
@@ -1,0 +1,38 @@
+package reader
+
+import (
+	"github.com/keboola/keboola-as-code/internal/pkg/utils/errors"
+	"time"
+)
+
+const (
+	defaultVolumeIDWaitTimeout = 30 * time.Second
+)
+
+type config struct {
+	// waitForVolumeIDTimeout defines how long to wait for the existence of a file with the VolumeID,
+	// see OpenVolume function and Volume.waitForVolumeID method.
+	waitForVolumeIDTimeout time.Duration
+}
+
+type Option func(config *config)
+
+func WithWaitForVolumeIDTimeout(v time.Duration) Option {
+	return func(c *config) {
+		if v <= 0 {
+			panic(errors.New(`value must be greater than zero`))
+		}
+		c.waitForVolumeIDTimeout = v
+	}
+}
+
+func newConfig(opts []Option) config {
+	cfg := config{
+		waitForVolumeIDTimeout: defaultVolumeIDWaitTimeout,
+	}
+
+	for _, o := range opts {
+		o(&cfg)
+	}
+	return cfg
+}

--- a/internal/pkg/service/buffer/storage/local/reader/volume.go
+++ b/internal/pkg/service/buffer/storage/local/reader/volume.go
@@ -1,0 +1,138 @@
+package reader
+
+import (
+	"context"
+	"github.com/benbjohnson/clock"
+	"github.com/gofrs/flock"
+	"github.com/keboola/keboola-as-code/internal/pkg/log"
+	"github.com/keboola/keboola-as-code/internal/pkg/service/buffer/storage"
+	"github.com/keboola/keboola-as-code/internal/pkg/service/buffer/storage/local"
+	"github.com/keboola/keboola-as-code/internal/pkg/utils/errors"
+	"os"
+	"path/filepath"
+	"strings"
+	"sync"
+	"time"
+)
+
+const (
+	// lockFile ensures only one opening of the volume for reading
+	lockFile                = "reader.lock"
+	waitForVolumeIDInterval = 500 * time.Millisecond
+)
+
+type Volume struct {
+	config config
+	logger log.Logger
+	clock  clock.Clock
+	path   string
+
+	ctx    context.Context
+	cancel context.CancelFunc
+	wg     *sync.WaitGroup
+
+	volumeID storage.VolumeID
+	lock     *flock.Flock
+}
+
+// OpenVolume volume for writing.
+//   - It is checked that the volume path exists.
+//   - The local.VolumeIDFile is loaded.
+//   - If the local.VolumeIDFile doesn't exist, the function waits until the writer.OpenFile function will create it.
+//   - The lockFile ensures only one opening of the volume for reading.
+func OpenVolume(ctx context.Context, logger log.Logger, clock clock.Clock, path string, opts ...Option) (*Volume, error) {
+	logger.Infof(`opening volume "%s"`, path)
+	v := &Volume{
+		config: newConfig(opts),
+		logger: logger,
+		clock:  clock,
+		path:   path,
+		wg:     &sync.WaitGroup{},
+	}
+
+	v.ctx, v.cancel = context.WithCancel(ctx)
+
+	// Check volume directory
+	if err := local.CheckVolumeDir(v.path); err != nil {
+		return nil, err
+	}
+
+	// Wait for volume ID
+	if volumeID, err := v.waitForVolumeID(); err == nil {
+		v.volumeID = volumeID
+	} else {
+		return nil, err
+	}
+
+	// Create lock file
+	// Note: If it is necessary to use the filesystem mounted in read-only mode,
+	// this lock can be removed from the code, if it is ensured that only one reader is running at a time.
+	{
+		v.lock = flock.New(filepath.Join(v.path, lockFile))
+		if locked, err := v.lock.TryLock(); err != nil {
+			return nil, errors.Errorf(`cannot acquire reader lock "%s": %w`, v.lock.Path(), err)
+		} else if !locked {
+			return nil, errors.Errorf(`cannot acquire reader lock "%s": already locked`, v.lock.Path())
+		}
+	}
+
+	v.logger.Info("opened volume")
+	return v, nil
+}
+
+func (v *Volume) VolumeID() storage.VolumeID {
+	return v.volumeID
+}
+
+func (v *Volume) Close() error {
+	errs := errors.NewMultiError()
+	v.logger.Info("closing volume")
+
+	// Cancel all operations
+	v.cancel()
+
+	// Wait for all operations
+	v.wg.Wait()
+
+	// Release the lock
+	if err := v.lock.Unlock(); err != nil {
+		errs.Append(errors.Errorf(`cannot release reader lock "%s": %w`, v.lock.Path(), err))
+	}
+	if err := os.Remove(v.lock.Path()); err != nil {
+		errs.Append(errors.Errorf(`cannot remove reader lock "%s": %w`, v.lock.Path(), err))
+	}
+
+	v.logger.Info("closed volume")
+	return errs.ErrorOrNil()
+}
+
+// waitForVolumeID waits for the file with volume ID.
+// The file is created by the writer.OpenVolume
+// and this reader.OpenVolume is waiting for it.
+func (v *Volume) waitForVolumeID() (storage.VolumeID, error) {
+	ticker := v.clock.Ticker(waitForVolumeIDInterval)
+	defer ticker.Stop()
+
+	timeout := v.config.waitForVolumeIDTimeout
+	timeoutC := v.clock.After(timeout)
+
+	path := filepath.Join(v.path, local.VolumeIDFile)
+	for {
+		// Try open the file
+		if content, err := os.ReadFile(path); err == nil {
+			return storage.VolumeID(strings.TrimSpace(string(content))), nil
+		} else if !errors.Is(err, os.ErrNotExist) {
+			return "", errors.Errorf(`cannot open volume ID file "%s": %w`, path, err)
+		} else {
+			v.logger.Infof(`waiting for volume ID file`)
+		}
+
+		select {
+		case <-ticker.C:
+			// One more attempt
+		case <-timeoutC:
+			// Stop on timeout
+			return "", errors.Errorf(`cannot open volume ID file "%s": waiting timeout after %s`, path, timeout)
+		}
+	}
+}

--- a/internal/pkg/service/buffer/storage/local/reader/volume_test.go
+++ b/internal/pkg/service/buffer/storage/local/reader/volume_test.go
@@ -1,0 +1,256 @@
+package reader
+
+import (
+	"context"
+	"fmt"
+	"github.com/benbjohnson/clock"
+	"github.com/gofrs/flock"
+	"github.com/keboola/go-utils/pkg/wildcards"
+	"github.com/keboola/keboola-as-code/internal/pkg/filesystem"
+	"github.com/keboola/keboola-as-code/internal/pkg/log"
+	"github.com/keboola/keboola-as-code/internal/pkg/service/buffer/storage"
+	"github.com/keboola/keboola-as-code/internal/pkg/service/buffer/storage/local"
+	"github.com/keboola/keboola-as-code/internal/pkg/utils/errors"
+	"github.com/stretchr/testify/assert"
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+	"time"
+)
+
+func TestOpenVolume_NonExistentPath(t *testing.T) {
+	t.Parallel()
+	tc := newVolumeTestCase(t)
+	tc.VolumePath = filesystem.Join("non-existent", "path")
+
+	_, err := tc.OpenVolume()
+	if assert.Error(t, err) {
+		assert.True(t, errors.Is(err, os.ErrNotExist))
+	}
+}
+
+func TestOpenVolume_FileNotDir(t *testing.T) {
+	t.Parallel()
+	tc := newVolumeTestCase(t)
+	tc.VolumePath = filesystem.Join(t.TempDir(), "file")
+
+	// Create file
+	assert.NoError(t, os.WriteFile(tc.VolumePath, []byte("foo"), 0o640))
+
+	_, err := tc.OpenVolume()
+	if assert.Error(t, err) {
+		assert.Equal(t, fmt.Sprintf(`cannot open volume "%s": the path is not directory`, tc.VolumePath), err.Error())
+	}
+}
+
+func TestOpenVolume_Error_DirPermissions(t *testing.T) {
+	t.Parallel()
+	tc := newVolumeTestCase(t)
+
+	// Volume directory is readonly
+	assert.NoError(t, os.Chmod(tc.VolumePath, 0o440))
+
+	_, err := tc.OpenVolume()
+	if assert.Error(t, err) {
+		assert.True(t, errors.Is(err, os.ErrPermission))
+	}
+}
+
+func TestOpenVolume_Error_VolumeFilePermissions(t *testing.T) {
+	t.Parallel()
+	tc := newVolumeTestCase(t)
+
+	// Volume ID file is not readable
+	path := filesystem.Join(tc.VolumePath, local.VolumeIDFile)
+	assert.NoError(t, os.WriteFile(path, []byte("abc"), 0o640))
+	assert.NoError(t, os.Chmod(path, 0o110))
+
+	_, err := tc.OpenVolume()
+	if assert.Error(t, err) {
+		assert.True(t, errors.Is(err, os.ErrPermission), err.Error())
+	}
+}
+
+func TestOpenVolume_Ok(t *testing.T) {
+	t.Parallel()
+	tc := newVolumeTestCase(t)
+
+	// Create volume ID file
+	assert.NoError(t, os.WriteFile(filepath.Join(tc.VolumePath, local.VolumeIDFile), []byte("abcdef"), 0o640))
+
+	volume, err := tc.OpenVolume()
+	assert.NoError(t, err)
+	assert.Equal(t, storage.VolumeID("abcdef"), volume.VolumeID())
+
+	// Lock is locked by the volume
+	lock := flock.New(filepath.Join(tc.VolumePath, lockFile))
+	locked, err := lock.TryLock()
+	assert.False(t, locked)
+	assert.NoError(t, err)
+
+	// Lock is release by Close method
+	assert.NoError(t, volume.Close())
+	assert.NoFileExists(t, lock.Path())
+	locked, err = lock.TryLock()
+	assert.True(t, locked)
+	assert.NoError(t, err)
+	assert.NoError(t, lock.Unlock())
+
+	// Check logs
+	tc.AssertLogs(`
+INFO  opening volume "%s"
+INFO  opened volume
+INFO  closing volume
+INFO  closed volume
+`)
+}
+
+func TestOpenVolume_WaitForVolumeIDFile_Ok(t *testing.T) {
+	t.Parallel()
+	tc := newVolumeTestCase(t)
+
+	// Start opening the volume in background
+	var volume *Volume
+	done := make(chan struct{})
+	go func() {
+		defer close(done)
+		var err error
+		timeout := 5 * waitForVolumeIDInterval
+		volume, err = tc.OpenVolume(WithWaitForVolumeIDTimeout(timeout))
+		assert.NoError(t, err)
+		assert.Equal(t, storage.VolumeID("abcdef"), volume.VolumeID())
+	}()
+
+	// Create the file after a while
+	tc.Clock.Add(waitForVolumeIDInterval)
+	tc.Clock.Add(waitForVolumeIDInterval)
+	assert.NoError(t, os.WriteFile(filepath.Join(tc.VolumePath, local.VolumeIDFile), []byte("abcdef"), 0o640))
+	tc.Clock.Add(waitForVolumeIDInterval)
+
+	// Wait for the goroutine
+	select {
+	case <-done:
+	case <-time.After(5 * time.Second):
+		assert.Fail(t, "timeout")
+	}
+
+	// Lock is locked by the volume
+	lock := flock.New(filepath.Join(tc.VolumePath, lockFile))
+	locked, err := lock.TryLock()
+	assert.False(t, locked)
+	assert.NoError(t, err)
+
+	// Lock is release by Close method
+	assert.NoError(t, volume.Close())
+	assert.NoFileExists(t, lock.Path())
+	locked, err = lock.TryLock()
+	assert.True(t, locked)
+	assert.NoError(t, err)
+	assert.NoError(t, lock.Unlock())
+
+	// Check logs
+	tc.AssertLogs(`
+INFO  opening volume "%s"
+INFO  waiting for volume ID file
+INFO  waiting for volume ID file
+INFO  opened volume
+INFO  closing volume
+INFO  closed volume
+`)
+}
+
+func TestOpenVolume_WaitForVolumeIDFile_Timeout(t *testing.T) {
+	t.Parallel()
+	tc := newVolumeTestCase(t)
+
+	timeout := 5 * waitForVolumeIDInterval
+
+	// Start opening the volume in background
+	done := make(chan struct{})
+	go func() {
+		defer close(done)
+		_, err := tc.OpenVolume(WithWaitForVolumeIDTimeout(timeout))
+		if assert.Error(t, err) {
+			wildcards.Assert(t, `cannot open volume ID file "%s": waiting timeout after %s`, err.Error())
+		}
+	}()
+
+	// Simulate timeout
+	for elapsed := time.Duration(0); elapsed <= timeout; elapsed += waitForVolumeIDInterval {
+		tc.Clock.Add(waitForVolumeIDInterval)
+	}
+
+	// Wait for the goroutine
+	select {
+	case <-done:
+	case <-time.After(5 * time.Second):
+		assert.Fail(t, "timeout")
+	}
+
+	// Check logs
+	// Note: waiting message is present 6x, because wait and timeout timers are triggered at the same time.
+	// The clock is mocked, so the first registered timer = wait is unlocked first.
+	tc.AssertLogs(`
+INFO  opening volume "%s"
+INFO  waiting for volume ID file
+INFO  waiting for volume ID file
+INFO  waiting for volume ID file
+INFO  waiting for volume ID file
+INFO  waiting for volume ID file
+INFO  waiting for volume ID file
+`)
+}
+
+// TestOpenVolume_VolumeLock tests that only one volume instance can be active at a time.
+func TestOpenVolume_VolumeLock(t *testing.T) {
+	t.Parallel()
+	tc := newVolumeTestCase(t)
+
+	// Create volume ID file
+	assert.NoError(t, os.WriteFile(filepath.Join(tc.VolumePath, local.VolumeIDFile), []byte("abcdef"), 0o640))
+
+	// Open volume - first instance - ok
+	_, err := tc.OpenVolume()
+	assert.NoError(t, err)
+
+	// Open volume - second instance - error
+	_, err = tc.OpenVolume()
+	if assert.Error(t, err) {
+		wildcards.Assert(t, `cannot acquire reader lock "%s": already locked`, err.Error())
+	}
+}
+
+type volumeTestCase struct {
+	T          testing.TB
+	Ctx        context.Context
+	Logger     log.DebugLogger
+	Clock      *clock.Mock
+	VolumePath string
+}
+
+func newVolumeTestCase(t testing.TB) *volumeTestCase {
+	ctx, cancel := context.WithTimeout(context.Background(), 10*time.Second)
+	t.Cleanup(func() {
+		cancel()
+	})
+
+	logger := log.NewDebugLogger()
+	tmpDir := t.TempDir()
+
+	return &volumeTestCase{
+		T:          t,
+		Ctx:        ctx,
+		Logger:     logger,
+		Clock:      clock.NewMock(),
+		VolumePath: tmpDir,
+	}
+}
+
+func (tc *volumeTestCase) OpenVolume(opts ...Option) (*Volume, error) {
+	return OpenVolume(tc.Ctx, tc.Logger, tc.Clock, tc.VolumePath, opts...)
+}
+
+func (tc *volumeTestCase) AssertLogs(expected string) bool {
+	return wildcards.Assert(tc.T, strings.TrimSpace(expected), strings.TrimSpace(tc.Logger.AllMessages()))
+}

--- a/internal/pkg/service/buffer/storage/local/writer/config.go
+++ b/internal/pkg/service/buffer/storage/local/writer/config.go
@@ -1,0 +1,15 @@
+package writer
+
+type config struct {
+}
+
+type Option func(config *config)
+
+func newConfig(opts []Option) config {
+	cfg := config{}
+
+	for _, o := range opts {
+		o(&cfg)
+	}
+	return cfg
+}

--- a/internal/pkg/service/buffer/storage/local/writer/disksync/disksync.go
+++ b/internal/pkg/service/buffer/storage/local/writer/disksync/disksync.go
@@ -243,7 +243,7 @@ func (s *Syncer) doSync() *notify.Notifier {
 	s.notifier = notify.New()
 	s.notifierLock.Unlock()
 
-	// Reset timer for periodical sync
+	// Schedule next periodical sync
 	s.timer.Reset(s.config.IntervalTrigger)
 
 	s.wg.Add(1)

--- a/internal/pkg/service/buffer/storage/local/writer/volume.go
+++ b/internal/pkg/service/buffer/storage/local/writer/volume.go
@@ -1,0 +1,152 @@
+package writer
+
+import (
+	"bytes"
+	"context"
+	"github.com/benbjohnson/clock"
+	"github.com/gofrs/flock"
+	"github.com/keboola/keboola-as-code/internal/pkg/filesystem"
+	"github.com/keboola/keboola-as-code/internal/pkg/log"
+	"github.com/keboola/keboola-as-code/internal/pkg/service/buffer/storage"
+	"github.com/keboola/keboola-as-code/internal/pkg/service/buffer/storage/local"
+	"github.com/keboola/keboola-as-code/internal/pkg/utils/errors"
+	"os"
+	"path/filepath"
+	"sync"
+)
+
+const (
+	// drainFile blocks opening of the volume for writing
+	drainFile = "drain"
+	// lockFile ensures only one opening of the volume for writing
+	lockFile          = "writer.lock"
+	volumeIDFileFlags = os.O_WRONLY | os.O_CREATE | os.O_EXCL
+	volumeIDFilePerm  = 0o640
+)
+
+// Volume represents a local directory intended for slices writing.
+type Volume struct {
+	config config
+	logger log.Logger
+	clock  clock.Clock
+	path   string
+
+	ctx    context.Context
+	cancel context.CancelFunc
+	wg     *sync.WaitGroup
+
+	volumeID storage.VolumeID
+	lock     *flock.Flock
+}
+
+// OpenVolume volume for writing.
+//   - It is checked that the volume path exists.
+//   - If the drainFile exists, then writing is prohibited and the function ends with an error.
+//   - The local.VolumeIDFile is loaded or generated, it contains storage.VolumeID, unique identifier of the volume.
+//   - The lockFile ensures only one opening of the volume for writing.
+func OpenVolume(ctx context.Context, logger log.Logger, clock clock.Clock, path string, opts ...Option) (*Volume, error) {
+	logger.Infof(`opening volume "%s"`, path)
+	v := &Volume{
+		config: newConfig(opts),
+		logger: logger,
+		clock:  clock,
+		path:   path,
+		wg:     &sync.WaitGroup{},
+	}
+
+	v.ctx, v.cancel = context.WithCancel(ctx)
+
+	// Check volume directory
+	if err := local.CheckVolumeDir(v.path); err != nil {
+		return nil, err
+	}
+
+	// Check if the drain file exists, if so, the volume is blocked for writing
+	if _, err := os.Stat(filesystem.Join(v.path, drainFile)); err == nil {
+		return nil, errors.Errorf(`cannot open volume for writing: found "%s" file`, drainFile)
+	} else if err != nil && !errors.Is(err, os.ErrNotExist) {
+		return nil, err
+	}
+
+	// Read volume ID from the file, create it if not exists.
+	// The "local/reader.Volume" is waiting for the file.
+	{
+		idFilePath := filepath.Join(v.path, local.VolumeIDFile)
+		content, err := os.ReadFile(idFilePath)
+
+		// VolumeID file doesn't exist, create it
+		if errors.Is(err, os.ErrNotExist) {
+			id := storage.GenerateVolumeID()
+			logger.Infof(`generated volume ID "%s"`, id)
+			content = []byte(id)
+			err = createVolumeIDFile(idFilePath, content)
+		}
+
+		// Check VolumeID file error
+		if err != nil {
+			return nil, errors.Errorf(`cannot open volume ID file "%s": %w`, idFilePath, err)
+		}
+
+		// Store volume ID
+		v.volumeID = storage.VolumeID(bytes.TrimSpace(content))
+	}
+
+	// Create lock file
+	{
+		v.lock = flock.New(filepath.Join(v.path, lockFile))
+		if locked, err := v.lock.TryLock(); err != nil {
+			return nil, errors.Errorf(`cannot acquire writer lock "%s": %w`, v.lock.Path(), err)
+		} else if !locked {
+			return nil, errors.Errorf(`cannot acquire writer lock "%s": already locked`, v.lock.Path())
+		}
+	}
+
+	v.logger.Info("opened volume")
+	return v, nil
+}
+
+func (v *Volume) VolumeID() storage.VolumeID {
+	return v.volumeID
+}
+
+func (v *Volume) Close() error {
+	errs := errors.NewMultiError()
+	v.logger.Info("closing volume")
+
+	// Cancel all operations
+	v.cancel()
+
+	// Wait for all operations
+	v.wg.Wait()
+
+	// Release the lock
+	if err := v.lock.Unlock(); err != nil {
+		errs.Append(errors.Errorf(`cannot release writer lock "%s": %w`, v.lock.Path(), err))
+	}
+	if err := os.Remove(v.lock.Path()); err != nil {
+		errs.Append(errors.Errorf(`cannot remove writer lock "%s": %w`, v.lock.Path(), err))
+	}
+
+	v.logger.Info("closed volume")
+	return errs.ErrorOrNil()
+}
+
+func createVolumeIDFile(path string, content []byte) error {
+	f, err := os.OpenFile(path, volumeIDFileFlags, volumeIDFilePerm)
+	if err != nil {
+		return err
+	}
+
+	_, writeErr := f.Write(content)
+	syncErr := f.Sync()
+	closeErr := f.Close()
+
+	if writeErr != nil {
+		return writeErr
+	} else if syncErr != nil {
+		return syncErr
+	} else if closeErr != nil {
+		return closeErr
+	}
+	return nil
+}

--- a/internal/pkg/service/buffer/storage/local/writer/volume_test.go
+++ b/internal/pkg/service/buffer/storage/local/writer/volume_test.go
@@ -1,0 +1,230 @@
+package writer
+
+import (
+	"context"
+	"fmt"
+	"github.com/benbjohnson/clock"
+	"github.com/gofrs/flock"
+	"github.com/keboola/go-utils/pkg/wildcards"
+	"github.com/keboola/keboola-as-code/internal/pkg/filesystem"
+	"github.com/keboola/keboola-as-code/internal/pkg/log"
+	"github.com/keboola/keboola-as-code/internal/pkg/service/buffer/storage"
+	"github.com/keboola/keboola-as-code/internal/pkg/service/buffer/storage/local"
+	"github.com/keboola/keboola-as-code/internal/pkg/utils/errors"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+	"time"
+)
+
+func TestOpenVolume_NonExistentPath(t *testing.T) {
+	t.Parallel()
+	tc := newVolumeTestCase(t)
+	tc.VolumePath = filesystem.Join("non-existent", "path")
+
+	_, err := tc.OpenVolume()
+	if assert.Error(t, err) {
+		assert.True(t, errors.Is(err, os.ErrNotExist))
+	}
+}
+
+func TestOpenVolume_FileNotDir(t *testing.T) {
+	t.Parallel()
+	tc := newVolumeTestCase(t)
+	tc.VolumePath = filesystem.Join(t.TempDir(), "file")
+
+	// Create file
+	assert.NoError(t, os.WriteFile(tc.VolumePath, []byte("foo"), 0o640))
+
+	_, err := tc.OpenVolume()
+	if assert.Error(t, err) {
+		assert.Equal(t, fmt.Sprintf(`cannot open volume "%s": the path is not directory`, tc.VolumePath), err.Error())
+	}
+}
+
+func TestOpenVolume_Error_DirPermissions(t *testing.T) {
+	t.Parallel()
+	tc := newVolumeTestCase(t)
+
+	// Volume directory is readonly
+	assert.NoError(t, os.Chmod(tc.VolumePath, 0o440))
+
+	_, err := tc.OpenVolume()
+	if assert.Error(t, err) {
+		assert.True(t, errors.Is(err, os.ErrPermission))
+	}
+}
+
+func TestOpenVolume_Error_VolumeFilePermissions(t *testing.T) {
+	t.Parallel()
+	tc := newVolumeTestCase(t)
+
+	// Volume ID file is not readable
+	path := filesystem.Join(tc.VolumePath, local.VolumeIDFile)
+	assert.NoError(t, os.WriteFile(path, []byte("abc"), 0o640))
+	assert.NoError(t, os.Chmod(path, 0o110))
+
+	_, err := tc.OpenVolume()
+	if assert.Error(t, err) {
+		assert.True(t, errors.Is(err, os.ErrPermission))
+	}
+}
+
+// TestOpenVolume_DrainFile tests that the volume can be blocked for writing by a drain file.
+func TestOpenVolume_DrainFile(t *testing.T) {
+	t.Parallel()
+	tc := newVolumeTestCase(t)
+
+	// Create an empty drain file
+	assert.NoError(t, os.WriteFile(filepath.Join(tc.VolumePath, drainFile), nil, 0o640))
+
+	// Type open volume
+	_, err := tc.OpenVolume()
+	if assert.Error(t, err) {
+		assert.Equal(t, `cannot open volume for writing: found "drain" file`, err.Error())
+	}
+}
+
+// TestOpenVolume_GenerateVolumeID tests that the file with the volume ID is generated if not exists.
+func TestOpenVolume_GenerateVolumeID(t *testing.T) {
+	t.Parallel()
+	tc := newVolumeTestCase(t)
+
+	// Open volume - it generates the file
+	volume, err := tc.OpenVolume()
+	require.NoError(t, err)
+
+	// Read the volume ID file and check content length
+	idFilePath := filepath.Join(tc.VolumePath, local.VolumeIDFile)
+	if assert.FileExists(t, idFilePath) {
+		content, err := os.ReadFile(idFilePath)
+		assert.NoError(t, err)
+		assert.Len(t, content, storage.VolumeIDLength)
+
+		// Volume ID reported by the volume instance match the file content
+		assert.Equal(t, storage.VolumeID(content), volume.VolumeID())
+	}
+
+	// Lock is locked by the volume
+	lock := flock.New(filepath.Join(tc.VolumePath, lockFile))
+	locked, err := lock.TryLock()
+	assert.False(t, locked)
+	assert.NoError(t, err)
+
+	// Lock is release by Close method
+	assert.NoError(t, volume.Close())
+	assert.NoFileExists(t, lock.Path())
+	locked, err = lock.TryLock()
+	assert.True(t, locked)
+	assert.NoError(t, err)
+	assert.NoError(t, lock.Unlock())
+
+	// Check logs
+	tc.AssertLogs(`
+INFO  opening volume "%s"
+INFO  generated volume ID "%s"
+INFO  opened volume
+INFO  closing volume
+INFO  closed volume
+`)
+}
+
+// TestOpenVolume_LoadVolumeID tests that the volume ID is loaded from the file if it exists.
+func TestOpenVolume_LoadVolumeID(t *testing.T) {
+	t.Parallel()
+	tc := newVolumeTestCase(t)
+
+	// Write volume ID file
+	idFilePath := filepath.Join(tc.VolumePath, local.VolumeIDFile)
+	writeContent := []byte("  123456789  ")
+	require.NoError(t, os.WriteFile(idFilePath, writeContent, 0o0640))
+
+	// Open volume - it loads the file
+	volume, err := tc.OpenVolume()
+	require.NoError(t, err)
+
+	// Volume ID reported by the volume instance match the file content
+	assert.Equal(t, storage.VolumeID("123456789"), volume.VolumeID())
+
+	// File content remains same
+	if assert.FileExists(t, idFilePath) {
+		content, err := os.ReadFile(idFilePath)
+		assert.NoError(t, err)
+		assert.Equal(t, writeContent, content)
+	}
+
+	// Lock is locked by the volume
+	lock := flock.New(filepath.Join(tc.VolumePath, lockFile))
+	locked, err := lock.TryLock()
+	assert.False(t, locked)
+	assert.NoError(t, err)
+
+	// Lock is release by Close method
+	assert.NoError(t, volume.Close())
+	assert.NoFileExists(t, lock.Path())
+	locked, err = lock.TryLock()
+	assert.True(t, locked)
+	assert.NoError(t, err)
+	assert.NoError(t, lock.Unlock())
+
+	// Check logs
+	tc.AssertLogs(`
+INFO  opening volume "%s"
+INFO  opened volume
+INFO  closing volume
+INFO  closed volume
+`)
+}
+
+// TestOpenVolume_VolumeLock tests that only one volume instance can be active at a time.
+func TestOpenVolume_VolumeLock(t *testing.T) {
+	t.Parallel()
+	tc := newVolumeTestCase(t)
+
+	// Open volume - first instance - ok
+	_, err := tc.OpenVolume()
+	assert.NoError(t, err)
+
+	// Open volume - second instance - error
+	_, err = tc.OpenVolume()
+	if assert.Error(t, err) {
+		wildcards.Assert(t, `cannot acquire writer lock "%s": already locked`, err.Error())
+	}
+}
+
+type volumeTestCase struct {
+	T          testing.TB
+	Ctx        context.Context
+	Logger     log.DebugLogger
+	Clock      *clock.Mock
+	VolumePath string
+}
+
+func newVolumeTestCase(t testing.TB) *volumeTestCase {
+	ctx, cancel := context.WithTimeout(context.Background(), 10*time.Second)
+	t.Cleanup(func() {
+		cancel()
+	})
+
+	logger := log.NewDebugLogger()
+	tmpDir := t.TempDir()
+
+	return &volumeTestCase{
+		T:          t,
+		Ctx:        ctx,
+		Logger:     logger,
+		Clock:      clock.NewMock(),
+		VolumePath: tmpDir,
+	}
+}
+
+func (tc *volumeTestCase) OpenVolume(opts ...Option) (*Volume, error) {
+	return OpenVolume(tc.Ctx, tc.Logger, tc.Clock, tc.VolumePath, opts...)
+}
+
+func (tc *volumeTestCase) AssertLogs(expected string) bool {
+	return wildcards.Assert(tc.T, strings.TrimSpace(expected), strings.TrimSpace(tc.Logger.AllMessages()))
+}


### PR DESCRIPTION
Jira: https://keboola.atlassian.net/browse/PSGO-285

Changes:
- Added `storage/local/reader.OpenVolume` function.
- Added `storage/local/writer.OpenVolume` function.

--------------

Coverage nie je `100%`, zlozito by sa simulovali chyby vo filesystem locks.

![image](https://github.com/keboola/keboola-as-code/assets/19371734/7124e017-03f9-434e-aec5-253b55465473)

----------------