### PR TITLE
Add local/writer/csv + benchmarks

### DIFF
--- a/internal/pkg/service/buffer/storage/local/writer/base/base.go
+++ b/internal/pkg/service/buffer/storage/local/writer/base/base.go
@@ -1,19 +1,14 @@
 package base
 
 import (
-	"bufio"
 	"github.com/benbjohnson/clock"
-	"github.com/c2h5oh/datasize"
 	"github.com/keboola/keboola-as-code/internal/pkg/log"
 	"github.com/keboola/keboola-as-code/internal/pkg/service/buffer/storage"
 	"github.com/keboola/keboola-as-code/internal/pkg/service/buffer/storage/compression"
 	"github.com/keboola/keboola-as-code/internal/pkg/service/buffer/storage/local/writer/disksync"
 	"github.com/keboola/keboola-as-code/internal/pkg/service/buffer/storage/local/writer/writechain"
 	"github.com/keboola/keboola-as-code/internal/pkg/service/buffer/store/model/column"
-	"io"
 )
-
-const fileBufferSize = 64 * datasize.KB
 
 type chain = writechain.Chain
 
@@ -29,7 +24,7 @@ type Writer struct {
 }
 
 func NewWriter(logger log.Logger, clock clock.Clock, slice *storage.Slice, dirPath string, filePath string, chain *writechain.Chain) *Writer {
-	w := &Writer{
+	return &Writer{
 		chain:    chain,
 		syncer:   disksync.NewSyncer(logger, clock, slice.LocalStorage.Sync, chain),
 		logger:   logger,
@@ -37,13 +32,6 @@ func NewWriter(logger log.Logger, clock clock.Clock, slice *storage.Slice, dirPa
 		dirPath:  dirPath,
 		filePath: filePath,
 	}
-
-	// Add a small buffer before the file
-	w.chain.PrependWriter(func(writer writechain.Writer) io.Writer {
-		return bufio.NewWriterSize(writer, int(fileBufferSize.Bytes()))
-	})
-
-	return w
 }
 
 func (w *Writer) Logger() log.Logger {

--- a/internal/pkg/service/buffer/storage/local/writer/config.go
+++ b/internal/pkg/service/buffer/storage/local/writer/config.go
@@ -11,7 +11,8 @@ type Option func(config *config)
 
 func newConfig(opts []Option) config {
 	cfg := config{
-		allocator: allocate.DefaultAllocator{},
+		allocator:     allocate.DefaultAllocator{},
+		writerFactory: DefaultFactory,
 	}
 
 	for _, o := range opts {

--- a/internal/pkg/service/buffer/storage/local/writer/count/counter.go
+++ b/internal/pkg/service/buffer/storage/local/writer/count/counter.go
@@ -1,0 +1,103 @@
+// Package count provides a counter with backup to a file.
+package count
+
+import (
+	"github.com/keboola/keboola-as-code/internal/pkg/utils/errors"
+	"github.com/keboola/keboola-as-code/internal/pkg/utils/strhelper"
+	"go.uber.org/atomic"
+	"io"
+	"os"
+	"strconv"
+	"strings"
+)
+
+// Counter is an atomic counter.
+type Counter struct {
+	value *atomic.Uint64
+}
+
+// CounterWithBackup in addition to Counter allows to read and save the counter value to a backup file.
+type CounterWithBackup struct {
+	*Counter
+	backup backup
+}
+
+// backup interface contains used methods from *os.File.
+type backup interface {
+	Read(p []byte) (n int, err error)
+	Write(p []byte) (n int, err error)
+	Seek(offset int64, whence int) (ret int64, err error)
+	Close() error
+}
+
+func NewCounter() *Counter {
+	return &Counter{value: atomic.NewUint64(0)}
+}
+
+func NewCounterWithBackupFile(filePath string) (*CounterWithBackup, error) {
+	backupFile, err := os.OpenFile(filePath, os.O_CREATE|os.O_RDWR, 0o640)
+	if err != nil {
+		return nil, err
+	}
+
+	return NewCounterWithBackup(backupFile)
+}
+
+func NewCounterWithBackup(backup backup) (*CounterWithBackup, error) {
+	// Read value
+	buffer := make([]byte, 32)
+	n, err := io.ReadFull(backup, buffer)
+	if err != nil && !errors.Is(err, io.EOF) && !errors.Is(err, io.ErrUnexpectedEOF) {
+		return nil, errors.Errorf(`cannot read from the backup file: %w`, err)
+	}
+
+	// Parse value
+	var value uint64
+	content := string(buffer[0:n])
+	if content != "" {
+		value, err = strconv.ParseUint(strings.TrimSpace(content), 10, 64)
+		if err != nil {
+			content = strhelper.Truncate(content, 20, "...")
+			return nil, errors.Errorf(`content "%s" of the backup file is not valid uint64`, content)
+		}
+	}
+
+	// Create writer and set the counter value
+	c := &CounterWithBackup{Counter: NewCounter(), backup: backup}
+	c.value.Store(value)
+	return c, nil
+}
+
+func (c *Counter) Add(n uint64) uint64 {
+	return c.value.Add(n)
+}
+
+func (c *Counter) Count() uint64 {
+	return c.value.Load()
+}
+
+func (c *CounterWithBackup) Flush() error {
+	// Seek to the beginning of the file
+	// The size counter can only grow, so it guarantees that the entire file will be overwritten.
+	if _, err := c.backup.Seek(0, io.SeekStart); err != nil {
+		return errors.Errorf(`cannot seek the backup file: %w`, err)
+	}
+
+	if _, err := c.backup.Write([]byte(strconv.FormatUint(c.value.Load(), 10))); err != nil {
+		return errors.Errorf(`cannot write to the backup file: %w`, err)
+	}
+
+	return nil
+}
+
+func (c *CounterWithBackup) Close() error {
+	if err := c.Flush(); err != nil {
+		return err
+	}
+
+	if err := c.backup.Close(); err != nil {
+		return errors.Errorf(`cannot close the backup file: %w`, err)
+	}
+
+	return nil
+}

--- a/internal/pkg/service/buffer/storage/local/writer/count/counter_test.go
+++ b/internal/pkg/service/buffer/storage/local/writer/count/counter_test.go
@@ -1,0 +1,205 @@
+package count
+
+import (
+	"bytes"
+	"github.com/keboola/keboola-as-code/internal/pkg/utils/errors"
+	"github.com/stretchr/testify/assert"
+	"io"
+	"os"
+	"path/filepath"
+	"testing"
+)
+
+func TestCounter(t *testing.T) {
+	t.Parallel()
+
+	c := NewCounter()
+
+	// Empty
+	assert.Equal(t, uint64(0), c.Count())
+
+	// Empty
+	assert.Equal(t, uint64(0), c.Count())
+
+	// Add 0
+	c.Add(0)
+	assert.Equal(t, uint64(0), c.Count())
+
+	// Add 3
+	c.Add(3)
+	assert.Equal(t, uint64(3), c.Count())
+
+	// Add 2
+	c.Add(2)
+	assert.Equal(t, uint64(5), c.Count())
+}
+
+func TestMeterWithBackup(t *testing.T) {
+	t.Parallel()
+
+	backupPath := filepath.Join(t.TempDir(), "backup")
+	m, err := NewCounterWithBackupFile(backupPath)
+	assert.NoError(t, err)
+
+	// Empty
+	assert.Equal(t, uint64(0), m.Count())
+
+	// Add 0
+	m.Add(0)
+	assert.Equal(t, uint64(0), m.Count())
+
+	// Add 3
+	m.Add(3)
+	assert.Equal(t, uint64(3), m.Count())
+
+	// Add 2
+	m.Add(2)
+	assert.Equal(t, uint64(5), m.Count())
+
+	// Flush backup
+	assert.NoError(t, m.Flush())
+	content, err := os.ReadFile(backupPath)
+	assert.NoError(t, err)
+	assert.Equal(t, "5", string(content))
+
+	// Add 4
+	m.Add(4)
+	assert.Equal(t, uint64(9), m.Count())
+
+	// Close (flush backup)
+	assert.NoError(t, m.Close())
+	content, err = os.ReadFile(backupPath)
+	assert.NoError(t, err)
+	assert.Equal(t, "9", string(content))
+
+	// Reopen - load from backup
+	m, err = NewCounterWithBackupFile(backupPath)
+	assert.NoError(t, err)
+	assert.Equal(t, uint64(9), m.Count())
+
+	// Add 6
+	m.Add(6)
+	assert.Equal(t, uint64(15), m.Count())
+
+	// Close
+	assert.NoError(t, m.Close())
+	content, err = os.ReadFile(backupPath)
+	assert.NoError(t, err)
+	assert.Equal(t, "15", string(content))
+}
+
+func TestMeterWithBackup_OpenError_Missing(t *testing.T) {
+	t.Parallel()
+
+	// Read error
+	_, err := NewCounterWithBackupFile("/missing/file")
+	assert.Error(t, err)
+}
+
+func TestMeterWithBackup_OpenError_Invalid(t *testing.T) {
+	t.Parallel()
+
+	backupPath := filepath.Join(t.TempDir(), "backup")
+	assert.NoError(t, os.WriteFile(backupPath, []byte("foo"), 0o640))
+
+	_, err := NewCounterWithBackupFile(backupPath)
+	if assert.Error(t, err) {
+		assert.Equal(t, `content "foo" of the backup file is not valid uint64`, err.Error())
+	}
+}
+
+func TestMeterWithBackup_ReadError(t *testing.T) {
+	t.Parallel()
+
+	// Read error
+	backupBuf := &testBuffer{}
+	backupBuf.readError = errors.New("some read error")
+	_, err := NewCounterWithBackup(backupBuf)
+	if assert.Error(t, err) {
+		assert.Equal(t, "cannot read from the backup file: some read error", err.Error())
+	}
+}
+
+func TestMeterWithBackup_FlushError(t *testing.T) {
+	t.Parallel()
+
+	backupBuf := &testBuffer{}
+	m, err := NewCounterWithBackup(backupBuf)
+	assert.NoError(t, err)
+
+	// Seek error
+	backupBuf.seekError = errors.New("some seek error")
+	err = m.Flush()
+	if assert.Error(t, err) {
+		assert.Equal(t, "cannot seek the backup file: some seek error", err.Error())
+	}
+
+	// Write error
+	backupBuf.seekError = nil
+	backupBuf.writeError = errors.New("some write error")
+	err = m.Flush()
+	if assert.Error(t, err) {
+		assert.Equal(t, "cannot write to the backup file: some write error", err.Error())
+	}
+}
+
+func TestMeterWithBackup_CloseError(t *testing.T) {
+	t.Parallel()
+
+	backupBuf := &testBuffer{}
+	m, err := NewCounterWithBackup(backupBuf)
+	assert.NoError(t, err)
+
+	// Write error
+	backupBuf.writeError = errors.New("some write error")
+	err = m.Close()
+	if assert.Error(t, err) {
+		assert.Equal(t, "cannot write to the backup file: some write error", err.Error())
+	}
+
+	// Close error
+	backupBuf.writeError = nil
+	backupBuf.closeError = errors.New("some close error")
+	err = m.Close()
+	if assert.Error(t, err) {
+		assert.Equal(t, "cannot close the backup file: some close error", err.Error())
+	}
+}
+
+type testBuffer struct {
+	bytes.Buffer
+	readError  error
+	seekError  error
+	writeError error
+	closeError error
+}
+
+func (w *testBuffer) Seek(offset int64, whence int) (ret int64, err error) {
+	if w.seekError != nil {
+		return 0, w.seekError
+	}
+	if offset == 0 && whence == io.SeekStart {
+		w.Buffer.Reset()
+	} else {
+		panic(errors.New("unexpected seek"))
+	}
+	return 0, nil
+}
+
+func (w *testBuffer) Read(p []byte) (n int, err error) {
+	if w.readError != nil {
+		return 0, w.readError
+	}
+	return w.Buffer.Read(p)
+}
+
+func (w *testBuffer) Write(p []byte) (int, error) {
+	if w.writeError != nil {
+		return 0, w.writeError
+	}
+	return w.Buffer.Write(p)
+}
+
+func (w *testBuffer) Close() error {
+	return w.closeError
+}

--- a/internal/pkg/service/buffer/storage/local/writer/csv/csv.go
+++ b/internal/pkg/service/buffer/storage/local/writer/csv/csv.go
@@ -1,0 +1,170 @@
+package csv
+
+import (
+	"encoding/csv"
+	"github.com/c2h5oh/datasize"
+	"github.com/keboola/keboola-as-code/internal/pkg/service/buffer/storage"
+	compressionWriter "github.com/keboola/keboola-as-code/internal/pkg/service/buffer/storage/compression/writer"
+	"github.com/keboola/keboola-as-code/internal/pkg/service/buffer/storage/local/writer/base"
+	"github.com/keboola/keboola-as-code/internal/pkg/service/buffer/storage/local/writer/count"
+	"github.com/keboola/keboola-as-code/internal/pkg/service/buffer/storage/local/writer/size"
+	"github.com/keboola/keboola-as-code/internal/pkg/service/buffer/storage/local/writer/writechain"
+	"github.com/keboola/keboola-as-code/internal/pkg/service/buffer/store/model/column"
+	"github.com/keboola/keboola-as-code/internal/pkg/utils/errors"
+	"github.com/spf13/cast"
+	"io"
+	"path/filepath"
+	"sync"
+)
+
+const (
+	rowsCounterFile      = "rows_count"
+	compressedSizeFile   = "compressed_size"
+	uncompressedSizeFile = "uncompressed_size"
+)
+
+type Writer struct {
+	base    *base.Writer
+	columns column.Columns
+	// csvWriter writers to the Chain in the baseWriter.
+	csvWriter *csv.Writer
+	// csvWriterLock serializes writes to the internal csv.Writer buffer
+	csvWriterLock *sync.Mutex
+	// rowsCounter counts successfully written rows.
+	rowsCounter *count.CounterWithBackup
+	// compressedMeter measures size of the data after compression, if any.
+	compressedMeter *size.MeterWithBackup
+	// uncompressedMeter measures size of the data before compression, if any.
+	uncompressedMeter *size.MeterWithBackup
+}
+
+func NewWriter(b *base.Writer) (w *Writer, err error) {
+	w = &Writer{
+		base:          b,
+		columns:       b.Columns(),
+		csvWriterLock: &sync.Mutex{},
+	}
+
+	// Measure size of compressed data
+	_, err = w.base.PrependWriterOrErr(func(writer writechain.Writer) (out io.Writer, err error) {
+		w.compressedMeter, err = size.NewMeterWithBackupFile(writer, filepath.Join(w.base.DirPath(), compressedSizeFile))
+		return w.compressedMeter, err
+	})
+	if err != nil {
+		return nil, err
+	}
+
+	// Add compression, if a compression writer is created, the method returns true
+	compression, err := w.base.PrependWriterOrErr(func(writer writechain.Writer) (io.Writer, error) {
+		return compressionWriter.New(writer, w.base.Compression())
+	})
+	if err != nil {
+		return nil, err
+	}
+
+	// Measure size of uncompressed CSV data
+	if compression {
+		_, err = w.base.PrependWriterOrErr(func(writer writechain.Writer) (_ io.Writer, err error) {
+			w.uncompressedMeter, err = size.NewMeterWithBackupFile(writer, filepath.Join(w.base.DirPath(), uncompressedSizeFile))
+			return w.uncompressedMeter, err
+		})
+		if err != nil {
+			return nil, err
+		}
+	} else {
+		// Size of the compressed and uncompressed data is same
+		w.uncompressedMeter = w.compressedMeter
+	}
+
+	// Setup rows counter
+	w.rowsCounter, err = count.NewCounterWithBackupFile(filepath.Join(w.base.DirPath(), rowsCounterFile))
+	if err == nil {
+		// Backup the counter value on Flush and Close
+		w.base.PrependFlusherCloser(w.rowsCounter)
+	} else {
+		return nil, err
+	}
+
+	// Setup CSV writer
+	w.csvWriter = csv.NewWriter(w.base)
+	w.base.PrependFlushFn(w.csvWriter, func() error {
+		w.csvWriterLock.Lock()
+		w.csvWriter.Flush()
+		err = w.csvWriter.Error()
+		w.csvWriterLock.Unlock()
+		return err
+	})
+
+	return w, nil
+}
+
+func (w *Writer) WriteRow(values []any) error {
+	// Check values count
+	if len(values) != len(w.columns) {
+		return errors.Errorf(`expected %d columns in the row, given %d`, len(w.columns), len(values))
+	}
+
+	// Cast all values to string
+	var err error
+	strings := make([]string, len(w.columns))
+	for i, v := range values {
+		if strings[i], err = cast.ToStringE(v); err != nil {
+			columnName := w.columns[i].ColumnName()
+			return errors.Errorf(`cannot convert value of the column "%s" to the string: %w`, columnName, err)
+		}
+	}
+
+	// Write CSV row
+	// This WriteRow method can be called multiple times in parallel.
+	// One write to the CSV Writer invokes multiple writes to the underlying writers,
+	// so a lock must be used to prevent data mix-up.
+	notifier, err := w.base.DoWithNotify(func() error {
+		w.csvWriterLock.Lock()
+		err = w.csvWriter.Write(strings)
+		w.csvWriterLock.Unlock()
+		w.base.AddWriteOp(1)
+		return err
+	})
+
+	// Return writer error
+	if err != nil {
+		return err
+	}
+
+	// Wait for sync to disk, return sync error, if any
+	err = notifier.Wait()
+	if err != nil {
+		return err
+	}
+
+	w.rowsCounter.Add(1)
+	return nil
+}
+
+func (w *Writer) RowsCount() uint64 {
+	return w.rowsCounter.Count()
+}
+
+func (w *Writer) CompressedSize() datasize.ByteSize {
+	return w.compressedMeter.Size()
+}
+
+func (w *Writer) UncompressedSize() datasize.ByteSize {
+	return w.uncompressedMeter.Size()
+}
+
+func (w *Writer) SliceKey() storage.SliceKey {
+	return w.base.SliceKey()
+}
+
+func (w *Writer) DirPath() string {
+	return w.base.DirPath()
+}
+
+func (w *Writer) FilePath() string {
+	return w.base.FilePath()
+}
+
+func (w *Writer) Close() error {
+	return w.base.Close()
+}

--- a/internal/pkg/service/buffer/storage/local/writer/csv/csv.svg
+++ b/internal/pkg/service/buffer/storage/local/writer/csv/csv.svg
@@ -1,0 +1,5028 @@
+<?xml version="1.0" encoding="UTF-8" standalone="no"?>
+<svg 
+   width="940.07996pt"
+   height="183.12pt"
+   viewBox="0 0 940.07996 183.12"
+   version="1.1"
+   id="svg1917"
+   xmlns:xlink="http://www.w3.org/1999/xlink"
+   xmlns="http://www.w3.org/2000/svg"
+   xmlns:svg="http://www.w3.org/2000/svg" content="%3Cmxfile%20host%3D%22app.diagrams.net%22%20modified%3D%222023-09-02T06%3A44%3A28.310Z%22%20agent%3D%22Mozilla%2F5.0%20(X11%3B%20Linux%20x86_64)%20AppleWebKit%2F537.36%20(KHTML%2C%20like%20Gecko)%20Chrome%2F116.0.0.0%20Safari%2F537.36%22%20version%3D%2221.7.1%22%20etag%3D%22oIzER6VxMNoYQEckMiSM%22%20type%3D%22google%22%3E%20%20%20%3Cdiagram%20name%3D%22Page-1%22%20id%3D%222sl53pGc-cbV1IV_ghaV%22%3E%20%20%20%20%20%3CmxGraphModel%20dx%3D%222607%22%20dy%3D%221654%22%20grid%3D%221%22%20gridSize%3D%2210%22%20guides%3D%221%22%20tooltips%3D%221%22%20connect%3D%221%22%20arrows%3D%221%22%20fold%3D%221%22%20page%3D%221%22%20pageScale%3D%221%22%20pageWidth%3D%22827%22%20pageHeight%3D%221169%22%20math%3D%220%22%20shadow%3D%220%22%3E%20%20%20%20%20%20%20%3Croot%3E%20%20%20%20%20%20%20%20%20%3CmxCell%20id%3D%220%22%20%2F%3E%20%20%20%20%20%20%20%20%20%3CmxCell%20id%3D%221%22%20parent%3D%220%22%20%2F%3E%20%20%20%20%20%20%20%20%20%3CmxCell%20id%3D%222%22%20value%3D%22%22%20style%3D%22rounded%3D0%3BwhiteSpace%3Dwrap%3Bhtml%3D1%3BfillColor%3Ddefault%3BstrokeColor%3Dnone%3B%22%20vertex%3D%221%22%20parent%3D%221%22%3E%20%20%20%20%20%20%20%20%20%20%20%3CmxGeometry%20x%3D%22-724%22%20y%3D%221470%22%20width%3D%221252%22%20height%3D%22241%22%20as%3D%22geometry%22%20%2F%3E%20%20%20%20%20%20%20%20%20%3C%2FmxCell%3E%20%20%20%20%20%20%20%20%20%3CmxCell%20id%3D%223%22%20value%3D%22%26lt%3Bfont%20style%3D%26quot%3Bfont-size%3A%2010px%3B%26quot%3B%26gt%3Bwritechain.Chain%26lt%3B%2Ffont%26gt%3B%22%20style%3D%22text%3Bhtml%3D1%3Balign%3Dleft%3BverticalAlign%3Dmiddle%3BwhiteSpace%3Dwrap%3Brounded%3D0%3BfontStyle%3D0%3BfontSize%3D10%3B%22%20vertex%3D%221%22%20parent%3D%221%22%3E%20%20%20%20%20%20%20%20%20%20%20%3CmxGeometry%20x%3D%22-254.25%22%20y%3D%221482%22%20width%3D%22110%22%20height%3D%2219%22%20as%3D%22geometry%22%20%2F%3E%20%20%20%20%20%20%20%20%20%3C%2FmxCell%3E%20%20%20%20%20%20%20%20%20%3CmxCell%20id%3D%224%22%20value%3D%22%22%20style%3D%22rounded%3D0%3BwhiteSpace%3Dwrap%3Bhtml%3D1%3BstrokeWidth%3D2%3B%22%20vertex%3D%221%22%20parent%3D%221%22%3E%20%20%20%20%20%20%20%20%20%20%20%3CmxGeometry%20x%3D%22-254.25%22%20y%3D%221506%22%20width%3D%22522.5%22%20height%3D%2285%22%20as%3D%22geometry%22%20%2F%3E%20%20%20%20%20%20%20%20%20%3C%2FmxCell%3E%20%20%20%20%20%20%20%20%20%3CmxCell%20id%3D%225%22%20value%3D%22OS%20%26lt%3Bbr%20style%3D%26quot%3Bfont-size%3A%2010px%3B%26quot%3B%26gt%3Bdisk%20%26lt%3Bbr%20style%3D%26quot%3Bfont-size%3A%2010px%3B%26quot%3B%26gt%3Bcache%22%20style%3D%22rounded%3D0%3BwhiteSpace%3Dwrap%3Bhtml%3D1%3BverticalAlign%3Dmiddle%3BfontStyle%3D1%3BfontSize%3D10%3BfillColor%3D%23f5f5f5%3BfontColor%3D%23333333%3BstrokeColor%3D%23666666%3B%22%20vertex%3D%221%22%20parent%3D%221%22%3E%20%20%20%20%20%20%20%20%20%20%20%3CmxGeometry%20x%3D%22332.3499999999999%22%20y%3D%221517%22%20width%3D%2260%22%20height%3D%2260%22%20as%3D%22geometry%22%20%2F%3E%20%20%20%20%20%20%20%20%20%3C%2FmxCell%3E%20%20%20%20%20%20%20%20%20%3CmxCell%20id%3D%226%22%20style%3D%22edgeStyle%3DorthogonalEdgeStyle%3Brounded%3D0%3BorthogonalLoop%3D1%3BjettySize%3Dauto%3Bhtml%3D1%3BexitX%3D1%3BexitY%3D0.25%3BexitDx%3D0%3BexitDy%3D0%3BentryX%3D0%3BentryY%3D0.25%3BentryDx%3D0%3BentryDy%3D0%3BendArrow%3Dblock%3BendFill%3D1%3B%22%20edge%3D%221%22%20source%3D%224%22%20target%3D%225%22%20parent%3D%221%22%3E%20%20%20%20%20%20%20%20%20%20%20%3CmxGeometry%20relative%3D%221%22%20as%3D%22geometry%22%3E%20%20%20%20%20%20%20%20%20%20%20%20%20%3CArray%20as%3D%22points%22%3E%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%3CmxPoint%20x%3D%22268%22%20y%3D%221532%22%20%2F%3E%20%20%20%20%20%20%20%20%20%20%20%20%20%3C%2FArray%3E%20%20%20%20%20%20%20%20%20%20%20%3C%2FmxGeometry%3E%20%20%20%20%20%20%20%20%20%3C%2FmxCell%3E%20%20%20%20%20%20%20%20%20%3CmxCell%20id%3D%227%22%20value%3D%22disk%22%20style%3D%22rounded%3D0%3BwhiteSpace%3Dwrap%3Bhtml%3D1%3BverticalAlign%3Dmiddle%3BfontStyle%3D1%3BfontSize%3D10%3BfillColor%3D%23f5f5f5%3BfontColor%3D%23333333%3BstrokeColor%3D%23666666%3B%22%20vertex%3D%221%22%20parent%3D%221%22%3E%20%20%20%20%20%20%20%20%20%20%20%3CmxGeometry%20x%3D%22451.31999999999994%22%20y%3D%221517%22%20width%3D%2258.68%22%20height%3D%2260%22%20as%3D%22geometry%22%20%2F%3E%20%20%20%20%20%20%20%20%20%3C%2FmxCell%3E%20%20%20%20%20%20%20%20%20%3CmxCell%20id%3D%228%22%20style%3D%22edgeStyle%3DorthogonalEdgeStyle%3Brounded%3D0%3BorthogonalLoop%3D1%3BjettySize%3Dauto%3Bhtml%3D1%3BexitX%3D1%3BexitY%3D0.25%3BexitDx%3D0%3BexitDy%3D0%3BentryX%3D0%3BentryY%3D0.25%3BentryDx%3D0%3BentryDy%3D0%3BstrokeWidth%3D2%3BstrokeColor%3D%23009900%3BendArrow%3Dblock%3BendFill%3D1%3B%22%20edge%3D%221%22%20source%3D%225%22%20target%3D%227%22%20parent%3D%221%22%3E%20%20%20%20%20%20%20%20%20%20%20%3CmxGeometry%20relative%3D%221%22%20as%3D%22geometry%22%20%2F%3E%20%20%20%20%20%20%20%20%20%3C%2FmxCell%3E%20%20%20%20%20%20%20%20%20%3CmxCell%20id%3D%229%22%20value%3D%22file.Sync%22%20style%3D%22edgeLabel%3Bhtml%3D1%3Balign%3Dcenter%3BverticalAlign%3Dmiddle%3Bresizable%3D0%3Bpoints%3D%5B%5D%3BfontSize%3D10%3BfontStyle%3D1%3BfontColor%3D%23009900%3B%22%20vertex%3D%221%22%20connectable%3D%220%22%20parent%3D%228%22%3E%20%20%20%20%20%20%20%20%20%20%20%3CmxGeometry%20x%3D%22-0.1569%22%20y%3D%22-1%22%20relative%3D%221%22%20as%3D%22geometry%22%3E%20%20%20%20%20%20%20%20%20%20%20%20%20%3CmxPoint%20x%3D%223%22%20y%3D%227%22%20as%3D%22offset%22%20%2F%3E%20%20%20%20%20%20%20%20%20%20%20%3C%2FmxGeometry%3E%20%20%20%20%20%20%20%20%20%3C%2FmxCell%3E%20%20%20%20%20%20%20%20%20%3CmxCell%20id%3D%2210%22%20value%3D%22file.Write%22%20style%3D%22edgeLabel%3Bhtml%3D1%3Balign%3Dcenter%3BverticalAlign%3Dmiddle%3Bresizable%3D0%3Bpoints%3D%5B%5D%3BfontSize%3D10%3B%22%20connectable%3D%220%22%20vertex%3D%221%22%20parent%3D%221%22%3E%20%20%20%20%20%20%20%20%20%20%20%3CmxGeometry%20x%3D%22296.9970588235293%22%20y%3D%221540%22%20as%3D%22geometry%22%20%2F%3E%20%20%20%20%20%20%20%20%20%3C%2FmxCell%3E%20%20%20%20%20%20%20%20%20%3CmxCell%20id%3D%2211%22%20value%3D%22%26lt%3Bspan%20style%3D%26quot%3Bfont-weight%3A%20normal%3B%26quot%3B%26gt%3Bslice%26lt%3B%2Fspan%26gt%3B%26lt%3Bbr%26gt%3BFile%22%20style%3D%22rounded%3D0%3BwhiteSpace%3Dwrap%3Bhtml%3D1%3BverticalAlign%3Dmiddle%3BfontStyle%3D1%3BspacingTop%3D0%3BfontSize%3D10%3BfillColor%3D%23fff2cc%3BstrokeColor%3D%23d6b656%3B%22%20vertex%3D%221%22%20parent%3D%221%22%3E%20%20%20%20%20%20%20%20%20%20%20%3CmxGeometry%20x%3D%22200%22%20y%3D%221517%22%20width%3D%2260%22%20height%3D%2260%22%20as%3D%22geometry%22%20%2F%3E%20%20%20%20%20%20%20%20%20%3C%2FmxCell%3E%20%20%20%20%20%20%20%20%20%3CmxCell%20id%3D%2212%22%20value%3D%22buffer%22%20style%3D%22rounded%3D0%3BwhiteSpace%3Dwrap%3Bhtml%3D1%3BverticalAlign%3Dmiddle%3BfontStyle%3D1%3BspacingTop%3D0%3BfontSize%3D10%3B%22%20vertex%3D%221%22%20parent%3D%221%22%3E%20%20%20%20%20%20%20%20%20%20%20%3CmxGeometry%20x%3D%22130%22%20y%3D%221517%22%20width%3D%2260%22%20height%3D%2260%22%20as%3D%22geometry%22%20%2F%3E%20%20%20%20%20%20%20%20%20%3C%2FmxCell%3E%20%20%20%20%20%20%20%20%20%3CmxCell%20id%3D%2213%22%20value%3D%22rows%26lt%3Bbr%26gt%3Bcounter%26lt%3Bbr%26gt%3Bflush%20fn%22%20style%3D%22rounded%3D0%3BwhiteSpace%3Dwrap%3Bhtml%3D1%3BverticalAlign%3Dmiddle%3BfontStyle%3D1%3BspacingTop%3D0%3BfontSize%3D10%3Bdashed%3D1%3BfillColor%3D%23dae8fc%3BstrokeColor%3D%236c8ebf%3B%22%20vertex%3D%221%22%20parent%3D%221%22%3E%20%20%20%20%20%20%20%20%20%20%20%3CmxGeometry%20x%3D%22-170%22%20y%3D%221517%22%20width%3D%2260%22%20height%3D%2260%22%20as%3D%22geometry%22%20%2F%3E%20%20%20%20%20%20%20%20%20%3C%2FmxCell%3E%20%20%20%20%20%20%20%20%20%3CmxCell%20id%3D%2214%22%20value%3D%22%26lt%3Bbr%26gt%3Bcompression%26lt%3Bbr%26gt%3Bwriter%22%20style%3D%22rounded%3D0%3BwhiteSpace%3Dwrap%3Bhtml%3D1%3BverticalAlign%3Dtop%3BfontStyle%3D1%3BspacingTop%3D0%3BfontSize%3D10%3BfillColor%3D%23dae8fc%3BstrokeColor%3D%236c8ebf%3B%22%20vertex%3D%221%22%20parent%3D%221%22%3E%20%20%20%20%20%20%20%20%20%20%20%3CmxGeometry%20x%3D%22-30%22%20y%3D%221517%22%20width%3D%2280%22%20height%3D%2260%22%20as%3D%22geometry%22%20%2F%3E%20%20%20%20%20%20%20%20%20%3C%2FmxCell%3E%20%20%20%20%20%20%20%20%20%3CmxCell%20id%3D%2215%22%20value%3D%22CSV%26lt%3Bbr%26gt%3Bwriter%20%26lt%3Bbr%26gt%3Bflush%20fn%22%20style%3D%22rounded%3D0%3BwhiteSpace%3Dwrap%3Bhtml%3D1%3BverticalAlign%3Dmiddle%3BfontStyle%3D1%3BspacingTop%3D0%3BfontSize%3D10%3Bdashed%3D1%3BfillColor%3D%23dae8fc%3BstrokeColor%3D%236c8ebf%3B%22%20vertex%3D%221%22%20parent%3D%221%22%3E%20%20%20%20%20%20%20%20%20%20%20%3CmxGeometry%20x%3D%22-240%22%20y%3D%221517%22%20width%3D%2260%22%20height%3D%2260%22%20as%3D%22geometry%22%20%2F%3E%20%20%20%20%20%20%20%20%20%3C%2FmxCell%3E%20%20%20%20%20%20%20%20%20%3CmxCell%20id%3D%2216%22%20value%3D%22%26lt%3Bspan%20style%3D%26quot%3Bfont-weight%3A%20normal%3B%26quot%3B%26gt%3Bsize%26lt%3B%2Fspan%26gt%3B%26lt%3Bbr%20style%3D%26quot%3Bborder-color%3A%20var(--border-color)%3B%26quot%3B%26gt%3BMeter%26lt%3Bbr%20style%3D%26quot%3Bborder-color%3A%20var(--border-color)%3B%26quot%3B%26gt%3BWith%26lt%3Bbr%20style%3D%26quot%3Bborder-color%3A%20var(--border-color)%3B%26quot%3B%26gt%3BBackup%22%20style%3D%22rounded%3D0%3BwhiteSpace%3Dwrap%3Bhtml%3D1%3BverticalAlign%3Dmiddle%3BfontStyle%3D1%3BspacingTop%3D0%3BfontSize%3D10%3BfillColor%3D%23dae8fc%3BstrokeColor%3D%236c8ebf%3B%22%20vertex%3D%221%22%20parent%3D%221%22%3E%20%20%20%20%20%20%20%20%20%20%20%3CmxGeometry%20x%3D%2260%22%20y%3D%221517%22%20width%3D%2260%22%20height%3D%2260%22%20as%3D%22geometry%22%20%2F%3E%20%20%20%20%20%20%20%20%20%3C%2FmxCell%3E%20%20%20%20%20%20%20%20%20%3CmxCell%20id%3D%2217%22%20value%3D%22%26lt%3Bi%20style%3D%26quot%3Bfont-size%3A%2010px%3B%26quot%3B%26gt%3B%26lt%3Bfont%20style%3D%26quot%3Bfont-size%3A%2010px%3B%26quot%3B%26gt%3Bcompression%20is%20optional%26lt%3B%2Ffont%26gt%3B%26lt%3B%2Fi%26gt%3B%22%20style%3D%22text%3Bhtml%3D1%3BstrokeColor%3Dnone%3BfillColor%3Dnone%3Balign%3Dcenter%3BverticalAlign%3Dmiddle%3BwhiteSpace%3Dwrap%3Brounded%3D0%3BfontSize%3D10%3B%22%20vertex%3D%221%22%20parent%3D%221%22%3E%20%20%20%20%20%20%20%20%20%20%20%3CmxGeometry%20x%3D%22-92.5%22%20y%3D%221476.5%22%20width%3D%22135%22%20height%3D%2230%22%20as%3D%22geometry%22%20%2F%3E%20%20%20%20%20%20%20%20%20%3C%2FmxCell%3E%20%20%20%20%20%20%20%20%20%3CmxCell%20id%3D%2218%22%20style%3D%22edgeStyle%3DorthogonalEdgeStyle%3Brounded%3D0%3BorthogonalLoop%3D1%3BjettySize%3Dauto%3Bhtml%3D1%3BexitX%3D1%3BexitY%3D0.25%3BexitDx%3D0%3BexitDy%3D0%3BentryX%3D0%3BentryY%3D0.313%3BentryDx%3D0%3BentryDy%3D0%3BentryPerimeter%3D0%3BendArrow%3Dblock%3BendFill%3D1%3B%22%20edge%3D%221%22%20source%3D%2220%22%20target%3D%224%22%20parent%3D%221%22%3E%20%20%20%20%20%20%20%20%20%20%20%3CmxGeometry%20relative%3D%221%22%20as%3D%22geometry%22%20%2F%3E%20%20%20%20%20%20%20%20%20%3C%2FmxCell%3E%20%20%20%20%20%20%20%20%20%3CmxCell%20id%3D%2219%22%20value%3D%22Write(bytes)%22%20style%3D%22edgeLabel%3Bhtml%3D1%3Balign%3Dcenter%3BverticalAlign%3Dmiddle%3Bresizable%3D0%3Bpoints%3D%5B%5D%3BfontSize%3D10%3B%22%20vertex%3D%221%22%20connectable%3D%220%22%20parent%3D%2218%22%3E%20%20%20%20%20%20%20%20%20%20%20%3CmxGeometry%20x%3D%22-0.1607%22%20y%3D%22-2%22%20relative%3D%221%22%20as%3D%22geometry%22%3E%20%20%20%20%20%20%20%20%20%20%20%20%20%3CmxPoint%20x%3D%223%22%20y%3D%22-13%22%20as%3D%22offset%22%20%2F%3E%20%20%20%20%20%20%20%20%20%20%20%3C%2FmxGeometry%3E%20%20%20%20%20%20%20%20%20%3C%2FmxCell%3E%20%20%20%20%20%20%20%20%20%3CmxCell%20id%3D%2220%22%20value%3D%22%26lt%3Bspan%20style%3D%26quot%3Bfont-size%3A%2010px%3B%26quot%3B%26gt%3Bdisksync%26lt%3Bbr%26gt%3B%26lt%3Bb%26gt%3BSyncer%26lt%3B%2Fb%26gt%3B%26lt%3B%2Fspan%26gt%3B%22%20style%3D%22rounded%3D0%3BwhiteSpace%3Dwrap%3Bhtml%3D1%3BverticalAlign%3Dmiddle%3BfontStyle%3D0%3BspacingTop%3D0%3BfontSize%3D10%3BstrokeWidth%3D1%3BstrokeColor%3D%23b85450%3BfillColor%3D%23f8cecc%3B%22%20vertex%3D%221%22%20parent%3D%221%22%3E%20%20%20%20%20%20%20%20%20%20%20%3CmxGeometry%20x%3D%22-390%22%20y%3D%221517%22%20width%3D%2270%22%20height%3D%2264%22%20as%3D%22geometry%22%20%2F%3E%20%20%20%20%20%20%20%20%20%3C%2FmxCell%3E%20%20%20%20%20%20%20%20%20%3CmxCell%20id%3D%2221%22%20style%3D%22edgeStyle%3DelbowEdgeStyle%3Brounded%3D0%3BorthogonalLoop%3D1%3BjettySize%3Dauto%3Bhtml%3D1%3BexitX%3D1%3BexitY%3D0.25%3BexitDx%3D0%3BexitDy%3D0%3BentryX%3D0%3BentryY%3D0.25%3BentryDx%3D0%3BentryDy%3D0%3Belbow%3Dvertical%3BendArrow%3Dblock%3BendFill%3D1%3B%22%20edge%3D%221%22%20source%3D%2226%22%20target%3D%2220%22%20parent%3D%221%22%3E%20%20%20%20%20%20%20%20%20%20%20%3CmxGeometry%20relative%3D%221%22%20as%3D%22geometry%22%20%2F%3E%20%20%20%20%20%20%20%20%20%3C%2FmxCell%3E%20%20%20%20%20%20%20%20%20%3CmxCell%20id%3D%2222%22%20value%3D%22Write(bytes)%20%2F%26amp%3Bnbsp%3BAddWriteOp(1)%22%20style%3D%22edgeLabel%3Bhtml%3D1%3Balign%3Dcenter%3BverticalAlign%3Dmiddle%3Bresizable%3D0%3Bpoints%3D%5B%5D%3BfontSize%3D10%3B%22%20vertex%3D%221%22%20connectable%3D%220%22%20parent%3D%2221%22%3E%20%20%20%20%20%20%20%20%20%20%20%3CmxGeometry%20x%3D%22-0.0679%22%20relative%3D%221%22%20as%3D%22geometry%22%3E%20%20%20%20%20%20%20%20%20%20%20%20%20%3CmxPoint%20x%3D%226%22%20y%3D%22-10%22%20as%3D%22offset%22%20%2F%3E%20%20%20%20%20%20%20%20%20%20%20%3C%2FmxGeometry%3E%20%20%20%20%20%20%20%20%20%3C%2FmxCell%3E%20%20%20%20%20%20%20%20%20%3CmxCell%20id%3D%2223%22%20style%3D%22edgeStyle%3DorthogonalEdgeStyle%3Brounded%3D0%3BorthogonalLoop%3D1%3BjettySize%3Dauto%3Bhtml%3D1%3BexitX%3D0%3BexitY%3D0.25%3BexitDx%3D0%3BexitDy%3D0%3BstartArrow%3Dblock%3BstartFill%3D1%3BendArrow%3Dnone%3BendFill%3D0%3B%22%20edge%3D%221%22%20source%3D%2226%22%20parent%3D%221%22%3E%20%20%20%20%20%20%20%20%20%20%20%3CmxGeometry%20relative%3D%221%22%20as%3D%22geometry%22%3E%20%20%20%20%20%20%20%20%20%20%20%20%20%3CmxPoint%20x%3D%22-700%22%20y%3D%221531.2162162162163%22%20as%3D%22targetPoint%22%20%2F%3E%20%20%20%20%20%20%20%20%20%20%20%3C%2FmxGeometry%3E%20%20%20%20%20%20%20%20%20%3C%2FmxCell%3E%20%20%20%20%20%20%20%20%20%3CmxCell%20id%3D%2224%22%20value%3D%22WriteRow(values)%22%20style%3D%22edgeLabel%3Bhtml%3D1%3Balign%3Dcenter%3BverticalAlign%3Dmiddle%3Bresizable%3D0%3Bpoints%3D%5B%5D%3BfontSize%3D10%3B%22%20vertex%3D%221%22%20connectable%3D%220%22%20parent%3D%2223%22%3E%20%20%20%20%20%20%20%20%20%20%20%3CmxGeometry%20x%3D%220.2042%22%20y%3D%22-1%22%20relative%3D%221%22%20as%3D%22geometry%22%3E%20%20%20%20%20%20%20%20%20%20%20%20%20%3CmxPoint%20x%3D%22-1%22%20y%3D%22-10%22%20as%3D%22offset%22%20%2F%3E%20%20%20%20%20%20%20%20%20%20%20%3C%2FmxGeometry%3E%20%20%20%20%20%20%20%20%20%3C%2FmxCell%3E%20%20%20%20%20%20%20%20%20%3CmxCell%20id%3D%2225%22%20style%3D%22edgeStyle%3DorthogonalEdgeStyle%3Brounded%3D0%3BorthogonalLoop%3D1%3BjettySize%3Dauto%3Bhtml%3D1%3BexitX%3D0.853%3BexitY%3D-0.004%3BexitDx%3D0%3BexitDy%3D0%3BendArrow%3Dblock%3BendFill%3D1%3BstrokeWidth%3D2%3BstrokeColor%3D%23009900%3BexitPerimeter%3D0%3B%22%20edge%3D%221%22%20source%3D%2226%22%20parent%3D%221%22%3E%20%20%20%20%20%20%20%20%20%20%20%3CmxGeometry%20relative%3D%221%22%20as%3D%22geometry%22%3E%20%20%20%20%20%20%20%20%20%20%20%20%20%3CmxPoint%20x%3D%22-710%22%20y%3D%221497%22%20as%3D%22targetPoint%22%20%2F%3E%20%20%20%20%20%20%20%20%20%20%20%20%20%3CArray%20as%3D%22points%22%3E%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%3CmxPoint%20x%3D%22-560%22%20y%3D%221497%22%20%2F%3E%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%3CmxPoint%20x%3D%22-700%22%20y%3D%221497%22%20%2F%3E%20%20%20%20%20%20%20%20%20%20%20%20%20%3C%2FArray%3E%20%20%20%20%20%20%20%20%20%20%20%3C%2FmxGeometry%3E%20%20%20%20%20%20%20%20%20%3C%2FmxCell%3E%20%20%20%20%20%20%20%20%20%3CmxCell%20id%3D%2226%22%20value%3D%22%26lt%3Bbr%26gt%3B%26lt%3Bb%26gt%3BCSV%26lt%3B%2Fb%26gt%3B%26lt%3Bbr%26gt%3B%26lt%3Bb%26gt%3BWriter%26lt%3B%2Fb%26gt%3B%22%20style%3D%22rounded%3D0%3BwhiteSpace%3Dwrap%3Bhtml%3D1%3BverticalAlign%3Dtop%3BfontStyle%3D0%3BspacingTop%3D0%3BfontSize%3D10%3BstrokeWidth%3D1%3BstrokeColor%3D%236c8ebf%3BfillColor%3D%23dae8fc%3B%22%20vertex%3D%221%22%20parent%3D%221%22%3E%20%20%20%20%20%20%20%20%20%20%20%3CmxGeometry%20x%3D%22-620%22%20y%3D%221516.25%22%20width%3D%2270%22%20height%3D%2260.75%22%20as%3D%22geometry%22%20%2F%3E%20%20%20%20%20%20%20%20%20%3C%2FmxCell%3E%20%20%20%20%20%20%20%20%20%3CmxCell%20id%3D%2227%22%20value%3D%22buffer%22%20style%3D%22rounded%3D0%3BwhiteSpace%3Dwrap%3Bhtml%3D1%3BfontSize%3D10%3BfillColor%3D%23f5f5f5%3BfontColor%3D%23333333%3BstrokeColor%3D%23666666%3Bopacity%3D70%3B%22%20vertex%3D%221%22%20parent%3D%221%22%3E%20%20%20%20%20%20%20%20%20%20%20%3CmxGeometry%20x%3D%22-15%22%20y%3D%221562%22%20width%3D%2250%22%20height%3D%2215%22%20as%3D%22geometry%22%20%2F%3E%20%20%20%20%20%20%20%20%20%3C%2FmxCell%3E%20%20%20%20%20%20%20%20%20%3CmxCell%20id%3D%2228%22%20value%3D%22buffer%22%20style%3D%22rounded%3D0%3BwhiteSpace%3Dwrap%3Bhtml%3D1%3BfontSize%3D10%3BfillColor%3D%23f5f5f5%3BfontColor%3D%23333333%3BstrokeColor%3D%23666666%3Bopacity%3D70%3B%22%20vertex%3D%221%22%20parent%3D%221%22%3E%20%20%20%20%20%20%20%20%20%20%20%3CmxGeometry%20x%3D%22-610%22%20y%3D%221562%22%20width%3D%2250%22%20height%3D%2215%22%20as%3D%22geometry%22%20%2F%3E%20%20%20%20%20%20%20%20%20%3C%2FmxCell%3E%20%20%20%20%20%20%20%20%20%3CmxCell%20id%3D%2229%22%20value%3D%22count%26lt%3Bbr%26gt%3B%26lt%3Bb%26gt%3BCounter%26lt%3B%2Fb%26gt%3B%26lt%3Bbr%26gt%3B%26lt%3Bb%26gt%3BWith%26lt%3B%2Fb%26gt%3B%26lt%3Bbr%26gt%3B%26lt%3Bb%26gt%3BBackup%26lt%3B%2Fb%26gt%3B%22%20style%3D%22rounded%3D0%3BwhiteSpace%3Dwrap%3Bhtml%3D1%3BverticalAlign%3Dtop%3BfontStyle%3D0%3BspacingTop%3D0%3BfontSize%3D10%3BstrokeWidth%3D1%3BstrokeColor%3D%236c8ebf%3BfillColor%3D%23dae8fc%3B%22%20vertex%3D%221%22%20parent%3D%221%22%3E%20%20%20%20%20%20%20%20%20%20%20%3CmxGeometry%20x%3D%22-490%22%20y%3D%221540.25%22%20width%3D%2270%22%20height%3D%2260.75%22%20as%3D%22geometry%22%20%2F%3E%20%20%20%20%20%20%20%20%20%3C%2FmxCell%3E%20%20%20%20%20%20%20%20%20%3CmxCell%20id%3D%2230%22%20value%3D%22rows_count%22%20style%3D%22rounded%3D0%3BwhiteSpace%3Dwrap%3Bhtml%3D1%3BverticalAlign%3Dmiddle%3BfontStyle%3D0%3BfontSize%3D10%3BfillColor%3D%23fff2cc%3BstrokeColor%3D%23d6b656%3B%22%20vertex%3D%221%22%20parent%3D%221%22%3E%20%20%20%20%20%20%20%20%20%20%20%3CmxGeometry%20x%3D%22-510%22%20y%3D%221651%22%20width%3D%22110%22%20height%3D%2220%22%20as%3D%22geometry%22%20%2F%3E%20%20%20%20%20%20%20%20%20%3C%2FmxCell%3E%20%20%20%20%20%20%20%20%20%3CmxCell%20id%3D%2231%22%20style%3D%22edgeStyle%3DorthogonalEdgeStyle%3Brounded%3D0%3BorthogonalLoop%3D1%3BjettySize%3Dauto%3Bhtml%3D1%3BexitX%3D0.5%3BexitY%3D1%3BexitDx%3D0%3BexitDy%3D0%3BentryX%3D0.5%3BentryY%3D0%3BentryDx%3D0%3BentryDy%3D0%3BendArrow%3Dblock%3BendFill%3D1%3B%22%20edge%3D%221%22%20source%3D%2229%22%20target%3D%2230%22%20parent%3D%221%22%3E%20%20%20%20%20%20%20%20%20%20%20%3CmxGeometry%20relative%3D%221%22%20as%3D%22geometry%22%20%2F%3E%20%20%20%20%20%20%20%20%20%3C%2FmxCell%3E%20%20%20%20%20%20%20%20%20%3CmxCell%20id%3D%2232%22%20value%3D%22on%20flush%3A%20update%20backup%20file%22%20style%3D%22edgeLabel%3Bhtml%3D1%3Balign%3Dcenter%3BverticalAlign%3Dmiddle%3Bresizable%3D0%3Bpoints%3D%5B%5D%3BfontSize%3D10%3B%22%20vertex%3D%221%22%20connectable%3D%220%22%20parent%3D%2231%22%3E%20%20%20%20%20%20%20%20%20%20%20%3CmxGeometry%20x%3D%22-0.2564%22%20relative%3D%221%22%20as%3D%22geometry%22%3E%20%20%20%20%20%20%20%20%20%20%20%20%20%3CmxPoint%20y%3D%225%22%20as%3D%22offset%22%20%2F%3E%20%20%20%20%20%20%20%20%20%20%20%3C%2FmxGeometry%3E%20%20%20%20%20%20%20%20%20%3C%2FmxCell%3E%20%20%20%20%20%20%20%20%20%3CmxCell%20id%3D%2233%22%20value%3D%22uncompressed_size%22%20style%3D%22rounded%3D0%3BwhiteSpace%3Dwrap%3Bhtml%3D1%3BverticalAlign%3Dmiddle%3BfontStyle%3D0%3BfontSize%3D10%3BfillColor%3D%23fff2cc%3BstrokeColor%3D%23d6b656%3B%22%20vertex%3D%221%22%20parent%3D%221%22%3E%20%20%20%20%20%20%20%20%20%20%20%3CmxGeometry%20x%3D%22-125%22%20y%3D%221651%22%20width%3D%22110%22%20height%3D%2220%22%20as%3D%22geometry%22%20%2F%3E%20%20%20%20%20%20%20%20%20%3C%2FmxCell%3E%20%20%20%20%20%20%20%20%20%3CmxCell%20id%3D%2234%22%20value%3D%22compressed_size%22%20style%3D%22rounded%3D0%3BwhiteSpace%3Dwrap%3Bhtml%3D1%3BverticalAlign%3Dmiddle%3BfontStyle%3D0%3BfontSize%3D10%3BfillColor%3D%23fff2cc%3BstrokeColor%3D%23d6b656%3B%22%20vertex%3D%221%22%20parent%3D%221%22%3E%20%20%20%20%20%20%20%20%20%20%20%3CmxGeometry%20x%3D%2235%22%20y%3D%221651%22%20width%3D%22110%22%20height%3D%2220%22%20as%3D%22geometry%22%20%2F%3E%20%20%20%20%20%20%20%20%20%3C%2FmxCell%3E%20%20%20%20%20%20%20%20%20%3CmxCell%20id%3D%2235%22%20style%3D%22edgeStyle%3DorthogonalEdgeStyle%3Brounded%3D0%3BorthogonalLoop%3D1%3BjettySize%3Dauto%3Bhtml%3D1%3BexitX%3D0.5%3BexitY%3D1%3BexitDx%3D0%3BexitDy%3D0%3BentryX%3D0.5%3BentryY%3D0%3BentryDx%3D0%3BentryDy%3D0%3B%22%20edge%3D%221%22%20source%3D%2216%22%20target%3D%2234%22%20parent%3D%221%22%3E%20%20%20%20%20%20%20%20%20%20%20%3CmxGeometry%20relative%3D%221%22%20as%3D%22geometry%22%20%2F%3E%20%20%20%20%20%20%20%20%20%3C%2FmxCell%3E%20%20%20%20%20%20%20%20%20%3CmxCell%20id%3D%2236%22%20value%3D%22%26lt%3Bspan%20style%3D%26quot%3Bfont-weight%3A%20normal%3B%26quot%3B%26gt%3Bsize.%26lt%3B%2Fspan%26gt%3B%26lt%3Bbr%26gt%3BMeter%26lt%3Bbr%26gt%3BWith%26lt%3Bbr%26gt%3BBackup%22%20style%3D%22rounded%3D0%3BwhiteSpace%3Dwrap%3Bhtml%3D1%3BverticalAlign%3Dmiddle%3BfontStyle%3D1%3BspacingTop%3D0%3BfontSize%3D10%3BfillColor%3D%23dae8fc%3BstrokeColor%3D%236c8ebf%3B%22%20vertex%3D%221%22%20parent%3D%221%22%3E%20%20%20%20%20%20%20%20%20%20%20%3CmxGeometry%20x%3D%22-100%22%20y%3D%221517%22%20width%3D%2260%22%20height%3D%2260%22%20as%3D%22geometry%22%20%2F%3E%20%20%20%20%20%20%20%20%20%3C%2FmxCell%3E%20%20%20%20%20%20%20%20%20%3CmxCell%20id%3D%2237%22%20value%3D%22%22%20style%3D%22rounded%3D0%3BwhiteSpace%3Dwrap%3Bhtml%3D1%3BfillColor%3Dnone%3Bdashed%3D1%3BdashPattern%3D1%201%3B%22%20vertex%3D%221%22%20parent%3D%221%22%3E%20%20%20%20%20%20%20%20%20%20%20%3CmxGeometry%20x%3D%22-105%22%20y%3D%221501%22%20width%3D%22160%22%20height%3D%2296%22%20as%3D%22geometry%22%20%2F%3E%20%20%20%20%20%20%20%20%20%3C%2FmxCell%3E%20%20%20%20%20%20%20%20%20%3CmxCell%20id%3D%2238%22%20value%3D%22on%20flush%3A%20update%20backup%20file%22%20style%3D%22edgeLabel%3Bhtml%3D1%3Balign%3Dcenter%3BverticalAlign%3Dmiddle%3Bresizable%3D0%3Bpoints%3D%5B%5D%3BfontSize%3D10%3B%22%20vertex%3D%221%22%20connectable%3D%220%22%20parent%3D%221%22%3E%20%20%20%20%20%20%20%20%20%20%20%3CmxGeometry%20x%3D%2290%22%20y%3D%221620.9995364238414%22%20as%3D%22geometry%22%3E%20%20%20%20%20%20%20%20%20%20%20%20%20%3CmxPoint%20x%3D%22-5%22%20y%3D%221%22%20as%3D%22offset%22%20%2F%3E%20%20%20%20%20%20%20%20%20%20%20%3C%2FmxGeometry%3E%20%20%20%20%20%20%20%20%20%3C%2FmxCell%3E%20%20%20%20%20%20%20%20%20%3CmxCell%20id%3D%2239%22%20style%3D%22edgeStyle%3DorthogonalEdgeStyle%3Brounded%3D0%3BorthogonalLoop%3D1%3BjettySize%3Dauto%3Bhtml%3D1%3BexitX%3D0.5%3BexitY%3D1%3BexitDx%3D0%3BexitDy%3D0%3BentryX%3D0.5%3BentryY%3D0%3BentryDx%3D0%3BentryDy%3D0%3BendArrow%3Dblock%3BendFill%3D1%3B%22%20edge%3D%221%22%20source%3D%2236%22%20target%3D%2233%22%20parent%3D%221%22%3E%20%20%20%20%20%20%20%20%20%20%20%3CmxGeometry%20relative%3D%221%22%20as%3D%22geometry%22%20%2F%3E%20%20%20%20%20%20%20%20%20%3C%2FmxCell%3E%20%20%20%20%20%20%20%20%20%3CmxCell%20id%3D%2240%22%20style%3D%22edgeStyle%3DorthogonalEdgeStyle%3Brounded%3D0%3BorthogonalLoop%3D1%3BjettySize%3Dauto%3Bhtml%3D1%3BexitX%3D0.25%3BexitY%3D0%3BexitDx%3D0%3BexitDy%3D0%3BentryX%3D-0.003%3BentryY%3D0.166%3BentryDx%3D0%3BentryDy%3D0%3BentryPerimeter%3D0%3BstrokeWidth%3D2%3BstrokeColor%3D%23009900%3BendArrow%3Dblock%3BendFill%3D1%3B%22%20edge%3D%221%22%20source%3D%2220%22%20target%3D%2229%22%20parent%3D%221%22%3E%20%20%20%20%20%20%20%20%20%20%20%3CmxGeometry%20relative%3D%221%22%20as%3D%22geometry%22%3E%20%20%20%20%20%20%20%20%20%20%20%20%20%3CArray%20as%3D%22points%22%3E%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%3CmxPoint%20x%3D%22-373%22%20y%3D%221497%22%20%2F%3E%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%3CmxPoint%20x%3D%22-560%22%20y%3D%221497%22%20%2F%3E%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%3CmxPoint%20x%3D%22-560%22%20y%3D%221550%22%20%2F%3E%20%20%20%20%20%20%20%20%20%20%20%20%20%3C%2FArray%3E%20%20%20%20%20%20%20%20%20%20%20%3C%2FmxGeometry%3E%20%20%20%20%20%20%20%20%20%3C%2FmxCell%3E%20%20%20%20%20%20%20%20%20%3CmxCell%20id%3D%2241%22%20value%3D%22SYNC%20OK%22%20style%3D%22edgeLabel%3Bhtml%3D1%3Balign%3Dcenter%3BverticalAlign%3Dmiddle%3Bresizable%3D0%3Bpoints%3D%5B%5D%3BfontStyle%3D1%3BfontColor%3D%23009900%3BfontSize%3D10%3B%22%20vertex%3D%221%22%20connectable%3D%220%22%20parent%3D%2240%22%3E%20%20%20%20%20%20%20%20%20%20%20%3CmxGeometry%20x%3D%22-0.2465%22%20y%3D%22-1%22%20relative%3D%221%22%20as%3D%22geometry%22%3E%20%20%20%20%20%20%20%20%20%20%20%20%20%3CmxPoint%20x%3D%22-87%22%20y%3D%22-10%22%20as%3D%22offset%22%20%2F%3E%20%20%20%20%20%20%20%20%20%20%20%3C%2FmxGeometry%3E%20%20%20%20%20%20%20%20%20%3C%2FmxCell%3E%20%20%20%20%20%20%20%20%20%3CmxCell%20id%3D%2242%22%20value%3D%22add%20row%22%20style%3D%22edgeLabel%3Bhtml%3D1%3Balign%3Dcenter%3BverticalAlign%3Dmiddle%3Bresizable%3D0%3Bpoints%3D%5B%5D%3BfontColor%3D%23009900%3BfontSize%3D10%3BfontStyle%3D1%22%20vertex%3D%221%22%20connectable%3D%220%22%20parent%3D%2240%22%3E%20%20%20%20%20%20%20%20%20%20%20%3CmxGeometry%20x%3D%220.7909%22%20y%3D%22-3%22%20relative%3D%221%22%20as%3D%22geometry%22%3E%20%20%20%20%20%20%20%20%20%20%20%20%20%3CmxPoint%20x%3D%225%22%20y%3D%227%22%20as%3D%22offset%22%20%2F%3E%20%20%20%20%20%20%20%20%20%20%20%3C%2FmxGeometry%3E%20%20%20%20%20%20%20%20%20%3C%2FmxCell%3E%20%20%20%20%20%20%20%20%20%3CmxCell%20id%3D%2243%22%20style%3D%22edgeStyle%3DelbowEdgeStyle%3Brounded%3D0%3BorthogonalLoop%3D1%3BjettySize%3Dauto%3Bhtml%3D1%3BexitX%3D1%3BexitY%3D0.5%3BexitDx%3D0%3BexitDy%3D0%3BentryX%3D0.003%3BentryY%3D0.867%3BentryDx%3D0%3BentryDy%3D0%3BentryPerimeter%3D0%3Belbow%3Dhorizontal%3BstrokeWidth%3D2%3BstrokeColor%3D%23009900%3BendArrow%3Dblock%3BendFill%3D1%3B%22%20edge%3D%221%22%20source%3D%2245%22%20target%3D%224%22%20parent%3D%221%22%3E%20%20%20%20%20%20%20%20%20%20%20%3CmxGeometry%20relative%3D%221%22%20as%3D%22geometry%22%20%2F%3E%20%20%20%20%20%20%20%20%20%3C%2FmxCell%3E%20%20%20%20%20%20%20%20%20%3CmxCell%20id%3D%2244%22%20value%3D%22SYNC%22%20style%3D%22edgeLabel%3Bhtml%3D1%3Balign%3Dcenter%3BverticalAlign%3Dmiddle%3Bresizable%3D0%3Bpoints%3D%5B%5D%3BfontSize%3D10%3BfontColor%3D%23009900%3BfontStyle%3D1%22%20vertex%3D%221%22%20connectable%3D%220%22%20parent%3D%2243%22%3E%20%20%20%20%20%20%20%20%20%20%20%3CmxGeometry%20x%3D%220.3678%22%20y%3D%22-1%22%20relative%3D%221%22%20as%3D%22geometry%22%3E%20%20%20%20%20%20%20%20%20%20%20%20%20%3CmxPoint%20x%3D%22-16%22%20y%3D%22-10%22%20as%3D%22offset%22%20%2F%3E%20%20%20%20%20%20%20%20%20%20%20%3C%2FmxGeometry%3E%20%20%20%20%20%20%20%20%20%3C%2FmxCell%3E%20%20%20%20%20%20%20%20%20%3CmxCell%20id%3D%2245%22%20value%3D%22triggers%22%20style%3D%22rounded%3D0%3BwhiteSpace%3Dwrap%3Bhtml%3D1%3BverticalAlign%3Dmiddle%3BfontStyle%3D1%3BspacingTop%3D0%3BfontSize%3D10%3BstrokeWidth%3D1%3BstrokeColor%3D%23b85450%3BfillColor%3D%23f8cecc%3B%22%20vertex%3D%221%22%20parent%3D%221%22%3E%20%20%20%20%20%20%20%20%20%20%20%3CmxGeometry%20x%3D%22-390%22%20y%3D%221568.75%22%20width%3D%2270%22%20height%3D%2223.25%22%20as%3D%22geometry%22%20%2F%3E%20%20%20%20%20%20%20%20%20%3C%2FmxCell%3E%20%20%20%20%20%20%20%20%20%3CmxCell%20id%3D%2246%22%20value%3D%22%26lt%3Bfont%20style%3D%26quot%3Bfont-size%3A%2010px%3B%26quot%3B%26gt%3B%26lt%3Bspan%20style%3D%26quot%3Bfont-weight%3A%20normal%3B%26quot%3B%26gt%3B%26lt%3Bi%26gt%3Bgetter%20%26lt%3B%2Fi%26gt%3Bcsv.Writer.%26lt%3B%2Fspan%26gt%3BRowsCount()%26lt%3B%2Ffont%26gt%3B%22%20style%3D%22text%3Bhtml%3D1%3BstrokeColor%3Dnone%3BfillColor%3Dnone%3Balign%3Dcenter%3BverticalAlign%3Dmiddle%3BwhiteSpace%3Dwrap%3Brounded%3D0%3BfontSize%3D10%3BfontStyle%3D1%22%20vertex%3D%221%22%20parent%3D%221%22%3E%20%20%20%20%20%20%20%20%20%20%20%3CmxGeometry%20x%3D%22-522.5%22%20y%3D%221671%22%20width%3D%22135%22%20height%3D%2230%22%20as%3D%22geometry%22%20%2F%3E%20%20%20%20%20%20%20%20%20%3C%2FmxCell%3E%20%20%20%20%20%20%20%20%20%3CmxCell%20id%3D%2247%22%20value%3D%22%26lt%3Bfont%20style%3D%26quot%3Bfont-size%3A%2010px%3B%26quot%3B%26gt%3B%26lt%3Bi%20style%3D%26quot%3Bborder-color%3A%20var(--border-color)%3B%20font-weight%3A%20400%3B%26quot%3B%26gt%3Bgetter%26amp%3Bnbsp%3B%26lt%3B%2Fi%26gt%3B%26lt%3Bbr%26gt%3B%26lt%3Bspan%20style%3D%26quot%3Bfont-weight%3A%20normal%3B%26quot%3B%26gt%3Bcsv.Writer.%26lt%3B%2Fspan%26gt%3BUncompressedSize()%26lt%3B%2Ffont%26gt%3B%22%20style%3D%22text%3Bhtml%3D1%3BstrokeColor%3Dnone%3BfillColor%3Dnone%3Balign%3Dcenter%3BverticalAlign%3Dmiddle%3BwhiteSpace%3Dwrap%3Brounded%3D0%3BfontSize%3D10%3BfontStyle%3D1%22%20vertex%3D%221%22%20parent%3D%221%22%3E%20%20%20%20%20%20%20%20%20%20%20%3CmxGeometry%20x%3D%22-148.75%22%20y%3D%221671%22%20width%3D%22157.5%22%20height%3D%2230%22%20as%3D%22geometry%22%20%2F%3E%20%20%20%20%20%20%20%20%20%3C%2FmxCell%3E%20%20%20%20%20%20%20%20%20%3CmxCell%20id%3D%2248%22%20value%3D%22%26lt%3Bfont%20style%3D%26quot%3Bfont-size%3A%2010px%3B%26quot%3B%26gt%3B%26lt%3Bi%20style%3D%26quot%3Bborder-color%3A%20var(--border-color)%3B%20font-weight%3A%20400%3B%26quot%3B%26gt%3Bgetter%26amp%3Bnbsp%3B%26lt%3B%2Fi%26gt%3B%26lt%3Bbr%26gt%3B%26lt%3Bspan%20style%3D%26quot%3Bfont-weight%3A%20normal%3B%26quot%3B%26gt%3Bcsv.Writer.%26lt%3B%2Fspan%26gt%3BCompressedSize()%26lt%3B%2Ffont%26gt%3B%22%20style%3D%22text%3Bhtml%3D1%3BstrokeColor%3Dnone%3BfillColor%3Dnone%3Balign%3Dcenter%3BverticalAlign%3Dmiddle%3BwhiteSpace%3Dwrap%3Brounded%3D0%3BfontSize%3D10%3BfontStyle%3D1%22%20vertex%3D%221%22%20parent%3D%221%22%3E%20%20%20%20%20%20%20%20%20%20%20%3CmxGeometry%20x%3D%2215.25%22%20y%3D%221671%22%20width%3D%22157.5%22%20height%3D%2230%22%20as%3D%22geometry%22%20%2F%3E%20%20%20%20%20%20%20%20%20%3C%2FmxCell%3E%20%20%20%20%20%20%20%20%20%3CmxCell%20id%3D%2249%22%20value%3D%221%22%20style%3D%22ellipse%3BwhiteSpace%3Dwrap%3Bhtml%3D1%3Baspect%3Dfixed%3BfillColor%3D%23BCC8D9%3BstrokeColor%3D%236c8ebf%3BfontColor%3D%23003366%3BfontStyle%3D1%3BfontSize%3D10%3B%22%20vertex%3D%221%22%20parent%3D%221%22%3E%20%20%20%20%20%20%20%20%20%20%20%3CmxGeometry%20x%3D%22-217.62%22%20y%3D%221568.75%22%20width%3D%2215.25%22%20height%3D%2215.25%22%20as%3D%22geometry%22%20%2F%3E%20%20%20%20%20%20%20%20%20%3C%2FmxCell%3E%20%20%20%20%20%20%20%20%20%3CmxCell%20id%3D%2250%22%20value%3D%222%22%20style%3D%22ellipse%3BwhiteSpace%3Dwrap%3Bhtml%3D1%3Baspect%3Dfixed%3BfillColor%3D%23BCC8D9%3BstrokeColor%3D%236c8ebf%3BfontColor%3D%23003366%3BfontStyle%3D1%3BfontSize%3D10%3B%22%20vertex%3D%221%22%20parent%3D%221%22%3E%20%20%20%20%20%20%20%20%20%20%20%3CmxGeometry%20x%3D%22-147.62%22%20y%3D%221568.75%22%20width%3D%2215.25%22%20height%3D%2215.25%22%20as%3D%22geometry%22%20%2F%3E%20%20%20%20%20%20%20%20%20%3C%2FmxCell%3E%20%20%20%20%20%20%20%20%20%3CmxCell%20id%3D%2251%22%20style%3D%22edgeStyle%3DorthogonalEdgeStyle%3Brounded%3D0%3BorthogonalLoop%3D1%3BjettySize%3Dauto%3Bhtml%3D1%3BexitX%3D0.5%3BexitY%3D0%3BexitDx%3D0%3BexitDy%3D0%3BentryX%3D0.5%3BentryY%3D1%3BentryDx%3D0%3BentryDy%3D0%3BendArrow%3Dblock%3BendFill%3D1%3B%22%20edge%3D%221%22%20source%3D%2253%22%20target%3D%2228%22%20parent%3D%221%22%3E%20%20%20%20%20%20%20%20%20%20%20%3CmxGeometry%20relative%3D%221%22%20as%3D%22geometry%22%20%2F%3E%20%20%20%20%20%20%20%20%20%3C%2FmxCell%3E%20%20%20%20%20%20%20%20%20%3CmxCell%20id%3D%2252%22%20value%3D%22flush%20the%20buffer%22%20style%3D%22edgeLabel%3Bhtml%3D1%3Balign%3Dcenter%3BverticalAlign%3Dmiddle%3Bresizable%3D0%3Bpoints%3D%5B%5D%3BfontSize%3D10%3B%22%20vertex%3D%221%22%20connectable%3D%220%22%20parent%3D%2251%22%3E%20%20%20%20%20%20%20%20%20%20%20%3CmxGeometry%20x%3D%22-0.1474%22%20y%3D%221%22%20relative%3D%221%22%20as%3D%22geometry%22%3E%20%20%20%20%20%20%20%20%20%20%20%20%20%3CmxPoint%20as%3D%22offset%22%20%2F%3E%20%20%20%20%20%20%20%20%20%20%20%3C%2FmxGeometry%3E%20%20%20%20%20%20%20%20%20%3C%2FmxCell%3E%20%20%20%20%20%20%20%20%20%3CmxCell%20id%3D%2253%22%20value%3D%221%22%20style%3D%22ellipse%3BwhiteSpace%3Dwrap%3Bhtml%3D1%3Baspect%3Dfixed%3BfillColor%3D%23BCC8D9%3BstrokeColor%3D%236c8ebf%3BfontColor%3D%23003366%3BfontStyle%3D1%3BfontSize%3D10%3B%22%20vertex%3D%221%22%20parent%3D%221%22%3E%20%20%20%20%20%20%20%20%20%20%20%3CmxGeometry%20x%3D%22-592.63%22%20y%3D%221621%22%20width%3D%2215.25%22%20height%3D%2215.25%22%20as%3D%22geometry%22%20%2F%3E%20%20%20%20%20%20%20%20%20%3C%2FmxCell%3E%20%20%20%20%20%20%20%20%20%3CmxCell%20id%3D%2254%22%20value%3D%222%22%20style%3D%22ellipse%3BwhiteSpace%3Dwrap%3Bhtml%3D1%3Baspect%3Dfixed%3BfillColor%3D%23BCC8D9%3BstrokeColor%3D%236c8ebf%3BfontColor%3D%23003366%3BfontStyle%3D1%3BfontSize%3D10%3B%22%20vertex%3D%221%22%20parent%3D%221%22%3E%20%20%20%20%20%20%20%20%20%20%20%3CmxGeometry%20x%3D%22-462.62%22%20y%3D%221595.75%22%20width%3D%2215.25%22%20height%3D%2215.25%22%20as%3D%22geometry%22%20%2F%3E%20%20%20%20%20%20%20%20%20%3C%2FmxCell%3E%20%20%20%20%20%20%20%20%20%3CmxCell%20id%3D%2255%22%20value%3D%22%26amp%3Bnbsp%3B1.%20count%20of%20pending%20writes%26lt%3Bbr%20style%3D%26quot%3Bfont-size%3A%2010px%3B%26quot%3B%26gt%3B%26amp%3Bnbsp%3B2.%20bytes%20written%26lt%3Bbr%20style%3D%26quot%3Bfont-size%3A%2010px%3B%26quot%3B%26gt%3B%26amp%3Bnbsp%3B3.%20time%20elapsed%20since%20sync%22%20style%3D%22rounded%3D0%3BwhiteSpace%3Dwrap%3Bhtml%3D1%3BfontSize%3D10%3BfillColor%3D%23f8cecc%3BstrokeColor%3D%23b85450%3Balign%3Dleft%3B%22%20vertex%3D%221%22%20parent%3D%221%22%3E%20%20%20%20%20%20%20%20%20%20%20%3CmxGeometry%20x%3D%22-374%22%20y%3D%221610%22%20width%3D%22129%22%20height%3D%2250%22%20as%3D%22geometry%22%20%2F%3E%20%20%20%20%20%20%20%20%20%3C%2FmxCell%3E%20%20%20%20%20%20%20%20%20%3CmxCell%20id%3D%2256%22%20style%3D%22rounded%3D0%3BorthogonalLoop%3D1%3BjettySize%3Dauto%3Bhtml%3D1%3BexitX%3D0.5%3BexitY%3D1%3BexitDx%3D0%3BexitDy%3D0%3BentryX%3D0.151%3BentryY%3D0.009%3BentryDx%3D0%3BentryDy%3D0%3BstartArrow%3Doval%3BstartFill%3D1%3BendArrow%3Dnone%3BendFill%3D0%3BfillColor%3D%23f8cecc%3BstrokeColor%3D%23b85450%3BentryPerimeter%3D0%3B%22%20edge%3D%221%22%20source%3D%2245%22%20target%3D%2255%22%20parent%3D%221%22%3E%20%20%20%20%20%20%20%20%20%20%20%3CmxGeometry%20relative%3D%221%22%20as%3D%22geometry%22%20%2F%3E%20%20%20%20%20%20%20%20%20%3C%2FmxCell%3E%20%20%20%20%20%20%20%20%20%3CmxCell%20id%3D%2257%22%20value%3D%22%26lt%3Bspan%20style%3D%26quot%3Bfont-weight%3A%20normal%3B%26quot%3B%26gt%3Bdisksync.%26lt%3B%2Fspan%26gt%3BConfig%22%20style%3D%22text%3Bhtml%3D1%3BstrokeColor%3Dnone%3BfillColor%3Dnone%3Balign%3Dcenter%3BverticalAlign%3Dmiddle%3BwhiteSpace%3Dwrap%3Brounded%3D0%3BfontSize%3D10%3BfontStyle%3D1%22%20vertex%3D%221%22%20parent%3D%221%22%3E%20%20%20%20%20%20%20%20%20%20%20%3CmxGeometry%20x%3D%22-368.5%22%20y%3D%221655%22%20width%3D%22114.5%22%20height%3D%2230%22%20as%3D%22geometry%22%20%2F%3E%20%20%20%20%20%20%20%20%20%3C%2FmxCell%3E%20%20%20%20%20%20%20%20%20%3CmxCell%20id%3D%2258%22%20value%3D%22on%20flush%3A%20update%20backup%20file%22%20style%3D%22edgeLabel%3Bhtml%3D1%3Balign%3Dcenter%3BverticalAlign%3Dmiddle%3Bresizable%3D0%3Bpoints%3D%5B%5D%3BfontSize%3D10%3B%22%20vertex%3D%221%22%20connectable%3D%220%22%20parent%3D%221%22%3E%20%20%20%20%20%20%20%20%20%20%20%3CmxGeometry%20x%3D%22-70%22%20y%3D%221620.9995364238414%22%20as%3D%22geometry%22%20%2F%3E%20%20%20%20%20%20%20%20%20%3C%2FmxCell%3E%20%20%20%20%20%20%20%3C%2Froot%3E%20%20%20%20%20%3C%2FmxGraphModel%3E%20%20%20%3C%2Fdiagram%3E%20%3C%2Fmxfile%3E%20">
+  <defs
+     id="defs289">
+    <g
+       id="g284">
+      <g
+         id="glyph-0-0">
+        <path
+           d="M 0.9375 0 L 0.9375 -4.6875 L 4.6875 -4.6875 L 4.6875 0 Z M 1.0625 -0.125 L 4.578125 -0.125 L 4.578125 -4.578125 L 1.0625 -4.578125 Z M 1.0625 -0.125 "
+           id="path2" />
+      </g>
+      <g
+         id="glyph-0-1">
+        <path
+           d="M 1.21875 0 L 0.015625 -3.890625 L 0.703125 -3.890625 L 1.328125 -1.640625 L 1.546875 -0.8125 C 1.554688 -0.851563 1.625 -1.117188 1.75 -1.609375 L 2.375 -3.890625 L 3.046875 -3.890625 L 3.640625 -1.640625 L 3.828125 -0.890625 L 4.046875 -1.640625 L 4.71875 -3.890625 L 5.359375 -3.890625 L 4.140625 0 L 3.453125 0 L 2.84375 -2.328125 L 2.6875 -2.984375 L 1.90625 0 Z M 1.21875 0 "
+           id="path5" />
+      </g>
+      <g
+         id="glyph-0-2">
+        <path
+           d="M 0.484375 0 L 0.484375 -3.890625 L 1.078125 -3.890625 L 1.078125 -3.296875 C 1.234375 -3.578125 1.375 -3.757813 1.5 -3.84375 C 1.625 -3.9375 1.765625 -3.984375 1.921875 -3.984375 C 2.140625 -3.984375 2.363281 -3.910156 2.59375 -3.765625 L 2.375 -3.15625 C 2.207031 -3.25 2.046875 -3.296875 1.890625 -3.296875 C 1.742188 -3.296875 1.613281 -3.25 1.5 -3.15625 C 1.382813 -3.070313 1.300781 -2.957031 1.25 -2.8125 C 1.175781 -2.570313 1.140625 -2.3125 1.140625 -2.03125 L 1.140625 0 Z M 0.484375 0 "
+           id="path8" />
+      </g>
+      <g
+         id="glyph-0-3">
+        <path
+           d="M 0.5 -4.609375 L 0.5 -5.375 L 1.15625 -5.375 L 1.15625 -4.609375 Z M 0.5 0 L 0.5 -3.890625 L 1.15625 -3.890625 L 1.15625 0 Z M 0.5 0 "
+           id="path11" />
+      </g>
+      <g
+         id="glyph-0-4">
+        <path
+           d="M 1.9375 -0.59375 L 2.03125 0 C 1.84375 0.03125 1.675781 0.046875 1.53125 0.046875 C 1.289063 0.046875 1.101563 0.0078125 0.96875 -0.0625 C 0.84375 -0.132813 0.75 -0.234375 0.6875 -0.359375 C 0.632813 -0.484375 0.609375 -0.742188 0.609375 -1.140625 L 0.609375 -3.375 L 0.125 -3.375 L 0.125 -3.890625 L 0.609375 -3.890625 L 0.609375 -4.859375 L 1.265625 -5.25 L 1.265625 -3.890625 L 1.9375 -3.890625 L 1.9375 -3.375 L 1.265625 -3.375 L 1.265625 -1.109375 C 1.265625 -0.921875 1.273438 -0.796875 1.296875 -0.734375 C 1.328125 -0.679688 1.367188 -0.640625 1.421875 -0.609375 C 1.472656 -0.578125 1.546875 -0.5625 1.640625 -0.5625 C 1.710938 -0.5625 1.8125 -0.570313 1.9375 -0.59375 Z M 1.9375 -0.59375 "
+           id="path14" />
+      </g>
+      <g
+         id="glyph-0-5">
+        <path
+           d="M 3.15625 -1.25 L 3.84375 -1.171875 C 3.726563 -0.773438 3.523438 -0.460938 3.234375 -0.234375 C 2.953125 -0.015625 2.582031 0.09375 2.125 0.09375 C 1.5625 0.09375 1.113281 -0.0820313 0.78125 -0.4375 C 0.445313 -0.789063 0.28125 -1.28125 0.28125 -1.90625 C 0.28125 -2.5625 0.445313 -3.070313 0.78125 -3.4375 C 1.113281 -3.800781 1.550781 -3.984375 2.09375 -3.984375 C 2.613281 -3.984375 3.035156 -3.804688 3.359375 -3.453125 C 3.691406 -3.097656 3.859375 -2.597656 3.859375 -1.953125 C 3.859375 -1.910156 3.859375 -1.851563 3.859375 -1.78125 L 0.953125 -1.78125 C 0.984375 -1.351563 1.101563 -1.023438 1.3125 -0.796875 C 1.53125 -0.566406 1.800781 -0.453125 2.125 -0.453125 C 2.375 -0.453125 2.582031 -0.515625 2.75 -0.640625 C 2.914063 -0.765625 3.050781 -0.96875 3.15625 -1.25 Z M 1 -2.3125 L 3.171875 -2.3125 C 3.140625 -2.644531 3.054688 -2.890625 2.921875 -3.046875 C 2.703125 -3.304688 2.425781 -3.4375 2.09375 -3.4375 C 1.789063 -3.4375 1.535156 -3.332031 1.328125 -3.125 C 1.128906 -2.925781 1.019531 -2.65625 1 -2.3125 Z M 1 -2.3125 "
+           id="path17" />
+      </g>
+      <g
+         id="glyph-0-6">
+        <path
+           d="M 3.03125 -1.421875 L 3.6875 -1.34375 C 3.613281 -0.894531 3.429688 -0.539063 3.140625 -0.28125 C 2.847656 -0.03125 2.488281 0.09375 2.0625 0.09375 C 1.53125 0.09375 1.101563 -0.078125 0.78125 -0.421875 C 0.457031 -0.773438 0.296875 -1.28125 0.296875 -1.9375 C 0.296875 -2.351563 0.363281 -2.71875 0.5 -3.03125 C 0.632813 -3.34375 0.84375 -3.578125 1.125 -3.734375 C 1.414063 -3.898438 1.726563 -3.984375 2.0625 -3.984375 C 2.488281 -3.984375 2.832031 -3.875 3.09375 -3.65625 C 3.363281 -3.445313 3.539063 -3.144531 3.625 -2.75 L 2.984375 -2.640625 C 2.921875 -2.910156 2.8125 -3.109375 2.65625 -3.234375 C 2.5 -3.367188 2.3125 -3.4375 2.09375 -3.4375 C 1.757813 -3.4375 1.488281 -3.316406 1.28125 -3.078125 C 1.070313 -2.835938 0.96875 -2.460938 0.96875 -1.953125 C 0.96875 -1.429688 1.066406 -1.050781 1.265625 -0.8125 C 1.472656 -0.570313 1.734375 -0.453125 2.046875 -0.453125 C 2.304688 -0.453125 2.523438 -0.53125 2.703125 -0.6875 C 2.878906 -0.851563 2.988281 -1.097656 3.03125 -1.421875 Z M 3.03125 -1.421875 "
+           id="path20" />
+      </g>
+      <g
+         id="glyph-0-7">
+        <path
+           d="M 0.5 0 L 0.5 -5.375 L 1.15625 -5.375 L 1.15625 -3.4375 C 1.457031 -3.800781 1.84375 -3.984375 2.3125 -3.984375 C 2.601563 -3.984375 2.851563 -3.925781 3.0625 -3.8125 C 3.28125 -3.695313 3.429688 -3.535156 3.515625 -3.328125 C 3.609375 -3.128906 3.65625 -2.84375 3.65625 -2.46875 L 3.65625 0 L 3 0 L 3 -2.46875 C 3 -2.789063 2.925781 -3.023438 2.78125 -3.171875 C 2.644531 -3.328125 2.445313 -3.40625 2.1875 -3.40625 C 1.988281 -3.40625 1.800781 -3.351563 1.625 -3.25 C 1.457031 -3.15625 1.335938 -3.019531 1.265625 -2.84375 C 1.191406 -2.664063 1.15625 -2.425781 1.15625 -2.125 L 1.15625 0 Z M 0.5 0 "
+           id="path23" />
+      </g>
+      <g
+         id="glyph-0-8">
+        <path
+           d="M 3.03125 -0.484375 C 2.789063 -0.273438 2.554688 -0.125 2.328125 -0.03125 C 2.097656 0.0507813 1.851563 0.09375 1.59375 0.09375 C 1.164063 0.09375 0.835938 -0.0078125 0.609375 -0.21875 C 0.378906 -0.425781 0.265625 -0.695313 0.265625 -1.03125 C 0.265625 -1.21875 0.304688 -1.390625 0.390625 -1.546875 C 0.484375 -1.703125 0.597656 -1.828125 0.734375 -1.921875 C 0.878906 -2.015625 1.039063 -2.085938 1.21875 -2.140625 C 1.34375 -2.171875 1.535156 -2.203125 1.796875 -2.234375 C 2.328125 -2.304688 2.722656 -2.382813 2.984375 -2.46875 C 2.984375 -2.5625 2.984375 -2.617188 2.984375 -2.640625 C 2.984375 -2.910156 2.921875 -3.097656 2.796875 -3.203125 C 2.628906 -3.359375 2.378906 -3.4375 2.046875 -3.4375 C 1.734375 -3.4375 1.503906 -3.378906 1.359375 -3.265625 C 1.210938 -3.160156 1.101563 -2.96875 1.03125 -2.6875 L 0.390625 -2.78125 C 0.441406 -3.050781 0.535156 -3.269531 0.671875 -3.4375 C 0.804688 -3.613281 1 -3.75 1.25 -3.84375 C 1.507813 -3.9375 1.804688 -3.984375 2.140625 -3.984375 C 2.472656 -3.984375 2.742188 -3.941406 2.953125 -3.859375 C 3.160156 -3.785156 3.3125 -3.6875 3.40625 -3.5625 C 3.5 -3.445313 3.566406 -3.296875 3.609375 -3.109375 C 3.628906 -3.003906 3.640625 -2.804688 3.640625 -2.515625 L 3.640625 -1.625 C 3.640625 -1.007813 3.65625 -0.617188 3.6875 -0.453125 C 3.71875 -0.296875 3.773438 -0.144531 3.859375 0 L 3.171875 0 C 3.097656 -0.132813 3.050781 -0.296875 3.03125 -0.484375 Z M 2.984375 -1.953125 C 2.742188 -1.859375 2.382813 -1.773438 1.90625 -1.703125 C 1.632813 -1.660156 1.441406 -1.613281 1.328125 -1.5625 C 1.210938 -1.519531 1.125 -1.453125 1.0625 -1.359375 C 1 -1.265625 0.96875 -1.160156 0.96875 -1.046875 C 0.96875 -0.867188 1.035156 -0.71875 1.171875 -0.59375 C 1.304688 -0.476563 1.503906 -0.421875 1.765625 -0.421875 C 2.015625 -0.421875 2.238281 -0.476563 2.4375 -0.59375 C 2.632813 -0.707031 2.78125 -0.859375 2.875 -1.046875 C 2.945313 -1.203125 2.984375 -1.421875 2.984375 -1.703125 Z M 2.984375 -1.953125 "
+           id="path26" />
+      </g>
+      <g
+         id="glyph-0-9">
+        <path
+           d="M 0.5 0 L 0.5 -3.890625 L 1.09375 -3.890625 L 1.09375 -3.34375 C 1.375 -3.769531 1.785156 -3.984375 2.328125 -3.984375 C 2.554688 -3.984375 2.769531 -3.9375 2.96875 -3.84375 C 3.164063 -3.757813 3.3125 -3.648438 3.40625 -3.515625 C 3.507813 -3.378906 3.582031 -3.21875 3.625 -3.03125 C 3.644531 -2.90625 3.65625 -2.691406 3.65625 -2.390625 L 3.65625 0 L 3 0 L 3 -2.359375 C 3 -2.628906 2.972656 -2.832031 2.921875 -2.96875 C 2.867188 -3.101563 2.773438 -3.207031 2.640625 -3.28125 C 2.515625 -3.363281 2.363281 -3.40625 2.1875 -3.40625 C 1.90625 -3.40625 1.660156 -3.316406 1.453125 -3.140625 C 1.253906 -2.960938 1.15625 -2.625 1.15625 -2.125 L 1.15625 0 Z M 0.5 0 "
+           id="path29" />
+      </g>
+      <g
+         id="glyph-0-10">
+        <path
+           d="M 0.6875 0 L 0.6875 -0.75 L 1.4375 -0.75 L 1.4375 0 Z M 0.6875 0 "
+           id="path32" />
+      </g>
+      <g
+         id="glyph-0-11">
+        <path
+           d="M 4.40625 -1.875 L 5.125 -1.703125 C 4.96875 -1.117188 4.695313 -0.671875 4.3125 -0.359375 C 3.925781 -0.0546875 3.453125 0.09375 2.890625 0.09375 C 2.316406 0.09375 1.847656 -0.0195313 1.484375 -0.25 C 1.117188 -0.488281 0.84375 -0.832031 0.65625 -1.28125 C 0.46875 -1.726563 0.375 -2.207031 0.375 -2.71875 C 0.375 -3.28125 0.476563 -3.769531 0.6875 -4.1875 C 0.90625 -4.601563 1.210938 -4.914063 1.609375 -5.125 C 2.003906 -5.34375 2.4375 -5.453125 2.90625 -5.453125 C 3.445313 -5.453125 3.898438 -5.316406 4.265625 -5.046875 C 4.628906 -4.773438 4.882813 -4.390625 5.03125 -3.890625 L 4.328125 -3.734375 C 4.203125 -4.117188 4.019531 -4.398438 3.78125 -4.578125 C 3.550781 -4.765625 3.253906 -4.859375 2.890625 -4.859375 C 2.484375 -4.859375 2.140625 -4.757813 1.859375 -4.5625 C 1.578125 -4.363281 1.378906 -4.097656 1.265625 -3.765625 C 1.160156 -3.429688 1.109375 -3.085938 1.109375 -2.734375 C 1.109375 -2.273438 1.171875 -1.875 1.296875 -1.53125 C 1.429688 -1.1875 1.640625 -0.929688 1.921875 -0.765625 C 2.203125 -0.597656 2.507813 -0.515625 2.84375 -0.515625 C 3.238281 -0.515625 3.570313 -0.628906 3.84375 -0.859375 C 4.125 -1.085938 4.3125 -1.425781 4.40625 -1.875 Z M 4.40625 -1.875 "
+           id="path35" />
+      </g>
+      <g
+         id="glyph-0-12">
+        <path
+           d="M 0.65625 0 L 0.65625 -3.375 L 0.0625 -3.375 L 0.0625 -3.890625 L 0.65625 -3.890625 L 0.65625 -4.296875 C 0.65625 -4.554688 0.675781 -4.753906 0.71875 -4.890625 C 0.78125 -5.054688 0.890625 -5.191406 1.046875 -5.296875 C 1.210938 -5.398438 1.441406 -5.453125 1.734375 -5.453125 C 1.910156 -5.453125 2.113281 -5.429688 2.34375 -5.390625 L 2.25 -4.8125 C 2.113281 -4.84375 1.984375 -4.859375 1.859375 -4.859375 C 1.660156 -4.859375 1.519531 -4.8125 1.4375 -4.71875 C 1.351563 -4.632813 1.3125 -4.476563 1.3125 -4.25 L 1.3125 -3.890625 L 2.0625 -3.890625 L 2.0625 -3.375 L 1.3125 -3.375 L 1.3125 0 Z M 0.65625 0 "
+           id="path38" />
+      </g>
+      <g
+         id="glyph-0-13">
+        <path
+           d="M 0.484375 0 L 0.484375 -5.375 L 1.140625 -5.375 L 1.140625 0 Z M 0.484375 0 "
+           id="path41" />
+      </g>
+      <g
+         id="glyph-0-14">
+        <path
+           d="M 1.515625 0 L 0.09375 -5.375 L 0.828125 -5.375 L 1.640625 -1.84375 C 1.722656 -1.476563 1.796875 -1.113281 1.859375 -0.75 C 1.992188 -1.320313 2.078125 -1.65625 2.109375 -1.75 L 3.125 -5.375 L 3.984375 -5.375 L 4.75 -2.65625 C 4.945313 -1.976563 5.085938 -1.34375 5.171875 -0.75 C 5.242188 -1.09375 5.332031 -1.484375 5.4375 -1.921875 L 6.28125 -5.375 L 7 -5.375 L 5.515625 0 L 4.84375 0 L 3.703125 -4.09375 C 3.609375 -4.4375 3.550781 -4.644531 3.53125 -4.71875 C 3.476563 -4.46875 3.425781 -4.257813 3.375 -4.09375 L 2.234375 0 Z M 1.515625 0 "
+           id="path44" />
+      </g>
+      <g
+         id="glyph-0-15">
+        <path
+           d="M 0.234375 -1.15625 L 0.875 -1.265625 C 0.914063 -1.003906 1.019531 -0.800781 1.1875 -0.65625 C 1.351563 -0.519531 1.585938 -0.453125 1.890625 -0.453125 C 2.191406 -0.453125 2.414063 -0.515625 2.5625 -0.640625 C 2.707031 -0.765625 2.78125 -0.910156 2.78125 -1.078125 C 2.78125 -1.222656 2.71875 -1.335938 2.59375 -1.421875 C 2.5 -1.484375 2.273438 -1.554688 1.921875 -1.640625 C 1.429688 -1.765625 1.09375 -1.867188 0.90625 -1.953125 C 0.71875 -2.046875 0.578125 -2.171875 0.484375 -2.328125 C 0.390625 -2.492188 0.34375 -2.671875 0.34375 -2.859375 C 0.34375 -3.023438 0.378906 -3.179688 0.453125 -3.328125 C 0.535156 -3.484375 0.644531 -3.609375 0.78125 -3.703125 C 0.882813 -3.773438 1.023438 -3.835938 1.203125 -3.890625 C 1.378906 -3.953125 1.566406 -3.984375 1.765625 -3.984375 C 2.078125 -3.984375 2.347656 -3.9375 2.578125 -3.84375 C 2.804688 -3.757813 2.972656 -3.640625 3.078125 -3.484375 C 3.191406 -3.335938 3.269531 -3.140625 3.3125 -2.890625 L 2.671875 -2.796875 C 2.640625 -2.992188 2.550781 -3.148438 2.40625 -3.265625 C 2.269531 -3.378906 2.070313 -3.4375 1.8125 -3.4375 C 1.507813 -3.4375 1.296875 -3.382813 1.171875 -3.28125 C 1.046875 -3.1875 0.984375 -3.070313 0.984375 -2.9375 C 0.984375 -2.851563 1.007813 -2.773438 1.0625 -2.703125 C 1.113281 -2.628906 1.195313 -2.570313 1.3125 -2.53125 C 1.375 -2.5 1.566406 -2.441406 1.890625 -2.359375 C 2.359375 -2.234375 2.679688 -2.128906 2.859375 -2.046875 C 3.046875 -1.972656 3.191406 -1.859375 3.296875 -1.703125 C 3.398438 -1.554688 3.453125 -1.367188 3.453125 -1.140625 C 3.453125 -0.921875 3.390625 -0.710938 3.265625 -0.515625 C 3.140625 -0.328125 2.953125 -0.175781 2.703125 -0.0625 C 2.460938 0.0390625 2.191406 0.09375 1.890625 0.09375 C 1.390625 0.09375 1.003906 -0.0078125 0.734375 -0.21875 C 0.472656 -0.4375 0.304688 -0.75 0.234375 -1.15625 Z M 0.234375 -1.15625 "
+           id="path47" />
+      </g>
+      <g
+         id="glyph-0-16">
+        <path
+           d="M 0.140625 0 L 0.140625 -0.53125 L 2.625 -3.375 C 2.34375 -3.363281 2.09375 -3.359375 1.875 -3.359375 L 0.296875 -3.359375 L 0.296875 -3.890625 L 3.46875 -3.890625 L 3.46875 -3.453125 L 1.359375 -0.984375 L 0.953125 -0.53125 C 1.253906 -0.550781 1.535156 -0.5625 1.796875 -0.5625 L 3.59375 -0.5625 L 3.59375 0 Z M 0.140625 0 "
+           id="path50" />
+      </g>
+      <g
+         id="glyph-0-17">
+        <path
+           d="M 1.75 1.578125 C 1.382813 1.117188 1.078125 0.582031 0.828125 -0.03125 C 0.578125 -0.644531 0.453125 -1.28125 0.453125 -1.9375 C 0.453125 -2.519531 0.546875 -3.078125 0.734375 -3.609375 C 0.953125 -4.234375 1.289063 -4.847656 1.75 -5.453125 L 2.234375 -5.453125 C 1.929688 -4.953125 1.734375 -4.59375 1.640625 -4.375 C 1.492188 -4.039063 1.378906 -3.6875 1.296875 -3.3125 C 1.179688 -2.863281 1.125 -2.40625 1.125 -1.9375 C 1.125 -0.757813 1.492188 0.410156 2.234375 1.578125 Z M 1.75 1.578125 "
+           id="path53" />
+      </g>
+      <g
+         id="glyph-0-18">
+        <path
+           d="M 1.109375 0 L 0.484375 0 L 0.484375 -5.375 L 1.15625 -5.375 L 1.15625 -3.453125 C 1.425781 -3.804688 1.78125 -3.984375 2.21875 -3.984375 C 2.457031 -3.984375 2.679688 -3.929688 2.890625 -3.828125 C 3.109375 -3.734375 3.285156 -3.597656 3.421875 -3.421875 C 3.554688 -3.253906 3.660156 -3.046875 3.734375 -2.796875 C 3.816406 -2.546875 3.859375 -2.28125 3.859375 -2 C 3.859375 -1.332031 3.691406 -0.816406 3.359375 -0.453125 C 3.035156 -0.0859375 2.644531 0.09375 2.1875 0.09375 C 1.726563 0.09375 1.367188 -0.0976563 1.109375 -0.484375 Z M 1.09375 -1.96875 C 1.09375 -1.507813 1.15625 -1.175781 1.28125 -0.96875 C 1.488281 -0.625 1.769531 -0.453125 2.125 -0.453125 C 2.414063 -0.453125 2.664063 -0.578125 2.875 -0.828125 C 3.082031 -1.078125 3.1875 -1.453125 3.1875 -1.953125 C 3.1875 -2.453125 3.082031 -2.820313 2.875 -3.0625 C 2.675781 -3.3125 2.4375 -3.4375 2.15625 -3.4375 C 1.863281 -3.4375 1.613281 -3.3125 1.40625 -3.0625 C 1.195313 -2.8125 1.09375 -2.445313 1.09375 -1.96875 Z M 1.09375 -1.96875 "
+           id="path56" />
+      </g>
+      <g
+         id="glyph-0-19">
+        <path
+           d="M 0.46875 1.5 L 0.390625 0.875 C 0.535156 0.914063 0.660156 0.9375 0.765625 0.9375 C 0.910156 0.9375 1.023438 0.910156 1.109375 0.859375 C 1.203125 0.816406 1.28125 0.75 1.34375 0.65625 C 1.382813 0.59375 1.445313 0.429688 1.53125 0.171875 C 1.550781 0.128906 1.570313 0.0703125 1.59375 0 L 0.125 -3.890625 L 0.828125 -3.890625 L 1.640625 -1.640625 C 1.742188 -1.347656 1.835938 -1.046875 1.921875 -0.734375 C 1.992188 -1.035156 2.082031 -1.332031 2.1875 -1.625 L 3.03125 -3.890625 L 3.6875 -3.890625 L 2.203125 0.0625 C 2.046875 0.488281 1.921875 0.785156 1.828125 0.953125 C 1.710938 1.171875 1.578125 1.328125 1.421875 1.421875 C 1.273438 1.523438 1.097656 1.578125 0.890625 1.578125 C 0.765625 1.578125 0.625 1.550781 0.46875 1.5 Z M 0.46875 1.5 "
+           id="path59" />
+      </g>
+      <g
+         id="glyph-0-20">
+        <path
+           d="M 0.921875 1.578125 L 0.453125 1.578125 C 1.179688 0.410156 1.546875 -0.757813 1.546875 -1.9375 C 1.546875 -2.394531 1.492188 -2.851563 1.390625 -3.3125 C 1.304688 -3.675781 1.191406 -4.023438 1.046875 -4.359375 C 0.953125 -4.578125 0.753906 -4.941406 0.453125 -5.453125 L 0.921875 -5.453125 C 1.378906 -4.847656 1.71875 -4.234375 1.9375 -3.609375 C 2.132813 -3.078125 2.234375 -2.519531 2.234375 -1.9375 C 2.234375 -1.28125 2.101563 -0.644531 1.84375 -0.03125 C 1.59375 0.582031 1.285156 1.117188 0.921875 1.578125 Z M 0.921875 1.578125 "
+           id="path62" />
+      </g>
+      <g
+         id="glyph-0-21">
+        <path
+           d="M 3.015625 0 L 3.015625 -0.484375 C 2.765625 -0.0976563 2.40625 0.09375 1.9375 0.09375 C 1.625 0.09375 1.335938 0.0078125 1.078125 -0.15625 C 0.816406 -0.332031 0.613281 -0.570313 0.46875 -0.875 C 0.320313 -1.1875 0.25 -1.539063 0.25 -1.9375 C 0.25 -2.320313 0.3125 -2.671875 0.4375 -2.984375 C 0.570313 -3.304688 0.769531 -3.550781 1.03125 -3.71875 C 1.289063 -3.894531 1.582031 -3.984375 1.90625 -3.984375 C 2.132813 -3.984375 2.335938 -3.929688 2.515625 -3.828125 C 2.703125 -3.734375 2.851563 -3.601563 2.96875 -3.4375 L 2.96875 -5.375 L 3.625 -5.375 L 3.625 0 Z M 0.9375 -1.9375 C 0.9375 -1.4375 1.039063 -1.0625 1.25 -0.8125 C 1.457031 -0.570313 1.707031 -0.453125 2 -0.453125 C 2.28125 -0.453125 2.519531 -0.566406 2.71875 -0.796875 C 2.925781 -1.035156 3.03125 -1.398438 3.03125 -1.890625 C 3.03125 -2.421875 2.925781 -2.8125 2.71875 -3.0625 C 2.507813 -3.3125 2.257813 -3.4375 1.96875 -3.4375 C 1.675781 -3.4375 1.429688 -3.316406 1.234375 -3.078125 C 1.035156 -2.835938 0.9375 -2.457031 0.9375 -1.9375 Z M 0.9375 -1.9375 "
+           id="path65" />
+      </g>
+      <g
+         id="glyph-0-22">
+        <path
+           d="M 0.5 0 L 0.5 -5.375 L 1.15625 -5.375 L 1.15625 -2.3125 L 2.71875 -3.890625 L 3.578125 -3.890625 L 2.078125 -2.453125 L 3.71875 0 L 2.90625 0 L 1.625 -1.984375 L 1.15625 -1.546875 L 1.15625 0 Z M 0.5 0 "
+           id="path68" />
+      </g>
+      <g
+         id="glyph-0-23" />
+      <g
+         id="glyph-0-24">
+        <path
+           d="M 0 0.09375 L 1.5625 -5.453125 L 2.078125 -5.453125 L 0.53125 0.09375 Z M 0 0.09375 "
+           id="path72" />
+      </g>
+      <g
+         id="glyph-0-25">
+        <path
+           d="M -0.015625 0 L 2.046875 -5.375 L 2.8125 -5.375 L 5.015625 0 L 4.203125 0 L 3.578125 -1.625 L 1.328125 -1.625 L 0.75 0 Z M 1.53125 -2.203125 L 3.359375 -2.203125 L 2.796875 -3.6875 C 2.628906 -4.144531 2.503906 -4.519531 2.421875 -4.8125 C 2.347656 -4.457031 2.25 -4.113281 2.125 -3.78125 Z M 1.53125 -2.203125 "
+           id="path75" />
+      </g>
+      <g
+         id="glyph-0-26">
+        <path
+           d="M 0.359375 -2.609375 C 0.359375 -3.503906 0.597656 -4.203125 1.078125 -4.703125 C 1.554688 -5.210938 2.175781 -5.46875 2.9375 -5.46875 C 3.425781 -5.46875 3.867188 -5.347656 4.265625 -5.109375 C 4.671875 -4.867188 4.976563 -4.535156 5.1875 -4.109375 C 5.394531 -3.691406 5.5 -3.210938 5.5 -2.671875 C 5.5 -2.128906 5.390625 -1.644531 5.171875 -1.21875 C 4.953125 -0.789063 4.640625 -0.460938 4.234375 -0.234375 C 3.828125 -0.015625 3.394531 0.09375 2.9375 0.09375 C 2.425781 0.09375 1.972656 -0.0234375 1.578125 -0.265625 C 1.179688 -0.515625 0.878906 -0.847656 0.671875 -1.265625 C 0.460938 -1.691406 0.359375 -2.140625 0.359375 -2.609375 Z M 1.09375 -2.609375 C 1.09375 -1.960938 1.265625 -1.453125 1.609375 -1.078125 C 1.960938 -0.703125 2.398438 -0.515625 2.921875 -0.515625 C 3.460938 -0.515625 3.90625 -0.703125 4.25 -1.078125 C 4.59375 -1.453125 4.765625 -1.988281 4.765625 -2.6875 C 4.765625 -3.125 4.691406 -3.503906 4.546875 -3.828125 C 4.398438 -4.148438 4.179688 -4.398438 3.890625 -4.578125 C 3.609375 -4.765625 3.289063 -4.859375 2.9375 -4.859375 C 2.4375 -4.859375 2.003906 -4.679688 1.640625 -4.328125 C 1.273438 -3.984375 1.09375 -3.410156 1.09375 -2.609375 Z M 1.09375 -2.609375 "
+           id="path78" />
+      </g>
+      <g
+         id="glyph-0-27">
+        <path
+           d="M 0.5 1.484375 L 0.5 -3.890625 L 1.09375 -3.890625 L 1.09375 -3.390625 C 1.238281 -3.585938 1.398438 -3.734375 1.578125 -3.828125 C 1.753906 -3.929688 1.96875 -3.984375 2.21875 -3.984375 C 2.550781 -3.984375 2.84375 -3.894531 3.09375 -3.71875 C 3.351563 -3.550781 3.546875 -3.3125 3.671875 -3 C 3.804688 -2.6875 3.875 -2.34375 3.875 -1.96875 C 3.875 -1.570313 3.800781 -1.210938 3.65625 -0.890625 C 3.507813 -0.578125 3.300781 -0.332031 3.03125 -0.15625 C 2.757813 0.0078125 2.472656 0.09375 2.171875 0.09375 C 1.953125 0.09375 1.753906 0.046875 1.578125 -0.046875 C 1.410156 -0.140625 1.269531 -0.257813 1.15625 -0.40625 L 1.15625 1.484375 Z M 1.09375 -1.921875 C 1.09375 -1.421875 1.191406 -1.050781 1.390625 -0.8125 C 1.597656 -0.570313 1.84375 -0.453125 2.125 -0.453125 C 2.425781 -0.453125 2.679688 -0.578125 2.890625 -0.828125 C 3.097656 -1.078125 3.203125 -1.460938 3.203125 -1.984375 C 3.203125 -2.472656 3.097656 -2.835938 2.890625 -3.078125 C 2.679688 -3.328125 2.4375 -3.453125 2.15625 -3.453125 C 1.875 -3.453125 1.625 -3.320313 1.40625 -3.0625 C 1.195313 -2.800781 1.09375 -2.421875 1.09375 -1.921875 Z M 1.09375 -1.921875 "
+           id="path81" />
+      </g>
+      <g
+         id="glyph-0-28">
+        <path
+           d="M 2.796875 0 L 2.140625 0 L 2.140625 -4.203125 C 1.972656 -4.046875 1.757813 -3.890625 1.5 -3.734375 C 1.25 -3.585938 1.019531 -3.476563 0.8125 -3.40625 L 0.8125 -4.046875 C 1.1875 -4.210938 1.507813 -4.421875 1.78125 -4.671875 C 2.0625 -4.921875 2.257813 -5.160156 2.375 -5.390625 L 2.796875 -5.390625 Z M 2.796875 0 "
+           id="path84" />
+      </g>
+      <g
+         id="glyph-0-29">
+        <path
+           d="M 0.59375 0 L 0.59375 -5.375 L 2.96875 -5.375 C 3.445313 -5.375 3.8125 -5.320313 4.0625 -5.21875 C 4.3125 -5.125 4.507813 -4.953125 4.65625 -4.703125 C 4.800781 -4.460938 4.875 -4.195313 4.875 -3.90625 C 4.875 -3.519531 4.75 -3.195313 4.5 -2.9375 C 4.257813 -2.675781 3.882813 -2.507813 3.375 -2.4375 C 3.5625 -2.351563 3.703125 -2.265625 3.796875 -2.171875 C 4.003906 -1.984375 4.203125 -1.75 4.390625 -1.46875 L 5.328125 0 L 4.421875 0 L 3.71875 -1.109375 C 3.507813 -1.429688 3.335938 -1.675781 3.203125 -1.84375 C 3.066406 -2.019531 2.945313 -2.140625 2.84375 -2.203125 C 2.738281 -2.273438 2.628906 -2.328125 2.515625 -2.359375 C 2.441406 -2.378906 2.3125 -2.390625 2.125 -2.390625 L 1.296875 -2.390625 L 1.296875 0 Z M 1.296875 -3 L 2.828125 -3 C 3.148438 -3 3.398438 -3.03125 3.578125 -3.09375 C 3.765625 -3.164063 3.90625 -3.273438 4 -3.421875 C 4.101563 -3.566406 4.15625 -3.726563 4.15625 -3.90625 C 4.15625 -4.15625 4.0625 -4.363281 3.875 -4.53125 C 3.6875 -4.695313 3.394531 -4.78125 3 -4.78125 L 1.296875 -4.78125 Z M 1.296875 -3 "
+           id="path87" />
+      </g>
+      <g
+         id="glyph-0-30">
+        <path
+           d="M 0.25 -1.9375 C 0.25 -2.664063 0.445313 -3.203125 0.84375 -3.546875 C 1.175781 -3.835938 1.585938 -3.984375 2.078125 -3.984375 C 2.609375 -3.984375 3.039063 -3.804688 3.375 -3.453125 C 3.71875 -3.097656 3.890625 -2.613281 3.890625 -2 C 3.890625 -1.5 3.8125 -1.101563 3.65625 -0.8125 C 3.507813 -0.53125 3.289063 -0.304688 3 -0.140625 C 2.71875 0.015625 2.410156 0.09375 2.078125 0.09375 C 1.523438 0.09375 1.082031 -0.078125 0.75 -0.421875 C 0.414063 -0.773438 0.25 -1.28125 0.25 -1.9375 Z M 0.921875 -1.9375 C 0.921875 -1.445313 1.03125 -1.078125 1.25 -0.828125 C 1.46875 -0.578125 1.742188 -0.453125 2.078125 -0.453125 C 2.398438 -0.453125 2.671875 -0.578125 2.890625 -0.828125 C 3.109375 -1.078125 3.21875 -1.457031 3.21875 -1.96875 C 3.21875 -2.445313 3.109375 -2.8125 2.890625 -3.0625 C 2.671875 -3.3125 2.398438 -3.4375 2.078125 -3.4375 C 1.742188 -3.4375 1.46875 -3.3125 1.25 -3.0625 C 1.03125 -2.8125 0.921875 -2.4375 0.921875 -1.9375 Z M 0.921875 -1.9375 "
+           id="path90" />
+      </g>
+      <g
+         id="glyph-0-31">
+        <path
+           d="M 1.578125 0 L 0.09375 -3.890625 L 0.796875 -3.890625 L 1.625 -1.5625 C 1.71875 -1.3125 1.800781 -1.050781 1.875 -0.78125 C 1.9375 -0.976563 2.019531 -1.222656 2.125 -1.515625 L 2.984375 -3.890625 L 3.65625 -3.890625 L 2.1875 0 Z M 1.578125 0 "
+           id="path93" />
+      </g>
+      <g
+         id="glyph-0-32">
+        <path
+           d="M 3.046875 0 L 3.046875 -0.578125 C 2.742188 -0.128906 2.332031 0.09375 1.8125 0.09375 C 1.582031 0.09375 1.367188 0.0507813 1.171875 -0.03125 C 0.972656 -0.125 0.820313 -0.238281 0.71875 -0.375 C 0.625 -0.507813 0.554688 -0.671875 0.515625 -0.859375 C 0.492188 -0.992188 0.484375 -1.203125 0.484375 -1.484375 L 0.484375 -3.890625 L 1.140625 -3.890625 L 1.140625 -1.734375 C 1.140625 -1.390625 1.148438 -1.15625 1.171875 -1.03125 C 1.210938 -0.863281 1.300781 -0.726563 1.4375 -0.625 C 1.570313 -0.53125 1.738281 -0.484375 1.9375 -0.484375 C 2.132813 -0.484375 2.316406 -0.53125 2.484375 -0.625 C 2.660156 -0.726563 2.785156 -0.867188 2.859375 -1.046875 C 2.929688 -1.222656 2.96875 -1.476563 2.96875 -1.8125 L 2.96875 -3.890625 L 3.640625 -3.890625 L 3.640625 0 Z M 3.046875 0 "
+           id="path96" />
+      </g>
+      <g
+         id="glyph-0-33">
+        <path
+           d="M -0.109375 1.484375 L -0.109375 1.015625 L 4.25 1.015625 L 4.25 1.484375 Z M -0.109375 1.484375 "
+           id="path99" />
+      </g>
+      <g
+         id="glyph-0-34">
+        <path
+           d="M 0.671875 -3.140625 L 0.671875 -3.890625 L 1.421875 -3.890625 L 1.421875 -3.140625 Z M 0.671875 0 L 0.671875 -0.75 L 1.421875 -0.75 L 1.421875 0 Z M 0.671875 0 "
+           id="path102" />
+      </g>
+      <g
+         id="glyph-0-35">
+        <path
+           d="M 0.5 0 L 0.5 -3.890625 L 1.078125 -3.890625 L 1.078125 -3.34375 C 1.203125 -3.53125 1.363281 -3.679688 1.5625 -3.796875 C 1.769531 -3.921875 2.003906 -3.984375 2.265625 -3.984375 C 2.554688 -3.984375 2.789063 -3.921875 2.96875 -3.796875 C 3.15625 -3.679688 3.285156 -3.515625 3.359375 -3.296875 C 3.671875 -3.753906 4.070313 -3.984375 4.5625 -3.984375 C 4.945313 -3.984375 5.242188 -3.875 5.453125 -3.65625 C 5.660156 -3.445313 5.765625 -3.117188 5.765625 -2.671875 L 5.765625 0 L 5.109375 0 L 5.109375 -2.453125 C 5.109375 -2.710938 5.085938 -2.898438 5.046875 -3.015625 C 5.003906 -3.128906 4.925781 -3.222656 4.8125 -3.296875 C 4.695313 -3.367188 4.566406 -3.40625 4.421875 -3.40625 C 4.140625 -3.40625 3.910156 -3.3125 3.734375 -3.125 C 3.554688 -2.945313 3.46875 -2.660156 3.46875 -2.265625 L 3.46875 0 L 2.8125 0 L 2.8125 -2.53125 C 2.8125 -2.820313 2.753906 -3.039063 2.640625 -3.1875 C 2.535156 -3.332031 2.359375 -3.40625 2.109375 -3.40625 C 1.929688 -3.40625 1.757813 -3.351563 1.59375 -3.25 C 1.4375 -3.15625 1.320313 -3.015625 1.25 -2.828125 C 1.1875 -2.640625 1.15625 -2.367188 1.15625 -2.015625 L 1.15625 0 Z M 0.5 0 "
+           id="path105" />
+      </g>
+      <g
+         id="glyph-0-36">
+        <path
+           d="M 0.375 0.328125 L 1.015625 0.421875 C 1.046875 0.617188 1.117188 0.757813 1.234375 0.84375 C 1.398438 0.96875 1.625 1.03125 1.90625 1.03125 C 2.207031 1.03125 2.441406 0.96875 2.609375 0.84375 C 2.773438 0.726563 2.890625 0.5625 2.953125 0.34375 C 2.984375 0.207031 3 -0.078125 3 -0.515625 C 2.707031 -0.171875 2.347656 0 1.921875 0 C 1.390625 0 0.972656 -0.191406 0.671875 -0.578125 C 0.378906 -0.960938 0.234375 -1.425781 0.234375 -1.96875 C 0.234375 -2.332031 0.300781 -2.671875 0.4375 -2.984375 C 0.570313 -3.304688 0.765625 -3.550781 1.015625 -3.71875 C 1.273438 -3.894531 1.578125 -3.984375 1.921875 -3.984375 C 2.378906 -3.984375 2.757813 -3.796875 3.0625 -3.421875 L 3.0625 -3.890625 L 3.671875 -3.890625 L 3.671875 -0.53125 C 3.671875 0.0703125 3.609375 0.5 3.484375 0.75 C 3.359375 1.007813 3.160156 1.210938 2.890625 1.359375 C 2.628906 1.503906 2.300781 1.578125 1.90625 1.578125 C 1.445313 1.578125 1.070313 1.472656 0.78125 1.265625 C 0.5 1.054688 0.363281 0.742188 0.375 0.328125 Z M 0.921875 -2.015625 C 0.921875 -1.503906 1.019531 -1.128906 1.21875 -0.890625 C 1.425781 -0.660156 1.679688 -0.546875 1.984375 -0.546875 C 2.285156 -0.546875 2.535156 -0.660156 2.734375 -0.890625 C 2.941406 -1.128906 3.046875 -1.5 3.046875 -2 C 3.046875 -2.46875 2.941406 -2.820313 2.734375 -3.0625 C 2.523438 -3.3125 2.269531 -3.4375 1.96875 -3.4375 C 1.675781 -3.4375 1.425781 -3.316406 1.21875 -3.078125 C 1.019531 -2.835938 0.921875 -2.484375 0.921875 -2.015625 Z M 0.921875 -2.015625 "
+           id="path108" />
+      </g>
+      <g
+         id="glyph-0-37">
+        <path
+           d="M 3.78125 -0.640625 L 3.78125 0 L 0.234375 0 C 0.222656 -0.15625 0.242188 -0.304688 0.296875 -0.453125 C 0.390625 -0.703125 0.535156 -0.941406 0.734375 -1.171875 C 0.929688 -1.410156 1.21875 -1.679688 1.59375 -1.984375 C 2.175781 -2.460938 2.570313 -2.84375 2.78125 -3.125 C 2.988281 -3.40625 3.09375 -3.671875 3.09375 -3.921875 C 3.09375 -4.179688 3 -4.398438 2.8125 -4.578125 C 2.625 -4.753906 2.378906 -4.84375 2.078125 -4.84375 C 1.765625 -4.84375 1.507813 -4.75 1.3125 -4.5625 C 1.125 -4.375 1.03125 -4.109375 1.03125 -3.765625 L 0.359375 -3.84375 C 0.398438 -4.34375 0.570313 -4.722656 0.875 -4.984375 C 1.175781 -5.253906 1.582031 -5.390625 2.09375 -5.390625 C 2.613281 -5.390625 3.019531 -5.242188 3.3125 -4.953125 C 3.613281 -4.671875 3.765625 -4.320313 3.765625 -3.90625 C 3.765625 -3.6875 3.71875 -3.472656 3.625 -3.265625 C 3.539063 -3.054688 3.394531 -2.835938 3.1875 -2.609375 C 2.988281 -2.378906 2.65625 -2.066406 2.1875 -1.671875 C 1.789063 -1.335938 1.535156 -1.109375 1.421875 -0.984375 C 1.304688 -0.867188 1.210938 -0.753906 1.140625 -0.640625 Z M 3.78125 -0.640625 "
+           id="path111" />
+      </g>
+      <g
+         id="glyph-0-38">
+        <path
+           d="M 0.3125 -1.421875 L 0.96875 -1.5 C 1.050781 -1.125 1.179688 -0.851563 1.359375 -0.6875 C 1.546875 -0.53125 1.769531 -0.453125 2.03125 -0.453125 C 2.332031 -0.453125 2.585938 -0.554688 2.796875 -0.765625 C 3.015625 -0.984375 3.125 -1.253906 3.125 -1.578125 C 3.125 -1.878906 3.023438 -2.125 2.828125 -2.3125 C 2.628906 -2.507813 2.378906 -2.609375 2.078125 -2.609375 C 1.953125 -2.609375 1.796875 -2.585938 1.609375 -2.546875 L 1.6875 -3.125 C 1.726563 -3.113281 1.765625 -3.109375 1.796875 -3.109375 C 2.078125 -3.109375 2.328125 -3.179688 2.546875 -3.328125 C 2.773438 -3.472656 2.890625 -3.703125 2.890625 -4.015625 C 2.890625 -4.253906 2.804688 -4.453125 2.640625 -4.609375 C 2.484375 -4.765625 2.273438 -4.84375 2.015625 -4.84375 C 1.753906 -4.84375 1.535156 -4.757813 1.359375 -4.59375 C 1.191406 -4.4375 1.085938 -4.195313 1.046875 -3.875 L 0.375 -4 C 0.457031 -4.4375 0.640625 -4.773438 0.921875 -5.015625 C 1.210938 -5.265625 1.570313 -5.390625 2 -5.390625 C 2.289063 -5.390625 2.554688 -5.328125 2.796875 -5.203125 C 3.046875 -5.078125 3.234375 -4.90625 3.359375 -4.6875 C 3.492188 -4.46875 3.5625 -4.238281 3.5625 -4 C 3.5625 -3.757813 3.5 -3.546875 3.375 -3.359375 C 3.25 -3.171875 3.066406 -3.019531 2.828125 -2.90625 C 3.140625 -2.832031 3.382813 -2.679688 3.5625 -2.453125 C 3.738281 -2.222656 3.828125 -1.929688 3.828125 -1.578125 C 3.828125 -1.109375 3.65625 -0.710938 3.3125 -0.390625 C 2.976563 -0.0664063 2.546875 0.09375 2.015625 0.09375 C 1.546875 0.09375 1.15625 -0.046875 0.84375 -0.328125 C 0.53125 -0.609375 0.351563 -0.972656 0.3125 -1.421875 Z M 0.3125 -1.421875 "
+           id="path114" />
+      </g>
+      <g
+         id="glyph-1-0">
+        <path
+           d="M 0.9375 0 L 0.9375 -4.6875 L 4.6875 -4.6875 L 4.6875 0 Z M 1.0625 -0.125 L 4.578125 -0.125 L 4.578125 -4.578125 L 1.0625 -4.578125 Z M 1.0625 -0.125 "
+           id="path117" />
+      </g>
+      <g
+         id="glyph-1-1">
+        <path
+           d="M 0.328125 -2.65625 C 0.328125 -3.195313 0.410156 -3.65625 0.578125 -4.03125 C 0.691406 -4.300781 0.851563 -4.546875 1.0625 -4.765625 C 1.28125 -4.984375 1.515625 -5.144531 1.765625 -5.25 C 2.097656 -5.382813 2.484375 -5.453125 2.921875 -5.453125 C 3.710938 -5.453125 4.34375 -5.207031 4.8125 -4.71875 C 5.289063 -4.226563 5.53125 -3.546875 5.53125 -2.671875 C 5.53125 -1.804688 5.296875 -1.128906 4.828125 -0.640625 C 4.359375 -0.148438 3.726563 0.09375 2.9375 0.09375 C 2.132813 0.09375 1.5 -0.148438 1.03125 -0.640625 C 0.5625 -1.128906 0.328125 -1.800781 0.328125 -2.65625 Z M 1.4375 -2.6875 C 1.4375 -2.082031 1.578125 -1.617188 1.859375 -1.296875 C 2.140625 -0.984375 2.5 -0.828125 2.9375 -0.828125 C 3.363281 -0.828125 3.710938 -0.984375 3.984375 -1.296875 C 4.265625 -1.609375 4.40625 -2.078125 4.40625 -2.703125 C 4.40625 -3.316406 4.269531 -3.773438 4 -4.078125 C 3.738281 -4.378906 3.382813 -4.53125 2.9375 -4.53125 C 2.488281 -4.53125 2.125 -4.375 1.84375 -4.0625 C 1.570313 -3.757813 1.4375 -3.300781 1.4375 -2.6875 Z M 1.4375 -2.6875 "
+           id="path120" />
+      </g>
+      <g
+         id="glyph-1-2">
+        <path
+           d="M 0.265625 -1.75 L 1.328125 -1.84375 C 1.390625 -1.488281 1.515625 -1.226563 1.703125 -1.0625 C 1.898438 -0.90625 2.164063 -0.828125 2.5 -0.828125 C 2.84375 -0.828125 3.101563 -0.898438 3.28125 -1.046875 C 3.457031 -1.191406 3.546875 -1.363281 3.546875 -1.5625 C 3.546875 -1.6875 3.507813 -1.789063 3.4375 -1.875 C 3.363281 -1.96875 3.234375 -2.046875 3.046875 -2.109375 C 2.921875 -2.160156 2.632813 -2.238281 2.1875 -2.34375 C 1.601563 -2.488281 1.191406 -2.664063 0.953125 -2.875 C 0.628906 -3.175781 0.46875 -3.539063 0.46875 -3.96875 C 0.46875 -4.238281 0.546875 -4.492188 0.703125 -4.734375 C 0.859375 -4.972656 1.082031 -5.148438 1.375 -5.265625 C 1.664063 -5.390625 2.015625 -5.453125 2.421875 -5.453125 C 3.097656 -5.453125 3.601563 -5.304688 3.9375 -5.015625 C 4.28125 -4.722656 4.460938 -4.328125 4.484375 -3.828125 L 3.40625 -3.78125 C 3.351563 -4.0625 3.25 -4.257813 3.09375 -4.375 C 2.945313 -4.5 2.71875 -4.5625 2.40625 -4.5625 C 2.09375 -4.5625 1.847656 -4.5 1.671875 -4.375 C 1.554688 -4.289063 1.5 -4.175781 1.5 -4.03125 C 1.5 -3.90625 1.550781 -3.796875 1.65625 -3.703125 C 1.800781 -3.585938 2.132813 -3.46875 2.65625 -3.34375 C 3.1875 -3.226563 3.578125 -3.101563 3.828125 -2.96875 C 4.078125 -2.832031 4.273438 -2.648438 4.421875 -2.421875 C 4.566406 -2.191406 4.640625 -1.90625 4.640625 -1.5625 C 4.640625 -1.257813 4.550781 -0.972656 4.375 -0.703125 C 4.207031 -0.429688 3.96875 -0.226563 3.65625 -0.09375 C 3.34375 0.03125 2.953125 0.09375 2.484375 0.09375 C 1.804688 0.09375 1.285156 -0.0625 0.921875 -0.375 C 0.554688 -0.6875 0.335938 -1.144531 0.265625 -1.75 Z M 0.265625 -1.75 "
+           id="path123" />
+      </g>
+      <g
+         id="glyph-1-3">
+        <path
+           d="M 4.109375 0 L 3.15625 0 L 3.15625 -0.578125 C 2.988281 -0.347656 2.796875 -0.175781 2.578125 -0.0625 C 2.367188 0.0390625 2.15625 0.09375 1.9375 0.09375 C 1.488281 0.09375 1.101563 -0.0859375 0.78125 -0.453125 C 0.46875 -0.816406 0.3125 -1.316406 0.3125 -1.953125 C 0.3125 -2.617188 0.460938 -3.125 0.765625 -3.46875 C 1.078125 -3.8125 1.472656 -3.984375 1.953125 -3.984375 C 2.378906 -3.984375 2.753906 -3.800781 3.078125 -3.4375 L 3.078125 -5.375 L 4.109375 -5.375 Z M 1.359375 -2.03125 C 1.359375 -1.613281 1.414063 -1.3125 1.53125 -1.125 C 1.695313 -0.851563 1.929688 -0.71875 2.234375 -0.71875 C 2.460938 -0.71875 2.660156 -0.816406 2.828125 -1.015625 C 2.992188 -1.222656 3.078125 -1.53125 3.078125 -1.9375 C 3.078125 -2.375 2.992188 -2.691406 2.828125 -2.890625 C 2.671875 -3.085938 2.46875 -3.1875 2.21875 -3.1875 C 1.976563 -3.1875 1.773438 -3.085938 1.609375 -2.890625 C 1.441406 -2.703125 1.359375 -2.414063 1.359375 -2.03125 Z M 1.359375 -2.03125 "
+           id="path126" />
+      </g>
+      <g
+         id="glyph-1-4">
+        <path
+           d="M 0.53125 -4.421875 L 0.53125 -5.375 L 1.5625 -5.375 L 1.5625 -4.421875 Z M 0.53125 0 L 0.53125 -3.890625 L 1.5625 -3.890625 L 1.5625 0 Z M 0.53125 0 "
+           id="path129" />
+      </g>
+      <g
+         id="glyph-1-5">
+        <path
+           d="M 0.171875 -1.109375 L 1.203125 -1.265625 C 1.253906 -1.066406 1.34375 -0.914063 1.46875 -0.8125 C 1.601563 -0.707031 1.796875 -0.65625 2.046875 -0.65625 C 2.304688 -0.65625 2.503906 -0.703125 2.640625 -0.796875 C 2.734375 -0.867188 2.78125 -0.960938 2.78125 -1.078125 C 2.78125 -1.148438 2.753906 -1.210938 2.703125 -1.265625 C 2.648438 -1.316406 2.535156 -1.363281 2.359375 -1.40625 C 1.523438 -1.59375 1 -1.757813 0.78125 -1.90625 C 0.46875 -2.113281 0.3125 -2.40625 0.3125 -2.78125 C 0.3125 -3.113281 0.441406 -3.394531 0.703125 -3.625 C 0.972656 -3.863281 1.390625 -3.984375 1.953125 -3.984375 C 2.484375 -3.984375 2.878906 -3.894531 3.140625 -3.71875 C 3.398438 -3.539063 3.578125 -3.285156 3.671875 -2.953125 L 2.703125 -2.765625 C 2.660156 -2.921875 2.582031 -3.035156 2.46875 -3.109375 C 2.351563 -3.191406 2.1875 -3.234375 1.96875 -3.234375 C 1.695313 -3.234375 1.503906 -3.195313 1.390625 -3.125 C 1.316406 -3.070313 1.28125 -3.003906 1.28125 -2.921875 C 1.28125 -2.847656 1.3125 -2.785156 1.375 -2.734375 C 1.46875 -2.660156 1.785156 -2.5625 2.328125 -2.4375 C 2.878906 -2.3125 3.265625 -2.160156 3.484375 -1.984375 C 3.703125 -1.796875 3.8125 -1.539063 3.8125 -1.21875 C 3.8125 -0.863281 3.660156 -0.554688 3.359375 -0.296875 C 3.066406 -0.0351563 2.628906 0.09375 2.046875 0.09375 C 1.515625 0.09375 1.09375 -0.015625 0.78125 -0.234375 C 0.46875 -0.453125 0.265625 -0.742188 0.171875 -1.109375 Z M 0.171875 -1.109375 "
+           id="path132" />
+      </g>
+      <g
+         id="glyph-1-6">
+        <path
+           d="M 0.5 0 L 0.5 -5.375 L 1.53125 -5.375 L 1.53125 -2.515625 L 2.734375 -3.890625 L 4 -3.890625 L 2.671875 -2.46875 L 4.09375 0 L 2.984375 0 L 2.015625 -1.75 L 1.53125 -1.25 L 1.53125 0 Z M 0.5 0 "
+           id="path135" />
+      </g>
+      <g
+         id="glyph-1-7">
+        <path
+           d="M 3.921875 -2.734375 L 2.921875 -2.5625 C 2.878906 -2.757813 2.796875 -2.910156 2.671875 -3.015625 C 2.554688 -3.117188 2.40625 -3.171875 2.21875 -3.171875 C 1.957031 -3.171875 1.75 -3.082031 1.59375 -2.90625 C 1.445313 -2.726563 1.375 -2.429688 1.375 -2.015625 C 1.375 -1.554688 1.445313 -1.226563 1.59375 -1.03125 C 1.75 -0.84375 1.960938 -0.75 2.234375 -0.75 C 2.421875 -0.75 2.578125 -0.800781 2.703125 -0.90625 C 2.828125 -1.019531 2.914063 -1.210938 2.96875 -1.484375 L 3.984375 -1.3125 C 3.878906 -0.851563 3.675781 -0.503906 3.375 -0.265625 C 3.082031 -0.0234375 2.679688 0.09375 2.171875 0.09375 C 1.609375 0.09375 1.15625 -0.0820313 0.8125 -0.4375 C 0.476563 -0.800781 0.3125 -1.300781 0.3125 -1.9375 C 0.3125 -2.582031 0.476563 -3.082031 0.8125 -3.4375 C 1.15625 -3.800781 1.617188 -3.984375 2.203125 -3.984375 C 2.671875 -3.984375 3.046875 -3.878906 3.328125 -3.671875 C 3.609375 -3.460938 3.804688 -3.148438 3.921875 -2.734375 Z M 3.921875 -2.734375 "
+           id="path138" />
+      </g>
+      <g
+         id="glyph-1-8">
+        <path
+           d="M 1.3125 -2.703125 L 0.375 -2.875 C 0.476563 -3.25 0.65625 -3.523438 0.90625 -3.703125 C 1.164063 -3.890625 1.550781 -3.984375 2.0625 -3.984375 C 2.519531 -3.984375 2.859375 -3.925781 3.078125 -3.8125 C 3.304688 -3.707031 3.460938 -3.570313 3.546875 -3.40625 C 3.640625 -3.238281 3.6875 -2.929688 3.6875 -2.484375 L 3.6875 -1.28125 C 3.6875 -0.9375 3.703125 -0.679688 3.734375 -0.515625 C 3.765625 -0.359375 3.828125 -0.1875 3.921875 0 L 2.90625 0 C 2.875 -0.0703125 2.835938 -0.171875 2.796875 -0.296875 C 2.785156 -0.359375 2.773438 -0.398438 2.765625 -0.421875 C 2.585938 -0.253906 2.398438 -0.125 2.203125 -0.03125 C 2.003906 0.0507813 1.789063 0.09375 1.5625 0.09375 C 1.15625 0.09375 0.835938 -0.015625 0.609375 -0.234375 C 0.378906 -0.453125 0.265625 -0.726563 0.265625 -1.0625 C 0.265625 -1.28125 0.316406 -1.472656 0.421875 -1.640625 C 0.523438 -1.816406 0.671875 -1.953125 0.859375 -2.046875 C 1.054688 -2.140625 1.332031 -2.21875 1.6875 -2.28125 C 2.164063 -2.375 2.5 -2.457031 2.6875 -2.53125 L 2.6875 -2.640625 C 2.6875 -2.835938 2.632813 -2.976563 2.53125 -3.0625 C 2.4375 -3.144531 2.253906 -3.1875 1.984375 -3.1875 C 1.796875 -3.1875 1.648438 -3.148438 1.546875 -3.078125 C 1.453125 -3.003906 1.375 -2.878906 1.3125 -2.703125 Z M 2.6875 -1.875 C 2.550781 -1.820313 2.335938 -1.765625 2.046875 -1.703125 C 1.765625 -1.648438 1.582031 -1.59375 1.5 -1.53125 C 1.363281 -1.4375 1.296875 -1.316406 1.296875 -1.171875 C 1.296875 -1.023438 1.347656 -0.898438 1.453125 -0.796875 C 1.566406 -0.691406 1.707031 -0.640625 1.875 -0.640625 C 2.050781 -0.640625 2.226563 -0.703125 2.40625 -0.828125 C 2.519531 -0.910156 2.597656 -1.019531 2.640625 -1.15625 C 2.671875 -1.25 2.6875 -1.414063 2.6875 -1.65625 Z M 2.6875 -1.875 "
+           id="path141" />
+      </g>
+      <g
+         id="glyph-1-9">
+        <path
+           d="M 1.5625 -5.375 L 1.5625 -3.390625 C 1.894531 -3.785156 2.289063 -3.984375 2.75 -3.984375 C 2.988281 -3.984375 3.203125 -3.9375 3.390625 -3.84375 C 3.585938 -3.757813 3.734375 -3.644531 3.828125 -3.5 C 3.921875 -3.363281 3.984375 -3.210938 4.015625 -3.046875 C 4.054688 -2.890625 4.078125 -2.632813 4.078125 -2.28125 L 4.078125 0 L 3.046875 0 L 3.046875 -2.046875 C 3.046875 -2.460938 3.023438 -2.722656 2.984375 -2.828125 C 2.953125 -2.941406 2.882813 -3.03125 2.78125 -3.09375 C 2.6875 -3.15625 2.5625 -3.1875 2.40625 -3.1875 C 2.238281 -3.1875 2.085938 -3.144531 1.953125 -3.0625 C 1.816406 -2.976563 1.71875 -2.851563 1.65625 -2.6875 C 1.59375 -2.519531 1.5625 -2.273438 1.5625 -1.953125 L 1.5625 0 L 0.53125 0 L 0.53125 -5.375 Z M 1.5625 -5.375 "
+           id="path144" />
+      </g>
+      <g
+         id="glyph-1-10">
+        <path
+           d="M 2.796875 -1.234375 L 3.8125 -1.0625 C 3.6875 -0.6875 3.476563 -0.398438 3.1875 -0.203125 C 2.90625 -0.00390625 2.550781 0.09375 2.125 0.09375 C 1.445313 0.09375 0.945313 -0.128906 0.625 -0.578125 C 0.363281 -0.929688 0.234375 -1.378906 0.234375 -1.921875 C 0.234375 -2.554688 0.398438 -3.054688 0.734375 -3.421875 C 1.078125 -3.796875 1.503906 -3.984375 2.015625 -3.984375 C 2.597656 -3.984375 3.054688 -3.789063 3.390625 -3.40625 C 3.722656 -3.019531 3.882813 -2.429688 3.875 -1.640625 L 1.296875 -1.640625 C 1.296875 -1.335938 1.375 -1.101563 1.53125 -0.9375 C 1.695313 -0.769531 1.898438 -0.6875 2.140625 -0.6875 C 2.296875 -0.6875 2.425781 -0.726563 2.53125 -0.8125 C 2.644531 -0.894531 2.734375 -1.035156 2.796875 -1.234375 Z M 2.84375 -2.28125 C 2.84375 -2.570313 2.769531 -2.796875 2.625 -2.953125 C 2.476563 -3.109375 2.296875 -3.1875 2.078125 -3.1875 C 1.859375 -3.1875 1.675781 -3.101563 1.53125 -2.9375 C 1.382813 -2.78125 1.3125 -2.5625 1.3125 -2.28125 Z M 2.84375 -2.28125 "
+           id="path147" />
+      </g>
+      <g
+         id="glyph-1-11">
+        <path
+           d="M 0.09375 -3.890625 L 0.65625 -3.890625 L 0.65625 -4.1875 C 0.65625 -4.507813 0.691406 -4.75 0.765625 -4.90625 C 0.835938 -5.070313 0.960938 -5.203125 1.140625 -5.296875 C 1.328125 -5.398438 1.566406 -5.453125 1.859375 -5.453125 C 2.148438 -5.453125 2.4375 -5.410156 2.71875 -5.328125 L 2.578125 -4.609375 C 2.410156 -4.648438 2.253906 -4.671875 2.109375 -4.671875 C 1.953125 -4.671875 1.84375 -4.632813 1.78125 -4.5625 C 1.71875 -4.488281 1.6875 -4.351563 1.6875 -4.15625 L 1.6875 -3.890625 L 2.453125 -3.890625 L 2.453125 -3.078125 L 1.6875 -3.078125 L 1.6875 0 L 0.65625 0 L 0.65625 -3.078125 L 0.09375 -3.078125 Z M 0.09375 -3.890625 "
+           id="path150" />
+      </g>
+      <g
+         id="glyph-1-12">
+        <path
+           d="M 0.53125 0 L 0.53125 -5.375 L 1.5625 -5.375 L 1.5625 0 Z M 0.53125 0 "
+           id="path153" />
+      </g>
+      <g
+         id="glyph-1-13">
+        <path
+           d="M 0.53125 0 L 0.53125 -1.03125 L 1.5625 -1.03125 L 1.5625 0 Z M 0.53125 0 "
+           id="path156" />
+      </g>
+      <g
+         id="glyph-1-14">
+        <path
+           d="M 0.046875 -3.890625 L 1.140625 -3.890625 L 2.078125 -1.125 L 2.984375 -3.890625 L 4.046875 -3.890625 L 2.671875 -0.140625 L 2.4375 0.53125 C 2.34375 0.757813 2.253906 0.929688 2.171875 1.046875 C 2.085938 1.171875 1.992188 1.269531 1.890625 1.34375 C 1.785156 1.414063 1.65625 1.472656 1.5 1.515625 C 1.34375 1.554688 1.164063 1.578125 0.96875 1.578125 C 0.769531 1.578125 0.578125 1.554688 0.390625 1.515625 L 0.296875 0.703125 C 0.460938 0.742188 0.609375 0.765625 0.734375 0.765625 C 0.972656 0.765625 1.148438 0.691406 1.265625 0.546875 C 1.378906 0.410156 1.46875 0.234375 1.53125 0.015625 Z M 0.046875 -3.890625 "
+           id="path159" />
+      </g>
+      <g
+         id="glyph-1-15">
+        <path
+           d="M 4.078125 0 L 3.046875 0 L 3.046875 -1.984375 C 3.046875 -2.398438 3.023438 -2.671875 2.984375 -2.796875 C 2.941406 -2.921875 2.867188 -3.015625 2.765625 -3.078125 C 2.671875 -3.148438 2.550781 -3.1875 2.40625 -3.1875 C 2.226563 -3.1875 2.066406 -3.132813 1.921875 -3.03125 C 1.785156 -2.9375 1.691406 -2.804688 1.640625 -2.640625 C 1.585938 -2.484375 1.5625 -2.191406 1.5625 -1.765625 L 1.5625 0 L 0.53125 0 L 0.53125 -3.890625 L 1.484375 -3.890625 L 1.484375 -3.3125 C 1.828125 -3.757813 2.253906 -3.984375 2.765625 -3.984375 C 2.992188 -3.984375 3.203125 -3.941406 3.390625 -3.859375 C 3.578125 -3.773438 3.71875 -3.664063 3.8125 -3.53125 C 3.914063 -3.40625 3.984375 -3.265625 4.015625 -3.109375 C 4.054688 -2.953125 4.078125 -2.722656 4.078125 -2.421875 Z M 4.078125 0 "
+           id="path162" />
+      </g>
+      <g
+         id="glyph-1-16">
+        <path
+           d="M 0.546875 0 L 0.546875 -5.375 L 4.234375 -5.375 L 4.234375 -4.453125 L 1.640625 -4.453125 L 1.640625 -3.1875 L 3.875 -3.1875 L 3.875 -2.28125 L 1.640625 -2.28125 L 1.640625 0 Z M 0.546875 0 "
+           id="path165" />
+      </g>
+      <g
+         id="glyph-1-17">
+        <path
+           d="M 0.5 0 L 0.5 -5.375 L 1.53125 -5.375 L 1.53125 -3.4375 C 1.84375 -3.800781 2.21875 -3.984375 2.65625 -3.984375 C 3.125 -3.984375 3.515625 -3.8125 3.828125 -3.46875 C 4.140625 -3.125 4.296875 -2.628906 4.296875 -1.984375 C 4.296875 -1.316406 4.132813 -0.800781 3.8125 -0.4375 C 3.5 -0.0820313 3.117188 0.09375 2.671875 0.09375 C 2.441406 0.09375 2.21875 0.0351563 2 -0.078125 C 1.789063 -0.191406 1.609375 -0.359375 1.453125 -0.578125 L 1.453125 0 Z M 1.515625 -2.03125 C 1.515625 -1.625 1.578125 -1.328125 1.703125 -1.140625 C 1.878906 -0.859375 2.117188 -0.71875 2.421875 -0.71875 C 2.640625 -0.71875 2.828125 -0.816406 2.984375 -1.015625 C 3.148438 -1.210938 3.234375 -1.519531 3.234375 -1.9375 C 3.234375 -2.375 3.148438 -2.691406 2.984375 -2.890625 C 2.828125 -3.085938 2.625 -3.1875 2.375 -3.1875 C 2.125 -3.1875 1.914063 -3.085938 1.75 -2.890625 C 1.59375 -2.703125 1.515625 -2.414063 1.515625 -2.03125 Z M 1.515625 -2.03125 "
+           id="path168" />
+      </g>
+      <g
+         id="glyph-1-18">
+        <path
+           d="M 3.09375 0 L 3.09375 -0.578125 C 2.957031 -0.367188 2.769531 -0.203125 2.53125 -0.078125 C 2.300781 0.0351563 2.0625 0.09375 1.8125 0.09375 C 1.550781 0.09375 1.316406 0.0351563 1.109375 -0.078125 C 0.898438 -0.191406 0.75 -0.351563 0.65625 -0.5625 C 0.5625 -0.769531 0.515625 -1.054688 0.515625 -1.421875 L 0.515625 -3.890625 L 1.546875 -3.890625 L 1.546875 -2.109375 C 1.546875 -1.554688 1.5625 -1.21875 1.59375 -1.09375 C 1.632813 -0.96875 1.703125 -0.867188 1.796875 -0.796875 C 1.898438 -0.734375 2.03125 -0.703125 2.1875 -0.703125 C 2.363281 -0.703125 2.519531 -0.75 2.65625 -0.84375 C 2.800781 -0.9375 2.898438 -1.050781 2.953125 -1.1875 C 3.003906 -1.332031 3.03125 -1.6875 3.03125 -2.25 L 3.03125 -3.890625 L 4.046875 -3.890625 L 4.046875 0 Z M 3.09375 0 "
+           id="path171" />
+      </g>
+      <g
+         id="glyph-1-19">
+        <path
+           d="M 1.53125 0 L 0.5 0 L 0.5 -3.890625 L 1.453125 -3.890625 L 1.453125 -3.34375 C 1.617188 -3.601563 1.765625 -3.773438 1.890625 -3.859375 C 2.023438 -3.941406 2.175781 -3.984375 2.34375 -3.984375 C 2.570313 -3.984375 2.796875 -3.914063 3.015625 -3.78125 L 2.703125 -2.890625 C 2.523438 -2.992188 2.363281 -3.046875 2.21875 -3.046875 C 2.070313 -3.046875 1.945313 -3.003906 1.84375 -2.921875 C 1.75 -2.847656 1.671875 -2.707031 1.609375 -2.5 C 1.554688 -2.289063 1.53125 -1.859375 1.53125 -1.203125 Z M 1.53125 0 "
+           id="path174" />
+      </g>
+      <g
+         id="glyph-1-20">
+        <path
+           d="M 0.296875 -2 C 0.296875 -2.34375 0.378906 -2.671875 0.546875 -2.984375 C 0.722656 -3.304688 0.960938 -3.550781 1.265625 -3.71875 C 1.578125 -3.894531 1.921875 -3.984375 2.296875 -3.984375 C 2.890625 -3.984375 3.375 -3.789063 3.75 -3.40625 C 4.125 -3.019531 4.3125 -2.535156 4.3125 -1.953125 C 4.3125 -1.367188 4.117188 -0.878906 3.734375 -0.484375 C 3.359375 -0.0976563 2.882813 0.09375 2.3125 0.09375 C 1.957031 0.09375 1.617188 0.015625 1.296875 -0.140625 C 0.972656 -0.304688 0.722656 -0.546875 0.546875 -0.859375 C 0.378906 -1.171875 0.296875 -1.550781 0.296875 -2 Z M 1.359375 -1.9375 C 1.359375 -1.550781 1.445313 -1.253906 1.625 -1.046875 C 1.8125 -0.847656 2.039063 -0.75 2.3125 -0.75 C 2.570313 -0.75 2.789063 -0.847656 2.96875 -1.046875 C 3.15625 -1.253906 3.25 -1.554688 3.25 -1.953125 C 3.25 -2.328125 3.15625 -2.617188 2.96875 -2.828125 C 2.789063 -3.035156 2.570313 -3.140625 2.3125 -3.140625 C 2.039063 -3.140625 1.8125 -3.035156 1.625 -2.828125 C 1.445313 -2.617188 1.359375 -2.320313 1.359375 -1.9375 Z M 1.359375 -1.9375 "
+           id="path177" />
+      </g>
+      <g
+         id="glyph-1-21">
+        <path
+           d="M 1.265625 0 L 0.03125 -3.890625 L 1.03125 -3.890625 L 1.765625 -1.34375 L 2.4375 -3.890625 L 3.421875 -3.890625 L 4.078125 -1.34375 L 4.8125 -3.890625 L 5.828125 -3.890625 L 4.578125 0 L 3.59375 0 L 2.921875 -2.5 L 2.265625 0 Z M 1.265625 0 "
+           id="path180" />
+      </g>
+      <g
+         id="glyph-1-22">
+        <path
+           d="M 2.328125 -3.890625 L 2.328125 -3.0625 L 1.625 -3.0625 L 1.625 -1.5 C 1.625 -1.1875 1.628906 -1.003906 1.640625 -0.953125 C 1.648438 -0.898438 1.675781 -0.851563 1.71875 -0.8125 C 1.769531 -0.78125 1.832031 -0.765625 1.90625 -0.765625 C 2 -0.765625 2.132813 -0.796875 2.3125 -0.859375 L 2.40625 -0.0625 C 2.164063 0.0390625 1.894531 0.09375 1.59375 0.09375 C 1.40625 0.09375 1.238281 0.0625 1.09375 0 C 0.945313 -0.0625 0.835938 -0.140625 0.765625 -0.234375 C 0.691406 -0.335938 0.644531 -0.472656 0.625 -0.640625 C 0.601563 -0.765625 0.59375 -1.007813 0.59375 -1.375 L 0.59375 -3.0625 L 0.109375 -3.0625 L 0.109375 -3.890625 L 0.59375 -3.890625 L 0.59375 -4.65625 L 1.625 -5.265625 L 1.625 -3.890625 Z M 2.328125 -3.890625 "
+           id="path183" />
+      </g>
+      <g
+         id="glyph-1-23" />
+      <g
+         id="glyph-1-24">
+        <path
+           d="M 0.46875 -3.890625 L 1.40625 -3.890625 L 1.40625 -3.359375 C 1.75 -3.773438 2.15625 -3.984375 2.625 -3.984375 C 2.875 -3.984375 3.085938 -3.929688 3.265625 -3.828125 C 3.453125 -3.722656 3.601563 -3.566406 3.71875 -3.359375 C 3.894531 -3.566406 4.082031 -3.722656 4.28125 -3.828125 C 4.476563 -3.929688 4.6875 -3.984375 4.90625 -3.984375 C 5.1875 -3.984375 5.425781 -3.921875 5.625 -3.796875 C 5.820313 -3.679688 5.972656 -3.515625 6.078125 -3.296875 C 6.148438 -3.128906 6.1875 -2.859375 6.1875 -2.484375 L 6.1875 0 L 5.15625 0 L 5.15625 -2.21875 C 5.15625 -2.601563 5.117188 -2.851563 5.046875 -2.96875 C 4.953125 -3.113281 4.804688 -3.1875 4.609375 -3.1875 C 4.460938 -3.1875 4.328125 -3.140625 4.203125 -3.046875 C 4.078125 -2.960938 3.984375 -2.835938 3.921875 -2.671875 C 3.867188 -2.503906 3.84375 -2.238281 3.84375 -1.875 L 3.84375 0 L 2.8125 0 L 2.8125 -2.125 C 2.8125 -2.507813 2.789063 -2.753906 2.75 -2.859375 C 2.71875 -2.972656 2.660156 -3.054688 2.578125 -3.109375 C 2.503906 -3.160156 2.40625 -3.1875 2.28125 -3.1875 C 2.113281 -3.1875 1.96875 -3.144531 1.84375 -3.0625 C 1.71875 -2.976563 1.625 -2.851563 1.5625 -2.6875 C 1.507813 -2.53125 1.484375 -2.265625 1.484375 -1.890625 L 1.484375 0 L 0.46875 0 Z M 0.46875 -3.890625 "
+           id="path187" />
+      </g>
+      <g
+         id="glyph-1-25">
+        <path
+           d="M 0.515625 -3.890625 L 1.46875 -3.890625 L 1.46875 -3.3125 C 1.59375 -3.507813 1.757813 -3.671875 1.96875 -3.796875 C 2.1875 -3.921875 2.425781 -3.984375 2.6875 -3.984375 C 3.132813 -3.984375 3.515625 -3.804688 3.828125 -3.453125 C 4.140625 -3.097656 4.296875 -2.601563 4.296875 -1.96875 C 4.296875 -1.320313 4.132813 -0.816406 3.8125 -0.453125 C 3.5 -0.0859375 3.117188 0.09375 2.671875 0.09375 C 2.453125 0.09375 2.253906 0.0507813 2.078125 -0.03125 C 1.910156 -0.125 1.726563 -0.273438 1.53125 -0.484375 L 1.53125 1.484375 L 0.515625 1.484375 Z M 1.53125 -2.015625 C 1.53125 -1.578125 1.613281 -1.253906 1.78125 -1.046875 C 1.957031 -0.835938 2.171875 -0.734375 2.421875 -0.734375 C 2.660156 -0.734375 2.859375 -0.828125 3.015625 -1.015625 C 3.171875 -1.203125 3.25 -1.515625 3.25 -1.953125 C 3.25 -2.367188 3.164063 -2.675781 3 -2.875 C 2.84375 -3.070313 2.644531 -3.171875 2.40625 -3.171875 C 2.15625 -3.171875 1.945313 -3.070313 1.78125 -2.875 C 1.613281 -2.675781 1.53125 -2.390625 1.53125 -2.015625 Z M 1.53125 -2.015625 "
+           id="path190" />
+      </g>
+      <g
+         id="glyph-1-26">
+        <path
+           d="M 3.984375 -1.96875 L 5.03125 -1.640625 C 4.875 -1.054688 4.609375 -0.617188 4.234375 -0.328125 C 3.859375 -0.046875 3.378906 0.09375 2.796875 0.09375 C 2.085938 0.09375 1.503906 -0.148438 1.046875 -0.640625 C 0.585938 -1.128906 0.359375 -1.796875 0.359375 -2.640625 C 0.359375 -3.535156 0.585938 -4.226563 1.046875 -4.71875 C 1.503906 -5.207031 2.113281 -5.453125 2.875 -5.453125 C 3.53125 -5.453125 4.0625 -5.257813 4.46875 -4.875 C 4.707031 -4.644531 4.890625 -4.316406 5.015625 -3.890625 L 3.9375 -3.640625 C 3.875 -3.910156 3.742188 -4.125 3.546875 -4.28125 C 3.347656 -4.445313 3.101563 -4.53125 2.8125 -4.53125 C 2.414063 -4.53125 2.09375 -4.382813 1.84375 -4.09375 C 1.59375 -3.8125 1.46875 -3.351563 1.46875 -2.71875 C 1.46875 -2.039063 1.585938 -1.554688 1.828125 -1.265625 C 2.078125 -0.972656 2.398438 -0.828125 2.796875 -0.828125 C 3.078125 -0.828125 3.320313 -0.921875 3.53125 -1.109375 C 3.738281 -1.296875 3.890625 -1.582031 3.984375 -1.96875 Z M 3.984375 -1.96875 "
+           id="path193" />
+      </g>
+      <g
+         id="glyph-1-27">
+        <path
+           d="M 1.921875 0 L 0 -5.375 L 1.171875 -5.375 L 2.53125 -1.390625 L 3.84375 -5.375 L 5 -5.375 L 3.078125 0 Z M 1.921875 0 "
+           id="path196" />
+      </g>
+      <g
+         id="glyph-1-28">
+        <path
+           d="M 0.53125 0 L 0.53125 -5.375 L 2.15625 -5.375 L 3.125 -1.703125 L 4.09375 -5.375 L 5.71875 -5.375 L 5.71875 0 L 4.703125 0 L 4.703125 -4.21875 L 3.640625 0 L 2.59375 0 L 1.53125 -4.21875 L 1.53125 0 Z M 0.53125 0 "
+           id="path199" />
+      </g>
+      <g
+         id="glyph-1-29">
+        <path
+           d="M 1.3125 0 L 0.03125 -5.375 L 1.140625 -5.375 L 1.9375 -1.6875 L 2.921875 -5.375 L 4.21875 -5.375 L 5.15625 -1.625 L 5.984375 -5.375 L 7.078125 -5.375 L 5.765625 0 L 4.625 0 L 3.546875 -4.015625 L 2.484375 0 Z M 1.3125 0 "
+           id="path202" />
+      </g>
+      <g
+         id="glyph-1-30">
+        <path
+           d="M 0.546875 -5.375 L 2.703125 -5.375 C 3.117188 -5.375 3.429688 -5.351563 3.640625 -5.3125 C 3.847656 -5.28125 4.035156 -5.207031 4.203125 -5.09375 C 4.367188 -4.976563 4.503906 -4.828125 4.609375 -4.640625 C 4.722656 -4.453125 4.78125 -4.242188 4.78125 -4.015625 C 4.78125 -3.765625 4.710938 -3.535156 4.578125 -3.328125 C 4.441406 -3.117188 4.257813 -2.960938 4.03125 -2.859375 C 4.351563 -2.753906 4.601563 -2.585938 4.78125 -2.359375 C 4.957031 -2.128906 5.046875 -1.863281 5.046875 -1.5625 C 5.046875 -1.3125 4.988281 -1.070313 4.875 -0.84375 C 4.757813 -0.613281 4.601563 -0.425781 4.40625 -0.28125 C 4.207031 -0.144531 3.96875 -0.0625 3.6875 -0.03125 C 3.5 -0.0078125 3.0625 0 2.375 0 L 0.546875 0 Z M 1.640625 -4.46875 L 1.640625 -3.234375 L 2.34375 -3.234375 C 2.769531 -3.234375 3.03125 -3.238281 3.125 -3.25 C 3.3125 -3.269531 3.457031 -3.332031 3.5625 -3.4375 C 3.675781 -3.550781 3.734375 -3.691406 3.734375 -3.859375 C 3.734375 -4.023438 3.6875 -4.160156 3.59375 -4.265625 C 3.5 -4.367188 3.363281 -4.429688 3.1875 -4.453125 C 3.070313 -4.460938 2.757813 -4.46875 2.25 -4.46875 Z M 1.640625 -2.34375 L 1.640625 -0.90625 L 2.640625 -0.90625 C 3.023438 -0.90625 3.269531 -0.914063 3.375 -0.9375 C 3.539063 -0.96875 3.671875 -1.039063 3.765625 -1.15625 C 3.867188 -1.269531 3.921875 -1.421875 3.921875 -1.609375 C 3.921875 -1.765625 3.878906 -1.898438 3.796875 -2.015625 C 3.722656 -2.128906 3.613281 -2.210938 3.46875 -2.265625 C 3.320313 -2.316406 3.003906 -2.34375 2.515625 -2.34375 Z M 1.640625 -2.34375 "
+           id="path205" />
+      </g>
+      <g
+         id="glyph-1-31">
+        <path
+           d="M 1.953125 0 L 1.953125 -2.265625 L -0.015625 -5.375 L 1.265625 -5.375 L 2.515625 -3.25 L 3.765625 -5.375 L 5.015625 -5.375 L 3.03125 -2.25 L 3.03125 0 Z M 1.953125 0 "
+           id="path208" />
+      </g>
+      <g
+         id="glyph-1-32">
+        <path
+           d="M 0.5625 0 L 0.5625 -5.375 L 1.609375 -5.375 L 3.8125 -1.78125 L 3.8125 -5.375 L 4.8125 -5.375 L 4.8125 0 L 3.734375 0 L 1.5625 -3.5 L 1.5625 0 Z M 0.5625 0 "
+           id="path211" />
+      </g>
+      <g
+         id="glyph-1-33">
+        <path
+           d="M 0.5625 0 L 0.5625 -5.375 L 1.640625 -5.375 L 1.640625 -2.984375 L 3.828125 -5.375 L 5.296875 -5.375 L 3.265625 -3.28125 L 5.40625 0 L 4 0 L 2.515625 -2.515625 L 1.640625 -1.625 L 1.640625 0 Z M 0.5625 0 "
+           id="path214" />
+      </g>
+      <g
+         id="glyph-1-34">
+        <path
+           d="M 0.4375 0.25 L 1.625 0.40625 C 1.632813 0.539063 1.675781 0.632813 1.75 0.6875 C 1.851563 0.757813 2.007813 0.796875 2.21875 0.796875 C 2.488281 0.796875 2.6875 0.753906 2.8125 0.671875 C 2.90625 0.617188 2.976563 0.53125 3.03125 0.40625 C 3.0625 0.320313 3.078125 0.164063 3.078125 -0.0625 L 3.078125 -0.625 C 2.765625 -0.207031 2.375 0 1.90625 0 C 1.382813 0 0.972656 -0.21875 0.671875 -0.65625 C 0.429688 -1.007813 0.3125 -1.445313 0.3125 -1.96875 C 0.3125 -2.613281 0.46875 -3.109375 0.78125 -3.453125 C 1.09375 -3.804688 1.484375 -3.984375 1.953125 -3.984375 C 2.429688 -3.984375 2.828125 -3.769531 3.140625 -3.34375 L 3.140625 -3.890625 L 4.109375 -3.890625 L 4.109375 -0.40625 C 4.109375 0.0625 4.066406 0.40625 3.984375 0.625 C 3.910156 0.851563 3.804688 1.03125 3.671875 1.15625 C 3.535156 1.289063 3.351563 1.394531 3.125 1.46875 C 2.894531 1.539063 2.601563 1.578125 2.25 1.578125 C 1.59375 1.578125 1.125 1.460938 0.84375 1.234375 C 0.570313 1.015625 0.4375 0.726563 0.4375 0.375 C 0.4375 0.34375 0.4375 0.300781 0.4375 0.25 Z M 1.359375 -2.03125 C 1.359375 -1.613281 1.4375 -1.304688 1.59375 -1.109375 C 1.757813 -0.921875 1.957031 -0.828125 2.1875 -0.828125 C 2.445313 -0.828125 2.660156 -0.925781 2.828125 -1.125 C 3.003906 -1.320313 3.09375 -1.613281 3.09375 -2 C 3.09375 -2.40625 3.007813 -2.703125 2.84375 -2.890625 C 2.675781 -3.085938 2.46875 -3.1875 2.21875 -3.1875 C 1.96875 -3.1875 1.757813 -3.085938 1.59375 -2.890625 C 1.4375 -2.703125 1.359375 -2.414063 1.359375 -2.03125 Z M 1.359375 -2.03125 "
+           id="path217" />
+      </g>
+      <g
+         id="glyph-1-35">
+        <path
+           d="M 0.546875 0 L 0.546875 -5.375 L 2.828125 -5.375 C 3.398438 -5.375 3.816406 -5.320313 4.078125 -5.21875 C 4.335938 -5.125 4.546875 -4.953125 4.703125 -4.703125 C 4.859375 -4.460938 4.9375 -4.179688 4.9375 -3.859375 C 4.9375 -3.460938 4.816406 -3.128906 4.578125 -2.859375 C 4.347656 -2.597656 3.992188 -2.4375 3.515625 -2.375 C 3.753906 -2.238281 3.945313 -2.085938 4.09375 -1.921875 C 4.25 -1.753906 4.457031 -1.460938 4.71875 -1.046875 L 5.375 0 L 4.078125 0 L 3.296875 -1.171875 C 3.015625 -1.585938 2.820313 -1.847656 2.71875 -1.953125 C 2.625 -2.066406 2.519531 -2.140625 2.40625 -2.171875 C 2.289063 -2.210938 2.109375 -2.234375 1.859375 -2.234375 L 1.640625 -2.234375 L 1.640625 0 Z M 1.640625 -3.09375 L 2.4375 -3.09375 C 2.957031 -3.09375 3.28125 -3.113281 3.40625 -3.15625 C 3.539063 -3.207031 3.644531 -3.285156 3.71875 -3.390625 C 3.789063 -3.492188 3.828125 -3.628906 3.828125 -3.796875 C 3.828125 -3.972656 3.773438 -4.113281 3.671875 -4.21875 C 3.578125 -4.332031 3.441406 -4.40625 3.265625 -4.4375 C 3.179688 -4.445313 2.921875 -4.453125 2.484375 -4.453125 L 1.640625 -4.453125 Z M 1.640625 -3.09375 "
+           id="path220" />
+      </g>
+      <g
+         id="glyph-1-36">
+        <path
+           d="M 2.25 1.578125 L 1.53125 1.578125 C 1.164063 1.015625 0.882813 0.429688 0.6875 -0.171875 C 0.488281 -0.785156 0.390625 -1.375 0.390625 -1.9375 C 0.390625 -2.644531 0.507813 -3.316406 0.75 -3.953125 C 0.957031 -4.492188 1.222656 -4.992188 1.546875 -5.453125 L 2.25 -5.453125 C 1.914063 -4.710938 1.6875 -4.082031 1.5625 -3.5625 C 1.4375 -3.050781 1.375 -2.503906 1.375 -1.921875 C 1.375 -1.523438 1.410156 -1.113281 1.484375 -0.6875 C 1.554688 -0.269531 1.660156 0.125 1.796875 0.5 C 1.878906 0.75 2.03125 1.109375 2.25 1.578125 Z M 2.25 1.578125 "
+           id="path223" />
+      </g>
+      <g
+         id="glyph-1-37">
+        <path
+           d="M 0.25 1.578125 C 0.457031 1.140625 0.601563 0.804688 0.6875 0.578125 C 0.769531 0.347656 0.84375 0.0820313 0.90625 -0.21875 C 0.976563 -0.519531 1.03125 -0.804688 1.0625 -1.078125 C 1.101563 -1.359375 1.125 -1.640625 1.125 -1.921875 C 1.125 -2.503906 1.0625 -3.050781 0.9375 -3.5625 C 0.8125 -4.082031 0.582031 -4.710938 0.25 -5.453125 L 0.9375 -5.453125 C 1.3125 -4.929688 1.597656 -4.375 1.796875 -3.78125 C 2.003906 -3.195313 2.109375 -2.601563 2.109375 -2 C 2.109375 -1.488281 2.03125 -0.941406 1.875 -0.359375 C 1.6875 0.296875 1.382813 0.941406 0.96875 1.578125 Z M 0.25 1.578125 "
+           id="path226" />
+      </g>
+      <g
+         id="glyph-1-38">
+        <path
+           d="M 0.53125 -5.375 L 1.625 -5.375 L 1.625 -2.46875 C 1.625 -2 1.632813 -1.695313 1.65625 -1.5625 C 1.707031 -1.34375 1.816406 -1.164063 1.984375 -1.03125 C 2.160156 -0.894531 2.398438 -0.828125 2.703125 -0.828125 C 3.015625 -0.828125 3.25 -0.890625 3.40625 -1.015625 C 3.5625 -1.148438 3.65625 -1.304688 3.6875 -1.484375 C 3.71875 -1.671875 3.734375 -1.976563 3.734375 -2.40625 L 3.734375 -5.375 L 4.8125 -5.375 L 4.8125 -2.546875 C 4.8125 -1.898438 4.78125 -1.441406 4.71875 -1.171875 C 4.664063 -0.910156 4.5625 -0.6875 4.40625 -0.5 C 4.25 -0.320313 4.035156 -0.175781 3.765625 -0.0625 C 3.503906 0.0390625 3.164063 0.09375 2.75 0.09375 C 2.226563 0.09375 1.832031 0.0351563 1.5625 -0.078125 C 1.300781 -0.203125 1.09375 -0.359375 0.9375 -0.546875 C 0.789063 -0.734375 0.691406 -0.929688 0.640625 -1.140625 C 0.566406 -1.453125 0.53125 -1.90625 0.53125 -2.5 Z M 0.53125 -5.375 "
+           id="path229" />
+      </g>
+      <g
+         id="glyph-1-39">
+        <path
+           d="M 0.125 0 L 0.125 -0.796875 L 1.578125 -2.46875 C 1.816406 -2.75 1.992188 -2.945313 2.109375 -3.0625 C 1.992188 -3.050781 1.835938 -3.046875 1.640625 -3.046875 L 0.265625 -3.03125 L 0.265625 -3.890625 L 3.484375 -3.890625 L 3.484375 -3.15625 L 2 -1.453125 L 1.46875 -0.875 C 1.757813 -0.894531 1.9375 -0.90625 2 -0.90625 L 3.59375 -0.90625 L 3.59375 0 Z M 0.125 0 "
+           id="path232" />
+      </g>
+      <g
+         id="glyph-1-40">
+        <path
+           d="M 2.953125 0 L 1.921875 0 L 1.921875 -3.875 C 1.546875 -3.519531 1.101563 -3.257813 0.59375 -3.09375 L 0.59375 -4.03125 C 0.863281 -4.113281 1.15625 -4.28125 1.46875 -4.53125 C 1.78125 -4.78125 1.992188 -5.066406 2.109375 -5.390625 L 2.953125 -5.390625 Z M 2.953125 0 "
+           id="path235" />
+      </g>
+      <g
+         id="glyph-1-41">
+        <path
+           d="M 3.796875 -0.953125 L 3.796875 0 L 0.1875 0 C 0.226563 -0.363281 0.34375 -0.707031 0.53125 -1.03125 C 0.726563 -1.351563 1.117188 -1.78125 1.703125 -2.3125 C 2.160156 -2.75 2.441406 -3.039063 2.546875 -3.1875 C 2.691406 -3.40625 2.765625 -3.617188 2.765625 -3.828125 C 2.765625 -4.054688 2.703125 -4.226563 2.578125 -4.34375 C 2.453125 -4.46875 2.28125 -4.53125 2.0625 -4.53125 C 1.851563 -4.53125 1.679688 -4.46875 1.546875 -4.34375 C 1.421875 -4.21875 1.347656 -4.003906 1.328125 -3.703125 L 0.3125 -3.796875 C 0.375 -4.367188 0.5625 -4.773438 0.875 -5.015625 C 1.195313 -5.265625 1.601563 -5.390625 2.09375 -5.390625 C 2.625 -5.390625 3.039063 -5.242188 3.34375 -4.953125 C 3.644531 -4.671875 3.796875 -4.316406 3.796875 -3.890625 C 3.796875 -3.648438 3.75 -3.421875 3.65625 -3.203125 C 3.570313 -2.984375 3.4375 -2.753906 3.25 -2.515625 C 3.125 -2.359375 2.898438 -2.128906 2.578125 -1.828125 C 2.253906 -1.535156 2.046875 -1.335938 1.953125 -1.234375 C 1.867188 -1.140625 1.800781 -1.046875 1.75 -0.953125 Z M 3.796875 -0.953125 "
+           id="path238" />
+      </g>
+      <g
+         id="glyph-2-0">
+        <path
+           d="M 0.9375 0 L 0.9375 -4.6875 L 4.6875 -4.6875 L 4.6875 0 Z M 1.0625 -0.125 L 4.578125 -0.125 L 4.578125 -4.578125 L 1.0625 -4.578125 Z M 1.0625 -0.125 "
+           id="path241" />
+      </g>
+      <g
+         id="glyph-2-1">
+        <path
+           d="M 2.9375 -1.421875 L 3.59375 -1.34375 C 3.425781 -0.863281 3.1875 -0.503906 2.875 -0.265625 C 2.570313 -0.0234375 2.226563 0.09375 1.84375 0.09375 C 1.414063 0.09375 1.070313 -0.0390625 0.8125 -0.3125 C 0.550781 -0.59375 0.421875 -0.976563 0.421875 -1.46875 C 0.421875 -1.894531 0.503906 -2.3125 0.671875 -2.71875 C 0.835938 -3.132813 1.078125 -3.445313 1.390625 -3.65625 C 1.710938 -3.875 2.070313 -3.984375 2.46875 -3.984375 C 2.882813 -3.984375 3.210938 -3.863281 3.453125 -3.625 C 3.703125 -3.382813 3.828125 -3.070313 3.828125 -2.6875 L 3.171875 -2.640625 C 3.171875 -2.890625 3.097656 -3.082031 2.953125 -3.21875 C 2.816406 -3.363281 2.632813 -3.4375 2.40625 -3.4375 C 2.144531 -3.4375 1.914063 -3.347656 1.71875 -3.171875 C 1.519531 -3.003906 1.363281 -2.75 1.25 -2.40625 C 1.144531 -2.0625 1.09375 -1.734375 1.09375 -1.421875 C 1.09375 -1.085938 1.164063 -0.835938 1.3125 -0.671875 C 1.457031 -0.503906 1.640625 -0.421875 1.859375 -0.421875 C 2.066406 -0.421875 2.269531 -0.503906 2.46875 -0.671875 C 2.664063 -0.835938 2.820313 -1.085938 2.9375 -1.421875 Z M 2.9375 -1.421875 "
+           id="path244" />
+      </g>
+      <g
+         id="glyph-2-2">
+        <path
+           d="M 0.359375 -1.46875 C 0.359375 -2.226563 0.582031 -2.859375 1.03125 -3.359375 C 1.40625 -3.773438 1.890625 -3.984375 2.484375 -3.984375 C 2.953125 -3.984375 3.328125 -3.832031 3.609375 -3.53125 C 3.898438 -3.238281 4.046875 -2.84375 4.046875 -2.34375 C 4.046875 -1.90625 3.957031 -1.492188 3.78125 -1.109375 C 3.601563 -0.722656 3.347656 -0.425781 3.015625 -0.21875 C 2.679688 -0.0078125 2.328125 0.09375 1.953125 0.09375 C 1.648438 0.09375 1.375 0.03125 1.125 -0.09375 C 0.882813 -0.226563 0.695313 -0.414063 0.5625 -0.65625 C 0.425781 -0.894531 0.359375 -1.164063 0.359375 -1.46875 Z M 1.03125 -1.546875 C 1.03125 -1.179688 1.117188 -0.898438 1.296875 -0.703125 C 1.472656 -0.515625 1.695313 -0.421875 1.96875 -0.421875 C 2.101563 -0.421875 2.238281 -0.445313 2.375 -0.5 C 2.519531 -0.5625 2.648438 -0.648438 2.765625 -0.765625 C 2.890625 -0.890625 2.992188 -1.023438 3.078125 -1.171875 C 3.160156 -1.328125 3.226563 -1.488281 3.28125 -1.65625 C 3.351563 -1.894531 3.390625 -2.128906 3.390625 -2.359375 C 3.390625 -2.703125 3.300781 -2.972656 3.125 -3.171875 C 2.945313 -3.367188 2.726563 -3.46875 2.46875 -3.46875 C 2.257813 -3.46875 2.066406 -3.414063 1.890625 -3.3125 C 1.722656 -3.21875 1.566406 -3.070313 1.421875 -2.875 C 1.285156 -2.6875 1.1875 -2.46875 1.125 -2.21875 C 1.0625 -1.96875 1.03125 -1.742188 1.03125 -1.546875 Z M 1.03125 -1.546875 "
+           id="path247" />
+      </g>
+      <g
+         id="glyph-2-3">
+        <path
+           d="M 0.25 0 L 1.0625 -3.890625 L 1.71875 -3.890625 L 1.578125 -3.25 C 1.828125 -3.519531 2.046875 -3.707031 2.234375 -3.8125 C 2.429688 -3.925781 2.644531 -3.984375 2.875 -3.984375 C 3.113281 -3.984375 3.316406 -3.914063 3.484375 -3.78125 C 3.648438 -3.65625 3.757813 -3.476563 3.8125 -3.25 C 4.007813 -3.488281 4.210938 -3.671875 4.421875 -3.796875 C 4.640625 -3.921875 4.875 -3.984375 5.125 -3.984375 C 5.445313 -3.984375 5.6875 -3.90625 5.84375 -3.75 C 6.007813 -3.59375 6.09375 -3.375 6.09375 -3.09375 C 6.09375 -2.976563 6.066406 -2.78125 6.015625 -2.5 L 5.484375 0 L 4.828125 0 L 5.359375 -2.578125 C 5.398438 -2.785156 5.421875 -2.929688 5.421875 -3.015625 C 5.421875 -3.148438 5.378906 -3.253906 5.296875 -3.328125 C 5.222656 -3.398438 5.113281 -3.4375 4.96875 -3.4375 C 4.769531 -3.4375 4.566406 -3.375 4.359375 -3.25 C 4.148438 -3.132813 3.988281 -2.976563 3.875 -2.78125 C 3.769531 -2.582031 3.671875 -2.285156 3.578125 -1.890625 L 3.1875 0 L 2.53125 0 L 3.078125 -2.625 C 3.117188 -2.800781 3.140625 -2.925781 3.140625 -3 C 3.140625 -3.132813 3.097656 -3.238281 3.015625 -3.3125 C 2.929688 -3.394531 2.828125 -3.4375 2.703125 -3.4375 C 2.515625 -3.4375 2.316406 -3.375 2.109375 -3.25 C 1.910156 -3.132813 1.742188 -2.96875 1.609375 -2.75 C 1.484375 -2.539063 1.378906 -2.238281 1.296875 -1.84375 L 0.90625 0 Z M 0.25 0 "
+           id="path250" />
+      </g>
+      <g
+         id="glyph-2-4">
+        <path
+           d="M -0.078125 1.484375 L 1.046875 -3.890625 L 1.65625 -3.890625 L 1.546875 -3.34375 C 1.773438 -3.582031 1.976563 -3.75 2.15625 -3.84375 C 2.332031 -3.9375 2.519531 -3.984375 2.71875 -3.984375 C 3.09375 -3.984375 3.398438 -3.847656 3.640625 -3.578125 C 3.890625 -3.304688 4.015625 -2.914063 4.015625 -2.40625 C 4.015625 -2.007813 3.945313 -1.644531 3.8125 -1.3125 C 3.675781 -0.976563 3.507813 -0.707031 3.3125 -0.5 C 3.125 -0.300781 2.925781 -0.148438 2.71875 -0.046875 C 2.519531 0.046875 2.316406 0.09375 2.109375 0.09375 C 1.640625 0.09375 1.28125 -0.144531 1.03125 -0.625 L 0.59375 1.484375 Z M 1.234375 -1.59375 C 1.234375 -1.300781 1.253906 -1.097656 1.296875 -0.984375 C 1.359375 -0.828125 1.457031 -0.695313 1.59375 -0.59375 C 1.738281 -0.5 1.898438 -0.453125 2.078125 -0.453125 C 2.460938 -0.453125 2.769531 -0.664063 3 -1.09375 C 3.238281 -1.519531 3.359375 -1.957031 3.359375 -2.40625 C 3.359375 -2.738281 3.273438 -2.992188 3.109375 -3.171875 C 2.953125 -3.347656 2.757813 -3.4375 2.53125 -3.4375 C 2.363281 -3.4375 2.207031 -3.390625 2.0625 -3.296875 C 1.914063 -3.210938 1.78125 -3.082031 1.65625 -2.90625 C 1.53125 -2.726563 1.425781 -2.507813 1.34375 -2.25 C 1.269531 -2 1.234375 -1.78125 1.234375 -1.59375 Z M 1.234375 -1.59375 "
+           id="path253" />
+      </g>
+      <g
+         id="glyph-2-5">
+        <path
+           d="M 0.25 0 L 1.0625 -3.890625 L 1.640625 -3.890625 L 1.484375 -3.09375 C 1.679688 -3.394531 1.875 -3.617188 2.0625 -3.765625 C 2.257813 -3.910156 2.457031 -3.984375 2.65625 -3.984375 C 2.789063 -3.984375 2.953125 -3.929688 3.140625 -3.828125 L 2.875 -3.21875 C 2.757813 -3.300781 2.632813 -3.34375 2.5 -3.34375 C 2.269531 -3.34375 2.03125 -3.210938 1.78125 -2.953125 C 1.539063 -2.691406 1.347656 -2.226563 1.203125 -1.5625 L 0.875 0 Z M 0.25 0 "
+           id="path256" />
+      </g>
+      <g
+         id="glyph-2-6">
+        <path
+           d="M 3.109375 -1.328125 L 3.75 -1.25 C 3.65625 -0.9375 3.441406 -0.632813 3.109375 -0.34375 C 2.773438 -0.0507813 2.378906 0.09375 1.921875 0.09375 C 1.628906 0.09375 1.363281 0.0234375 1.125 -0.109375 C 0.882813 -0.242188 0.703125 -0.4375 0.578125 -0.6875 C 0.453125 -0.945313 0.390625 -1.238281 0.390625 -1.5625 C 0.390625 -1.988281 0.488281 -2.398438 0.6875 -2.796875 C 0.882813 -3.191406 1.140625 -3.488281 1.453125 -3.6875 C 1.765625 -3.882813 2.101563 -3.984375 2.46875 -3.984375 C 2.925781 -3.984375 3.289063 -3.835938 3.5625 -3.546875 C 3.84375 -3.253906 3.984375 -2.859375 3.984375 -2.359375 C 3.984375 -2.171875 3.96875 -1.976563 3.9375 -1.78125 L 1.078125 -1.78125 C 1.066406 -1.707031 1.0625 -1.640625 1.0625 -1.578125 C 1.0625 -1.210938 1.144531 -0.929688 1.3125 -0.734375 C 1.476563 -0.546875 1.679688 -0.453125 1.921875 -0.453125 C 2.148438 -0.453125 2.375 -0.523438 2.59375 -0.671875 C 2.8125 -0.828125 2.984375 -1.046875 3.109375 -1.328125 Z M 1.171875 -2.28125 L 3.359375 -2.28125 C 3.359375 -2.351563 3.359375 -2.40625 3.359375 -2.4375 C 3.359375 -2.769531 3.273438 -3.019531 3.109375 -3.1875 C 2.953125 -3.363281 2.738281 -3.453125 2.46875 -3.453125 C 2.1875 -3.453125 1.925781 -3.351563 1.6875 -3.15625 C 1.457031 -2.96875 1.285156 -2.675781 1.171875 -2.28125 Z M 1.171875 -2.28125 "
+           id="path259" />
+      </g>
+      <g
+         id="glyph-2-7">
+        <path
+           d="M 0.3125 -1.328125 L 0.96875 -1.375 C 0.96875 -1.175781 1 -1.007813 1.0625 -0.875 C 1.125 -0.75 1.234375 -0.640625 1.390625 -0.546875 C 1.546875 -0.460938 1.726563 -0.421875 1.9375 -0.421875 C 2.226563 -0.421875 2.445313 -0.476563 2.59375 -0.59375 C 2.738281 -0.71875 2.8125 -0.859375 2.8125 -1.015625 C 2.8125 -1.128906 2.769531 -1.238281 2.6875 -1.34375 C 2.59375 -1.445313 2.367188 -1.570313 2.015625 -1.71875 C 1.671875 -1.863281 1.445313 -1.96875 1.34375 -2.03125 C 1.1875 -2.132813 1.066406 -2.253906 0.984375 -2.390625 C 0.898438 -2.523438 0.859375 -2.679688 0.859375 -2.859375 C 0.859375 -3.160156 0.976563 -3.421875 1.21875 -3.640625 C 1.46875 -3.867188 1.8125 -3.984375 2.25 -3.984375 C 2.738281 -3.984375 3.109375 -3.867188 3.359375 -3.640625 C 3.617188 -3.410156 3.753906 -3.113281 3.765625 -2.75 L 3.109375 -2.703125 C 3.097656 -2.929688 3.015625 -3.113281 2.859375 -3.25 C 2.703125 -3.394531 2.484375 -3.46875 2.203125 -3.46875 C 1.972656 -3.46875 1.789063 -3.414063 1.65625 -3.3125 C 1.53125 -3.207031 1.46875 -3.09375 1.46875 -2.96875 C 1.46875 -2.84375 1.523438 -2.734375 1.640625 -2.640625 C 1.710938 -2.578125 1.898438 -2.476563 2.203125 -2.34375 C 2.710938 -2.125 3.035156 -1.953125 3.171875 -1.828125 C 3.378906 -1.628906 3.484375 -1.382813 3.484375 -1.09375 C 3.484375 -0.894531 3.421875 -0.703125 3.296875 -0.515625 C 3.179688 -0.335938 3.003906 -0.191406 2.765625 -0.078125 C 2.523438 0.0351563 2.238281 0.09375 1.90625 0.09375 C 1.457031 0.09375 1.078125 -0.0195313 0.765625 -0.25 C 0.441406 -0.46875 0.289063 -0.828125 0.3125 -1.328125 Z M 0.3125 -1.328125 "
+           id="path262" />
+      </g>
+      <g
+         id="glyph-2-8">
+        <path
+           d="M 1.1875 -4.625 L 1.34375 -5.375 L 2 -5.375 L 1.84375 -4.625 Z M 0.21875 0 L 1.03125 -3.890625 L 1.703125 -3.890625 L 0.890625 0 Z M 0.21875 0 "
+           id="path265" />
+      </g>
+      <g
+         id="glyph-2-9">
+        <path
+           d="M 0.25 0 L 1.0625 -3.890625 L 1.65625 -3.890625 L 1.515625 -3.21875 C 1.773438 -3.476563 2.019531 -3.671875 2.25 -3.796875 C 2.476563 -3.921875 2.710938 -3.984375 2.953125 -3.984375 C 3.265625 -3.984375 3.507813 -3.894531 3.6875 -3.71875 C 3.863281 -3.550781 3.953125 -3.320313 3.953125 -3.03125 C 3.953125 -2.882813 3.921875 -2.660156 3.859375 -2.359375 L 3.375 0 L 2.703125 0 L 3.21875 -2.46875 C 3.269531 -2.707031 3.296875 -2.882813 3.296875 -3 C 3.296875 -3.125 3.25 -3.226563 3.15625 -3.3125 C 3.070313 -3.394531 2.945313 -3.4375 2.78125 -3.4375 C 2.4375 -3.4375 2.128906 -3.3125 1.859375 -3.0625 C 1.597656 -2.820313 1.410156 -2.40625 1.296875 -1.8125 L 0.90625 0 Z M 0.25 0 "
+           id="path268" />
+      </g>
+      <g
+         id="glyph-2-10" />
+      <g
+         id="glyph-2-11">
+        <path
+           d="M 1.796875 -0.53125 L 1.6875 0 C 1.53125 0.0390625 1.378906 0.0625 1.234375 0.0625 C 0.960938 0.0625 0.75 0 0.59375 -0.125 C 0.476563 -0.226563 0.421875 -0.363281 0.421875 -0.53125 C 0.421875 -0.613281 0.453125 -0.804688 0.515625 -1.109375 L 0.984375 -3.375 L 0.46875 -3.375 L 0.578125 -3.890625 L 1.09375 -3.890625 L 1.296875 -4.84375 L 2.046875 -5.296875 L 1.765625 -3.890625 L 2.40625 -3.890625 L 2.296875 -3.375 L 1.65625 -3.375 L 1.203125 -1.234375 C 1.140625 -0.953125 1.109375 -0.785156 1.109375 -0.734375 C 1.109375 -0.660156 1.128906 -0.601563 1.171875 -0.5625 C 1.222656 -0.519531 1.300781 -0.5 1.40625 -0.5 C 1.550781 -0.5 1.679688 -0.507813 1.796875 -0.53125 Z M 1.796875 -0.53125 "
+           id="path272" />
+      </g>
+      <g
+         id="glyph-2-12">
+        <path
+           d="M 2.875 -0.484375 C 2.644531 -0.285156 2.421875 -0.140625 2.203125 -0.046875 C 1.992188 0.046875 1.769531 0.09375 1.53125 0.09375 C 1.164063 0.09375 0.875 -0.0078125 0.65625 -0.21875 C 0.4375 -0.4375 0.328125 -0.710938 0.328125 -1.046875 C 0.328125 -1.253906 0.375 -1.441406 0.46875 -1.609375 C 0.570313 -1.785156 0.703125 -1.921875 0.859375 -2.015625 C 1.023438 -2.117188 1.226563 -2.191406 1.46875 -2.234375 C 1.625 -2.265625 1.90625 -2.285156 2.3125 -2.296875 C 2.726563 -2.316406 3.03125 -2.363281 3.21875 -2.4375 C 3.269531 -2.613281 3.296875 -2.765625 3.296875 -2.890625 C 3.296875 -3.046875 3.238281 -3.164063 3.125 -3.25 C 2.96875 -3.375 2.742188 -3.4375 2.453125 -3.4375 C 2.171875 -3.4375 1.941406 -3.375 1.765625 -3.25 C 1.585938 -3.125 1.457031 -2.945313 1.375 -2.71875 L 0.703125 -2.78125 C 0.847656 -3.164063 1.066406 -3.460938 1.359375 -3.671875 C 1.660156 -3.878906 2.035156 -3.984375 2.484375 -3.984375 C 2.960938 -3.984375 3.34375 -3.867188 3.625 -3.640625 C 3.84375 -3.460938 3.953125 -3.238281 3.953125 -2.96875 C 3.953125 -2.757813 3.921875 -2.519531 3.859375 -2.25 L 3.640625 -1.28125 C 3.566406 -0.96875 3.53125 -0.71875 3.53125 -0.53125 C 3.53125 -0.40625 3.5625 -0.226563 3.625 0 L 2.953125 0 C 2.910156 -0.125 2.882813 -0.285156 2.875 -0.484375 Z M 3.109375 -1.96875 C 3.023438 -1.9375 2.925781 -1.910156 2.8125 -1.890625 C 2.707031 -1.867188 2.53125 -1.847656 2.28125 -1.828125 C 1.894531 -1.785156 1.625 -1.738281 1.46875 -1.6875 C 1.3125 -1.632813 1.191406 -1.550781 1.109375 -1.4375 C 1.023438 -1.320313 0.984375 -1.195313 0.984375 -1.0625 C 0.984375 -0.875 1.046875 -0.71875 1.171875 -0.59375 C 1.304688 -0.476563 1.492188 -0.421875 1.734375 -0.421875 C 1.953125 -0.421875 2.160156 -0.476563 2.359375 -0.59375 C 2.566406 -0.707031 2.726563 -0.867188 2.84375 -1.078125 C 2.957031 -1.285156 3.046875 -1.582031 3.109375 -1.96875 Z M 3.109375 -1.96875 "
+           id="path275" />
+      </g>
+      <g
+         id="glyph-2-13">
+        <path
+           d="M 0.203125 0 L 1.3125 -5.375 L 1.984375 -5.375 L 0.859375 0 Z M 0.203125 0 "
+           id="path278" />
+      </g>
+      <g
+         id="glyph-2-14">
+        <path
+           d="M 0.21875 0.359375 L 0.875 0.40625 C 0.875 0.5625 0.894531 0.675781 0.9375 0.75 C 0.976563 0.832031 1.046875 0.894531 1.140625 0.9375 C 1.253906 0.988281 1.40625 1.015625 1.59375 1.015625 C 2 1.015625 2.289063 0.910156 2.46875 0.703125 C 2.582031 0.554688 2.6875 0.253906 2.78125 -0.203125 L 2.84375 -0.53125 C 2.5 -0.175781 2.132813 0 1.75 0 C 1.351563 0 1.019531 -0.144531 0.75 -0.4375 C 0.488281 -0.726563 0.359375 -1.132813 0.359375 -1.65625 C 0.359375 -2.09375 0.460938 -2.492188 0.671875 -2.859375 C 0.890625 -3.234375 1.140625 -3.515625 1.421875 -3.703125 C 1.710938 -3.890625 2.007813 -3.984375 2.3125 -3.984375 C 2.820313 -3.984375 3.21875 -3.738281 3.5 -3.25 L 3.625 -3.890625 L 4.234375 -3.890625 L 3.453125 -0.140625 C 3.367188 0.273438 3.253906 0.597656 3.109375 0.828125 C 2.972656 1.054688 2.78125 1.234375 2.53125 1.359375 C 2.28125 1.492188 1.992188 1.5625 1.671875 1.5625 C 1.359375 1.5625 1.085938 1.519531 0.859375 1.4375 C 0.640625 1.351563 0.472656 1.234375 0.359375 1.078125 C 0.242188 0.921875 0.1875 0.742188 0.1875 0.546875 C 0.1875 0.484375 0.195313 0.421875 0.21875 0.359375 Z M 1.046875 -1.71875 C 1.046875 -1.457031 1.066406 -1.257813 1.109375 -1.125 C 1.191406 -0.9375 1.300781 -0.789063 1.4375 -0.6875 C 1.570313 -0.59375 1.71875 -0.546875 1.875 -0.546875 C 2.09375 -0.546875 2.3125 -0.617188 2.53125 -0.765625 C 2.75 -0.921875 2.921875 -1.15625 3.046875 -1.46875 C 3.179688 -1.789063 3.25 -2.097656 3.25 -2.390625 C 3.25 -2.710938 3.160156 -2.96875 2.984375 -3.15625 C 2.804688 -3.34375 2.585938 -3.4375 2.328125 -3.4375 C 2.171875 -3.4375 2.015625 -3.394531 1.859375 -3.3125 C 1.710938 -3.226563 1.570313 -3.097656 1.4375 -2.921875 C 1.300781 -2.742188 1.203125 -2.53125 1.140625 -2.28125 C 1.078125 -2.03125 1.046875 -1.84375 1.046875 -1.71875 Z M 1.046875 -1.71875 "
+           id="path281" />
+      </g>
+    </g>
+    <clipPath
+       id="clip-0">
+      <path
+         clip-rule="nonzero"
+         d="M 0 0 L 940 0 L 940 181.546875 L 0 181.546875 Z M 0 0 "
+         id="path286" />
+    </clipPath>
+  </defs>
+  <g
+     clip-path="url(#clip-0)"
+     id="g293">
+    <path
+       fill-rule="nonzero"
+       fill="#ffffff"
+       fill-opacity="1"
+       d="m 0.375,0.375 h 939.25 V 181.17187 H 0.375 Z m 0,0"
+       id="path291" />
+  </g>
+  <g
+     fill="#000000"
+     fill-opacity="1"
+     id="g327">
+    <use
+       xlink:href="#glyph-0-1"
+       x="354.09415"
+       y="19.505184"
+       id="use295" />
+    <use
+       xlink:href="#glyph-0-2"
+       x="359.51184"
+       y="19.505184"
+       id="use297" />
+    <use
+       xlink:href="#glyph-0-3"
+       x="362.01004"
+       y="19.505184"
+       id="use299" />
+    <use
+       xlink:href="#glyph-0-4"
+       x="363.67676"
+       y="19.505184"
+       id="use301" />
+    <use
+       xlink:href="#glyph-0-5"
+       x="365.76105"
+       y="19.505184"
+       id="use303" />
+    <use
+       xlink:href="#glyph-0-6"
+       x="369.93332"
+       y="19.505184"
+       id="use305" />
+    <use
+       xlink:href="#glyph-0-7"
+       x="373.6843"
+       y="19.505184"
+       id="use307" />
+    <use
+       xlink:href="#glyph-0-8"
+       x="377.85657"
+       y="19.505184"
+       id="use309" />
+    <use
+       xlink:href="#glyph-0-3"
+       x="382.02881"
+       y="19.505184"
+       id="use311" />
+    <use
+       xlink:href="#glyph-0-9"
+       x="383.6955"
+       y="19.505184"
+       id="use313" />
+    <use
+       xlink:href="#glyph-0-10"
+       x="387.86777"
+       y="19.505184"
+       id="use315" />
+    <use
+       xlink:href="#glyph-0-11"
+       x="389.95206"
+       y="19.505184"
+       id="use317" />
+    <use
+       xlink:href="#glyph-0-7"
+       x="395.36975"
+       y="19.505184"
+       id="use319" />
+    <use
+       xlink:href="#glyph-0-8"
+       x="399.54199"
+       y="19.505184"
+       id="use321" />
+    <use
+       xlink:href="#glyph-0-3"
+       x="403.71426"
+       y="19.505184"
+       id="use323" />
+    <use
+       xlink:href="#glyph-0-9"
+       x="405.38095"
+       y="19.505184"
+       id="use325" />
+  </g>
+  <path
+     fill-rule="nonzero"
+     fill="rgb(100%, 100%, 100%)"
+     fill-opacity="1"
+     stroke-width="2"
+     stroke-linecap="butt"
+     stroke-linejoin="miter"
+     stroke="rgb(0%, 0%, 0%)"
+     stroke-opacity="1"
+     stroke-miterlimit="4"
+     d="M 469.750089 36.000844 L 992.251775 36.000844 L 992.251775 120.999075 L 469.750089 120.999075 Z M 469.750089 36.000844 "
+     transform="matrix(0.750199, 0, 0, 0.750199, 0, 0)"
+     id="path329" />
+  <path
+     fill-rule="nonzero"
+     fill="rgb(96.078491%, 96.078491%, 96.078491%)"
+     fill-opacity="1"
+     stroke-width="1"
+     stroke-linecap="butt"
+     stroke-linejoin="miter"
+     stroke="rgb(39.99939%, 39.99939%, 39.99939%)"
+     stroke-opacity="1"
+     stroke-miterlimit="4"
+     d="M 1056.349181 46.997787 L 1116.348852 46.997787 L 1116.348852 106.997457 L 1056.349181 106.997457 Z M 1056.349181 46.997787 "
+     transform="matrix(0.750199, 0, 0, 0.750199, 0.3751, 0.3751)"
+     id="path331" />
+  <g
+     fill="#333333"
+     fill-opacity="1"
+     id="g337">
+    <use
+       xlink:href="#glyph-1-1"
+       x="809.28937"
+       y="51.76376"
+       id="use333" />
+    <use
+       xlink:href="#glyph-1-2"
+       x="815.12463"
+       y="51.76376"
+       id="use335" />
+  </g>
+  <g
+     fill="#333333"
+     fill-opacity="1"
+     id="g347">
+    <use
+       xlink:href="#glyph-1-3"
+       x="807.20288"
+       y="60.766155"
+       id="use339" />
+    <use
+       xlink:href="#glyph-1-4"
+       x="811.7854"
+       y="60.766155"
+       id="use341" />
+    <use
+       xlink:href="#glyph-1-5"
+       x="813.86969"
+       y="60.766155"
+       id="use343" />
+    <use
+       xlink:href="#glyph-1-6"
+       x="818.04193"
+       y="60.766155"
+       id="use345" />
+  </g>
+  <g
+     fill="#333333"
+     fill-opacity="1"
+     id="g359">
+    <use
+       xlink:href="#glyph-1-7"
+       x="804.07312"
+       y="69.768547"
+       id="use349" />
+    <use
+       xlink:href="#glyph-1-8"
+       x="808.24536"
+       y="69.768547"
+       id="use351" />
+    <use
+       xlink:href="#glyph-1-7"
+       x="812.4176"
+       y="69.768547"
+       id="use353" />
+    <use
+       xlink:href="#glyph-1-9"
+       x="816.5899"
+       y="69.768547"
+       id="use355" />
+    <use
+       xlink:href="#glyph-1-10"
+       x="821.17242"
+       y="69.768547"
+       id="use357" />
+  </g>
+  <path
+     fill="none"
+     stroke-width="1"
+     stroke-linecap="butt"
+     stroke-linejoin="miter"
+     stroke="rgb(0%, 0%, 0%)"
+     stroke-opacity="1"
+     stroke-miterlimit="10"
+     d="M 992.251642 57.250269 L 992.298505 61.999006 L 1048.231548 61.999006 "
+     transform="matrix(0.750199, 0, 0, 0.750199, 0.3751, 0.3751)"
+     id="path361" />
+  <path
+     fill-rule="nonzero"
+     fill="rgb(0%, 0%, 0%)"
+     fill-opacity="1"
+     stroke-width="1"
+     stroke-linecap="butt"
+     stroke-linejoin="miter"
+     stroke="rgb(0%, 0%, 0%)"
+     stroke-opacity="1"
+     stroke-miterlimit="10"
+     d="M 1055.229687 61.999006 L 1048.231548 65.498075 L 1048.231548 58.499936 Z M 1055.229687 61.999006 "
+     transform="matrix(0.750199, 0, 0, 0.750199, 0.3751, 0.3751)"
+     id="path363" />
+  <path
+     fill-rule="nonzero"
+     fill="rgb(96.078491%, 96.078491%, 96.078491%)"
+     fill-opacity="1"
+     stroke-width="1"
+     stroke-linecap="butt"
+     stroke-linejoin="miter"
+     stroke="rgb(39.99939%, 39.99939%, 39.99939%)"
+     stroke-opacity="1"
+     stroke-miterlimit="4"
+     d="M 1175.317546 46.997787 L 1233.999859 46.997787 L 1233.999859 106.997457 L 1175.317546 106.997457 Z M 1175.317546 46.997787 "
+     transform="matrix(0.750199, 0, 0, 0.750199, 0.3751, 0.3751)"
+     id="path365" />
+  <g
+     fill="#333333"
+     fill-opacity="1"
+     id="g375">
+    <use
+       xlink:href="#glyph-1-3"
+       x="896.1015"
+       y="60.766155"
+       id="use367" />
+    <use
+       xlink:href="#glyph-1-4"
+       x="900.68402"
+       y="60.766155"
+       id="use369" />
+    <use
+       xlink:href="#glyph-1-5"
+       x="902.76831"
+       y="60.766155"
+       id="use371" />
+    <use
+       xlink:href="#glyph-1-6"
+       x="906.94055"
+       y="60.766155"
+       id="use373" />
+  </g>
+  <path
+     fill="none"
+     stroke-width="2"
+     stroke-linecap="butt"
+     stroke-linejoin="miter"
+     stroke="rgb(0%, 59.999084%, 0%)"
+     stroke-opacity="1"
+     stroke-miterlimit="10"
+     d="M 1116.348985 61.999139 L 1165.080818 61.999139 "
+     transform="matrix(0.750199, 0, 0, 0.750199, 0, 0)"
+     id="path377" />
+  <path
+     fill-rule="nonzero"
+     fill="rgb(0%, 59.999084%, 0%)"
+     fill-opacity="1"
+     stroke-width="2"
+     stroke-linecap="butt"
+     stroke-linejoin="miter"
+     stroke="rgb(0%, 59.999084%, 0%)"
+     stroke-opacity="1"
+     stroke-miterlimit="10"
+     d="M 1173.078691 61.999139 L 1165.080818 65.998075 L 1165.080818 58.000202 Z M 1173.078691 61.999139 "
+     transform="matrix(0.750199, 0, 0, 0.750199, 0, 0)"
+     id="path379" />
+  <path
+     fill-rule="nonzero"
+     fill="rgb(100%, 100%, 100%)"
+     fill-opacity="1"
+     d="M 843.972656 49.511719 L 874.734375 49.511719 L 874.734375 58.515625 L 843.972656 58.515625 Z M 843.972656 49.511719 "
+     id="path381" />
+  <g
+     fill="#009900"
+     fill-opacity="1"
+     id="g401">
+    <use
+       xlink:href="#glyph-1-11"
+       x="843.92749"
+       y="56.264957"
+       id="use383" />
+    <use
+       xlink:href="#glyph-1-4"
+       x="846.42572"
+       y="56.264957"
+       id="use385" />
+    <use
+       xlink:href="#glyph-1-12"
+       x="848.51001"
+       y="56.264957"
+       id="use387" />
+    <use
+       xlink:href="#glyph-1-10"
+       x="850.5943"
+       y="56.264957"
+       id="use389" />
+    <use
+       xlink:href="#glyph-1-13"
+       x="854.76654"
+       y="56.264957"
+       id="use391" />
+    <use
+       xlink:href="#glyph-1-2"
+       x="856.85083"
+       y="56.264957"
+       id="use393" />
+    <use
+       xlink:href="#glyph-1-14"
+       x="861.85461"
+       y="56.264957"
+       id="use395" />
+    <use
+       xlink:href="#glyph-1-15"
+       x="866.02686"
+       y="56.264957"
+       id="use397" />
+    <use
+       xlink:href="#glyph-1-7"
+       x="870.60938"
+       y="56.264957"
+       id="use399" />
+  </g>
+  <path
+     fill-rule="nonzero"
+     fill="rgb(100%, 100%, 100%)"
+     fill-opacity="1"
+     d="M 751.699219 49.511719 L 780.957031 49.511719 L 780.957031 58.515625 L 751.699219 58.515625 Z M 751.699219 49.511719 "
+     id="path403" />
+  <g
+     fill="#000000"
+     fill-opacity="1"
+     id="g417">
+    <use
+       xlink:href="#glyph-0-12"
+       x="751.80536"
+       y="56.264957"
+       id="use405" />
+    <use
+       xlink:href="#glyph-0-3"
+       x="753.88965"
+       y="56.264957"
+       id="use407" />
+    <use
+       xlink:href="#glyph-0-13"
+       x="755.55634"
+       y="56.264957"
+       id="use409" />
+    <use
+       xlink:href="#glyph-0-5"
+       x="757.22302"
+       y="56.264957"
+       id="use411" />
+    <use
+       xlink:href="#glyph-0-10"
+       x="761.39526"
+       y="56.264957"
+       id="use413" />
+    <use
+       xlink:href="#glyph-0-14"
+       x="763.47955"
+       y="56.264957"
+       id="use415" />
+  </g>
+  <g
+     fill="#000000"
+     fill-opacity="1"
+     id="g427">
+    <use
+       xlink:href="#glyph-0-2"
+       x="770.4248"
+       y="56.264957"
+       id="use419" />
+    <use
+       xlink:href="#glyph-0-3"
+       x="772.92303"
+       y="56.264957"
+       id="use421" />
+    <use
+       xlink:href="#glyph-0-4"
+       x="774.58972"
+       y="56.264957"
+       id="use423" />
+    <use
+       xlink:href="#glyph-0-5"
+       x="776.67401"
+       y="56.264957"
+       id="use425" />
+  </g>
+  <path
+     fill-rule="nonzero"
+     fill="rgb(100%, 94.898987%, 79.998779%)"
+     fill-opacity="1"
+     stroke-width="1"
+     stroke-linecap="butt"
+     stroke-linejoin="miter"
+     stroke="rgb(83.918762%, 71.369934%, 33.729553%)"
+     stroke-opacity="1"
+     stroke-miterlimit="4"
+     d="M 923.998958 46.997787 L 983.998628 46.997787 L 983.998628 106.997457 L 923.998958 106.997457 Z M 923.998958 46.997787 "
+     transform="matrix(0.750199, 0, 0, 0.750199, 0.3751, 0.3751)"
+     id="path429" />
+  <g
+     fill="#000000"
+     fill-opacity="1"
+     id="g441">
+    <use
+       xlink:href="#glyph-0-15"
+       x="708.17657"
+       y="56.264957"
+       id="use431" />
+    <use
+       xlink:href="#glyph-0-13"
+       x="711.92755"
+       y="56.264957"
+       id="use433" />
+    <use
+       xlink:href="#glyph-0-3"
+       x="713.59424"
+       y="56.264957"
+       id="use435" />
+    <use
+       xlink:href="#glyph-0-6"
+       x="715.26093"
+       y="56.264957"
+       id="use437" />
+    <use
+       xlink:href="#glyph-0-5"
+       x="719.01196"
+       y="56.264957"
+       id="use439" />
+  </g>
+  <g
+     fill="#000000"
+     fill-opacity="1"
+     id="g451">
+    <use
+       xlink:href="#glyph-1-16"
+       x="709.21979"
+       y="65.267349"
+       id="use443" />
+    <use
+       xlink:href="#glyph-1-4"
+       x="713.80231"
+       y="65.267349"
+       id="use445" />
+    <use
+       xlink:href="#glyph-1-12"
+       x="715.8866"
+       y="65.267349"
+       id="use447" />
+    <use
+       xlink:href="#glyph-1-10"
+       x="717.97089"
+       y="65.267349"
+       id="use449" />
+  </g>
+  <path
+     fill-rule="nonzero"
+     fill="rgb(100%, 100%, 100%)"
+     fill-opacity="1"
+     stroke-width="1"
+     stroke-linecap="butt"
+     stroke-linejoin="miter"
+     stroke="rgb(0%, 0%, 0%)"
+     stroke-opacity="1"
+     stroke-miterlimit="4"
+     d="M 854.001946 46.997787 L 914.001616 46.997787 L 914.001616 106.997457 L 854.001946 106.997457 Z M 854.001946 46.997787 "
+     transform="matrix(0.750199, 0, 0, 0.750199, 0.3751, 0.3751)"
+     id="path453" />
+  <g
+     fill="#000000"
+     fill-opacity="1"
+     id="g467">
+    <use
+       xlink:href="#glyph-1-17"
+       x="652.54456"
+       y="60.766155"
+       id="use455" />
+    <use
+       xlink:href="#glyph-1-18"
+       x="657.12708"
+       y="60.766155"
+       id="use457" />
+    <use
+       xlink:href="#glyph-1-11"
+       x="661.70959"
+       y="60.766155"
+       id="use459" />
+    <use
+       xlink:href="#glyph-1-11"
+       x="664.20782"
+       y="60.766155"
+       id="use461" />
+    <use
+       xlink:href="#glyph-1-10"
+       x="666.70605"
+       y="60.766155"
+       id="use463" />
+    <use
+       xlink:href="#glyph-1-19"
+       x="670.8783"
+       y="60.766155"
+       id="use465" />
+  </g>
+  <path
+     fill-rule="nonzero"
+     fill="rgb(85.488892%, 90.979004%, 98.81897%)"
+     fill-opacity="1"
+     d="M 415.984375 35.632813 L 460.996094 35.632813 L 460.996094 80.644531 L 415.984375 80.644531 Z M 415.984375 35.632813 "
+     id="path469" />
+  <path
+     fill-rule="nonzero"
+     fill="rgb(42.349243%, 55.688477%, 74.899292%)"
+     fill-opacity="1"
+     d="M 420.488281 35.257813 L 422.738281 35.257813 L 422.738281 36.007813 L 420.488281 36.007813 Z M 424.988281 35.257813 L 427.238281 35.257813 L 427.238281 36.007813 L 424.988281 36.007813 Z M 429.488281 35.257813 L 431.738281 35.257813 L 431.738281 36.007813 L 429.488281 36.007813 Z M 433.992188 35.257813 L 436.242188 35.257813 L 436.242188 36.007813 L 433.992188 36.007813 Z M 438.492188 35.257813 L 440.742188 35.257813 L 440.742188 36.007813 L 438.492188 36.007813 Z M 442.992188 35.257813 L 445.242188 35.257813 L 445.242188 36.007813 L 442.992188 36.007813 Z M 447.492188 35.257813 L 449.746094 35.257813 L 449.746094 36.007813 L 447.492188 36.007813 Z M 451.996094 35.257813 L 454.246094 35.257813 L 454.246094 36.007813 L 451.996094 36.007813 Z M 456.496094 35.257813 L 458.746094 35.257813 L 458.746094 36.007813 L 456.496094 36.007813 Z M 461.371094 35.632813 L 461.371094 37.886719 L 460.621094 37.886719 L 460.621094 35.632813 Z M 461.371094 40.136719 L 461.371094 42.386719 L 460.621094 42.386719 L 460.621094 40.136719 Z M 461.371094 44.636719 L 461.371094 46.886719 L 460.621094 46.886719 L 460.621094 44.636719 Z M 461.371094 49.136719 L 461.371094 51.386719 L 460.621094 51.386719 L 460.621094 49.136719 Z M 461.371094 53.640625 L 461.371094 55.890625 L 460.621094 55.890625 L 460.621094 53.640625 Z M 461.371094 58.140625 L 461.371094 60.390625 L 460.621094 60.390625 L 460.621094 58.140625 Z M 461.371094 62.640625 L 461.371094 64.890625 L 460.621094 64.890625 L 460.621094 62.640625 Z M 461.371094 67.144531 L 461.371094 69.394531 L 460.621094 69.394531 L 460.621094 67.144531 Z M 461.371094 71.644531 L 461.371094 73.894531 L 460.621094 73.894531 L 460.621094 71.644531 Z M 461.371094 76.144531 L 461.371094 78.394531 L 460.621094 78.394531 L 460.621094 76.144531 Z M 460.996094 81.023438 L 458.746094 81.023438 L 458.746094 80.269531 L 460.996094 80.269531 Z M 456.496094 81.023438 L 454.246094 81.023438 L 454.246094 80.269531 L 456.496094 80.269531 Z M 451.996094 81.023438 L 449.746094 81.023438 L 449.746094 80.269531 L 451.996094 80.269531 Z M 447.492188 81.023438 L 445.242188 81.023438 L 445.242188 80.269531 L 447.492188 80.269531 Z M 442.992188 81.023438 L 440.742188 81.023438 L 440.742188 80.269531 L 442.992188 80.269531 Z M 438.492188 81.023438 L 436.242188 81.023438 L 436.242188 80.269531 L 438.492188 80.269531 Z M 433.992188 81.023438 L 431.738281 81.023438 L 431.738281 80.269531 L 433.992188 80.269531 Z M 429.488281 81.023438 L 427.238281 81.023438 L 427.238281 80.269531 L 429.488281 80.269531 Z M 424.988281 81.023438 L 422.738281 81.023438 L 422.738281 80.269531 L 424.988281 80.269531 Z M 420.488281 81.023438 L 418.234375 81.023438 L 418.234375 80.269531 L 420.488281 80.269531 Z M 415.609375 80.644531 L 415.609375 78.394531 L 416.359375 78.394531 L 416.359375 80.644531 Z M 415.609375 76.144531 L 415.609375 73.894531 L 416.359375 73.894531 L 416.359375 76.144531 Z M 415.609375 71.644531 L 415.609375 69.394531 L 416.359375 69.394531 L 416.359375 71.644531 Z M 415.609375 67.144531 L 415.609375 64.890625 L 416.359375 64.890625 L 416.359375 67.144531 Z M 415.609375 62.640625 L 415.609375 60.390625 L 416.359375 60.390625 L 416.359375 62.640625 Z M 415.609375 58.140625 L 415.609375 55.890625 L 416.359375 55.890625 L 416.359375 58.140625 Z M 415.609375 53.640625 L 415.609375 51.386719 L 416.359375 51.386719 L 416.359375 53.640625 Z M 415.609375 49.136719 L 415.609375 46.886719 L 416.359375 46.886719 L 416.359375 49.136719 Z M 415.609375 44.636719 L 415.609375 42.386719 L 416.359375 42.386719 L 416.359375 44.636719 Z M 415.609375 40.136719 L 415.609375 37.886719 L 416.359375 37.886719 L 416.359375 40.136719 Z M 415.984375 35.257813 L 418.234375 35.257813 L 418.234375 36.007813 L 415.984375 36.007813 Z M 415.984375 35.257813 "
+     id="path471" />
+  <g
+     fill="#000000"
+     fill-opacity="1"
+     id="g481">
+    <use
+       xlink:href="#glyph-1-19"
+       x="429.34851"
+       y="51.76376"
+       id="use473" />
+    <use
+       xlink:href="#glyph-1-20"
+       x="432.26797"
+       y="51.76376"
+       id="use475" />
+    <use
+       xlink:href="#glyph-1-21"
+       x="436.85049"
+       y="51.76376"
+       id="use477" />
+    <use
+       xlink:href="#glyph-1-5"
+       x="442.68579"
+       y="51.76376"
+       id="use479" />
+  </g>
+  <g
+     fill="#000000"
+     fill-opacity="1"
+     id="g497">
+    <use
+       xlink:href="#glyph-1-7"
+       x="424.35501"
+       y="60.766155"
+       id="use483" />
+    <use
+       xlink:href="#glyph-1-20"
+       x="428.52725"
+       y="60.766155"
+       id="use485" />
+    <use
+       xlink:href="#glyph-1-18"
+       x="433.10977"
+       y="60.766155"
+       id="use487" />
+    <use
+       xlink:href="#glyph-1-15"
+       x="437.69229"
+       y="60.766155"
+       id="use489" />
+    <use
+       xlink:href="#glyph-1-22"
+       x="442.27481"
+       y="60.766155"
+       id="use491" />
+    <use
+       xlink:href="#glyph-1-10"
+       x="444.77301"
+       y="60.766155"
+       id="use493" />
+    <use
+       xlink:href="#glyph-1-19"
+       x="448.94528"
+       y="60.766155"
+       id="use495" />
+  </g>
+  <g
+     fill="#000000"
+     fill-opacity="1"
+     id="g515">
+    <use
+       xlink:href="#glyph-1-11"
+       x="424.56598"
+       y="69.768547"
+       id="use499" />
+    <use
+       xlink:href="#glyph-1-12"
+       x="427.06421"
+       y="69.768547"
+       id="use501" />
+    <use
+       xlink:href="#glyph-1-18"
+       x="429.1485"
+       y="69.768547"
+       id="use503" />
+    <use
+       xlink:href="#glyph-1-5"
+       x="433.73102"
+       y="69.768547"
+       id="use505" />
+    <use
+       xlink:href="#glyph-1-9"
+       x="437.90329"
+       y="69.768547"
+       id="use507" />
+    <use
+       xlink:href="#glyph-1-23"
+       x="442.48578"
+       y="69.768547"
+       id="use509" />
+    <use
+       xlink:href="#glyph-1-11"
+       x="444.5701"
+       y="69.768547"
+       id="use511" />
+    <use
+       xlink:href="#glyph-1-15"
+       x="447.0683"
+       y="69.768547"
+       id="use513" />
+  </g>
+  <path
+     fill-rule="nonzero"
+     fill="rgb(85.488892%, 90.979004%, 98.81897%)"
+     fill-opacity="1"
+     stroke-width="1"
+     stroke-linecap="butt"
+     stroke-linejoin="miter"
+     stroke="rgb(42.349243%, 55.688477%, 74.899292%)"
+     stroke-opacity="1"
+     stroke-miterlimit="4"
+     d="M 693.997618 46.997787 L 774.002385 46.997787 L 774.002385 106.997457 L 693.997618 106.997457 Z M 693.997618 46.997787 "
+     transform="matrix(0.750199, 0, 0, 0.750199, 0.3751, 0.3751)"
+     id="path517" />
+  <g
+     fill="#000000"
+     fill-opacity="1"
+     id="g541">
+    <use
+       xlink:href="#glyph-1-7"
+       x="527.29645"
+       y="56.264957"
+       id="use519" />
+    <use
+       xlink:href="#glyph-1-20"
+       x="531.46869"
+       y="56.264957"
+       id="use521" />
+    <use
+       xlink:href="#glyph-1-24"
+       x="536.05121"
+       y="56.264957"
+       id="use523" />
+    <use
+       xlink:href="#glyph-1-25"
+       x="542.72168"
+       y="56.264957"
+       id="use525" />
+    <use
+       xlink:href="#glyph-1-19"
+       x="547.3042"
+       y="56.264957"
+       id="use527" />
+    <use
+       xlink:href="#glyph-1-10"
+       x="550.22369"
+       y="56.264957"
+       id="use529" />
+    <use
+       xlink:href="#glyph-1-5"
+       x="554.39594"
+       y="56.264957"
+       id="use531" />
+    <use
+       xlink:href="#glyph-1-5"
+       x="558.56818"
+       y="56.264957"
+       id="use533" />
+    <use
+       xlink:href="#glyph-1-4"
+       x="562.74042"
+       y="56.264957"
+       id="use535" />
+    <use
+       xlink:href="#glyph-1-20"
+       x="564.82471"
+       y="56.264957"
+       id="use537" />
+    <use
+       xlink:href="#glyph-1-15"
+       x="569.40723"
+       y="56.264957"
+       id="use539" />
+  </g>
+  <g
+     fill="#000000"
+     fill-opacity="1"
+     id="g555">
+    <use
+       xlink:href="#glyph-1-21"
+       x="540.42493"
+       y="65.267349"
+       id="use543" />
+    <use
+       xlink:href="#glyph-1-19"
+       x="546.26019"
+       y="65.267349"
+       id="use545" />
+    <use
+       xlink:href="#glyph-1-4"
+       x="549.17969"
+       y="65.267349"
+       id="use547" />
+    <use
+       xlink:href="#glyph-1-22"
+       x="551.26398"
+       y="65.267349"
+       id="use549" />
+    <use
+       xlink:href="#glyph-1-10"
+       x="553.76221"
+       y="65.267349"
+       id="use551" />
+    <use
+       xlink:href="#glyph-1-19"
+       x="557.93445"
+       y="65.267349"
+       id="use553" />
+  </g>
+  <path
+     fill-rule="nonzero"
+     fill="rgb(85.488892%, 90.979004%, 98.81897%)"
+     fill-opacity="1"
+     d="M 363.472656 35.632813 L 408.484375 35.632813 L 408.484375 80.644531 L 363.472656 80.644531 Z M 363.472656 35.632813 "
+     id="path557" />
+  <path
+     fill-rule="nonzero"
+     fill="rgb(42.349243%, 55.688477%, 74.899292%)"
+     fill-opacity="1"
+     d="M 367.972656 35.257813 L 370.222656 35.257813 L 370.222656 36.007813 L 367.972656 36.007813 Z M 372.472656 35.257813 L 374.726563 35.257813 L 374.726563 36.007813 L 372.472656 36.007813 Z M 376.976563 35.257813 L 379.226563 35.257813 L 379.226563 36.007813 L 376.976563 36.007813 Z M 381.476563 35.257813 L 383.726563 35.257813 L 383.726563 36.007813 L 381.476563 36.007813 Z M 385.976563 35.257813 L 388.226563 35.257813 L 388.226563 36.007813 L 385.976563 36.007813 Z M 390.480469 35.257813 L 392.730469 35.257813 L 392.730469 36.007813 L 390.480469 36.007813 Z M 394.980469 35.257813 L 397.230469 35.257813 L 397.230469 36.007813 L 394.980469 36.007813 Z M 399.480469 35.257813 L 401.730469 35.257813 L 401.730469 36.007813 L 399.480469 36.007813 Z M 403.980469 35.257813 L 406.234375 35.257813 L 406.234375 36.007813 L 403.980469 36.007813 Z M 408.859375 35.632813 L 408.859375 37.886719 L 408.109375 37.886719 L 408.109375 35.632813 Z M 408.859375 40.136719 L 408.859375 42.386719 L 408.109375 42.386719 L 408.109375 40.136719 Z M 408.859375 44.636719 L 408.859375 46.886719 L 408.109375 46.886719 L 408.109375 44.636719 Z M 408.859375 49.136719 L 408.859375 51.386719 L 408.109375 51.386719 L 408.109375 49.136719 Z M 408.859375 53.640625 L 408.859375 55.890625 L 408.109375 55.890625 L 408.109375 53.640625 Z M 408.859375 58.140625 L 408.859375 60.390625 L 408.109375 60.390625 L 408.109375 58.140625 Z M 408.859375 62.640625 L 408.859375 64.890625 L 408.109375 64.890625 L 408.109375 62.640625 Z M 408.859375 67.144531 L 408.859375 69.394531 L 408.109375 69.394531 L 408.109375 67.144531 Z M 408.859375 71.644531 L 408.859375 73.894531 L 408.109375 73.894531 L 408.109375 71.644531 Z M 408.859375 76.144531 L 408.859375 78.394531 L 408.109375 78.394531 L 408.109375 76.144531 Z M 408.484375 81.023438 L 406.234375 81.023438 L 406.234375 80.269531 L 408.484375 80.269531 Z M 403.980469 81.023438 L 401.730469 81.023438 L 401.730469 80.269531 L 403.980469 80.269531 Z M 399.480469 81.023438 L 397.230469 81.023438 L 397.230469 80.269531 L 399.480469 80.269531 Z M 394.980469 81.023438 L 392.730469 81.023438 L 392.730469 80.269531 L 394.980469 80.269531 Z M 390.480469 81.023438 L 388.226563 81.023438 L 388.226563 80.269531 L 390.480469 80.269531 Z M 385.976563 81.023438 L 383.726563 81.023438 L 383.726563 80.269531 L 385.976563 80.269531 Z M 381.476563 81.023438 L 379.226563 81.023438 L 379.226563 80.269531 L 381.476563 80.269531 Z M 376.976563 81.023438 L 374.726563 81.023438 L 374.726563 80.269531 L 376.976563 80.269531 Z M 372.472656 81.023438 L 370.222656 81.023438 L 370.222656 80.269531 L 372.472656 80.269531 Z M 367.972656 81.023438 L 365.722656 81.023438 L 365.722656 80.269531 L 367.972656 80.269531 Z M 363.097656 80.644531 L 363.097656 78.394531 L 363.847656 78.394531 L 363.847656 80.644531 Z M 363.097656 76.144531 L 363.097656 73.894531 L 363.847656 73.894531 L 363.847656 76.144531 Z M 363.097656 71.644531 L 363.097656 69.394531 L 363.847656 69.394531 L 363.847656 71.644531 Z M 363.097656 67.144531 L 363.097656 64.890625 L 363.847656 64.890625 L 363.847656 67.144531 Z M 363.097656 62.640625 L 363.097656 60.390625 L 363.847656 60.390625 L 363.847656 62.640625 Z M 363.097656 58.140625 L 363.097656 55.890625 L 363.847656 55.890625 L 363.847656 58.140625 Z M 363.097656 53.640625 L 363.097656 51.386719 L 363.847656 51.386719 L 363.847656 53.640625 Z M 363.097656 49.136719 L 363.097656 46.886719 L 363.847656 46.886719 L 363.847656 49.136719 Z M 363.097656 44.636719 L 363.097656 42.386719 L 363.847656 42.386719 L 363.847656 44.636719 Z M 363.097656 40.136719 L 363.097656 37.886719 L 363.847656 37.886719 L 363.847656 40.136719 Z M 363.472656 35.257813 L 365.722656 35.257813 L 365.722656 36.007813 L 363.472656 36.007813 Z M 363.472656 35.257813 "
+     id="path559" />
+  <g
+     fill="#000000"
+     fill-opacity="1"
+     id="g567">
+    <use
+       xlink:href="#glyph-1-26"
+       x="377.87781"
+       y="51.76376"
+       id="use561" />
+    <use
+       xlink:href="#glyph-1-2"
+       x="383.2955"
+       y="51.76376"
+       id="use563" />
+    <use
+       xlink:href="#glyph-1-27"
+       x="388.29929"
+       y="51.76376"
+       id="use565" />
+  </g>
+  <g
+     fill="#000000"
+     fill-opacity="1"
+     id="g581">
+    <use
+       xlink:href="#glyph-1-21"
+       x="375.38104"
+       y="60.766155"
+       id="use569" />
+    <use
+       xlink:href="#glyph-1-19"
+       x="381.21634"
+       y="60.766155"
+       id="use571" />
+    <use
+       xlink:href="#glyph-1-4"
+       x="384.1358"
+       y="60.766155"
+       id="use573" />
+    <use
+       xlink:href="#glyph-1-22"
+       x="386.22009"
+       y="60.766155"
+       id="use575" />
+    <use
+       xlink:href="#glyph-1-10"
+       x="388.71832"
+       y="60.766155"
+       id="use577" />
+    <use
+       xlink:href="#glyph-1-19"
+       x="392.89056"
+       y="60.766155"
+       id="use579" />
+  </g>
+  <g
+     fill="#000000"
+     fill-opacity="1"
+     id="g599">
+    <use
+       xlink:href="#glyph-1-11"
+       x="372.05203"
+       y="69.768547"
+       id="use583" />
+    <use
+       xlink:href="#glyph-1-12"
+       x="374.55026"
+       y="69.768547"
+       id="use585" />
+    <use
+       xlink:href="#glyph-1-18"
+       x="376.63455"
+       y="69.768547"
+       id="use587" />
+    <use
+       xlink:href="#glyph-1-5"
+       x="381.21707"
+       y="69.768547"
+       id="use589" />
+    <use
+       xlink:href="#glyph-1-9"
+       x="385.38931"
+       y="69.768547"
+       id="use591" />
+    <use
+       xlink:href="#glyph-1-23"
+       x="389.97183"
+       y="69.768547"
+       id="use593" />
+    <use
+       xlink:href="#glyph-1-11"
+       x="392.05612"
+       y="69.768547"
+       id="use595" />
+    <use
+       xlink:href="#glyph-1-15"
+       x="394.55435"
+       y="69.768547"
+       id="use597" />
+  </g>
+  <path
+     fill-rule="nonzero"
+     fill="rgb(85.488892%, 90.979004%, 98.81897%)"
+     fill-opacity="1"
+     stroke-width="1"
+     stroke-linecap="butt"
+     stroke-linejoin="miter"
+     stroke="rgb(42.349243%, 55.688477%, 74.899292%)"
+     stroke-opacity="1"
+     stroke-miterlimit="4"
+     d="M 783.999727 46.997787 L 843.999397 46.997787 L 843.999397 106.997457 L 783.999727 106.997457 Z M 783.999727 46.997787 "
+     transform="matrix(0.750199, 0, 0, 0.750199, 0.3751, 0.3751)"
+     id="path601" />
+  <g
+     fill="#000000"
+     fill-opacity="1"
+     id="g611">
+    <use
+       xlink:href="#glyph-0-15"
+       x="603.9809"
+       y="47.262566"
+       id="use603" />
+    <use
+       xlink:href="#glyph-0-3"
+       x="607.73187"
+       y="47.262566"
+       id="use605" />
+    <use
+       xlink:href="#glyph-0-16"
+       x="609.39856"
+       y="47.262566"
+       id="use607" />
+    <use
+       xlink:href="#glyph-0-5"
+       x="613.1496"
+       y="47.262566"
+       id="use609" />
+  </g>
+  <g
+     fill="#000000"
+     fill-opacity="1"
+     id="g623">
+    <use
+       xlink:href="#glyph-1-28"
+       x="600.65186"
+       y="56.264957"
+       id="use613" />
+    <use
+       xlink:href="#glyph-1-10"
+       x="606.90106"
+       y="56.264957"
+       id="use615" />
+    <use
+       xlink:href="#glyph-1-22"
+       x="611.07336"
+       y="56.264957"
+       id="use617" />
+    <use
+       xlink:href="#glyph-1-10"
+       x="613.57153"
+       y="56.264957"
+       id="use619" />
+    <use
+       xlink:href="#glyph-1-19"
+       x="617.74384"
+       y="56.264957"
+       id="use621" />
+  </g>
+  <g
+     fill="#000000"
+     fill-opacity="1"
+     id="g627">
+    <use
+       xlink:href="#glyph-1-29"
+       x="602.56256"
+       y="65.267349"
+       id="use625" />
+  </g>
+  <g
+     fill="#000000"
+     fill-opacity="1"
+     id="g635">
+    <use
+       xlink:href="#glyph-1-4"
+       x="609.57733"
+       y="65.267349"
+       id="use629" />
+    <use
+       xlink:href="#glyph-1-22"
+       x="611.66162"
+       y="65.267349"
+       id="use631" />
+    <use
+       xlink:href="#glyph-1-9"
+       x="614.15985"
+       y="65.267349"
+       id="use633" />
+  </g>
+  <g
+     fill="#000000"
+     fill-opacity="1"
+     id="g649">
+    <use
+       xlink:href="#glyph-1-30"
+       x="597.11188"
+       y="74.269745"
+       id="use637" />
+    <use
+       xlink:href="#glyph-1-8"
+       x="602.52954"
+       y="74.269745"
+       id="use639" />
+    <use
+       xlink:href="#glyph-1-7"
+       x="606.70184"
+       y="74.269745"
+       id="use641" />
+    <use
+       xlink:href="#glyph-1-6"
+       x="610.87408"
+       y="74.269745"
+       id="use643" />
+    <use
+       xlink:href="#glyph-1-18"
+       x="615.04633"
+       y="74.269745"
+       id="use645" />
+    <use
+       xlink:href="#glyph-1-25"
+       x="619.62885"
+       y="74.269745"
+       id="use647" />
+  </g>
+  <g
+     fill="#000000"
+     fill-opacity="1"
+     id="g697">
+    <use
+       xlink:href="#glyph-2-1"
+       x="485.56659"
+       y="19.505184"
+       id="use651" />
+    <use
+       xlink:href="#glyph-2-2"
+       x="489.31757"
+       y="19.505184"
+       id="use653" />
+    <use
+       xlink:href="#glyph-2-3"
+       x="493.48984"
+       y="19.505184"
+       id="use655" />
+    <use
+       xlink:href="#glyph-2-4"
+       x="499.73904"
+       y="19.505184"
+       id="use657" />
+    <use
+       xlink:href="#glyph-2-5"
+       x="503.91132"
+       y="19.505184"
+       id="use659" />
+    <use
+       xlink:href="#glyph-2-6"
+       x="506.40952"
+       y="19.505184"
+       id="use661" />
+    <use
+       xlink:href="#glyph-2-7"
+       x="510.58179"
+       y="19.505184"
+       id="use663" />
+    <use
+       xlink:href="#glyph-2-7"
+       x="514.33276"
+       y="19.505184"
+       id="use665" />
+    <use
+       xlink:href="#glyph-2-8"
+       x="518.0838"
+       y="19.505184"
+       id="use667" />
+    <use
+       xlink:href="#glyph-2-2"
+       x="519.75049"
+       y="19.505184"
+       id="use669" />
+    <use
+       xlink:href="#glyph-2-9"
+       x="523.92273"
+       y="19.505184"
+       id="use671" />
+    <use
+       xlink:href="#glyph-2-10"
+       x="528.09497"
+       y="19.505184"
+       id="use673" />
+    <use
+       xlink:href="#glyph-2-8"
+       x="530.17926"
+       y="19.505184"
+       id="use675" />
+    <use
+       xlink:href="#glyph-2-7"
+       x="531.84595"
+       y="19.505184"
+       id="use677" />
+    <use
+       xlink:href="#glyph-2-10"
+       x="535.59698"
+       y="19.505184"
+       id="use679" />
+    <use
+       xlink:href="#glyph-2-2"
+       x="537.68127"
+       y="19.505184"
+       id="use681" />
+    <use
+       xlink:href="#glyph-2-4"
+       x="541.85352"
+       y="19.505184"
+       id="use683" />
+    <use
+       xlink:href="#glyph-2-11"
+       x="546.02576"
+       y="19.505184"
+       id="use685" />
+    <use
+       xlink:href="#glyph-2-8"
+       x="548.11005"
+       y="19.505184"
+       id="use687" />
+    <use
+       xlink:href="#glyph-2-2"
+       x="549.77679"
+       y="19.505184"
+       id="use689" />
+    <use
+       xlink:href="#glyph-2-9"
+       x="553.94904"
+       y="19.505184"
+       id="use691" />
+    <use
+       xlink:href="#glyph-2-12"
+       x="558.12128"
+       y="19.505184"
+       id="use693" />
+    <use
+       xlink:href="#glyph-2-13"
+       x="562.29352"
+       y="19.505184"
+       id="use695" />
+  </g>
+  <path
+     fill="none"
+     stroke-width="1"
+     stroke-linecap="butt"
+     stroke-linejoin="miter"
+     stroke="rgb(0%, 0%, 0%)"
+     stroke-opacity="1"
+     stroke-miterlimit="10"
+     d="M 404.001814 62.99874 L 436.899316 62.99874 L 461.632323 62.701944 "
+     transform="matrix(0.750199, 0, 0, 0.750199, 0.3751, 0.3751)"
+     id="path699" />
+  <path
+     fill-rule="nonzero"
+     fill="rgb(0%, 0%, 0%)"
+     fill-opacity="1"
+     stroke-width="1"
+     stroke-linecap="butt"
+     stroke-linejoin="miter"
+     stroke="rgb(0%, 0%, 0%)"
+     stroke-opacity="1"
+     stroke-miterlimit="10"
+     d="M 468.630462 62.618633 L 461.668771 66.201014 L 461.590667 59.197667 Z M 468.630462 62.618633 "
+     transform="matrix(0.750199, 0, 0, 0.750199, 0.3751, 0.3751)"
+     id="path701" />
+  <path
+     fill-rule="nonzero"
+     fill="rgb(100%, 100%, 100%)"
+     fill-opacity="1"
+     d="M 307.582031 36.007813 L 347.34375 36.007813 L 347.34375 45.011719 L 307.582031 45.011719 Z M 307.582031 36.007813 "
+     id="path703" />
+  <g
+     fill="#000000"
+     fill-opacity="1"
+     id="g707">
+    <use
+       xlink:href="#glyph-0-14"
+       x="307.31216"
+       y="42.761368"
+       id="use705" />
+  </g>
+  <g
+     fill="#000000"
+     fill-opacity="1"
+     id="g731">
+    <use
+       xlink:href="#glyph-0-2"
+       x="314.25739"
+       y="42.761368"
+       id="use709" />
+    <use
+       xlink:href="#glyph-0-3"
+       x="316.75558"
+       y="42.761368"
+       id="use711" />
+    <use
+       xlink:href="#glyph-0-4"
+       x="318.4223"
+       y="42.761368"
+       id="use713" />
+    <use
+       xlink:href="#glyph-0-5"
+       x="320.50659"
+       y="42.761368"
+       id="use715" />
+    <use
+       xlink:href="#glyph-0-17"
+       x="324.67883"
+       y="42.761368"
+       id="use717" />
+    <use
+       xlink:href="#glyph-0-18"
+       x="327.17706"
+       y="42.761368"
+       id="use719" />
+    <use
+       xlink:href="#glyph-0-19"
+       x="331.34933"
+       y="42.761368"
+       id="use721" />
+    <use
+       xlink:href="#glyph-0-4"
+       x="335.10031"
+       y="42.761368"
+       id="use723" />
+    <use
+       xlink:href="#glyph-0-5"
+       x="337.1846"
+       y="42.761368"
+       id="use725" />
+    <use
+       xlink:href="#glyph-0-15"
+       x="341.35687"
+       y="42.761368"
+       id="use727" />
+    <use
+       xlink:href="#glyph-0-20"
+       x="345.10785"
+       y="42.761368"
+       id="use729" />
+  </g>
+  <path
+     fill-rule="nonzero"
+     fill="rgb(97.24884%, 80.778503%, 79.998779%)"
+     fill-opacity="1"
+     stroke-width="1"
+     stroke-linecap="butt"
+     stroke-linejoin="miter"
+     stroke="rgb(72.158813%, 32.939148%, 31.369019%)"
+     stroke-opacity="1"
+     stroke-miterlimit="4"
+     d="M 333.999595 46.997787 L 404.001814 46.997787 L 404.001814 111.001601 L 333.999595 111.001601 Z M 333.999595 46.997787 "
+     transform="matrix(0.750199, 0, 0, 0.750199, 0.3751, 0.3751)"
+     id="path733" />
+  <g
+     fill="#000000"
+     fill-opacity="1"
+     id="g751">
+    <use
+       xlink:href="#glyph-0-21"
+       x="262.42914"
+       y="57.765354"
+       id="use735" />
+    <use
+       xlink:href="#glyph-0-3"
+       x="266.60138"
+       y="57.765354"
+       id="use737" />
+    <use
+       xlink:href="#glyph-0-15"
+       x="268.2681"
+       y="57.765354"
+       id="use739" />
+    <use
+       xlink:href="#glyph-0-22"
+       x="272.0191"
+       y="57.765354"
+       id="use741" />
+    <use
+       xlink:href="#glyph-0-15"
+       x="275.77008"
+       y="57.765354"
+       id="use743" />
+    <use
+       xlink:href="#glyph-0-19"
+       x="279.52109"
+       y="57.765354"
+       id="use745" />
+    <use
+       xlink:href="#glyph-0-9"
+       x="283.27209"
+       y="57.765354"
+       id="use747" />
+    <use
+       xlink:href="#glyph-0-6"
+       x="287.44434"
+       y="57.765354"
+       id="use749" />
+  </g>
+  <g
+     fill="#000000"
+     fill-opacity="1"
+     id="g765">
+    <use
+       xlink:href="#glyph-1-2"
+       x="264.30463"
+       y="66.767754"
+       id="use753" />
+    <use
+       xlink:href="#glyph-1-14"
+       x="269.30841"
+       y="66.767754"
+       id="use755" />
+    <use
+       xlink:href="#glyph-1-15"
+       x="273.48065"
+       y="66.767754"
+       id="use757" />
+    <use
+       xlink:href="#glyph-1-7"
+       x="278.06317"
+       y="66.767754"
+       id="use759" />
+    <use
+       xlink:href="#glyph-1-10"
+       x="282.23544"
+       y="66.767754"
+       id="use761" />
+    <use
+       xlink:href="#glyph-1-19"
+       x="286.40768"
+       y="66.767754"
+       id="use763" />
+  </g>
+  <path
+     fill="none"
+     stroke-width="1"
+     stroke-linecap="butt"
+     stroke-linejoin="miter"
+     stroke="rgb(0%, 0%, 0%)"
+     stroke-opacity="1"
+     stroke-miterlimit="10"
+     d="M 174.000474 61.441862 L 325.881962 61.967764 "
+     transform="matrix(0.750199, 0, 0, 0.750199, 0.3751, 0.3751)"
+     id="path767" />
+  <path
+     fill-rule="nonzero"
+     fill="rgb(0%, 0%, 0%)"
+     fill-opacity="1"
+     stroke-width="1"
+     stroke-linecap="butt"
+     stroke-linejoin="miter"
+     stroke="rgb(0%, 0%, 0%)"
+     stroke-opacity="1"
+     stroke-miterlimit="10"
+     d="M 332.880101 61.999006 L 325.871548 65.472041 L 325.892376 58.468695 Z M 332.880101 61.999006 "
+     transform="matrix(0.750199, 0, 0, 0.750199, 0.3751, 0.3751)"
+     id="path769" />
+  <path
+     fill-rule="nonzero"
+     fill="rgb(100%, 100%, 100%)"
+     fill-opacity="1"
+     d="M 144.039063 36.007813 L 240.0625 36.007813 L 240.0625 45.011719 L 144.039063 45.011719 Z M 144.039063 36.007813 "
+     id="path771" />
+  <g
+     fill="#000000"
+     fill-opacity="1"
+     id="g775">
+    <use
+       xlink:href="#glyph-0-14"
+       x="143.66319"
+       y="42.761368"
+       id="use773" />
+  </g>
+  <g
+     fill="#000000"
+     fill-opacity="1"
+     id="g803">
+    <use
+       xlink:href="#glyph-0-2"
+       x="150.6084"
+       y="42.761368"
+       id="use777" />
+    <use
+       xlink:href="#glyph-0-3"
+       x="153.10661"
+       y="42.761368"
+       id="use779" />
+    <use
+       xlink:href="#glyph-0-4"
+       x="154.77332"
+       y="42.761368"
+       id="use781" />
+    <use
+       xlink:href="#glyph-0-5"
+       x="156.85762"
+       y="42.761368"
+       id="use783" />
+    <use
+       xlink:href="#glyph-0-17"
+       x="161.02986"
+       y="42.761368"
+       id="use785" />
+    <use
+       xlink:href="#glyph-0-18"
+       x="163.52809"
+       y="42.761368"
+       id="use787" />
+    <use
+       xlink:href="#glyph-0-19"
+       x="167.70035"
+       y="42.761368"
+       id="use789" />
+    <use
+       xlink:href="#glyph-0-4"
+       x="171.45134"
+       y="42.761368"
+       id="use791" />
+    <use
+       xlink:href="#glyph-0-5"
+       x="173.53563"
+       y="42.761368"
+       id="use793" />
+    <use
+       xlink:href="#glyph-0-15"
+       x="177.70789"
+       y="42.761368"
+       id="use795" />
+    <use
+       xlink:href="#glyph-0-20"
+       x="181.45888"
+       y="42.761368"
+       id="use797" />
+    <use
+       xlink:href="#glyph-0-23"
+       x="183.95711"
+       y="42.761368"
+       id="use799" />
+    <use
+       xlink:href="#glyph-0-24"
+       x="186.0414"
+       y="42.761368"
+       id="use801" />
+  </g>
+  <g
+     fill="#000000"
+     fill-opacity="1"
+     id="g807">
+    <use
+       xlink:href="#glyph-0-23"
+       x="188.1257"
+       y="42.761368"
+       id="use805" />
+  </g>
+  <g
+     fill="#000000"
+     fill-opacity="1"
+     id="g817">
+    <use
+       xlink:href="#glyph-0-25"
+       x="189.79607"
+       y="42.761368"
+       id="use809" />
+    <use
+       xlink:href="#glyph-0-21"
+       x="194.79984"
+       y="42.761368"
+       id="use811" />
+    <use
+       xlink:href="#glyph-0-21"
+       x="198.97208"
+       y="42.761368"
+       id="use813" />
+    <use
+       xlink:href="#glyph-0-14"
+       x="203.14433"
+       y="42.761368"
+       id="use815" />
+  </g>
+  <g
+     fill="#000000"
+     fill-opacity="1"
+     id="g837">
+    <use
+       xlink:href="#glyph-0-2"
+       x="210.08954"
+       y="42.761368"
+       id="use819" />
+    <use
+       xlink:href="#glyph-0-3"
+       x="212.58777"
+       y="42.761368"
+       id="use821" />
+    <use
+       xlink:href="#glyph-0-4"
+       x="214.25447"
+       y="42.761368"
+       id="use823" />
+    <use
+       xlink:href="#glyph-0-5"
+       x="216.33876"
+       y="42.761368"
+       id="use825" />
+    <use
+       xlink:href="#glyph-0-26"
+       x="220.51102"
+       y="42.761368"
+       id="use827" />
+    <use
+       xlink:href="#glyph-0-27"
+       x="226.3463"
+       y="42.761368"
+       id="use829" />
+    <use
+       xlink:href="#glyph-0-17"
+       x="230.51855"
+       y="42.761368"
+       id="use831" />
+    <use
+       xlink:href="#glyph-0-28"
+       x="233.01678"
+       y="42.761368"
+       id="use833" />
+    <use
+       xlink:href="#glyph-0-20"
+       x="237.18903"
+       y="42.761368"
+       id="use835" />
+  </g>
+  <path
+     fill="none"
+     stroke-width="1"
+     stroke-linecap="butt"
+     stroke-linejoin="miter"
+     stroke="rgb(0%, 0%, 0%)"
+     stroke-opacity="1"
+     stroke-miterlimit="10"
+     d="M 95.880621 61.431448 L 64.498341 61.400207 L 23.998694 61.217964 "
+     transform="matrix(0.750199, 0, 0, 0.750199, 0.3751, 0.3751)"
+     id="path839" />
+  <path
+     fill-rule="nonzero"
+     fill="rgb(0%, 0%, 0%)"
+     fill-opacity="1"
+     stroke-width="1"
+     stroke-linecap="butt"
+     stroke-linejoin="miter"
+     stroke="rgb(0%, 0%, 0%)"
+     stroke-opacity="1"
+     stroke-miterlimit="10"
+     d="M 102.878761 61.441862 L 95.880621 64.930518 L 95.891035 57.932379 Z M 102.878761 61.441862 "
+     transform="matrix(0.750199, 0, 0, 0.750199, 0.3751, 0.3751)"
+     id="path841" />
+  <path
+     fill-rule="nonzero"
+     fill="rgb(100%, 100%, 100%)"
+     fill-opacity="1"
+     d="M 12.753906 34.507813 L 72.019531 34.507813 L 72.019531 43.511719 L 12.753906 43.511719 Z M 12.753906 34.507813 "
+     id="path843" />
+  <g
+     fill="#000000"
+     fill-opacity="1"
+     id="g847">
+    <use
+       xlink:href="#glyph-0-14"
+       x="12.858887"
+       y="41.260967"
+       id="use845" />
+  </g>
+  <g
+     fill="#000000"
+     fill-opacity="1"
+     id="g879">
+    <use
+       xlink:href="#glyph-0-2"
+       x="19.804092"
+       y="41.260967"
+       id="use849" />
+    <use
+       xlink:href="#glyph-0-3"
+       x="22.302317"
+       y="41.260967"
+       id="use851" />
+    <use
+       xlink:href="#glyph-0-4"
+       x="23.969019"
+       y="41.260967"
+       id="use853" />
+    <use
+       xlink:href="#glyph-0-5"
+       x="26.053312"
+       y="41.260967"
+       id="use855" />
+    <use
+       xlink:href="#glyph-0-29"
+       x="30.225563"
+       y="41.260967"
+       id="use857" />
+    <use
+       xlink:href="#glyph-0-30"
+       x="35.643265"
+       y="41.260967"
+       id="use859" />
+    <use
+       xlink:href="#glyph-0-1"
+       x="39.815517"
+       y="41.260967"
+       id="use861" />
+    <use
+       xlink:href="#glyph-0-17"
+       x="45.233215"
+       y="41.260967"
+       id="use863" />
+    <use
+       xlink:href="#glyph-0-31"
+       x="47.731438"
+       y="41.260967"
+       id="use865" />
+    <use
+       xlink:href="#glyph-0-8"
+       x="51.482437"
+       y="41.260967"
+       id="use867" />
+    <use
+       xlink:href="#glyph-0-13"
+       x="55.65469"
+       y="41.260967"
+       id="use869" />
+    <use
+       xlink:href="#glyph-0-32"
+       x="57.321392"
+       y="41.260967"
+       id="use871" />
+    <use
+       xlink:href="#glyph-0-5"
+       x="61.493641"
+       y="41.260967"
+       id="use873" />
+    <use
+       xlink:href="#glyph-0-15"
+       x="65.665894"
+       y="41.260967"
+       id="use875" />
+    <use
+       xlink:href="#glyph-0-20"
+       x="69.416893"
+       y="41.260967"
+       id="use877" />
+  </g>
+  <path
+     fill="none"
+     stroke-width="2"
+     stroke-linecap="butt"
+     stroke-linejoin="miter"
+     stroke="rgb(0%, 59.999084%, 0%)"
+     stroke-opacity="1"
+     stroke-miterlimit="10"
+     d="M 163.711676 46.008599 L 163.701262 26.998029 L 23.998827 26.998029 L 24.238346 26.998029 "
+     transform="matrix(0.750199, 0, 0, 0.750199, 0, 0)"
+     id="path881" />
+  <path
+     fill-rule="nonzero"
+     fill="rgb(0%, 59.999084%, 0%)"
+     fill-opacity="1"
+     stroke-width="2"
+     stroke-linecap="butt"
+     stroke-linejoin="miter"
+     stroke="rgb(0%, 59.999084%, 0%)"
+     stroke-opacity="1"
+     stroke-miterlimit="10"
+     d="M 16.240473 26.998029 L 24.238346 22.999093 L 24.238346 31.002173 Z M 16.240473 26.998029 "
+     transform="matrix(0.750199, 0, 0, 0.750199, 0, 0)"
+     id="path883" />
+  <path
+     fill-rule="nonzero"
+     fill="rgb(85.488892%, 90.979004%, 98.81897%)"
+     fill-opacity="1"
+     stroke-width="1"
+     stroke-linecap="butt"
+     stroke-linejoin="miter"
+     stroke="rgb(42.349243%, 55.688477%, 74.899292%)"
+     stroke-opacity="1"
+     stroke-miterlimit="4"
+     d="M 103.998254 46.247986 L 174.000474 46.247986 L 174.000474 106.997457 L 103.998254 106.997457 Z M 103.998254 46.247986 "
+     transform="matrix(0.750199, 0, 0, 0.750199, 0.3751, 0.3751)"
+     id="path885" />
+  <g
+     fill="#000000"
+     fill-opacity="1"
+     id="g893">
+    <use
+       xlink:href="#glyph-1-26"
+       x="96.564735"
+       y="55.514759"
+       id="use887" />
+    <use
+       xlink:href="#glyph-1-2"
+       x="101.98243"
+       y="55.514759"
+       id="use889" />
+    <use
+       xlink:href="#glyph-1-27"
+       x="106.98621"
+       y="55.514759"
+       id="use891" />
+  </g>
+  <g
+     fill="#000000"
+     fill-opacity="1"
+     id="g897">
+    <use
+       xlink:href="#glyph-1-29"
+       x="93.505325"
+       y="64.517151"
+       id="use895" />
+  </g>
+  <g
+     fill="#000000"
+     fill-opacity="1"
+     id="g909">
+    <use
+       xlink:href="#glyph-1-19"
+       x="100.45053"
+       y="64.517151"
+       id="use899" />
+    <use
+       xlink:href="#glyph-1-4"
+       x="103.37001"
+       y="64.517151"
+       id="use901" />
+    <use
+       xlink:href="#glyph-1-22"
+       x="105.4543"
+       y="64.517151"
+       id="use903" />
+    <use
+       xlink:href="#glyph-1-10"
+       x="107.95252"
+       y="64.517151"
+       id="use905" />
+    <use
+       xlink:href="#glyph-1-19"
+       x="112.12478"
+       y="64.517151"
+       id="use907" />
+  </g>
+  <path
+     fill-rule="nonzero"
+     fill="rgb(96.078491%, 96.078491%, 96.078491%)"
+     fill-opacity="0.702"
+     stroke-width="1"
+     stroke-linecap="butt"
+     stroke-linejoin="miter"
+     stroke="rgb(39.99939%, 39.99939%, 39.99939%)"
+     stroke-opacity="0.702"
+     stroke-miterlimit="4"
+     d="M 708.998837 92.001445 L 759.001166 92.001445 L 759.001166 106.997457 L 708.998837 106.997457 Z M 708.998837 92.001445 "
+     transform="matrix(0.750199, 0, 0, 0.750199, 0.3751, 0.3751)"
+     id="path911" />
+  <g
+     fill="#333333"
+     fill-opacity="1"
+     id="g919">
+    <use
+       xlink:href="#glyph-0-18"
+       x="541.11652"
+       y="78.020744"
+       id="use913" />
+    <use
+       xlink:href="#glyph-0-32"
+       x="545.28876"
+       y="78.020744"
+       id="use915" />
+    <use
+       xlink:href="#glyph-0-12"
+       x="549.461"
+       y="78.020744"
+       id="use917" />
+  </g>
+  <g
+     fill="#333333"
+     fill-opacity="1"
+     id="g927">
+    <use
+       xlink:href="#glyph-0-12"
+       x="551.40979"
+       y="78.020744"
+       id="use921" />
+    <use
+       xlink:href="#glyph-0-5"
+       x="553.49408"
+       y="78.020744"
+       id="use923" />
+    <use
+       xlink:href="#glyph-0-2"
+       x="557.66632"
+       y="78.020744"
+       id="use925" />
+  </g>
+  <path
+     fill-rule="nonzero"
+     fill="rgb(96.078491%, 96.078491%, 96.078491%)"
+     fill-opacity="0.702"
+     stroke-width="1"
+     stroke-linecap="butt"
+     stroke-linejoin="miter"
+     stroke="rgb(39.99939%, 39.99939%, 39.99939%)"
+     stroke-opacity="0.702"
+     stroke-miterlimit="4"
+     d="M 114.000803 92.001445 L 163.997925 92.001445 L 163.997925 106.997457 L 114.000803 106.997457 Z M 114.000803 92.001445 "
+     transform="matrix(0.750199, 0, 0, 0.750199, 0.3751, 0.3751)"
+     id="path929" />
+  <g
+     fill="#333333"
+     fill-opacity="1"
+     id="g937">
+    <use
+       xlink:href="#glyph-0-18"
+       x="94.747841"
+       y="78.020744"
+       id="use931" />
+    <use
+       xlink:href="#glyph-0-32"
+       x="98.920097"
+       y="78.020744"
+       id="use933" />
+    <use
+       xlink:href="#glyph-0-12"
+       x="103.09235"
+       y="78.020744"
+       id="use935" />
+  </g>
+  <g
+     fill="#333333"
+     fill-opacity="1"
+     id="g945">
+    <use
+       xlink:href="#glyph-0-12"
+       x="105.04111"
+       y="78.020744"
+       id="use939" />
+    <use
+       xlink:href="#glyph-0-5"
+       x="107.1254"
+       y="78.020744"
+       id="use941" />
+    <use
+       xlink:href="#glyph-0-2"
+       x="111.29765"
+       y="78.020744"
+       id="use943" />
+  </g>
+  <path
+     fill-rule="nonzero"
+     fill="rgb(85.488892%, 90.979004%, 98.81897%)"
+     fill-opacity="1"
+     stroke-width="1"
+     stroke-linecap="butt"
+     stroke-linejoin="miter"
+     stroke="rgb(42.349243%, 55.688477%, 74.899292%)"
+     stroke-opacity="1"
+     stroke-miterlimit="4"
+     d="M 234.000144 70.25202 L 304.002363 70.25202 L 304.002363 131.001491 L 234.000144 131.001491 Z M 234.000144 70.25202 "
+     transform="matrix(0.750199, 0, 0, 0.750199, 0.3751, 0.3751)"
+     id="path947" />
+  <g
+     fill="#000000"
+     fill-opacity="1"
+     id="g959">
+    <use
+       xlink:href="#glyph-0-6"
+       x="192.62543"
+       y="64.517151"
+       id="use949" />
+    <use
+       xlink:href="#glyph-0-30"
+       x="196.37643"
+       y="64.517151"
+       id="use951" />
+    <use
+       xlink:href="#glyph-0-32"
+       x="200.54868"
+       y="64.517151"
+       id="use953" />
+    <use
+       xlink:href="#glyph-0-9"
+       x="204.72093"
+       y="64.517151"
+       id="use955" />
+    <use
+       xlink:href="#glyph-0-4"
+       x="208.89319"
+       y="64.517151"
+       id="use957" />
+  </g>
+  <g
+     fill="#000000"
+     fill-opacity="1"
+     id="g975">
+    <use
+       xlink:href="#glyph-1-26"
+       x="187.42091"
+       y="73.519547"
+       id="use961" />
+    <use
+       xlink:href="#glyph-1-20"
+       x="192.83862"
+       y="73.519547"
+       id="use963" />
+    <use
+       xlink:href="#glyph-1-18"
+       x="197.42114"
+       y="73.519547"
+       id="use965" />
+    <use
+       xlink:href="#glyph-1-15"
+       x="202.00366"
+       y="73.519547"
+       id="use967" />
+    <use
+       xlink:href="#glyph-1-22"
+       x="206.58617"
+       y="73.519547"
+       id="use969" />
+    <use
+       xlink:href="#glyph-1-10"
+       x="209.0844"
+       y="73.519547"
+       id="use971" />
+    <use
+       xlink:href="#glyph-1-19"
+       x="213.25665"
+       y="73.519547"
+       id="use973" />
+  </g>
+  <g
+     fill="#000000"
+     fill-opacity="1"
+     id="g979">
+    <use
+       xlink:href="#glyph-1-29"
+       x="193.70384"
+       y="82.521935"
+       id="use977" />
+  </g>
+  <g
+     fill="#000000"
+     fill-opacity="1"
+     id="g987">
+    <use
+       xlink:href="#glyph-1-4"
+       x="200.71864"
+       y="82.521935"
+       id="use981" />
+    <use
+       xlink:href="#glyph-1-22"
+       x="202.80293"
+       y="82.521935"
+       id="use983" />
+    <use
+       xlink:href="#glyph-1-9"
+       x="205.30116"
+       y="82.521935"
+       id="use985" />
+  </g>
+  <g
+     fill="#000000"
+     fill-opacity="1"
+     id="g1001">
+    <use
+       xlink:href="#glyph-1-30"
+       x="188.25317"
+       y="91.52433"
+       id="use989" />
+    <use
+       xlink:href="#glyph-1-8"
+       x="193.67087"
+       y="91.52433"
+       id="use991" />
+    <use
+       xlink:href="#glyph-1-7"
+       x="197.84312"
+       y="91.52433"
+       id="use993" />
+    <use
+       xlink:href="#glyph-1-6"
+       x="202.01538"
+       y="91.52433"
+       id="use995" />
+    <use
+       xlink:href="#glyph-1-18"
+       x="206.18762"
+       y="91.52433"
+       id="use997" />
+    <use
+       xlink:href="#glyph-1-25"
+       x="210.77014"
+       y="91.52433"
+       id="use999" />
+  </g>
+  <path
+     fill-rule="nonzero"
+     fill="rgb(100%, 94.898987%, 79.998779%)"
+     fill-opacity="1"
+     stroke-width="1"
+     stroke-linecap="butt"
+     stroke-linejoin="miter"
+     stroke="rgb(83.918762%, 71.369934%, 33.729553%)"
+     stroke-opacity="1"
+     stroke-miterlimit="4"
+     d="M 214.000254 180.998613 L 324.002253 180.998613 L 324.002253 200.998503 L 214.000254 200.998503 Z M 214.000254 180.998613 "
+     transform="matrix(0.750199, 0, 0, 0.750199, 0.3751, 0.3751)"
+     id="path1003" />
+  <g
+     fill="#000000"
+     fill-opacity="1"
+     id="g1025">
+    <use
+       xlink:href="#glyph-0-2"
+       x="182.61496"
+       y="146.28889"
+       id="use1005" />
+    <use
+       xlink:href="#glyph-0-30"
+       x="185.11317"
+       y="146.28889"
+       id="use1007" />
+    <use
+       xlink:href="#glyph-0-1"
+       x="189.28543"
+       y="146.28889"
+       id="use1009" />
+    <use
+       xlink:href="#glyph-0-15"
+       x="194.70312"
+       y="146.28889"
+       id="use1011" />
+    <use
+       xlink:href="#glyph-0-33"
+       x="198.45413"
+       y="146.28889"
+       id="use1013" />
+    <use
+       xlink:href="#glyph-0-6"
+       x="202.62637"
+       y="146.28889"
+       id="use1015" />
+    <use
+       xlink:href="#glyph-0-30"
+       x="206.37738"
+       y="146.28889"
+       id="use1017" />
+    <use
+       xlink:href="#glyph-0-32"
+       x="210.54962"
+       y="146.28889"
+       id="use1019" />
+    <use
+       xlink:href="#glyph-0-9"
+       x="214.72188"
+       y="146.28889"
+       id="use1021" />
+    <use
+       xlink:href="#glyph-0-4"
+       x="218.89413"
+       y="146.28889"
+       id="use1023" />
+  </g>
+  <path
+     fill="none"
+     stroke-width="1"
+     stroke-linecap="butt"
+     stroke-linejoin="miter"
+     stroke="rgb(0%, 0%, 0%)"
+     stroke-opacity="1"
+     stroke-miterlimit="10"
+     d="M 269.001253 131.001491 L 269.001253 172.88098 "
+     transform="matrix(0.750199, 0, 0, 0.750199, 0.3751, 0.3751)"
+     id="path1027" />
+  <path
+     fill-rule="nonzero"
+     fill="rgb(0%, 0%, 0%)"
+     fill-opacity="1"
+     stroke-width="1"
+     stroke-linecap="butt"
+     stroke-linejoin="miter"
+     stroke="rgb(0%, 0%, 0%)"
+     stroke-opacity="1"
+     stroke-miterlimit="10"
+     d="M 269.001253 179.879119 L 265.502184 172.88098 L 272.500323 172.88098 Z M 269.001253 179.879119 "
+     transform="matrix(0.750199, 0, 0, 0.750199, 0.3751, 0.3751)"
+     id="path1029" />
+  <path
+     fill-rule="nonzero"
+     fill="rgb(100%, 100%, 100%)"
+     fill-opacity="1"
+     d="M 157.542969 113.28125 L 248.316406 113.28125 L 248.316406 122.28125 L 157.542969 122.28125 Z M 157.542969 113.28125 "
+     id="path1031" />
+  <g
+     fill="#000000"
+     fill-opacity="1"
+     id="g1089">
+    <use
+       xlink:href="#glyph-0-30"
+       x="157.26056"
+       y="120.03191"
+       id="use1033" />
+    <use
+       xlink:href="#glyph-0-9"
+       x="161.43282"
+       y="120.03191"
+       id="use1035" />
+    <use
+       xlink:href="#glyph-0-23"
+       x="165.60506"
+       y="120.03191"
+       id="use1037" />
+    <use
+       xlink:href="#glyph-0-12"
+       x="167.68936"
+       y="120.03191"
+       id="use1039" />
+    <use
+       xlink:href="#glyph-0-13"
+       x="169.77365"
+       y="120.03191"
+       id="use1041" />
+    <use
+       xlink:href="#glyph-0-32"
+       x="171.44035"
+       y="120.03191"
+       id="use1043" />
+    <use
+       xlink:href="#glyph-0-15"
+       x="175.61261"
+       y="120.03191"
+       id="use1045" />
+    <use
+       xlink:href="#glyph-0-7"
+       x="179.3636"
+       y="120.03191"
+       id="use1047" />
+    <use
+       xlink:href="#glyph-0-34"
+       x="183.53586"
+       y="120.03191"
+       id="use1049" />
+    <use
+       xlink:href="#glyph-0-23"
+       x="185.62015"
+       y="120.03191"
+       id="use1051" />
+    <use
+       xlink:href="#glyph-0-32"
+       x="187.70444"
+       y="120.03191"
+       id="use1053" />
+    <use
+       xlink:href="#glyph-0-27"
+       x="191.87669"
+       y="120.03191"
+       id="use1055" />
+    <use
+       xlink:href="#glyph-0-21"
+       x="196.04895"
+       y="120.03191"
+       id="use1057" />
+    <use
+       xlink:href="#glyph-0-8"
+       x="200.22119"
+       y="120.03191"
+       id="use1059" />
+    <use
+       xlink:href="#glyph-0-4"
+       x="204.39345"
+       y="120.03191"
+       id="use1061" />
+    <use
+       xlink:href="#glyph-0-5"
+       x="206.47774"
+       y="120.03191"
+       id="use1063" />
+    <use
+       xlink:href="#glyph-0-23"
+       x="210.64999"
+       y="120.03191"
+       id="use1065" />
+    <use
+       xlink:href="#glyph-0-18"
+       x="212.73428"
+       y="120.03191"
+       id="use1067" />
+    <use
+       xlink:href="#glyph-0-8"
+       x="216.90654"
+       y="120.03191"
+       id="use1069" />
+    <use
+       xlink:href="#glyph-0-6"
+       x="221.0788"
+       y="120.03191"
+       id="use1071" />
+    <use
+       xlink:href="#glyph-0-22"
+       x="224.82979"
+       y="120.03191"
+       id="use1073" />
+    <use
+       xlink:href="#glyph-0-32"
+       x="228.58078"
+       y="120.03191"
+       id="use1075" />
+    <use
+       xlink:href="#glyph-0-27"
+       x="232.75304"
+       y="120.03191"
+       id="use1077" />
+    <use
+       xlink:href="#glyph-0-23"
+       x="236.92529"
+       y="120.03191"
+       id="use1079" />
+    <use
+       xlink:href="#glyph-0-12"
+       x="239.00958"
+       y="120.03191"
+       id="use1081" />
+    <use
+       xlink:href="#glyph-0-3"
+       x="241.09387"
+       y="120.03191"
+       id="use1083" />
+    <use
+       xlink:href="#glyph-0-13"
+       x="242.76057"
+       y="120.03191"
+       id="use1085" />
+    <use
+       xlink:href="#glyph-0-5"
+       x="244.42728"
+       y="120.03191"
+       id="use1087" />
+  </g>
+  <path
+     fill-rule="nonzero"
+     fill="rgb(100%, 94.898987%, 79.998779%)"
+     fill-opacity="1"
+     stroke-width="1"
+     stroke-linecap="butt"
+     stroke-linejoin="miter"
+     stroke="rgb(83.918762%, 71.369934%, 33.729553%)"
+     stroke-opacity="1"
+     stroke-miterlimit="4"
+     d="M 599.002045 180.998613 L 708.998837 180.998613 L 708.998837 200.998503 L 599.002045 200.998503 Z M 599.002045 180.998613 "
+     transform="matrix(0.750199, 0, 0, 0.750199, 0.3751, 0.3751)"
+     id="path1091" />
+  <g
+     fill="#000000"
+     fill-opacity="1"
+     id="g1127">
+    <use
+       xlink:href="#glyph-0-32"
+       x="457.26999"
+       y="146.28889"
+       id="use1093" />
+    <use
+       xlink:href="#glyph-0-9"
+       x="461.44226"
+       y="146.28889"
+       id="use1095" />
+    <use
+       xlink:href="#glyph-0-6"
+       x="465.6145"
+       y="146.28889"
+       id="use1097" />
+    <use
+       xlink:href="#glyph-0-30"
+       x="469.36551"
+       y="146.28889"
+       id="use1099" />
+    <use
+       xlink:href="#glyph-0-35"
+       x="473.53775"
+       y="146.28889"
+       id="use1101" />
+    <use
+       xlink:href="#glyph-0-27"
+       x="479.78696"
+       y="146.28889"
+       id="use1103" />
+    <use
+       xlink:href="#glyph-0-2"
+       x="483.95923"
+       y="146.28889"
+       id="use1105" />
+    <use
+       xlink:href="#glyph-0-5"
+       x="486.45746"
+       y="146.28889"
+       id="use1107" />
+    <use
+       xlink:href="#glyph-0-15"
+       x="490.6297"
+       y="146.28889"
+       id="use1109" />
+    <use
+       xlink:href="#glyph-0-15"
+       x="494.38071"
+       y="146.28889"
+       id="use1111" />
+    <use
+       xlink:href="#glyph-0-5"
+       x="498.13168"
+       y="146.28889"
+       id="use1113" />
+    <use
+       xlink:href="#glyph-0-21"
+       x="502.30396"
+       y="146.28889"
+       id="use1115" />
+    <use
+       xlink:href="#glyph-0-33"
+       x="506.4762"
+       y="146.28889"
+       id="use1117" />
+    <use
+       xlink:href="#glyph-0-15"
+       x="510.64844"
+       y="146.28889"
+       id="use1119" />
+    <use
+       xlink:href="#glyph-0-3"
+       x="514.39941"
+       y="146.28889"
+       id="use1121" />
+    <use
+       xlink:href="#glyph-0-16"
+       x="516.06616"
+       y="146.28889"
+       id="use1123" />
+    <use
+       xlink:href="#glyph-0-5"
+       x="519.81714"
+       y="146.28889"
+       id="use1125" />
+  </g>
+  <path
+     fill-rule="nonzero"
+     fill="rgb(100%, 94.898987%, 79.998779%)"
+     fill-opacity="1"
+     stroke-width="1"
+     stroke-linecap="butt"
+     stroke-linejoin="miter"
+     stroke="rgb(83.918762%, 71.369934%, 33.729553%)"
+     stroke-opacity="1"
+     stroke-miterlimit="4"
+     d="M 759.001166 180.998613 L 868.997958 180.998613 L 868.997958 200.998503 L 759.001166 200.998503 Z M 759.001166 180.998613 "
+     transform="matrix(0.750199, 0, 0, 0.750199, 0.3751, 0.3751)"
+     id="path1129" />
+  <g
+     fill="#000000"
+     fill-opacity="1"
+     id="g1161">
+    <use
+       xlink:href="#glyph-0-6"
+       x="581.47491"
+       y="146.28889"
+       id="use1131" />
+    <use
+       xlink:href="#glyph-0-30"
+       x="585.22589"
+       y="146.28889"
+       id="use1133" />
+    <use
+       xlink:href="#glyph-0-35"
+       x="589.39813"
+       y="146.28889"
+       id="use1135" />
+    <use
+       xlink:href="#glyph-0-27"
+       x="595.64734"
+       y="146.28889"
+       id="use1137" />
+    <use
+       xlink:href="#glyph-0-2"
+       x="599.81964"
+       y="146.28889"
+       id="use1139" />
+    <use
+       xlink:href="#glyph-0-5"
+       x="602.31781"
+       y="146.28889"
+       id="use1141" />
+    <use
+       xlink:href="#glyph-0-15"
+       x="606.49011"
+       y="146.28889"
+       id="use1143" />
+    <use
+       xlink:href="#glyph-0-15"
+       x="610.24109"
+       y="146.28889"
+       id="use1145" />
+    <use
+       xlink:href="#glyph-0-5"
+       x="613.99207"
+       y="146.28889"
+       id="use1147" />
+    <use
+       xlink:href="#glyph-0-21"
+       x="618.16431"
+       y="146.28889"
+       id="use1149" />
+    <use
+       xlink:href="#glyph-0-33"
+       x="622.33661"
+       y="146.28889"
+       id="use1151" />
+    <use
+       xlink:href="#glyph-0-15"
+       x="626.50885"
+       y="146.28889"
+       id="use1153" />
+    <use
+       xlink:href="#glyph-0-3"
+       x="630.25983"
+       y="146.28889"
+       id="use1155" />
+    <use
+       xlink:href="#glyph-0-16"
+       x="631.92651"
+       y="146.28889"
+       id="use1157" />
+    <use
+       xlink:href="#glyph-0-5"
+       x="635.67755"
+       y="146.28889"
+       id="use1159" />
+  </g>
+  <path
+     fill="none"
+     stroke-width="1"
+     stroke-linecap="butt"
+     stroke-linejoin="miter"
+     stroke="rgb(0%, 0%, 0%)"
+     stroke-opacity="1"
+     stroke-miterlimit="10"
+     d="M 814.002165 106.997457 L 814.002165 174.630514 "
+     transform="matrix(0.750199, 0, 0, 0.750199, 0.3751, 0.3751)"
+     id="path1163" />
+  <path
+     fill-rule="nonzero"
+     fill="rgb(0%, 0%, 0%)"
+     fill-opacity="1"
+     stroke-width="1"
+     stroke-linecap="butt"
+     stroke-linejoin="miter"
+     stroke="rgb(0%, 0%, 0%)"
+     stroke-opacity="1"
+     stroke-miterlimit="10"
+     d="M 814.002165 179.879119 L 810.497889 172.88098 L 814.002165 174.630514 L 817.501235 172.88098 Z M 814.002165 179.879119 "
+     transform="matrix(0.750199, 0, 0, 0.750199, 0.3751, 0.3751)"
+     id="path1165" />
+  <path
+     fill-rule="nonzero"
+     fill="rgb(85.488892%, 90.979004%, 98.81897%)"
+     fill-opacity="1"
+     stroke-width="1"
+     stroke-linecap="butt"
+     stroke-linejoin="miter"
+     stroke="rgb(42.349243%, 55.688477%, 74.899292%)"
+     stroke-opacity="1"
+     stroke-miterlimit="4"
+     d="M 624.000606 46.997787 L 684.000276 46.997787 L 684.000276 106.997457 L 624.000606 106.997457 Z M 624.000606 46.997787 "
+     transform="matrix(0.750199, 0, 0, 0.750199, 0.3751, 0.3751)"
+     id="path1167" />
+  <g
+     fill="#000000"
+     fill-opacity="1"
+     id="g1179">
+    <use
+       xlink:href="#glyph-0-15"
+       x="482.91745"
+       y="47.262566"
+       id="use1169" />
+    <use
+       xlink:href="#glyph-0-3"
+       x="486.66843"
+       y="47.262566"
+       id="use1171" />
+    <use
+       xlink:href="#glyph-0-16"
+       x="488.33514"
+       y="47.262566"
+       id="use1173" />
+    <use
+       xlink:href="#glyph-0-5"
+       x="492.08615"
+       y="47.262566"
+       id="use1175" />
+    <use
+       xlink:href="#glyph-0-10"
+       x="496.25839"
+       y="47.262566"
+       id="use1177" />
+  </g>
+  <g
+     fill="#000000"
+     fill-opacity="1"
+     id="g1191">
+    <use
+       xlink:href="#glyph-1-28"
+       x="480.61996"
+       y="56.264957"
+       id="use1181" />
+    <use
+       xlink:href="#glyph-1-10"
+       x="486.86917"
+       y="56.264957"
+       id="use1183" />
+    <use
+       xlink:href="#glyph-1-22"
+       x="491.04141"
+       y="56.264957"
+       id="use1185" />
+    <use
+       xlink:href="#glyph-1-10"
+       x="493.53964"
+       y="56.264957"
+       id="use1187" />
+    <use
+       xlink:href="#glyph-1-19"
+       x="497.71191"
+       y="56.264957"
+       id="use1189" />
+  </g>
+  <g
+     fill="#000000"
+     fill-opacity="1"
+     id="g1195">
+    <use
+       xlink:href="#glyph-1-29"
+       x="482.53061"
+       y="65.267349"
+       id="use1193" />
+  </g>
+  <g
+     fill="#000000"
+     fill-opacity="1"
+     id="g1203">
+    <use
+       xlink:href="#glyph-1-4"
+       x="489.54544"
+       y="65.267349"
+       id="use1197" />
+    <use
+       xlink:href="#glyph-1-22"
+       x="491.62973"
+       y="65.267349"
+       id="use1199" />
+    <use
+       xlink:href="#glyph-1-9"
+       x="494.12796"
+       y="65.267349"
+       id="use1201" />
+  </g>
+  <g
+     fill="#000000"
+     fill-opacity="1"
+     id="g1217">
+    <use
+       xlink:href="#glyph-1-30"
+       x="477.07996"
+       y="74.269745"
+       id="use1205" />
+    <use
+       xlink:href="#glyph-1-8"
+       x="482.49765"
+       y="74.269745"
+       id="use1207" />
+    <use
+       xlink:href="#glyph-1-7"
+       x="486.66989"
+       y="74.269745"
+       id="use1209" />
+    <use
+       xlink:href="#glyph-1-6"
+       x="490.84216"
+       y="74.269745"
+       id="use1211" />
+    <use
+       xlink:href="#glyph-1-18"
+       x="495.0144"
+       y="74.269745"
+       id="use1213" />
+    <use
+       xlink:href="#glyph-1-25"
+       x="499.59692"
+       y="74.269745"
+       id="use1215" />
+  </g>
+  <path
+     fill-rule="nonzero"
+     fill="rgb(0%, 0%, 0%)"
+     fill-opacity="1"
+     d="M 466.25 23.257813 L 467 23.257813 L 467 24.007813 L 466.25 24.007813 Z M 467.75 23.257813 L 468.5 23.257813 L 468.5 24.007813 L 467.75 24.007813 Z M 469.25 23.257813 L 470 23.257813 L 470 24.007813 L 469.25 24.007813 Z M 470.75 23.257813 L 471.5 23.257813 L 471.5 24.007813 L 470.75 24.007813 Z M 472.25 23.257813 L 473 23.257813 L 473 24.007813 L 472.25 24.007813 Z M 473.75 23.257813 L 474.5 23.257813 L 474.5 24.007813 L 473.75 24.007813 Z M 475.25 23.257813 L 476 23.257813 L 476 24.007813 L 475.25 24.007813 Z M 476.75 23.257813 L 477.5 23.257813 L 477.5 24.007813 L 476.75 24.007813 Z M 478.253906 23.257813 L 479.003906 23.257813 L 479.003906 24.007813 L 478.253906 24.007813 Z M 479.753906 23.257813 L 480.503906 23.257813 L 480.503906 24.007813 L 479.753906 24.007813 Z M 481.253906 23.257813 L 482.003906 23.257813 L 482.003906 24.007813 L 481.253906 24.007813 Z M 482.753906 23.257813 L 483.503906 23.257813 L 483.503906 24.007813 L 482.753906 24.007813 Z M 484.253906 23.257813 L 485.003906 23.257813 L 485.003906 24.007813 L 484.253906 24.007813 Z M 485.753906 23.257813 L 486.503906 23.257813 L 486.503906 24.007813 L 485.753906 24.007813 Z M 487.253906 23.257813 L 488.003906 23.257813 L 488.003906 24.007813 L 487.253906 24.007813 Z M 488.753906 23.257813 L 489.503906 23.257813 L 489.503906 24.007813 L 488.753906 24.007813 Z M 490.253906 23.257813 L 491.003906 23.257813 L 491.003906 24.007813 L 490.253906 24.007813 Z M 491.753906 23.257813 L 492.507813 23.257813 L 492.507813 24.007813 L 491.753906 24.007813 Z M 493.257813 23.257813 L 494.007813 23.257813 L 494.007813 24.007813 L 493.257813 24.007813 Z M 494.757813 23.257813 L 495.507813 23.257813 L 495.507813 24.007813 L 494.757813 24.007813 Z M 496.257813 23.257813 L 497.007813 23.257813 L 497.007813 24.007813 L 496.257813 24.007813 Z M 497.757813 23.257813 L 498.507813 23.257813 L 498.507813 24.007813 L 497.757813 24.007813 Z M 499.257813 23.257813 L 500.007813 23.257813 L 500.007813 24.007813 L 499.257813 24.007813 Z M 500.757813 23.257813 L 501.507813 23.257813 L 501.507813 24.007813 L 500.757813 24.007813 Z M 502.257813 23.257813 L 503.007813 23.257813 L 503.007813 24.007813 L 502.257813 24.007813 Z M 503.757813 23.257813 L 504.507813 23.257813 L 504.507813 24.007813 L 503.757813 24.007813 Z M 505.257813 23.257813 L 506.007813 23.257813 L 506.007813 24.007813 L 505.257813 24.007813 Z M 506.757813 23.257813 L 507.511719 23.257813 L 507.511719 24.007813 L 506.757813 24.007813 Z M 508.261719 23.257813 L 509.011719 23.257813 L 509.011719 24.007813 L 508.261719 24.007813 Z M 509.761719 23.257813 L 510.511719 23.257813 L 510.511719 24.007813 L 509.761719 24.007813 Z M 511.261719 23.257813 L 512.011719 23.257813 L 512.011719 24.007813 L 511.261719 24.007813 Z M 512.761719 23.257813 L 513.511719 23.257813 L 513.511719 24.007813 L 512.761719 24.007813 Z M 514.261719 23.257813 L 515.011719 23.257813 L 515.011719 24.007813 L 514.261719 24.007813 Z M 515.761719 23.257813 L 516.511719 23.257813 L 516.511719 24.007813 L 515.761719 24.007813 Z M 517.261719 23.257813 L 518.011719 23.257813 L 518.011719 24.007813 L 517.261719 24.007813 Z M 518.761719 23.257813 L 519.511719 23.257813 L 519.511719 24.007813 L 518.761719 24.007813 Z M 520.261719 23.257813 L 521.011719 23.257813 L 521.011719 24.007813 L 520.261719 24.007813 Z M 521.765625 23.257813 L 522.515625 23.257813 L 522.515625 24.007813 L 521.765625 24.007813 Z M 523.265625 23.257813 L 524.015625 23.257813 L 524.015625 24.007813 L 523.265625 24.007813 Z M 524.765625 23.257813 L 525.515625 23.257813 L 525.515625 24.007813 L 524.765625 24.007813 Z M 526.265625 23.257813 L 527.015625 23.257813 L 527.015625 24.007813 L 526.265625 24.007813 Z M 527.765625 23.257813 L 528.515625 23.257813 L 528.515625 24.007813 L 527.765625 24.007813 Z M 529.265625 23.257813 L 530.015625 23.257813 L 530.015625 24.007813 L 529.265625 24.007813 Z M 530.765625 23.257813 L 531.515625 23.257813 L 531.515625 24.007813 L 530.765625 24.007813 Z M 532.265625 23.257813 L 533.015625 23.257813 L 533.015625 24.007813 L 532.265625 24.007813 Z M 533.765625 23.257813 L 534.515625 23.257813 L 534.515625 24.007813 L 533.765625 24.007813 Z M 535.265625 23.257813 L 536.015625 23.257813 L 536.015625 24.007813 L 535.265625 24.007813 Z M 536.769531 23.257813 L 537.519531 23.257813 L 537.519531 24.007813 L 536.769531 24.007813 Z M 538.269531 23.257813 L 539.019531 23.257813 L 539.019531 24.007813 L 538.269531 24.007813 Z M 539.769531 23.257813 L 540.519531 23.257813 L 540.519531 24.007813 L 539.769531 24.007813 Z M 541.269531 23.257813 L 542.019531 23.257813 L 542.019531 24.007813 L 541.269531 24.007813 Z M 542.769531 23.257813 L 543.519531 23.257813 L 543.519531 24.007813 L 542.769531 24.007813 Z M 544.269531 23.257813 L 545.019531 23.257813 L 545.019531 24.007813 L 544.269531 24.007813 Z M 545.769531 23.257813 L 546.519531 23.257813 L 546.519531 24.007813 L 545.769531 24.007813 Z M 547.269531 23.257813 L 548.019531 23.257813 L 548.019531 24.007813 L 547.269531 24.007813 Z M 548.769531 23.257813 L 549.519531 23.257813 L 549.519531 24.007813 L 548.769531 24.007813 Z M 550.269531 23.257813 L 551.019531 23.257813 L 551.019531 24.007813 L 550.269531 24.007813 Z M 551.773438 23.257813 L 552.523438 23.257813 L 552.523438 24.007813 L 551.773438 24.007813 Z M 553.273438 23.257813 L 554.023438 23.257813 L 554.023438 24.007813 L 553.273438 24.007813 Z M 554.773438 23.257813 L 555.523438 23.257813 L 555.523438 24.007813 L 554.773438 24.007813 Z M 556.273438 23.257813 L 557.023438 23.257813 L 557.023438 24.007813 L 556.273438 24.007813 Z M 557.773438 23.257813 L 558.523438 23.257813 L 558.523438 24.007813 L 557.773438 24.007813 Z M 559.273438 23.257813 L 560.023438 23.257813 L 560.023438 24.007813 L 559.273438 24.007813 Z M 560.773438 23.257813 L 561.523438 23.257813 L 561.523438 24.007813 L 560.773438 24.007813 Z M 562.273438 23.257813 L 563.023438 23.257813 L 563.023438 24.007813 L 562.273438 24.007813 Z M 563.773438 23.257813 L 564.523438 23.257813 L 564.523438 24.007813 L 563.773438 24.007813 Z M 565.273438 23.257813 L 566.027344 23.257813 L 566.027344 24.007813 L 565.273438 24.007813 Z M 566.777344 23.257813 L 567.527344 23.257813 L 567.527344 24.007813 L 566.777344 24.007813 Z M 568.277344 23.257813 L 569.027344 23.257813 L 569.027344 24.007813 L 568.277344 24.007813 Z M 569.777344 23.257813 L 570.527344 23.257813 L 570.527344 24.007813 L 569.777344 24.007813 Z M 571.277344 23.257813 L 572.027344 23.257813 L 572.027344 24.007813 L 571.277344 24.007813 Z M 572.777344 23.257813 L 573.527344 23.257813 L 573.527344 24.007813 L 572.777344 24.007813 Z M 574.277344 23.257813 L 575.027344 23.257813 L 575.027344 24.007813 L 574.277344 24.007813 Z M 575.777344 23.257813 L 576.527344 23.257813 L 576.527344 24.007813 L 575.777344 24.007813 Z M 577.277344 23.257813 L 578.027344 23.257813 L 578.027344 24.007813 L 577.277344 24.007813 Z M 578.777344 23.257813 L 579.527344 23.257813 L 579.527344 24.007813 L 578.777344 24.007813 Z M 580.277344 23.257813 L 581.03125 23.257813 L 581.03125 24.007813 L 580.277344 24.007813 Z M 581.78125 23.257813 L 582.53125 23.257813 L 582.53125 24.007813 L 581.78125 24.007813 Z M 583.28125 23.257813 L 584.03125 23.257813 L 584.03125 24.007813 L 583.28125 24.007813 Z M 585.15625 23.632813 L 585.15625 24.382813 L 584.40625 24.382813 L 584.40625 23.632813 Z M 585.15625 25.132813 L 585.15625 25.882813 L 584.40625 25.882813 L 584.40625 25.132813 Z M 585.15625 26.632813 L 585.15625 27.382813 L 584.40625 27.382813 L 584.40625 26.632813 Z M 585.15625 28.132813 L 585.15625 28.882813 L 584.40625 28.882813 L 584.40625 28.132813 Z M 585.15625 29.632813 L 585.15625 30.382813 L 584.40625 30.382813 L 584.40625 29.632813 Z M 585.15625 31.132813 L 585.15625 31.882813 L 584.40625 31.882813 L 584.40625 31.132813 Z M 585.15625 32.632813 L 585.15625 33.382813 L 584.40625 33.382813 L 584.40625 32.632813 Z M 585.15625 34.132813 L 585.15625 34.882813 L 584.40625 34.882813 L 584.40625 34.132813 Z M 585.15625 35.632813 L 585.15625 36.382813 L 584.40625 36.382813 L 584.40625 35.632813 Z M 585.15625 37.136719 L 585.15625 37.886719 L 584.40625 37.886719 L 584.40625 37.136719 Z M 585.15625 38.636719 L 585.15625 39.386719 L 584.40625 39.386719 L 584.40625 38.636719 Z M 585.15625 40.136719 L 585.15625 40.886719 L 584.40625 40.886719 L 584.40625 40.136719 Z M 585.15625 41.636719 L 585.15625 42.386719 L 584.40625 42.386719 L 584.40625 41.636719 Z M 585.15625 43.136719 L 585.15625 43.886719 L 584.40625 43.886719 L 584.40625 43.136719 Z M 585.15625 44.636719 L 585.15625 45.386719 L 584.40625 45.386719 L 584.40625 44.636719 Z M 585.15625 46.136719 L 585.15625 46.886719 L 584.40625 46.886719 L 584.40625 46.136719 Z M 585.15625 47.636719 L 585.15625 48.386719 L 584.40625 48.386719 L 584.40625 47.636719 Z M 585.15625 49.136719 L 585.15625 49.886719 L 584.40625 49.886719 L 584.40625 49.136719 Z M 585.15625 50.636719 L 585.15625 51.386719 L 584.40625 51.386719 L 584.40625 50.636719 Z M 585.15625 52.140625 L 585.15625 52.890625 L 584.40625 52.890625 L 584.40625 52.140625 Z M 585.15625 53.640625 L 585.15625 54.390625 L 584.40625 54.390625 L 584.40625 53.640625 Z M 585.15625 55.140625 L 585.15625 55.890625 L 584.40625 55.890625 L 584.40625 55.140625 Z M 585.15625 56.640625 L 585.15625 57.390625 L 584.40625 57.390625 L 584.40625 56.640625 Z M 585.15625 58.140625 L 585.15625 58.890625 L 584.40625 58.890625 L 584.40625 58.140625 Z M 585.15625 59.640625 L 585.15625 60.390625 L 584.40625 60.390625 L 584.40625 59.640625 Z M 585.15625 61.140625 L 585.15625 61.890625 L 584.40625 61.890625 L 584.40625 61.140625 Z M 585.15625 62.640625 L 585.15625 63.390625 L 584.40625 63.390625 L 584.40625 62.640625 Z M 585.15625 64.140625 L 585.15625 64.890625 L 584.40625 64.890625 L 584.40625 64.140625 Z M 585.15625 65.640625 L 585.15625 66.394531 L 584.40625 66.394531 L 584.40625 65.640625 Z M 585.15625 67.144531 L 585.15625 67.894531 L 584.40625 67.894531 L 584.40625 67.144531 Z M 585.15625 68.644531 L 585.15625 69.394531 L 584.40625 69.394531 L 584.40625 68.644531 Z M 585.15625 70.144531 L 585.15625 70.894531 L 584.40625 70.894531 L 584.40625 70.144531 Z M 585.15625 71.644531 L 585.15625 72.394531 L 584.40625 72.394531 L 584.40625 71.644531 Z M 585.15625 73.144531 L 585.15625 73.894531 L 584.40625 73.894531 L 584.40625 73.144531 Z M 585.15625 74.644531 L 585.15625 75.394531 L 584.40625 75.394531 L 584.40625 74.644531 Z M 585.15625 76.144531 L 585.15625 76.894531 L 584.40625 76.894531 L 584.40625 76.144531 Z M 585.15625 77.644531 L 585.15625 78.394531 L 584.40625 78.394531 L 584.40625 77.644531 Z M 585.15625 79.144531 L 585.15625 79.894531 L 584.40625 79.894531 L 584.40625 79.144531 Z M 585.15625 80.644531 L 585.15625 81.398438 L 584.40625 81.398438 L 584.40625 80.644531 Z M 585.15625 82.148438 L 585.15625 82.898438 L 584.40625 82.898438 L 584.40625 82.148438 Z M 585.15625 83.648438 L 585.15625 84.398438 L 584.40625 84.398438 L 584.40625 83.648438 Z M 585.15625 85.148438 L 585.15625 85.898438 L 584.40625 85.898438 L 584.40625 85.148438 Z M 585.15625 86.648438 L 585.15625 87.398438 L 584.40625 87.398438 L 584.40625 86.648438 Z M 585.15625 88.148438 L 585.15625 88.898438 L 584.40625 88.898438 L 584.40625 88.148438 Z M 585.15625 89.648438 L 585.15625 90.398438 L 584.40625 90.398438 L 584.40625 89.648438 Z M 585.15625 91.148438 L 585.15625 91.898438 L 584.40625 91.898438 L 584.40625 91.148438 Z M 585.15625 92.648438 L 585.15625 93.398438 L 584.40625 93.398438 L 584.40625 92.648438 Z M 585.15625 94.148438 L 585.15625 94.898438 L 584.40625 94.898438 L 584.40625 94.148438 Z M 584.78125 96.027344 L 584.03125 96.027344 L 584.03125 95.273438 L 584.78125 95.273438 Z M 583.28125 96.027344 L 582.53125 96.027344 L 582.53125 95.273438 L 583.28125 95.273438 Z M 581.78125 96.027344 L 581.03125 96.027344 L 581.03125 95.273438 L 581.78125 95.273438 Z M 580.277344 96.027344 L 579.527344 96.027344 L 579.527344 95.273438 L 580.277344 95.273438 Z M 578.777344 96.027344 L 578.027344 96.027344 L 578.027344 95.273438 L 578.777344 95.273438 Z M 577.277344 96.027344 L 576.527344 96.027344 L 576.527344 95.273438 L 577.277344 95.273438 Z M 575.777344 96.027344 L 575.027344 96.027344 L 575.027344 95.273438 L 575.777344 95.273438 Z M 574.277344 96.027344 L 573.527344 96.027344 L 573.527344 95.273438 L 574.277344 95.273438 Z M 572.777344 96.027344 L 572.027344 96.027344 L 572.027344 95.273438 L 572.777344 95.273438 Z M 571.277344 96.027344 L 570.527344 96.027344 L 570.527344 95.273438 L 571.277344 95.273438 Z M 569.777344 96.027344 L 569.027344 96.027344 L 569.027344 95.273438 L 569.777344 95.273438 Z M 568.277344 96.027344 L 567.527344 96.027344 L 567.527344 95.273438 L 568.277344 95.273438 Z M 566.777344 96.027344 L 566.027344 96.027344 L 566.027344 95.273438 L 566.777344 95.273438 Z M 565.273438 96.027344 L 564.523438 96.027344 L 564.523438 95.273438 L 565.273438 95.273438 Z M 563.773438 96.027344 L 563.023438 96.027344 L 563.023438 95.273438 L 563.773438 95.273438 Z M 562.273438 96.027344 L 561.523438 96.027344 L 561.523438 95.273438 L 562.273438 95.273438 Z M 560.773438 96.027344 L 560.023438 96.027344 L 560.023438 95.273438 L 560.773438 95.273438 Z M 559.273438 96.027344 L 558.523438 96.027344 L 558.523438 95.273438 L 559.273438 95.273438 Z M 557.773438 96.027344 L 557.023438 96.027344 L 557.023438 95.273438 L 557.773438 95.273438 Z M 556.273438 96.027344 L 555.523438 96.027344 L 555.523438 95.273438 L 556.273438 95.273438 Z M 554.773438 96.027344 L 554.023438 96.027344 L 554.023438 95.273438 L 554.773438 95.273438 Z M 553.273438 96.027344 L 552.523438 96.027344 L 552.523438 95.273438 L 553.273438 95.273438 Z M 551.773438 96.027344 L 551.019531 96.027344 L 551.019531 95.273438 L 551.773438 95.273438 Z M 550.269531 96.027344 L 549.519531 96.027344 L 549.519531 95.273438 L 550.269531 95.273438 Z M 548.769531 96.027344 L 548.019531 96.027344 L 548.019531 95.273438 L 548.769531 95.273438 Z M 547.269531 96.027344 L 546.519531 96.027344 L 546.519531 95.273438 L 547.269531 95.273438 Z M 545.769531 96.027344 L 545.019531 96.027344 L 545.019531 95.273438 L 545.769531 95.273438 Z M 544.269531 96.027344 L 543.519531 96.027344 L 543.519531 95.273438 L 544.269531 95.273438 Z M 542.769531 96.027344 L 542.019531 96.027344 L 542.019531 95.273438 L 542.769531 95.273438 Z M 541.269531 96.027344 L 540.519531 96.027344 L 540.519531 95.273438 L 541.269531 95.273438 Z M 539.769531 96.027344 L 539.019531 96.027344 L 539.019531 95.273438 L 539.769531 95.273438 Z M 538.269531 96.027344 L 537.519531 96.027344 L 537.519531 95.273438 L 538.269531 95.273438 Z M 536.769531 96.027344 L 536.015625 96.027344 L 536.015625 95.273438 L 536.769531 95.273438 Z M 535.265625 96.027344 L 534.515625 96.027344 L 534.515625 95.273438 L 535.265625 95.273438 Z M 533.765625 96.027344 L 533.015625 96.027344 L 533.015625 95.273438 L 533.765625 95.273438 Z M 532.265625 96.027344 L 531.515625 96.027344 L 531.515625 95.273438 L 532.265625 95.273438 Z M 530.765625 96.027344 L 530.015625 96.027344 L 530.015625 95.273438 L 530.765625 95.273438 Z M 529.265625 96.027344 L 528.515625 96.027344 L 528.515625 95.273438 L 529.265625 95.273438 Z M 527.765625 96.027344 L 527.015625 96.027344 L 527.015625 95.273438 L 527.765625 95.273438 Z M 526.265625 96.027344 L 525.515625 96.027344 L 525.515625 95.273438 L 526.265625 95.273438 Z M 524.765625 96.027344 L 524.015625 96.027344 L 524.015625 95.273438 L 524.765625 95.273438 Z M 523.265625 96.027344 L 522.515625 96.027344 L 522.515625 95.273438 L 523.265625 95.273438 Z M 521.765625 96.027344 L 521.011719 96.027344 L 521.011719 95.273438 L 521.765625 95.273438 Z M 520.261719 96.027344 L 519.511719 96.027344 L 519.511719 95.273438 L 520.261719 95.273438 Z M 518.761719 96.027344 L 518.011719 96.027344 L 518.011719 95.273438 L 518.761719 95.273438 Z M 517.261719 96.027344 L 516.511719 96.027344 L 516.511719 95.273438 L 517.261719 95.273438 Z M 515.761719 96.027344 L 515.011719 96.027344 L 515.011719 95.273438 L 515.761719 95.273438 Z M 514.261719 96.027344 L 513.511719 96.027344 L 513.511719 95.273438 L 514.261719 95.273438 Z M 512.761719 96.027344 L 512.011719 96.027344 L 512.011719 95.273438 L 512.761719 95.273438 Z M 511.261719 96.027344 L 510.511719 96.027344 L 510.511719 95.273438 L 511.261719 95.273438 Z M 509.761719 96.027344 L 509.011719 96.027344 L 509.011719 95.273438 L 509.761719 95.273438 Z M 508.261719 96.027344 L 507.511719 96.027344 L 507.511719 95.273438 L 508.261719 95.273438 Z M 506.757813 96.027344 L 506.007813 96.027344 L 506.007813 95.273438 L 506.757813 95.273438 Z M 505.257813 96.027344 L 504.507813 96.027344 L 504.507813 95.273438 L 505.257813 95.273438 Z M 503.757813 96.027344 L 503.007813 96.027344 L 503.007813 95.273438 L 503.757813 95.273438 Z M 502.257813 96.027344 L 501.507813 96.027344 L 501.507813 95.273438 L 502.257813 95.273438 Z M 500.757813 96.027344 L 500.007813 96.027344 L 500.007813 95.273438 L 500.757813 95.273438 Z M 499.257813 96.027344 L 498.507813 96.027344 L 498.507813 95.273438 L 499.257813 95.273438 Z M 497.757813 96.027344 L 497.007813 96.027344 L 497.007813 95.273438 L 497.757813 95.273438 Z M 496.257813 96.027344 L 495.507813 96.027344 L 495.507813 95.273438 L 496.257813 95.273438 Z M 494.757813 96.027344 L 494.007813 96.027344 L 494.007813 95.273438 L 494.757813 95.273438 Z M 493.257813 96.027344 L 492.507813 96.027344 L 492.507813 95.273438 L 493.257813 95.273438 Z M 491.753906 96.027344 L 491.003906 96.027344 L 491.003906 95.273438 L 491.753906 95.273438 Z M 490.253906 96.027344 L 489.503906 96.027344 L 489.503906 95.273438 L 490.253906 95.273438 Z M 488.753906 96.027344 L 488.003906 96.027344 L 488.003906 95.273438 L 488.753906 95.273438 Z M 487.253906 96.027344 L 486.503906 96.027344 L 486.503906 95.273438 L 487.253906 95.273438 Z M 485.753906 96.027344 L 485.003906 96.027344 L 485.003906 95.273438 L 485.753906 95.273438 Z M 484.253906 96.027344 L 483.503906 96.027344 L 483.503906 95.273438 L 484.253906 95.273438 Z M 482.753906 96.027344 L 482.003906 96.027344 L 482.003906 95.273438 L 482.753906 95.273438 Z M 481.253906 96.027344 L 480.503906 96.027344 L 480.503906 95.273438 L 481.253906 95.273438 Z M 479.753906 96.027344 L 479.003906 96.027344 L 479.003906 95.273438 L 479.753906 95.273438 Z M 478.253906 96.027344 L 477.5 96.027344 L 477.5 95.273438 L 478.253906 95.273438 Z M 476.75 96.027344 L 476 96.027344 L 476 95.273438 L 476.75 95.273438 Z M 475.25 96.027344 L 474.5 96.027344 L 474.5 95.273438 L 475.25 95.273438 Z M 473.75 96.027344 L 473 96.027344 L 473 95.273438 L 473.75 95.273438 Z M 472.25 96.027344 L 471.5 96.027344 L 471.5 95.273438 L 472.25 95.273438 Z M 470.75 96.027344 L 470 96.027344 L 470 95.273438 L 470.75 95.273438 Z M 469.25 96.027344 L 468.5 96.027344 L 468.5 95.273438 L 469.25 95.273438 Z M 467.75 96.027344 L 467 96.027344 L 467 95.273438 L 467.75 95.273438 Z M 466.25 96.027344 L 465.5 96.027344 L 465.5 95.273438 L 466.25 95.273438 Z M 464.375 95.652344 L 464.375 94.898438 L 465.125 94.898438 L 465.125 95.652344 Z M 464.375 94.148438 L 464.375 93.398438 L 465.125 93.398438 L 465.125 94.148438 Z M 464.375 92.648438 L 464.375 91.898438 L 465.125 91.898438 L 465.125 92.648438 Z M 464.375 91.148438 L 464.375 90.398438 L 465.125 90.398438 L 465.125 91.148438 Z M 464.375 89.648438 L 464.375 88.898438 L 465.125 88.898438 L 465.125 89.648438 Z M 464.375 88.148438 L 464.375 87.398438 L 465.125 87.398438 L 465.125 88.148438 Z M 464.375 86.648438 L 464.375 85.898438 L 465.125 85.898438 L 465.125 86.648438 Z M 464.375 85.148438 L 464.375 84.398438 L 465.125 84.398438 L 465.125 85.148438 Z M 464.375 83.648438 L 464.375 82.898438 L 465.125 82.898438 L 465.125 83.648438 Z M 464.375 82.148438 L 464.375 81.398438 L 465.125 81.398438 L 465.125 82.148438 Z M 464.375 80.644531 L 464.375 79.894531 L 465.125 79.894531 L 465.125 80.644531 Z M 464.375 79.144531 L 464.375 78.394531 L 465.125 78.394531 L 465.125 79.144531 Z M 464.375 77.644531 L 464.375 76.894531 L 465.125 76.894531 L 465.125 77.644531 Z M 464.375 76.144531 L 464.375 75.394531 L 465.125 75.394531 L 465.125 76.144531 Z M 464.375 74.644531 L 464.375 73.894531 L 465.125 73.894531 L 465.125 74.644531 Z M 464.375 73.144531 L 464.375 72.394531 L 465.125 72.394531 L 465.125 73.144531 Z M 464.375 71.644531 L 464.375 70.894531 L 465.125 70.894531 L 465.125 71.644531 Z M 464.375 70.144531 L 464.375 69.394531 L 465.125 69.394531 L 465.125 70.144531 Z M 464.375 68.644531 L 464.375 67.894531 L 465.125 67.894531 L 465.125 68.644531 Z M 464.375 67.144531 L 464.375 66.394531 L 465.125 66.394531 L 465.125 67.144531 Z M 464.375 65.640625 L 464.375 64.890625 L 465.125 64.890625 L 465.125 65.640625 Z M 464.375 64.140625 L 464.375 63.390625 L 465.125 63.390625 L 465.125 64.140625 Z M 464.375 62.640625 L 464.375 61.890625 L 465.125 61.890625 L 465.125 62.640625 Z M 464.375 61.140625 L 464.375 60.390625 L 465.125 60.390625 L 465.125 61.140625 Z M 464.375 59.640625 L 464.375 58.890625 L 465.125 58.890625 L 465.125 59.640625 Z M 464.375 58.140625 L 464.375 57.390625 L 465.125 57.390625 L 465.125 58.140625 Z M 464.375 56.640625 L 464.375 55.890625 L 465.125 55.890625 L 465.125 56.640625 Z M 464.375 55.140625 L 464.375 54.390625 L 465.125 54.390625 L 465.125 55.140625 Z M 464.375 53.640625 L 464.375 52.890625 L 465.125 52.890625 L 465.125 53.640625 Z M 464.375 52.140625 L 464.375 51.386719 L 465.125 51.386719 L 465.125 52.140625 Z M 464.375 50.636719 L 464.375 49.886719 L 465.125 49.886719 L 465.125 50.636719 Z M 464.375 49.136719 L 464.375 48.386719 L 465.125 48.386719 L 465.125 49.136719 Z M 464.375 47.636719 L 464.375 46.886719 L 465.125 46.886719 L 465.125 47.636719 Z M 464.375 46.136719 L 464.375 45.386719 L 465.125 45.386719 L 465.125 46.136719 Z M 464.375 44.636719 L 464.375 43.886719 L 465.125 43.886719 L 465.125 44.636719 Z M 464.375 43.136719 L 464.375 42.386719 L 465.125 42.386719 L 465.125 43.136719 Z M 464.375 41.636719 L 464.375 40.886719 L 465.125 40.886719 L 465.125 41.636719 Z M 464.375 40.136719 L 464.375 39.386719 L 465.125 39.386719 L 465.125 40.136719 Z M 464.375 38.636719 L 464.375 37.886719 L 465.125 37.886719 L 465.125 38.636719 Z M 464.375 37.136719 L 464.375 36.382813 L 465.125 36.382813 L 465.125 37.136719 Z M 464.375 35.632813 L 464.375 34.882813 L 465.125 34.882813 L 465.125 35.632813 Z M 464.375 34.132813 L 464.375 33.382813 L 465.125 33.382813 L 465.125 34.132813 Z M 464.375 32.632813 L 464.375 31.882813 L 465.125 31.882813 L 465.125 32.632813 Z M 464.375 31.132813 L 464.375 30.382813 L 465.125 30.382813 L 465.125 31.132813 Z M 464.375 29.632813 L 464.375 28.882813 L 465.125 28.882813 L 465.125 29.632813 Z M 464.375 28.132813 L 464.375 27.382813 L 465.125 27.382813 L 465.125 28.132813 Z M 464.375 26.632813 L 464.375 25.882813 L 465.125 25.882813 L 465.125 26.632813 Z M 464.375 25.132813 L 464.375 24.382813 L 465.125 24.382813 L 465.125 25.132813 Z M 464.75 23.257813 L 465.5 23.257813 L 465.5 24.007813 L 464.75 24.007813 Z M 464.75 23.257813 "
+     id="path1219" />
+  <path
+     fill-rule="nonzero"
+     fill="rgb(100%, 100%, 100%)"
+     fill-opacity="1"
+     d="M 562.648438 110.28125 L 653.421875 110.28125 L 653.421875 119.28125 L 562.648438 119.28125 Z M 562.648438 110.28125 "
+     id="path1221" />
+  <g
+     fill="#000000"
+     fill-opacity="1"
+     id="g1279">
+    <use
+       xlink:href="#glyph-0-30"
+       x="562.36823"
+       y="117.03111"
+       id="use1223" />
+    <use
+       xlink:href="#glyph-0-9"
+       x="566.54053"
+       y="117.03111"
+       id="use1225" />
+    <use
+       xlink:href="#glyph-0-23"
+       x="570.71277"
+       y="117.03111"
+       id="use1227" />
+    <use
+       xlink:href="#glyph-0-12"
+       x="572.79706"
+       y="117.03111"
+       id="use1229" />
+    <use
+       xlink:href="#glyph-0-13"
+       x="574.88135"
+       y="117.03111"
+       id="use1231" />
+    <use
+       xlink:href="#glyph-0-32"
+       x="576.54803"
+       y="117.03111"
+       id="use1233" />
+    <use
+       xlink:href="#glyph-0-15"
+       x="580.72028"
+       y="117.03111"
+       id="use1235" />
+    <use
+       xlink:href="#glyph-0-7"
+       x="584.47131"
+       y="117.03111"
+       id="use1237" />
+    <use
+       xlink:href="#glyph-0-34"
+       x="588.64355"
+       y="117.03111"
+       id="use1239" />
+    <use
+       xlink:href="#glyph-0-23"
+       x="590.72784"
+       y="117.03111"
+       id="use1241" />
+    <use
+       xlink:href="#glyph-0-32"
+       x="592.81213"
+       y="117.03111"
+       id="use1243" />
+    <use
+       xlink:href="#glyph-0-27"
+       x="596.98438"
+       y="117.03111"
+       id="use1245" />
+    <use
+       xlink:href="#glyph-0-21"
+       x="601.15662"
+       y="117.03111"
+       id="use1247" />
+    <use
+       xlink:href="#glyph-0-8"
+       x="605.32892"
+       y="117.03111"
+       id="use1249" />
+    <use
+       xlink:href="#glyph-0-4"
+       x="609.50116"
+       y="117.03111"
+       id="use1251" />
+    <use
+       xlink:href="#glyph-0-5"
+       x="611.58545"
+       y="117.03111"
+       id="use1253" />
+    <use
+       xlink:href="#glyph-0-23"
+       x="615.75769"
+       y="117.03111"
+       id="use1255" />
+    <use
+       xlink:href="#glyph-0-18"
+       x="617.84198"
+       y="117.03111"
+       id="use1257" />
+    <use
+       xlink:href="#glyph-0-8"
+       x="622.01422"
+       y="117.03111"
+       id="use1259" />
+    <use
+       xlink:href="#glyph-0-6"
+       x="626.18646"
+       y="117.03111"
+       id="use1261" />
+    <use
+       xlink:href="#glyph-0-22"
+       x="629.9375"
+       y="117.03111"
+       id="use1263" />
+    <use
+       xlink:href="#glyph-0-32"
+       x="633.68848"
+       y="117.03111"
+       id="use1265" />
+    <use
+       xlink:href="#glyph-0-27"
+       x="637.86072"
+       y="117.03111"
+       id="use1267" />
+    <use
+       xlink:href="#glyph-0-23"
+       x="642.03296"
+       y="117.03111"
+       id="use1269" />
+    <use
+       xlink:href="#glyph-0-12"
+       x="644.11725"
+       y="117.03111"
+       id="use1271" />
+    <use
+       xlink:href="#glyph-0-3"
+       x="646.2016"
+       y="117.03111"
+       id="use1273" />
+    <use
+       xlink:href="#glyph-0-13"
+       x="647.86829"
+       y="117.03111"
+       id="use1275" />
+    <use
+       xlink:href="#glyph-0-5"
+       x="649.53497"
+       y="117.03111"
+       id="use1277" />
+  </g>
+  <path
+     fill="none"
+     stroke-width="1"
+     stroke-linecap="butt"
+     stroke-linejoin="miter"
+     stroke="rgb(0%, 0%, 0%)"
+     stroke-opacity="1"
+     stroke-miterlimit="10"
+     d="M 653.997837 106.997457 L 653.997837 172.88098 "
+     transform="matrix(0.750199, 0, 0, 0.750199, 0.3751, 0.3751)"
+     id="path1281" />
+  <path
+     fill-rule="nonzero"
+     fill="rgb(0%, 0%, 0%)"
+     fill-opacity="1"
+     stroke-width="1"
+     stroke-linecap="butt"
+     stroke-linejoin="miter"
+     stroke="rgb(0%, 0%, 0%)"
+     stroke-opacity="1"
+     stroke-miterlimit="10"
+     d="M 653.997837 179.879119 L 650.498768 172.88098 L 657.502114 172.88098 Z M 653.997837 179.879119 "
+     transform="matrix(0.750199, 0, 0, 0.750199, 0.3751, 0.3751)"
+     id="path1283" />
+  <path
+     fill="none"
+     stroke-width="2"
+     stroke-linecap="butt"
+     stroke-linejoin="miter"
+     stroke="rgb(0%, 59.999084%, 0%)"
+     stroke-opacity="1"
+     stroke-miterlimit="10"
+     d="M 351.500282 46.997919 L 351.500282 26.998029 L 163.998058 26.998029 L 163.998058 80.301564 L 223.549931 80.327598 "
+     transform="matrix(0.750199, 0, 0, 0.750199, 0, 0)"
+     id="path1285" />
+  <path
+     fill-rule="nonzero"
+     fill="rgb(0%, 59.999084%, 0%)"
+     fill-opacity="1"
+     stroke-width="2"
+     stroke-linecap="butt"
+     stroke-linejoin="miter"
+     stroke="rgb(0%, 59.999084%, 0%)"
+     stroke-opacity="1"
+     stroke-miterlimit="10"
+     d="M 231.547804 80.327598 L 223.549931 84.331742 L 223.560345 76.328662 Z M 231.547804 80.327598 "
+     transform="matrix(0.750199, 0, 0, 0.750199, 0, 0)"
+     id="path1287" />
+  <path
+     fill-rule="nonzero"
+     fill="rgb(100%, 100%, 100%)"
+     fill-opacity="1"
+     d="M 103.527344 9.003906 L 137.285156 9.003906 L 137.285156 18.003906 L 103.527344 18.003906 Z M 103.527344 9.003906 "
+     id="path1289" />
+  <g
+     fill="#009900"
+     fill-opacity="1"
+     id="g1305">
+    <use
+       xlink:href="#glyph-1-2"
+       x="103.31653"
+       y="15.754188"
+       id="use1291" />
+    <use
+       xlink:href="#glyph-1-31"
+       x="108.3203"
+       y="15.754188"
+       id="use1293" />
+    <use
+       xlink:href="#glyph-1-32"
+       x="113.32407"
+       y="15.754188"
+       id="use1295" />
+    <use
+       xlink:href="#glyph-1-26"
+       x="118.74177"
+       y="15.754188"
+       id="use1297" />
+    <use
+       xlink:href="#glyph-1-23"
+       x="124.15947"
+       y="15.754188"
+       id="use1299" />
+    <use
+       xlink:href="#glyph-1-1"
+       x="126.24377"
+       y="15.754188"
+       id="use1301" />
+    <use
+       xlink:href="#glyph-1-33"
+       x="132.07906"
+       y="15.754188"
+       id="use1303" />
+  </g>
+  <path
+     fill-rule="nonzero"
+     fill="rgb(100%, 100%, 100%)"
+     fill-opacity="1"
+     d="M 139.535156 64.515625 L 168.792969 64.515625 L 168.792969 73.519531 L 139.535156 73.519531 Z M 139.535156 64.515625 "
+     id="path1307" />
+  <g
+     fill="#009900"
+     fill-opacity="1"
+     id="g1323">
+    <use
+       xlink:href="#glyph-1-8"
+       x="139.78326"
+       y="71.268944"
+       id="use1309" />
+    <use
+       xlink:href="#glyph-1-3"
+       x="143.95551"
+       y="71.268944"
+       id="use1311" />
+    <use
+       xlink:href="#glyph-1-3"
+       x="148.53802"
+       y="71.268944"
+       id="use1313" />
+    <use
+       xlink:href="#glyph-1-23"
+       x="153.12054"
+       y="71.268944"
+       id="use1315" />
+    <use
+       xlink:href="#glyph-1-19"
+       x="155.20483"
+       y="71.268944"
+       id="use1317" />
+    <use
+       xlink:href="#glyph-1-20"
+       x="158.12431"
+       y="71.268944"
+       id="use1319" />
+    <use
+       xlink:href="#glyph-1-21"
+       x="162.70683"
+       y="71.268944"
+       id="use1321" />
+  </g>
+  <path
+     fill="none"
+     stroke-width="2"
+     stroke-linecap="butt"
+     stroke-linejoin="miter"
+     stroke="rgb(0%, 59.999084%, 0%)"
+     stroke-opacity="1"
+     stroke-miterlimit="10"
+     d="M 404.001947 110.382107 L 437.998115 110.382107 L 461.080519 109.89786 "
+     transform="matrix(0.750199, 0, 0, 0.750199, 0, 0)"
+     id="path1325" />
+  <path
+     fill-rule="nonzero"
+     fill="rgb(0%, 59.999084%, 0%)"
+     fill-opacity="1"
+     stroke-width="2"
+     stroke-linecap="butt"
+     stroke-linejoin="miter"
+     stroke="rgb(0%, 59.999084%, 0%)"
+     stroke-opacity="1"
+     stroke-miterlimit="10"
+     d="M 469.078392 109.741652 L 461.169037 113.902004 L 461.002415 105.898924 Z M 469.078392 109.741652 "
+     transform="matrix(0.750199, 0, 0, 0.750199, 0, 0)"
+     id="path1327" />
+  <path
+     fill-rule="nonzero"
+     fill="rgb(100%, 100%, 100%)"
+     fill-opacity="1"
+     d="M 316.585938 72.019531 L 336.839844 72.019531 L 336.839844 81.023438 L 316.585938 81.023438 Z M 316.585938 72.019531 "
+     id="path1329" />
+  <g
+     fill="#009900"
+     fill-opacity="1"
+     id="g1339">
+    <use
+       xlink:href="#glyph-1-2"
+       x="316.29111"
+       y="78.770943"
+       id="use1331" />
+    <use
+       xlink:href="#glyph-1-31"
+       x="321.29489"
+       y="78.770943"
+       id="use1333" />
+    <use
+       xlink:href="#glyph-1-32"
+       x="326.29868"
+       y="78.770943"
+       id="use1335" />
+    <use
+       xlink:href="#glyph-1-26"
+       x="331.71637"
+       y="78.770943"
+       id="use1337" />
+  </g>
+  <path
+     fill-rule="nonzero"
+     fill="rgb(97.24884%, 80.778503%, 79.998779%)"
+     fill-opacity="1"
+     stroke-width="1"
+     stroke-linecap="butt"
+     stroke-linejoin="miter"
+     stroke="rgb(72.158813%, 32.939148%, 31.369019%)"
+     stroke-opacity="1"
+     stroke-miterlimit="4"
+     d="M 333.999595 98.74965 L 404.001814 98.74965 L 404.001814 121.998676 L 333.999595 121.998676 Z M 333.999595 98.74965 "
+     transform="matrix(0.750199, 0, 0, 0.750199, 0.3751, 0.3751)"
+     id="path1341" />
+  <g
+     fill="#000000"
+     fill-opacity="1"
+     id="g1359">
+    <use
+       xlink:href="#glyph-1-22"
+       x="262.85114"
+       y="85.522736"
+       id="use1343" />
+    <use
+       xlink:href="#glyph-1-19"
+       x="265.34933"
+       y="85.522736"
+       id="use1345" />
+    <use
+       xlink:href="#glyph-1-4"
+       x="268.26883"
+       y="85.522736"
+       id="use1347" />
+    <use
+       xlink:href="#glyph-1-34"
+       x="270.35312"
+       y="85.522736"
+       id="use1349" />
+    <use
+       xlink:href="#glyph-1-34"
+       x="274.93564"
+       y="85.522736"
+       id="use1351" />
+    <use
+       xlink:href="#glyph-1-10"
+       x="279.51816"
+       y="85.522736"
+       id="use1353" />
+    <use
+       xlink:href="#glyph-1-19"
+       x="283.6904"
+       y="85.522736"
+       id="use1355" />
+    <use
+       xlink:href="#glyph-1-5"
+       x="286.60989"
+       y="85.522736"
+       id="use1357" />
+  </g>
+  <g
+     fill="#000000"
+     fill-opacity="1"
+     id="g1373">
+    <use
+       xlink:href="#glyph-2-14"
+       x="192.57854"
+       y="160.54268"
+       id="use1361" />
+    <use
+       xlink:href="#glyph-2-6"
+       x="196.75079"
+       y="160.54268"
+       id="use1363" />
+    <use
+       xlink:href="#glyph-2-11"
+       x="200.92305"
+       y="160.54268"
+       id="use1365" />
+    <use
+       xlink:href="#glyph-2-11"
+       x="203.00734"
+       y="160.54268"
+       id="use1367" />
+    <use
+       xlink:href="#glyph-2-6"
+       x="205.09163"
+       y="160.54268"
+       id="use1369" />
+    <use
+       xlink:href="#glyph-2-5"
+       x="209.26389"
+       y="160.54268"
+       id="use1371" />
+  </g>
+  <g
+     fill="#000000"
+     fill-opacity="1"
+     id="g1381">
+    <use
+       xlink:href="#glyph-0-6"
+       x="161.6797"
+       y="169.54507"
+       id="use1375" />
+    <use
+       xlink:href="#glyph-0-15"
+       x="165.43069"
+       y="169.54507"
+       id="use1377" />
+    <use
+       xlink:href="#glyph-0-31"
+       x="169.1817"
+       y="169.54507"
+       id="use1379" />
+  </g>
+  <g
+     fill="#000000"
+     fill-opacity="1"
+     id="g1387">
+    <use
+       xlink:href="#glyph-0-10"
+       x="172.3759"
+       y="169.54507"
+       id="use1383" />
+    <use
+       xlink:href="#glyph-0-14"
+       x="174.46021"
+       y="169.54507"
+       id="use1385" />
+  </g>
+  <g
+     fill="#000000"
+     fill-opacity="1"
+     id="g1399">
+    <use
+       xlink:href="#glyph-0-2"
+       x="181.40541"
+       y="169.54507"
+       id="use1389" />
+    <use
+       xlink:href="#glyph-0-3"
+       x="183.90363"
+       y="169.54507"
+       id="use1391" />
+    <use
+       xlink:href="#glyph-0-4"
+       x="185.57033"
+       y="169.54507"
+       id="use1393" />
+    <use
+       xlink:href="#glyph-0-5"
+       x="187.65463"
+       y="169.54507"
+       id="use1395" />
+    <use
+       xlink:href="#glyph-0-2"
+       x="191.82687"
+       y="169.54507"
+       id="use1397" />
+  </g>
+  <g
+     fill="#000000"
+     fill-opacity="1"
+     id="g1403">
+    <use
+       xlink:href="#glyph-0-10"
+       x="193.91118"
+       y="169.54507"
+       id="use1401" />
+  </g>
+  <g
+     fill="#000000"
+     fill-opacity="1"
+     id="g1427">
+    <use
+       xlink:href="#glyph-1-35"
+       x="196.00133"
+       y="169.54507"
+       id="use1405" />
+    <use
+       xlink:href="#glyph-1-20"
+       x="201.41902"
+       y="169.54507"
+       id="use1407" />
+    <use
+       xlink:href="#glyph-1-21"
+       x="206.00154"
+       y="169.54507"
+       id="use1409" />
+    <use
+       xlink:href="#glyph-1-5"
+       x="211.83684"
+       y="169.54507"
+       id="use1411" />
+    <use
+       xlink:href="#glyph-1-26"
+       x="216.00909"
+       y="169.54507"
+       id="use1413" />
+    <use
+       xlink:href="#glyph-1-20"
+       x="221.42679"
+       y="169.54507"
+       id="use1415" />
+    <use
+       xlink:href="#glyph-1-18"
+       x="226.00931"
+       y="169.54507"
+       id="use1417" />
+    <use
+       xlink:href="#glyph-1-15"
+       x="230.59183"
+       y="169.54507"
+       id="use1419" />
+    <use
+       xlink:href="#glyph-1-22"
+       x="235.17433"
+       y="169.54507"
+       id="use1421" />
+    <use
+       xlink:href="#glyph-1-36"
+       x="237.67256"
+       y="169.54507"
+       id="use1423" />
+    <use
+       xlink:href="#glyph-1-37"
+       x="240.17079"
+       y="169.54507"
+       id="use1425" />
+  </g>
+  <g
+     fill="#000000"
+     fill-opacity="1"
+     id="g1441">
+    <use
+       xlink:href="#glyph-2-14"
+       x="479.98697"
+       y="160.54268"
+       id="use1429" />
+    <use
+       xlink:href="#glyph-2-6"
+       x="484.15924"
+       y="160.54268"
+       id="use1431" />
+    <use
+       xlink:href="#glyph-2-11"
+       x="488.33148"
+       y="160.54268"
+       id="use1433" />
+    <use
+       xlink:href="#glyph-2-11"
+       x="490.41577"
+       y="160.54268"
+       id="use1435" />
+    <use
+       xlink:href="#glyph-2-6"
+       x="492.50006"
+       y="160.54268"
+       id="use1437" />
+    <use
+       xlink:href="#glyph-2-5"
+       x="496.67233"
+       y="160.54268"
+       id="use1439" />
+  </g>
+  <g
+     fill="#000000"
+     fill-opacity="1"
+     id="g1445">
+    <use
+       xlink:href="#glyph-2-10"
+       x="499.17053"
+       y="160.54268"
+       id="use1443" />
+  </g>
+  <g
+     fill="#000000"
+     fill-opacity="1"
+     id="g1453">
+    <use
+       xlink:href="#glyph-0-6"
+       x="436.35818"
+       y="169.54507"
+       id="use1447" />
+    <use
+       xlink:href="#glyph-0-15"
+       x="440.10919"
+       y="169.54507"
+       id="use1449" />
+    <use
+       xlink:href="#glyph-0-31"
+       x="443.86017"
+       y="169.54507"
+       id="use1451" />
+  </g>
+  <g
+     fill="#000000"
+     fill-opacity="1"
+     id="g1459">
+    <use
+       xlink:href="#glyph-0-10"
+       x="447.05438"
+       y="169.54507"
+       id="use1455" />
+    <use
+       xlink:href="#glyph-0-14"
+       x="449.13867"
+       y="169.54507"
+       id="use1457" />
+  </g>
+  <g
+     fill="#000000"
+     fill-opacity="1"
+     id="g1471">
+    <use
+       xlink:href="#glyph-0-2"
+       x="456.08389"
+       y="169.54507"
+       id="use1461" />
+    <use
+       xlink:href="#glyph-0-3"
+       x="458.58212"
+       y="169.54507"
+       id="use1463" />
+    <use
+       xlink:href="#glyph-0-4"
+       x="460.24881"
+       y="169.54507"
+       id="use1465" />
+    <use
+       xlink:href="#glyph-0-5"
+       x="462.3331"
+       y="169.54507"
+       id="use1467" />
+    <use
+       xlink:href="#glyph-0-2"
+       x="466.50537"
+       y="169.54507"
+       id="use1469" />
+  </g>
+  <g
+     fill="#000000"
+     fill-opacity="1"
+     id="g1475">
+    <use
+       xlink:href="#glyph-0-10"
+       x="468.58966"
+       y="169.54507"
+       id="use1473" />
+  </g>
+  <g
+     fill="#000000"
+     fill-opacity="1"
+     id="g1513">
+    <use
+       xlink:href="#glyph-1-38"
+       x="470.67981"
+       y="169.54507"
+       id="use1477" />
+    <use
+       xlink:href="#glyph-1-15"
+       x="476.0975"
+       y="169.54507"
+       id="use1479" />
+    <use
+       xlink:href="#glyph-1-7"
+       x="480.68002"
+       y="169.54507"
+       id="use1481" />
+    <use
+       xlink:href="#glyph-1-20"
+       x="484.85229"
+       y="169.54507"
+       id="use1483" />
+    <use
+       xlink:href="#glyph-1-24"
+       x="489.43478"
+       y="169.54507"
+       id="use1485" />
+    <use
+       xlink:href="#glyph-1-25"
+       x="496.10529"
+       y="169.54507"
+       id="use1487" />
+    <use
+       xlink:href="#glyph-1-19"
+       x="500.68781"
+       y="169.54507"
+       id="use1489" />
+    <use
+       xlink:href="#glyph-1-10"
+       x="503.60727"
+       y="169.54507"
+       id="use1491" />
+    <use
+       xlink:href="#glyph-1-5"
+       x="507.77951"
+       y="169.54507"
+       id="use1493" />
+    <use
+       xlink:href="#glyph-1-5"
+       x="511.95178"
+       y="169.54507"
+       id="use1495" />
+    <use
+       xlink:href="#glyph-1-10"
+       x="516.12402"
+       y="169.54507"
+       id="use1497" />
+    <use
+       xlink:href="#glyph-1-3"
+       x="520.29626"
+       y="169.54507"
+       id="use1499" />
+    <use
+       xlink:href="#glyph-1-2"
+       x="524.87878"
+       y="169.54507"
+       id="use1501" />
+    <use
+       xlink:href="#glyph-1-4"
+       x="529.88257"
+       y="169.54507"
+       id="use1503" />
+    <use
+       xlink:href="#glyph-1-39"
+       x="531.96686"
+       y="169.54507"
+       id="use1505" />
+    <use
+       xlink:href="#glyph-1-10"
+       x="535.71783"
+       y="169.54507"
+       id="use1507" />
+    <use
+       xlink:href="#glyph-1-36"
+       x="539.89008"
+       y="169.54507"
+       id="use1509" />
+    <use
+       xlink:href="#glyph-1-37"
+       x="542.38831"
+       y="169.54507"
+       id="use1511" />
+  </g>
+  <g
+     fill="#000000"
+     fill-opacity="1"
+     id="g1527">
+    <use
+       xlink:href="#glyph-2-14"
+       x="603.01965"
+       y="160.54268"
+       id="use1515" />
+    <use
+       xlink:href="#glyph-2-6"
+       x="607.19196"
+       y="160.54268"
+       id="use1517" />
+    <use
+       xlink:href="#glyph-2-11"
+       x="611.3642"
+       y="160.54268"
+       id="use1519" />
+    <use
+       xlink:href="#glyph-2-11"
+       x="613.44849"
+       y="160.54268"
+       id="use1521" />
+    <use
+       xlink:href="#glyph-2-6"
+       x="615.53278"
+       y="160.54268"
+       id="use1523" />
+    <use
+       xlink:href="#glyph-2-5"
+       x="619.70502"
+       y="160.54268"
+       id="use1525" />
+  </g>
+  <g
+     fill="#000000"
+     fill-opacity="1"
+     id="g1531">
+    <use
+       xlink:href="#glyph-2-10"
+       x="622.20325"
+       y="160.54268"
+       id="use1529" />
+  </g>
+  <g
+     fill="#000000"
+     fill-opacity="1"
+     id="g1539">
+    <use
+       xlink:href="#glyph-0-6"
+       x="563.7749"
+       y="169.54507"
+       id="use1533" />
+    <use
+       xlink:href="#glyph-0-15"
+       x="567.52588"
+       y="169.54507"
+       id="use1535" />
+    <use
+       xlink:href="#glyph-0-31"
+       x="571.27686"
+       y="169.54507"
+       id="use1537" />
+  </g>
+  <g
+     fill="#000000"
+     fill-opacity="1"
+     id="g1545">
+    <use
+       xlink:href="#glyph-0-10"
+       x="574.47107"
+       y="169.54507"
+       id="use1541" />
+    <use
+       xlink:href="#glyph-0-14"
+       x="576.55536"
+       y="169.54507"
+       id="use1543" />
+  </g>
+  <g
+     fill="#000000"
+     fill-opacity="1"
+     id="g1557">
+    <use
+       xlink:href="#glyph-0-2"
+       x="583.50055"
+       y="169.54507"
+       id="use1547" />
+    <use
+       xlink:href="#glyph-0-3"
+       x="585.99878"
+       y="169.54507"
+       id="use1549" />
+    <use
+       xlink:href="#glyph-0-4"
+       x="587.66553"
+       y="169.54507"
+       id="use1551" />
+    <use
+       xlink:href="#glyph-0-5"
+       x="589.74982"
+       y="169.54507"
+       id="use1553" />
+    <use
+       xlink:href="#glyph-0-2"
+       x="593.92206"
+       y="169.54507"
+       id="use1555" />
+  </g>
+  <g
+     fill="#000000"
+     fill-opacity="1"
+     id="g1561">
+    <use
+       xlink:href="#glyph-0-10"
+       x="596.00635"
+       y="169.54507"
+       id="use1559" />
+  </g>
+  <g
+     fill="#000000"
+     fill-opacity="1"
+     id="g1595">
+    <use
+       xlink:href="#glyph-1-26"
+       x="598.0965"
+       y="169.54507"
+       id="use1563" />
+    <use
+       xlink:href="#glyph-1-20"
+       x="603.51422"
+       y="169.54507"
+       id="use1565" />
+    <use
+       xlink:href="#glyph-1-24"
+       x="608.09674"
+       y="169.54507"
+       id="use1567" />
+    <use
+       xlink:href="#glyph-1-25"
+       x="614.76721"
+       y="169.54507"
+       id="use1569" />
+    <use
+       xlink:href="#glyph-1-19"
+       x="619.34973"
+       y="169.54507"
+       id="use1571" />
+    <use
+       xlink:href="#glyph-1-10"
+       x="622.26917"
+       y="169.54507"
+       id="use1573" />
+    <use
+       xlink:href="#glyph-1-5"
+       x="626.44141"
+       y="169.54507"
+       id="use1575" />
+    <use
+       xlink:href="#glyph-1-5"
+       x="630.61371"
+       y="169.54507"
+       id="use1577" />
+    <use
+       xlink:href="#glyph-1-10"
+       x="634.78595"
+       y="169.54507"
+       id="use1579" />
+    <use
+       xlink:href="#glyph-1-3"
+       x="638.95819"
+       y="169.54507"
+       id="use1581" />
+    <use
+       xlink:href="#glyph-1-2"
+       x="643.54071"
+       y="169.54507"
+       id="use1583" />
+    <use
+       xlink:href="#glyph-1-4"
+       x="648.54449"
+       y="169.54507"
+       id="use1585" />
+    <use
+       xlink:href="#glyph-1-39"
+       x="650.62878"
+       y="169.54507"
+       id="use1587" />
+    <use
+       xlink:href="#glyph-1-10"
+       x="654.37976"
+       y="169.54507"
+       id="use1589" />
+    <use
+       xlink:href="#glyph-1-36"
+       x="658.552"
+       y="169.54507"
+       id="use1591" />
+    <use
+       xlink:href="#glyph-1-37"
+       x="661.05023"
+       y="169.54507"
+       id="use1593" />
+  </g>
+  <path
+     fill-rule="nonzero"
+     fill="rgb(73.728943%, 78.42865%, 85.099792%)"
+     fill-opacity="1"
+     stroke-width="1"
+     stroke-linecap="butt"
+     stroke-linejoin="miter"
+     stroke="rgb(42.349243%, 55.688477%, 74.899292%)"
+     stroke-opacity="1"
+     stroke-miterlimit="4"
+     d="M 521.626786 106.37783 C 521.626786 106.882904 521.574717 107.377564 521.480992 107.867017 C 521.38206 108.356471 521.236265 108.83551 521.043608 109.298928 C 520.850951 109.762347 520.616638 110.19973 520.34067 110.616286 C 520.059495 111.032842 519.747078 111.418156 519.393005 111.772229 C 519.038933 112.126302 518.653618 112.443925 518.237062 112.719894 C 517.820507 112.995862 517.377916 113.235382 516.919704 113.422832 C 516.456286 113.615489 515.977247 113.761283 515.487794 113.860215 C 514.99834 113.953941 514.498473 114.00601 513.998606 114.00601 C 513.498739 114.00601 513.004079 113.953941 512.514626 113.860215 C 512.019966 113.761283 511.546133 113.615489 511.082715 113.422832 C 510.619296 113.235382 510.181913 112.995862 509.765357 112.719894 C 509.348801 112.443925 508.963487 112.126302 508.609414 111.772229 C 508.255342 111.418156 507.937718 111.032842 507.66175 110.616286 C 507.380574 110.19973 507.146262 109.762347 506.953605 109.298928 C 506.766154 108.83551 506.62036 108.356471 506.521428 107.867017 C 506.422496 107.377564 506.375633 106.882904 506.375633 106.37783 C 506.375633 105.877963 506.422496 105.383303 506.521428 104.89385 C 506.62036 104.39919 506.766154 103.925357 506.953605 103.461939 C 507.146262 102.99852 507.380574 102.561137 507.66175 102.144581 C 507.937718 101.728025 508.255342 101.342711 508.609414 100.988638 C 508.963487 100.634566 509.348801 100.316942 509.765357 100.040973 C 510.181913 99.759798 510.619296 99.525486 511.082715 99.332828 C 511.546133 99.145378 512.019966 98.999584 512.514626 98.900652 C 513.004079 98.80172 513.498739 98.754857 513.998606 98.754857 C 514.498473 98.754857 514.99834 98.80172 515.487794 98.900652 C 515.977247 98.999584 516.456286 99.145378 516.919704 99.332828 C 517.377916 99.525486 517.820507 99.759798 518.237062 100.040973 C 518.653618 100.316942 519.038933 100.634566 519.393005 100.988638 C 519.747078 101.342711 520.059495 101.728025 520.34067 102.144581 C 520.616638 102.561137 520.850951 102.99852 521.043608 103.461939 C 521.236265 103.925357 521.38206 104.39919 521.480992 104.89385 C 521.574717 105.383303 521.626786 105.877963 521.626786 106.37783 Z M 521.626786 106.37783 "
+     transform="matrix(0.750199, 0, 0, 0.750199, 0.3751, 0.3751)"
+     id="path1597" />
+  <g
+     fill="#003366"
+     fill-opacity="1"
+     id="g1601">
+    <use
+       xlink:href="#glyph-1-40"
+       x="383.14093"
+       y="82.521935"
+       id="use1599" />
+  </g>
+  <path
+     fill-rule="nonzero"
+     fill="rgb(73.728943%, 78.42865%, 85.099792%)"
+     fill-opacity="1"
+     stroke-width="1"
+     stroke-linecap="butt"
+     stroke-linejoin="miter"
+     stroke="rgb(42.349243%, 55.688477%, 74.899292%)"
+     stroke-opacity="1"
+     stroke-miterlimit="4"
+     d="M 591.623798 106.37783 C 591.623798 106.882904 591.576936 107.377564 591.478004 107.867017 C 591.379072 108.356471 591.238484 108.83551 591.045827 109.298928 C 590.85317 109.762347 590.618857 110.19973 590.337682 110.616286 C 590.061714 111.032842 589.74409 111.418156 589.390017 111.772229 C 589.035945 112.126302 588.65063 112.443925 588.234075 112.719894 C 587.817519 112.995862 587.380135 113.235382 586.916716 113.422832 C 586.453298 113.615489 585.979466 113.761283 585.490013 113.860215 C 584.995352 113.953941 584.500692 114.00601 584.000825 114.00601 C 583.500958 114.00601 583.001091 113.953941 582.511638 113.860215 C 582.022185 113.761283 581.543145 113.615489 581.079727 113.422832 C 580.621515 113.235382 580.178925 112.995862 579.762369 112.719894 C 579.345813 112.443925 578.960499 112.126302 578.606426 111.772229 C 578.252354 111.418156 577.939937 111.032842 577.658762 110.616286 C 577.382793 110.19973 577.148481 109.762347 576.955824 109.298928 C 576.763166 108.83551 576.617372 108.356471 576.523647 107.867017 C 576.424715 107.377564 576.372645 106.882904 576.372645 106.37783 C 576.372645 105.877963 576.424715 105.383303 576.523647 104.89385 C 576.617372 104.39919 576.763166 103.925357 576.955824 103.461939 C 577.148481 102.99852 577.382793 102.561137 577.658762 102.144581 C 577.939937 101.728025 578.252354 101.342711 578.606426 100.988638 C 578.960499 100.634566 579.345813 100.316942 579.762369 100.040973 C 580.178925 99.759798 580.621515 99.525486 581.079727 99.332828 C 581.543145 99.145378 582.022185 98.999584 582.511638 98.900652 C 583.001091 98.80172 583.500958 98.754857 584.000825 98.754857 C 584.500692 98.754857 584.995352 98.80172 585.490013 98.900652 C 585.979466 98.999584 586.453298 99.145378 586.916716 99.332828 C 587.380135 99.525486 587.817519 99.759798 588.234075 100.040973 C 588.65063 100.316942 589.035945 100.634566 589.390017 100.988638 C 589.74409 101.342711 590.061714 101.728025 590.337682 102.144581 C 590.618857 102.561137 590.85317 102.99852 591.045827 103.461939 C 591.238484 103.925357 591.379072 104.39919 591.478004 104.89385 C 591.576936 105.383303 591.623798 105.877963 591.623798 106.37783 Z M 591.623798 106.37783 "
+     transform="matrix(0.750199, 0, 0, 0.750199, 0.3751, 0.3751)"
+     id="path1603" />
+  <g
+     fill="#003366"
+     fill-opacity="1"
+     id="g1607">
+    <use
+       xlink:href="#glyph-1-41"
+       x="435.65488"
+       y="82.521935"
+       id="use1605" />
+  </g>
+  <path
+     fill="none"
+     stroke-width="1"
+     stroke-linecap="butt"
+     stroke-linejoin="miter"
+     stroke="rgb(0%, 0%, 0%)"
+     stroke-opacity="1"
+     stroke-miterlimit="10"
+     d="M 138.999364 151.001381 L 138.999364 115.120297 "
+     transform="matrix(0.750199, 0, 0, 0.750199, 0.3751, 0.3751)"
+     id="path1609" />
+  <path
+     fill-rule="nonzero"
+     fill="rgb(0%, 0%, 0%)"
+     fill-opacity="1"
+     stroke-width="1"
+     stroke-linecap="butt"
+     stroke-linejoin="miter"
+     stroke="rgb(0%, 0%, 0%)"
+     stroke-opacity="1"
+     stroke-miterlimit="10"
+     d="M 138.999364 108.122158 L 142.498434 115.120297 L 135.500294 115.120297 Z M 138.999364 108.122158 "
+     transform="matrix(0.750199, 0, 0, 0.750199, 0.3751, 0.3751)"
+     id="path1611" />
+  <path
+     fill-rule="nonzero"
+     fill="rgb(100%, 100%, 100%)"
+     fill-opacity="1"
+     d="M 79.519531 95.273438 L 129.035156 95.273438 L 129.035156 104.277344 L 79.519531 104.277344 Z M 79.519531 95.273438 "
+     id="path1613" />
+  <g
+     fill="#000000"
+     fill-opacity="1"
+     id="g1641">
+    <use
+       xlink:href="#glyph-0-12"
+       x="79.157761"
+       y="102.02712"
+       id="use1615" />
+    <use
+       xlink:href="#glyph-0-13"
+       x="81.242058"
+       y="102.02712"
+       id="use1617" />
+    <use
+       xlink:href="#glyph-0-32"
+       x="82.90876"
+       y="102.02712"
+       id="use1619" />
+    <use
+       xlink:href="#glyph-0-15"
+       x="87.081009"
+       y="102.02712"
+       id="use1621" />
+    <use
+       xlink:href="#glyph-0-7"
+       x="90.832008"
+       y="102.02712"
+       id="use1623" />
+    <use
+       xlink:href="#glyph-0-23"
+       x="95.004257"
+       y="102.02712"
+       id="use1625" />
+    <use
+       xlink:href="#glyph-0-4"
+       x="97.088554"
+       y="102.02712"
+       id="use1627" />
+    <use
+       xlink:href="#glyph-0-7"
+       x="99.172852"
+       y="102.02712"
+       id="use1629" />
+    <use
+       xlink:href="#glyph-0-5"
+       x="103.3451"
+       y="102.02712"
+       id="use1631" />
+    <use
+       xlink:href="#glyph-0-23"
+       x="107.51735"
+       y="102.02712"
+       id="use1633" />
+    <use
+       xlink:href="#glyph-0-18"
+       x="109.60165"
+       y="102.02712"
+       id="use1635" />
+    <use
+       xlink:href="#glyph-0-32"
+       x="113.7739"
+       y="102.02712"
+       id="use1637" />
+    <use
+       xlink:href="#glyph-0-12"
+       x="117.94615"
+       y="102.02712"
+       id="use1639" />
+  </g>
+  <g
+     fill="#000000"
+     fill-opacity="1"
+     id="g1649">
+    <use
+       xlink:href="#glyph-0-12"
+       x="119.89491"
+       y="102.02712"
+       id="use1643" />
+    <use
+       xlink:href="#glyph-0-5"
+       x="121.9792"
+       y="102.02712"
+       id="use1645" />
+    <use
+       xlink:href="#glyph-0-2"
+       x="126.15146"
+       y="102.02712"
+       id="use1647" />
+  </g>
+  <path
+     fill-rule="nonzero"
+     fill="rgb(73.728943%, 78.42865%, 85.099792%)"
+     fill-opacity="1"
+     stroke-width="1"
+     stroke-linecap="butt"
+     stroke-linejoin="miter"
+     stroke="rgb(42.349243%, 55.688477%, 74.899292%)"
+     stroke-opacity="1"
+     stroke-miterlimit="4"
+     d="M 146.627544 158.629561 C 146.627544 159.129428 146.575474 159.624088 146.476542 160.118748 C 146.382817 160.608201 146.237023 161.087241 146.044366 161.545452 C 145.851709 162.008871 145.617396 162.451461 145.341428 162.868017 C 145.060252 163.284573 144.747835 163.669887 144.393763 164.02396 C 144.03969 164.378032 143.654376 164.690449 143.23782 164.971624 C 142.821264 165.247593 142.378674 165.481905 141.920462 165.674562 C 141.457044 165.86722 140.978005 166.013014 140.488551 166.106739 C 139.999098 166.205671 139.499231 166.252534 138.999364 166.252534 C 138.499497 166.252534 138.004837 166.205671 137.510177 166.106739 C 137.020723 166.013014 136.546891 165.86722 136.083473 165.674562 C 135.620054 165.481905 135.177464 165.247593 134.766115 164.971624 C 134.349559 164.690449 133.964245 164.378032 133.610172 164.02396 C 133.2561 163.669887 132.938476 163.284573 132.662507 162.868017 C 132.381332 162.451461 132.147019 162.008871 131.954362 161.545452 C 131.761705 161.087241 131.621118 160.608201 131.522186 160.118748 C 131.423254 159.624088 131.376391 159.129428 131.376391 158.629561 C 131.376391 158.129694 131.423254 157.635034 131.522186 157.140373 C 131.621118 156.65092 131.761705 156.177088 131.954362 155.71367 C 132.147019 155.250251 132.381332 154.80766 132.662507 154.396311 C 132.938476 153.979756 133.2561 153.594441 133.610172 153.240369 C 133.964245 152.886296 134.349559 152.568672 134.766115 152.287497 C 135.177464 152.011529 135.620054 151.777216 136.083473 151.584559 C 136.546891 151.391902 137.020723 151.251314 137.510177 151.152382 C 138.004837 151.05345 138.499497 151.006588 138.999364 151.006588 C 139.499231 151.006588 139.999098 151.05345 140.488551 151.152382 C 140.978005 151.251314 141.457044 151.391902 141.920462 151.584559 C 142.378674 151.777216 142.821264 152.011529 143.23782 152.287497 C 143.654376 152.568672 144.03969 152.886296 144.393763 153.240369 C 144.747835 153.594441 145.060252 153.979756 145.341428 154.396311 C 145.617396 154.80766 145.851709 155.250251 146.044366 155.71367 C 146.237023 156.177088 146.382817 156.65092 146.476542 157.140373 C 146.575474 157.635034 146.627544 158.129694 146.627544 158.629561 Z M 146.627544 158.629561 "
+     transform="matrix(0.750199, 0, 0, 0.750199, 0.3751, 0.3751)"
+     id="path1651" />
+  <g
+     fill="#003366"
+     fill-opacity="1"
+     id="g1655">
+    <use
+       xlink:href="#glyph-1-40"
+       x="101.81613"
+       y="122.28251"
+       id="use1653" />
+  </g>
+  <path
+     fill-rule="nonzero"
+     fill="rgb(73.728943%, 78.42865%, 85.099792%)"
+     fill-opacity="1"
+     stroke-width="1"
+     stroke-linecap="butt"
+     stroke-linejoin="miter"
+     stroke="rgb(42.349243%, 55.688477%, 74.899292%)"
+     stroke-opacity="1"
+     stroke-miterlimit="4"
+     d="M 276.624226 133.381066 C 276.624226 133.880933 276.577364 134.375594 276.478432 134.865047 C 276.3795 135.359707 276.233705 135.833539 276.046255 136.296958 C 275.853598 136.760376 275.619285 137.19776 275.33811 137.614316 C 275.062142 138.030872 274.744518 138.416186 274.390445 138.770258 C 274.036373 139.124331 273.651059 139.441955 273.234503 139.717923 C 272.817947 139.999098 272.380563 140.233411 271.917145 140.426068 C 271.453726 140.618725 270.979894 140.759313 270.485234 140.858245 C 269.995781 140.957177 269.501121 141.004039 269.001253 141.004039 C 268.501386 141.004039 268.001519 140.957177 267.512066 140.858245 C 267.022613 140.759313 266.543574 140.618725 266.080155 140.426068 C 265.621944 140.233411 265.179353 139.999098 264.762797 139.717923 C 264.346241 139.441955 263.960927 139.124331 263.606855 138.770258 C 263.252782 138.416186 262.940365 138.030872 262.65919 137.614316 C 262.383222 137.19776 262.148909 136.760376 261.956252 136.296958 C 261.763595 135.833539 261.6178 135.359707 261.524075 134.865047 C 261.425143 134.375594 261.373074 133.880933 261.373074 133.381066 C 261.373074 132.881199 261.425143 132.381332 261.524075 131.891879 C 261.6178 131.402426 261.763595 130.923386 261.956252 130.459968 C 262.148909 130.001757 262.383222 129.559166 262.65919 129.14261 C 262.940365 128.726054 263.252782 128.34074 263.606855 127.986667 C 263.960927 127.632595 264.346241 127.320178 264.762797 127.039003 C 265.179353 126.763034 265.621944 126.528722 266.080155 126.336065 C 266.543574 126.143408 267.022613 125.997613 267.512066 125.903888 C 268.001519 125.804956 268.501386 125.752886 269.001253 125.752886 C 269.501121 125.752886 269.995781 125.804956 270.485234 125.903888 C 270.979894 125.997613 271.453726 126.143408 271.917145 126.336065 C 272.380563 126.528722 272.817947 126.763034 273.234503 127.039003 C 273.651059 127.320178 274.036373 127.632595 274.390445 127.986667 C 274.744518 128.34074 275.062142 128.726054 275.33811 129.14261 C 275.619285 129.559166 275.853598 130.001757 276.046255 130.459968 C 276.233705 130.923386 276.3795 131.402426 276.478432 131.891879 C 276.577364 132.381332 276.624226 132.881199 276.624226 133.381066 Z M 276.624226 133.381066 "
+     transform="matrix(0.750199, 0, 0, 0.750199, 0.3751, 0.3751)"
+     id="path1657" />
+  <g
+     fill="#003366"
+     fill-opacity="1"
+     id="g1661">
+    <use
+       xlink:href="#glyph-1-41"
+       x="199.34206"
+       y="102.77732"
+       id="use1659" />
+  </g>
+  <path
+     fill-rule="nonzero"
+     fill="rgb(97.24884%, 80.778503%, 79.998779%)"
+     fill-opacity="1"
+     stroke-width="1"
+     stroke-linecap="butt"
+     stroke-linejoin="miter"
+     stroke="rgb(72.158813%, 32.939148%, 31.369019%)"
+     stroke-opacity="1"
+     stroke-miterlimit="4"
+     d="M 350.000548 139.999098 L 478.997497 139.999098 L 478.997497 190.001427 L 350.000548 190.001427 Z M 350.000548 139.999098 "
+     transform="matrix(0.750199, 0, 0, 0.750199, 0.3751, 0.3751)"
+     id="path1663" />
+  <g
+     fill="#000000"
+     fill-opacity="1"
+     id="g1667">
+    <use
+       xlink:href="#glyph-0-23"
+       x="264.07019"
+       y="117.78131"
+       id="use1665" />
+  </g>
+  <g
+     fill="#000000"
+     fill-opacity="1"
+     id="g1721">
+    <use
+       xlink:href="#glyph-0-28"
+       x="266.15448"
+       y="117.78131"
+       id="use1669" />
+    <use
+       xlink:href="#glyph-0-10"
+       x="270.32675"
+       y="117.78131"
+       id="use1671" />
+    <use
+       xlink:href="#glyph-0-23"
+       x="272.41104"
+       y="117.78131"
+       id="use1673" />
+    <use
+       xlink:href="#glyph-0-6"
+       x="274.49533"
+       y="117.78131"
+       id="use1675" />
+    <use
+       xlink:href="#glyph-0-30"
+       x="278.24634"
+       y="117.78131"
+       id="use1677" />
+    <use
+       xlink:href="#glyph-0-32"
+       x="282.41858"
+       y="117.78131"
+       id="use1679" />
+    <use
+       xlink:href="#glyph-0-9"
+       x="286.59085"
+       y="117.78131"
+       id="use1681" />
+    <use
+       xlink:href="#glyph-0-4"
+       x="290.76309"
+       y="117.78131"
+       id="use1683" />
+    <use
+       xlink:href="#glyph-0-23"
+       x="292.84738"
+       y="117.78131"
+       id="use1685" />
+    <use
+       xlink:href="#glyph-0-30"
+       x="294.93167"
+       y="117.78131"
+       id="use1687" />
+    <use
+       xlink:href="#glyph-0-12"
+       x="299.10394"
+       y="117.78131"
+       id="use1689" />
+    <use
+       xlink:href="#glyph-0-23"
+       x="301.18823"
+       y="117.78131"
+       id="use1691" />
+    <use
+       xlink:href="#glyph-0-27"
+       x="303.27252"
+       y="117.78131"
+       id="use1693" />
+    <use
+       xlink:href="#glyph-0-5"
+       x="307.44476"
+       y="117.78131"
+       id="use1695" />
+    <use
+       xlink:href="#glyph-0-9"
+       x="311.61703"
+       y="117.78131"
+       id="use1697" />
+    <use
+       xlink:href="#glyph-0-21"
+       x="315.78928"
+       y="117.78131"
+       id="use1699" />
+    <use
+       xlink:href="#glyph-0-3"
+       x="319.96152"
+       y="117.78131"
+       id="use1701" />
+    <use
+       xlink:href="#glyph-0-9"
+       x="321.62823"
+       y="117.78131"
+       id="use1703" />
+    <use
+       xlink:href="#glyph-0-36"
+       x="325.80048"
+       y="117.78131"
+       id="use1705" />
+    <use
+       xlink:href="#glyph-0-23"
+       x="329.97272"
+       y="117.78131"
+       id="use1707" />
+    <use
+       xlink:href="#glyph-0-1"
+       x="332.05704"
+       y="117.78131"
+       id="use1709" />
+    <use
+       xlink:href="#glyph-0-2"
+       x="337.47473"
+       y="117.78131"
+       id="use1711" />
+    <use
+       xlink:href="#glyph-0-3"
+       x="339.97293"
+       y="117.78131"
+       id="use1713" />
+    <use
+       xlink:href="#glyph-0-4"
+       x="341.63965"
+       y="117.78131"
+       id="use1715" />
+    <use
+       xlink:href="#glyph-0-5"
+       x="343.72394"
+       y="117.78131"
+       id="use1717" />
+    <use
+       xlink:href="#glyph-0-15"
+       x="347.89621"
+       y="117.78131"
+       id="use1719" />
+  </g>
+  <g
+     fill="#000000"
+     fill-opacity="1"
+     id="g1725">
+    <use
+       xlink:href="#glyph-0-23"
+       x="264.07019"
+       y="126.78371"
+       id="use1723" />
+  </g>
+  <g
+     fill="#000000"
+     fill-opacity="1"
+     id="g1759">
+    <use
+       xlink:href="#glyph-0-37"
+       x="266.15448"
+       y="126.78371"
+       id="use1727" />
+    <use
+       xlink:href="#glyph-0-10"
+       x="270.32675"
+       y="126.78371"
+       id="use1729" />
+    <use
+       xlink:href="#glyph-0-23"
+       x="272.41104"
+       y="126.78371"
+       id="use1731" />
+    <use
+       xlink:href="#glyph-0-18"
+       x="274.49533"
+       y="126.78371"
+       id="use1733" />
+    <use
+       xlink:href="#glyph-0-19"
+       x="278.66757"
+       y="126.78371"
+       id="use1735" />
+    <use
+       xlink:href="#glyph-0-4"
+       x="282.41858"
+       y="126.78371"
+       id="use1737" />
+    <use
+       xlink:href="#glyph-0-5"
+       x="284.50287"
+       y="126.78371"
+       id="use1739" />
+    <use
+       xlink:href="#glyph-0-15"
+       x="288.67514"
+       y="126.78371"
+       id="use1741" />
+    <use
+       xlink:href="#glyph-0-23"
+       x="292.42612"
+       y="126.78371"
+       id="use1743" />
+    <use
+       xlink:href="#glyph-0-1"
+       x="294.51041"
+       y="126.78371"
+       id="use1745" />
+    <use
+       xlink:href="#glyph-0-2"
+       x="299.92813"
+       y="126.78371"
+       id="use1747" />
+    <use
+       xlink:href="#glyph-0-3"
+       x="302.42633"
+       y="126.78371"
+       id="use1749" />
+    <use
+       xlink:href="#glyph-0-4"
+       x="304.09305"
+       y="126.78371"
+       id="use1751" />
+    <use
+       xlink:href="#glyph-0-4"
+       x="306.17734"
+       y="126.78371"
+       id="use1753" />
+    <use
+       xlink:href="#glyph-0-5"
+       x="308.26163"
+       y="126.78371"
+       id="use1755" />
+    <use
+       xlink:href="#glyph-0-9"
+       x="312.4339"
+       y="126.78371"
+       id="use1757" />
+  </g>
+  <g
+     fill="#000000"
+     fill-opacity="1"
+     id="g1763">
+    <use
+       xlink:href="#glyph-0-23"
+       x="264.07019"
+       y="135.7861"
+       id="use1761" />
+  </g>
+  <g
+     fill="#000000"
+     fill-opacity="1"
+     id="g1817">
+    <use
+       xlink:href="#glyph-0-38"
+       x="266.15448"
+       y="135.7861"
+       id="use1765" />
+    <use
+       xlink:href="#glyph-0-10"
+       x="270.32675"
+       y="135.7861"
+       id="use1767" />
+    <use
+       xlink:href="#glyph-0-23"
+       x="272.41104"
+       y="135.7861"
+       id="use1769" />
+    <use
+       xlink:href="#glyph-0-4"
+       x="274.49533"
+       y="135.7861"
+       id="use1771" />
+    <use
+       xlink:href="#glyph-0-3"
+       x="276.57962"
+       y="135.7861"
+       id="use1773" />
+    <use
+       xlink:href="#glyph-0-35"
+       x="278.24634"
+       y="135.7861"
+       id="use1775" />
+    <use
+       xlink:href="#glyph-0-5"
+       x="284.49554"
+       y="135.7861"
+       id="use1777" />
+    <use
+       xlink:href="#glyph-0-23"
+       x="288.66782"
+       y="135.7861"
+       id="use1779" />
+    <use
+       xlink:href="#glyph-0-5"
+       x="290.75211"
+       y="135.7861"
+       id="use1781" />
+    <use
+       xlink:href="#glyph-0-13"
+       x="294.92435"
+       y="135.7861"
+       id="use1783" />
+    <use
+       xlink:href="#glyph-0-8"
+       x="296.59106"
+       y="135.7861"
+       id="use1785" />
+    <use
+       xlink:href="#glyph-0-27"
+       x="300.76331"
+       y="135.7861"
+       id="use1787" />
+    <use
+       xlink:href="#glyph-0-15"
+       x="304.93555"
+       y="135.7861"
+       id="use1789" />
+    <use
+       xlink:href="#glyph-0-5"
+       x="308.68655"
+       y="135.7861"
+       id="use1791" />
+    <use
+       xlink:href="#glyph-0-21"
+       x="312.8588"
+       y="135.7861"
+       id="use1793" />
+    <use
+       xlink:href="#glyph-0-23"
+       x="317.03107"
+       y="135.7861"
+       id="use1795" />
+    <use
+       xlink:href="#glyph-0-15"
+       x="319.11536"
+       y="135.7861"
+       id="use1797" />
+    <use
+       xlink:href="#glyph-0-3"
+       x="322.86633"
+       y="135.7861"
+       id="use1799" />
+    <use
+       xlink:href="#glyph-0-9"
+       x="324.53305"
+       y="135.7861"
+       id="use1801" />
+    <use
+       xlink:href="#glyph-0-6"
+       x="328.70529"
+       y="135.7861"
+       id="use1803" />
+    <use
+       xlink:href="#glyph-0-5"
+       x="332.4563"
+       y="135.7861"
+       id="use1805" />
+    <use
+       xlink:href="#glyph-0-23"
+       x="336.62854"
+       y="135.7861"
+       id="use1807" />
+    <use
+       xlink:href="#glyph-0-15"
+       x="338.71286"
+       y="135.7861"
+       id="use1809" />
+    <use
+       xlink:href="#glyph-0-19"
+       x="342.46384"
+       y="135.7861"
+       id="use1811" />
+    <use
+       xlink:href="#glyph-0-9"
+       x="346.21484"
+       y="135.7861"
+       id="use1813" />
+    <use
+       xlink:href="#glyph-0-6"
+       x="350.38708"
+       y="135.7861"
+       id="use1815" />
+  </g>
+  <path
+     fill="none"
+     stroke-width="1"
+     stroke-linecap="butt"
+     stroke-linejoin="miter"
+     stroke="rgb(72.158813%, 32.939148%, 31.369019%)"
+     stroke-opacity="1"
+     stroke-miterlimit="10"
+     d="M 369.078809 124.997879 L 369.479744 140.452103 "
+     transform="matrix(0.750199, 0, 0, 0.750199, 0.3751, 0.3751)"
+     id="path1819" />
+  <path
+     fill-rule="nonzero"
+     fill="rgb(72.158813%, 32.939148%, 31.369019%)"
+     fill-opacity="1"
+     stroke-width="1"
+     stroke-linecap="butt"
+     stroke-linejoin="miter"
+     stroke="rgb(72.158813%, 32.939148%, 31.369019%)"
+     stroke-opacity="1"
+     stroke-miterlimit="4"
+     d="M 371.999907 121.998676 C 371.999907 122.399611 371.921803 122.779719 371.770801 123.149412 C 371.6198 123.513898 371.401108 123.841936 371.119932 124.123111 C 370.838757 124.404287 370.515926 124.617772 370.146233 124.77398 C 369.781747 124.924982 369.396432 124.997879 369.000704 124.997879 C 368.599769 124.997879 368.219662 124.924982 367.849969 124.77398 C 367.485482 124.617772 367.157444 124.404287 366.876269 124.123111 C 366.595094 123.841936 366.381609 123.513898 366.230608 123.149412 C 366.074399 122.779719 366.001502 122.399611 366.001502 121.998676 C 366.001502 121.602948 366.074399 121.217634 366.230608 120.853148 C 366.381609 120.483454 366.595094 120.160623 366.876269 119.879448 C 367.157444 119.598273 367.485482 119.379581 367.849969 119.22858 C 368.219662 119.077578 368.599769 118.999474 369.000704 118.999474 C 369.396432 118.999474 369.781747 119.077578 370.146233 119.22858 C 370.515926 119.379581 370.838757 119.598273 371.119932 119.879448 C 371.401108 120.160623 371.6198 120.483454 371.770801 120.853148 C 371.921803 121.217634 371.999907 121.602948 371.999907 121.998676 Z M 371.999907 121.998676 "
+     transform="matrix(0.750199, 0, 0, 0.750199, 0.3751, 0.3751)"
+     id="path1821" />
+  <g
+     fill="#000000"
+     fill-opacity="1"
+     id="g1841">
+    <use
+       xlink:href="#glyph-0-21"
+       x="282.90726"
+       y="153.04068"
+       id="use1823" />
+    <use
+       xlink:href="#glyph-0-3"
+       x="287.0795"
+       y="153.04068"
+       id="use1825" />
+    <use
+       xlink:href="#glyph-0-15"
+       x="288.74619"
+       y="153.04068"
+       id="use1827" />
+    <use
+       xlink:href="#glyph-0-22"
+       x="292.49719"
+       y="153.04068"
+       id="use1829" />
+    <use
+       xlink:href="#glyph-0-15"
+       x="296.2482"
+       y="153.04068"
+       id="use1831" />
+    <use
+       xlink:href="#glyph-0-19"
+       x="299.99918"
+       y="153.04068"
+       id="use1833" />
+    <use
+       xlink:href="#glyph-0-9"
+       x="303.75018"
+       y="153.04068"
+       id="use1835" />
+    <use
+       xlink:href="#glyph-0-6"
+       x="307.92242"
+       y="153.04068"
+       id="use1837" />
+    <use
+       xlink:href="#glyph-0-10"
+       x="311.67343"
+       y="153.04068"
+       id="use1839" />
+  </g>
+  <g
+     fill="#000000"
+     fill-opacity="1"
+     id="g1855">
+    <use
+       xlink:href="#glyph-1-26"
+       x="313.75919"
+       y="153.04068"
+       id="use1843" />
+    <use
+       xlink:href="#glyph-1-20"
+       x="319.17688"
+       y="153.04068"
+       id="use1845" />
+    <use
+       xlink:href="#glyph-1-15"
+       x="323.7594"
+       y="153.04068"
+       id="use1847" />
+    <use
+       xlink:href="#glyph-1-11"
+       x="328.34192"
+       y="153.04068"
+       id="use1849" />
+    <use
+       xlink:href="#glyph-1-4"
+       x="330.84015"
+       y="153.04068"
+       id="use1851" />
+    <use
+       xlink:href="#glyph-1-34"
+       x="332.92444"
+       y="153.04068"
+       id="use1853" />
+  </g>
+  <path
+     fill-rule="nonzero"
+     fill="rgb(100%, 100%, 100%)"
+     fill-opacity="1"
+     d="M 446.367188 109.527344 L 537.144531 109.527344 L 537.144531 118.53125 L 446.367188 118.53125 Z M 446.367188 109.527344 "
+     id="path1857" />
+  <g
+     fill="#000000"
+     fill-opacity="1"
+     id="g1915">
+    <use
+       xlink:href="#glyph-0-30"
+       x="446.08734"
+       y="116.28091"
+       id="use1859" />
+    <use
+       xlink:href="#glyph-0-9"
+       x="450.25958"
+       y="116.28091"
+       id="use1861" />
+    <use
+       xlink:href="#glyph-0-23"
+       x="454.43185"
+       y="116.28091"
+       id="use1863" />
+    <use
+       xlink:href="#glyph-0-12"
+       x="456.51614"
+       y="116.28091"
+       id="use1865" />
+    <use
+       xlink:href="#glyph-0-13"
+       x="458.60043"
+       y="116.28091"
+       id="use1867" />
+    <use
+       xlink:href="#glyph-0-32"
+       x="460.26712"
+       y="116.28091"
+       id="use1869" />
+    <use
+       xlink:href="#glyph-0-15"
+       x="464.43939"
+       y="116.28091"
+       id="use1871" />
+    <use
+       xlink:href="#glyph-0-7"
+       x="468.19037"
+       y="116.28091"
+       id="use1873" />
+    <use
+       xlink:href="#glyph-0-34"
+       x="472.36264"
+       y="116.28091"
+       id="use1875" />
+    <use
+       xlink:href="#glyph-0-23"
+       x="474.44693"
+       y="116.28091"
+       id="use1877" />
+    <use
+       xlink:href="#glyph-0-32"
+       x="476.53122"
+       y="116.28091"
+       id="use1879" />
+    <use
+       xlink:href="#glyph-0-27"
+       x="480.70346"
+       y="116.28091"
+       id="use1881" />
+    <use
+       xlink:href="#glyph-0-21"
+       x="484.87573"
+       y="116.28091"
+       id="use1883" />
+    <use
+       xlink:href="#glyph-0-8"
+       x="489.04797"
+       y="116.28091"
+       id="use1885" />
+    <use
+       xlink:href="#glyph-0-4"
+       x="493.22021"
+       y="116.28091"
+       id="use1887" />
+    <use
+       xlink:href="#glyph-0-5"
+       x="495.30453"
+       y="116.28091"
+       id="use1889" />
+    <use
+       xlink:href="#glyph-0-23"
+       x="499.47678"
+       y="116.28091"
+       id="use1891" />
+    <use
+       xlink:href="#glyph-0-18"
+       x="501.56107"
+       y="116.28091"
+       id="use1893" />
+    <use
+       xlink:href="#glyph-0-8"
+       x="505.73331"
+       y="116.28091"
+       id="use1895" />
+    <use
+       xlink:href="#glyph-0-6"
+       x="509.90558"
+       y="116.28091"
+       id="use1897" />
+    <use
+       xlink:href="#glyph-0-22"
+       x="513.65656"
+       y="116.28091"
+       id="use1899" />
+    <use
+       xlink:href="#glyph-0-32"
+       x="517.40759"
+       y="116.28091"
+       id="use1901" />
+    <use
+       xlink:href="#glyph-0-27"
+       x="521.57983"
+       y="116.28091"
+       id="use1903" />
+    <use
+       xlink:href="#glyph-0-23"
+       x="525.75208"
+       y="116.28091"
+       id="use1905" />
+    <use
+       xlink:href="#glyph-0-12"
+       x="527.83636"
+       y="116.28091"
+       id="use1907" />
+    <use
+       xlink:href="#glyph-0-3"
+       x="529.92065"
+       y="116.28091"
+       id="use1909" />
+    <use
+       xlink:href="#glyph-0-13"
+       x="531.58734"
+       y="116.28091"
+       id="use1911" />
+    <use
+       xlink:href="#glyph-0-5"
+       x="533.25409"
+       y="116.28091"
+       id="use1913" />
+  </g>
+</svg>

--- a/internal/pkg/service/buffer/storage/local/writer/csv/csv_benchmark_test.go
+++ b/internal/pkg/service/buffer/storage/local/writer/csv/csv_benchmark_test.go
@@ -1,0 +1,263 @@
+package csv_test
+
+import (
+	"compress/gzip"
+	"context"
+	"github.com/c2h5oh/datasize"
+	"github.com/keboola/keboola-as-code/internal/pkg/service/buffer/storage"
+	"github.com/keboola/keboola-as-code/internal/pkg/service/buffer/storage/compression"
+	"github.com/keboola/keboola-as-code/internal/pkg/service/buffer/storage/local/writer/disksync"
+	"github.com/keboola/keboola-as-code/internal/pkg/service/buffer/storage/local/writer/test/benchmark"
+	"github.com/keboola/keboola-as-code/internal/pkg/service/buffer/store/model/column"
+	"github.com/klauspost/compress/zstd"
+	"testing"
+	"time"
+)
+
+const (
+	benchmarkRowLength  = 1 * datasize.KB
+	benchmarkUniqueRows = 1000
+)
+
+// BenchmarkCSVWriter benchmarks different configuration options of the csv.Writer.
+//
+// Run
+//
+//	go test -p 1 -benchmem ./internal/pkg/service/buffer/storage/local/writer/csv \
+//	-bench=. -benchtime=10000x -count 1 | tee benchmark.txt
+//
+// Optionally format results
+//
+//	benchstat benchmark.txt
+func BenchmarkCSVWrite(b *testing.B) {
+	cases := []struct {
+		Name      string
+		Configure func(wb *benchmark.WriterBenchmark)
+	}{
+		{
+			Name: "compression=None,sync=None",
+			Configure: func(wb *benchmark.WriterBenchmark) {
+				wb.Sync = disksync.Config{Mode: disksync.ModeDisabled}
+			},
+		},
+		{
+			Name: "compression=None,sync=ToDisk,wait=true",
+			Configure: func(wb *benchmark.WriterBenchmark) {
+				wb.Sync.Mode = disksync.ModeDisk
+				wb.Sync.Wait = true
+			},
+		},
+		{
+			Name: "compression=None,sync=ToDisk,wait=false",
+			Configure: func(wb *benchmark.WriterBenchmark) {
+				wb.Sync.Mode = disksync.ModeDisk
+				wb.Sync.Wait = false
+			},
+		},
+		{
+			Name: "compression=None,sync=ToCache,wait=true",
+			Configure: func(wb *benchmark.WriterBenchmark) {
+				wb.Sync.Mode = disksync.ModeCache
+				wb.Sync.Wait = true
+			},
+		},
+		{
+			Name: "compression=None,sync=ToCache,wait=false",
+			Configure: func(wb *benchmark.WriterBenchmark) {
+				wb.Sync.Mode = disksync.ModeCache
+				wb.Sync.Wait = false
+			},
+		},
+		{
+			Name: "compression=GZIP_Standard_BestSpeed,sync=ToDisk,wait=true",
+			Configure: func(wb *benchmark.WriterBenchmark) {
+				wb.Compression = compression.DefaultGZIPConfig()
+				wb.Compression.GZIP.Impl = compression.GZIPImplStandard
+				wb.Compression.GZIP.Level = gzip.BestSpeed
+				wb.Sync.Mode = disksync.ModeDisk
+				wb.Sync.Wait = true
+			},
+		},
+		{
+			Name: "compression=GZIP_Standard_BestSpeed,sync=ToDisk,wait=false",
+			Configure: func(wb *benchmark.WriterBenchmark) {
+				wb.Compression = compression.DefaultGZIPConfig()
+				wb.Compression.GZIP.Impl = compression.GZIPImplStandard
+				wb.Compression.GZIP.Level = gzip.BestSpeed
+				wb.Sync.Mode = disksync.ModeDisk
+				wb.Sync.Wait = false
+			},
+		},
+		{
+			Name: "compression=GZIP_Fast_BestSpeed,sync=ToDisk,wait=true",
+			Configure: func(wb *benchmark.WriterBenchmark) {
+				wb.Compression = compression.DefaultGZIPConfig()
+				wb.Compression.GZIP.Impl = compression.GZIPImplFast
+				wb.Compression.GZIP.Level = gzip.BestSpeed
+				wb.Sync.Mode = disksync.ModeDisk
+				wb.Sync.Wait = true
+			},
+		},
+		{
+			Name: "compression=GZIP_Fast_BestSpeed,sync=ToDisk,wait=false",
+			Configure: func(wb *benchmark.WriterBenchmark) {
+				wb.Compression = compression.DefaultGZIPConfig()
+				wb.Compression.GZIP.Impl = compression.GZIPImplFast
+				wb.Compression.GZIP.Level = gzip.BestSpeed
+				wb.Sync.Mode = disksync.ModeDisk
+				wb.Sync.Wait = false
+			},
+		},
+		{
+			Name: "compression=GZIP_Parallel_BestSpeed,sync=ToDisk,wait=true",
+			Configure: func(wb *benchmark.WriterBenchmark) {
+				wb.Compression = compression.DefaultGZIPConfig()
+				wb.Compression.GZIP.Impl = compression.GZIPImplParallel
+				wb.Compression.GZIP.Level = gzip.BestSpeed
+				wb.Sync.Mode = disksync.ModeDisk
+				wb.Sync.Wait = true
+			},
+		},
+		{
+			Name: "compression=GZIP_Parallel_BestSpeed,sync=ToDisk,wait=false",
+			Configure: func(wb *benchmark.WriterBenchmark) {
+				wb.Compression = compression.DefaultGZIPConfig()
+				wb.Compression.GZIP.Impl = compression.GZIPImplParallel
+				wb.Compression.GZIP.Level = gzip.BestSpeed
+				wb.Sync.Mode = disksync.ModeDisk
+				wb.Sync.Wait = false
+			},
+		},
+		{
+			Name: "compression=GZIP_Parallel_DefaultCompression,sync=ToDisk,wait=true",
+			Configure: func(wb *benchmark.WriterBenchmark) {
+				wb.Compression = compression.DefaultGZIPConfig()
+				wb.Compression.GZIP.Impl = compression.GZIPImplParallel
+				wb.Compression.GZIP.Level = 6
+				wb.Sync.Mode = disksync.ModeDisk
+				wb.Sync.Wait = true
+			},
+		},
+		{
+			Name: "compression=GZIP_Parallel_DefaultCompression,sync=ToDisk,wait=false",
+			Configure: func(wb *benchmark.WriterBenchmark) {
+				wb.Compression = compression.DefaultGZIPConfig()
+				wb.Compression.GZIP.Impl = compression.GZIPImplParallel
+				wb.Compression.GZIP.Level = 6
+				wb.Sync.Mode = disksync.ModeDisk
+				wb.Sync.Wait = false
+			},
+		},
+
+		{
+			Name: "compression=ZSTD_SpeedFastest,sync=ToDisk,wait=true",
+			Configure: func(wb *benchmark.WriterBenchmark) {
+				wb.Compression = compression.DefaultZSTDConfig()
+				wb.Compression.ZSTD.Level = 1
+				wb.Sync.Mode = disksync.ModeDisk
+				wb.Sync.Wait = true
+			},
+		},
+		{
+			Name: "compression=ZSTD_SpeedFastest,sync=ToDisk,wait=false",
+			Configure: func(wb *benchmark.WriterBenchmark) {
+				wb.Compression = compression.DefaultZSTDConfig()
+				wb.Compression.ZSTD.Level = zstd.SpeedFastest
+				wb.Sync.Mode = disksync.ModeDisk
+				wb.Sync.Wait = false
+			},
+		},
+		{
+			Name: "compression=ZSTD_SpeedDefault,sync=ToDisk,wait=true",
+			Configure: func(wb *benchmark.WriterBenchmark) {
+				wb.Compression = compression.DefaultZSTDConfig()
+				wb.Compression.ZSTD.Level = zstd.SpeedDefault
+				wb.Sync.Mode = disksync.ModeDisk
+				wb.Sync.Wait = true
+			},
+		},
+		{
+			Name: "compression=ZSTD_SpeedDefault,sync=ToDisk,wait=false",
+			Configure: func(wb *benchmark.WriterBenchmark) {
+				wb.Compression = compression.DefaultZSTDConfig()
+				wb.Compression.ZSTD.Level = zstd.SpeedDefault
+				wb.Sync.Mode = disksync.ModeDisk
+				wb.Sync.Wait = false
+			},
+		},
+	}
+
+	for _, tc := range cases {
+		b.Run(tc.Name, func(b *testing.B) {
+			newBenchmark(tc.Configure).Run(b)
+		})
+	}
+}
+
+func newBenchmark(configure func(wb *benchmark.WriterBenchmark)) *benchmark.WriterBenchmark {
+	columns := column.Columns{
+		// 8 columns, only the count is important for CSV
+		column.ID{},
+		column.Datetime{},
+		column.Body{},
+		column.Template{},
+		column.Template{},
+		column.Template{},
+		column.Template{},
+		column.Template{},
+	}
+
+	wb := &benchmark.WriterBenchmark{
+		Parallelism: 10000,
+		FileType:    storage.FileTypeCSV,
+		Columns:     columns,
+		Allocate:    100 * datasize.MB,
+		Sync: disksync.Config{
+			Mode:            disksync.ModeDisk,
+			Wait:            true,
+			CheckInterval:   5 * time.Millisecond,
+			CountTrigger:    500,
+			BytesTrigger:    1 * datasize.MB,
+			IntervalTrigger: 50 * time.Millisecond,
+		},
+		Compression: compression.DefaultNoneConfig(),
+		DataChFactory: func(ctx context.Context, n int, g *benchmark.RandomStringGenerator) <-chan []any {
+			ch := make(chan []any, 1000)
+			columnsCount := len(columns)
+			columnLength := int(benchmarkRowLength.Bytes()) / columnsCount
+
+			// Pre-generate unique rows
+			rows := make([][]any, benchmarkUniqueRows)
+			for i := 0; i < benchmarkUniqueRows; i++ {
+				rows[i] = make([]any, columnsCount)
+				for j := 0; j < len(columns); j++ {
+					rows[i][j] = g.RandomString(columnLength)
+				}
+			}
+
+			// Send the pre-generated rows to the channel over and over
+			go func() {
+				defer close(ch)
+				row := 0
+				for i := 0; i < n; i++ {
+					if ctx.Err() != nil {
+						break
+					}
+					ch <- rows[row]
+					row++
+					if row == benchmarkUniqueRows {
+						row = 0
+					}
+				}
+			}()
+
+			return ch
+		},
+	}
+
+	if configure != nil {
+		configure(wb)
+	}
+
+	return wb
+}

--- a/internal/pkg/service/buffer/storage/local/writer/csv/csv_test.go
+++ b/internal/pkg/service/buffer/storage/local/writer/csv/csv_test.go
@@ -1,0 +1,226 @@
+package csv_test
+
+import (
+	"compress/gzip"
+	"context"
+	"fmt"
+	"github.com/benbjohnson/clock"
+	"github.com/c2h5oh/datasize"
+	"github.com/keboola/keboola-as-code/internal/pkg/log"
+	"github.com/keboola/keboola-as-code/internal/pkg/service/buffer/storage"
+	"github.com/keboola/keboola-as-code/internal/pkg/service/buffer/storage/compression"
+	"github.com/keboola/keboola-as-code/internal/pkg/service/buffer/storage/local/writer"
+	"github.com/keboola/keboola-as-code/internal/pkg/service/buffer/storage/local/writer/disksync"
+	"github.com/keboola/keboola-as-code/internal/pkg/service/buffer/storage/local/writer/test/testcase"
+	"github.com/keboola/keboola-as-code/internal/pkg/service/buffer/store/model/column"
+	"github.com/keboola/keboola-as-code/internal/pkg/utils/errors"
+	"github.com/keboola/keboola-as-code/internal/pkg/validator"
+	"github.com/klauspost/compress/zstd"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	"io"
+	"strings"
+	"testing"
+	"time"
+)
+
+type fileCompression struct {
+	Name        string
+	Config      compression.Config
+	FileDecoder func(t *testing.T, r io.Reader) io.Reader
+}
+
+func TestCSVWriter_InvalidNumberOfValues(t *testing.T) {
+	t.Parallel()
+
+	ctx, cancel := context.WithTimeout(context.Background(), 10*time.Second)
+	defer cancel()
+
+	// Open volume
+	volume, err := writer.OpenVolume(ctx, log.NewNopLogger(), clock.New(), t.TempDir())
+	require.NoError(t, err)
+
+	// Create slice
+	slice := testcase.NewTestSlice(volume)
+	slice.Type = storage.FileTypeCSV
+	slice.Columns = column.Columns{column.ID{Name: "id"}, column.Body{Name: "body"}} // <<<<< two columns
+	val := validator.New()
+	assert.NoError(t, val.Validate(ctx, slice))
+
+	// Create writer
+	w, err := volume.NewWriterFor(slice)
+	require.NoError(t, err)
+
+	// Write invalid number of values
+	err = w.WriteRow([]any{"foo"})
+	if assert.Error(t, err) {
+		assert.Equal(t, `expected 2 columns in the row, given 1`, err.Error())
+	}
+}
+
+func TestCSVWriter_CastToStringError(t *testing.T) {
+	t.Parallel()
+
+	ctx, cancel := context.WithTimeout(context.Background(), 10*time.Second)
+	defer cancel()
+
+	// Open volume
+	volume, err := writer.OpenVolume(ctx, log.NewNopLogger(), clock.New(), t.TempDir())
+	require.NoError(t, err)
+
+	// Create slice
+	slice := testcase.NewTestSlice(volume)
+	slice.Type = storage.FileTypeCSV
+	slice.Columns = column.Columns{column.ID{Name: "id"}}
+	val := validator.New()
+	assert.NoError(t, val.Validate(ctx, slice))
+
+	// Create writer
+	w, err := volume.NewWriterFor(slice)
+	require.NoError(t, err)
+
+	// Write invalid number of values
+	err = w.WriteRow([]any{struct{}{}})
+	if assert.Error(t, err) {
+		assert.Equal(t, `cannot convert value of the column "id" to the string: unable to cast struct {}{} of type struct {} to string`, err.Error())
+	}
+}
+
+func TestCSVWriter(t *testing.T) {
+	t.Parallel()
+
+	compressions := []fileCompression{
+		{
+			Name:   "none",
+			Config: compression.DefaultNoneConfig(),
+		},
+		{
+			Name:   "gzip",
+			Config: compression.DefaultGZIPConfig(),
+			FileDecoder: func(t *testing.T, r io.Reader) io.Reader {
+				r, err := gzip.NewReader(r)
+				require.NoError(t, err)
+				return r
+			},
+		},
+		{
+			Name:   "zstd",
+			Config: compression.DefaultZSTDConfig(),
+			FileDecoder: func(t *testing.T, r io.Reader) io.Reader {
+				r, err := zstd.NewReader(r)
+				require.NoError(t, err)
+				return r
+			},
+		},
+	}
+
+	syncModes := []disksync.Mode{
+		disksync.ModeDisabled,
+		disksync.ModeDisk,
+		disksync.ModeCache,
+	}
+
+	// Generate all possible combinations of the parameters
+	for _, comp := range compressions {
+		for _, syncMode := range syncModes {
+			for _, syncWait := range []bool{false, true} {
+				for _, parallelWrite := range []bool{false, true} {
+					// Skip invalid combination
+					if syncMode == disksync.ModeDisabled && syncWait {
+						continue
+					}
+
+					// Run test case
+					if tc := newTestCase(comp, syncMode, syncWait, parallelWrite); tc != nil {
+						t.Run(tc.Name, func(t *testing.T) {
+							tc.Run(t)
+						})
+					}
+				}
+			}
+		}
+	}
+}
+
+func newTestCase(comp fileCompression, syncMode disksync.Mode, syncWait bool, parallelWrite bool) *testcase.WriterTestCase {
+	// Input rows
+	data := []testcase.RowBatch{
+		{
+			Parallel: parallelWrite,
+			Rows:     [][]any{{"abc", 123}, {`"def"`, 456}},
+		},
+		{
+			Parallel: parallelWrite,
+			Rows:     [][]any{{"foo", "bar"}, {`xyz`, false}},
+		},
+	}
+
+	// Expected file content
+	var validateFn func(t *testing.T, fileContent string)
+	if parallelWrite {
+		validateFn = func(t *testing.T, fileContent string) {
+			assert.Equal(t, 4, strings.Count(fileContent, "\n"))
+			assert.Contains(t, fileContent, "abc,123\n")
+			assert.Contains(t, fileContent, "\"\"\"def\"\"\",456\n")
+			assert.Contains(t, fileContent, "foo,bar\n")
+			assert.Contains(t, fileContent, "xyz,false\n")
+		}
+	} else {
+		validateFn = func(t *testing.T, fileContent string) {
+			assert.Equal(t, "abc,123\n\"\"\"def\"\"\",456\nfoo,bar\nxyz,false\n", fileContent)
+		}
+	}
+
+	// Set sync interval
+	var intervalTrigger time.Duration
+	if syncWait {
+		// Trigger sync by the intervalTrigger if syncWait=true
+		intervalTrigger = 10 * time.Millisecond
+	} else {
+		// Other writes are not blocking, sync is triggered by the writer Close.
+		intervalTrigger = 1 * time.Second
+	}
+
+	// Sync config
+	var syncConfig disksync.Config
+	switch syncMode {
+	case disksync.ModeDisabled:
+		syncConfig = disksync.Config{Mode: disksync.ModeDisabled}
+	case disksync.ModeDisk:
+		syncConfig = disksync.Config{
+			Mode:            disksync.ModeDisk,
+			Wait:            syncWait,
+			CheckInterval:   5 * time.Millisecond,
+			CountTrigger:    5000,
+			BytesTrigger:    1 * datasize.MB,
+			IntervalTrigger: intervalTrigger,
+		}
+	case disksync.ModeCache:
+		syncConfig = disksync.Config{
+			Mode:            disksync.ModeCache,
+			Wait:            syncWait,
+			CheckInterval:   5 * time.Millisecond,
+			CountTrigger:    5000,
+			BytesTrigger:    1 * datasize.MB,
+			IntervalTrigger: intervalTrigger,
+		}
+	default:
+		panic(errors.Errorf(`unexpected mode "%v"`, syncMode))
+	}
+
+	return &testcase.WriterTestCase{
+		Name:     fmt.Sprintf("compression=%s,syncMode=%s,wait=%t,parallelWrite=%t", comp.Name, syncMode, syncWait, parallelWrite),
+		FileType: storage.FileTypeCSV,
+		Columns: column.Columns{
+			// 2 columns, only the count is important for CSV
+			column.Body{},
+			column.Template{},
+		},
+		Allocate:    1 * datasize.MB,
+		Sync:        syncConfig,
+		Compression: comp.Config,
+		Data:        data,
+		FileDecoder: comp.FileDecoder,
+		Validator:   validateFn,
+	}
+}

--- a/internal/pkg/service/buffer/storage/local/writer/disksync/disksync.go
+++ b/internal/pkg/service/buffer/storage/local/writer/disksync/disksync.go
@@ -197,13 +197,13 @@ func (s *Syncer) Stop() error {
 	s.cancel()
 
 	// Run last sync
-	_ = s.TriggerSync(true).Wait()
+	err := s.TriggerSync(true).Wait()
 
 	// Wait for sync loop and running sync, if any
 	s.wg.Wait()
 
 	s.logger.Debug(`syncer stopped`)
-	return nil
+	return err
 }
 
 // TriggerSync initiates synchronization.

--- a/internal/pkg/service/buffer/storage/local/writer/disksync/disksync_test.go
+++ b/internal/pkg/service/buffer/storage/local/writer/disksync/disksync_test.go
@@ -411,7 +411,10 @@ func TestSyncWriter_SyncToDisk_Wait_Error(t *testing.T) {
 	assert.Equal(t, "data1data2data3", tc.Chain.Buffer.String())
 
 	// Close the syncWriter - it triggers the last sync
-	assert.NoError(t, syncer.Stop())
+	err := syncer.Stop()
+	if assert.Error(t, err) {
+		assert.Equal(t, "some sync error", err.Error())
+	}
 
 	// Check logs
 	tc.AssertLogs(`
@@ -514,7 +517,10 @@ func TestSyncWriter_SyncToDisk_NoWait_Error(t *testing.T) {
 	assert.Equal(t, "data1data2data3", tc.Chain.Buffer.String())
 
 	// Close the syncWriter - it triggers the last sync
-	assert.NoError(t, syncer.Stop())
+	err = syncer.Stop()
+	if assert.Error(t, err) {
+		assert.Equal(t, "some sync error", err.Error())
+	}
 
 	// Check logs
 	tc.AssertLogs(`
@@ -660,7 +666,10 @@ func TestSyncWriter_SyncToCache_Wait_Error(t *testing.T) {
 	assert.Equal(t, "data1data2data3", tc.Chain.Buffer.String())
 
 	// Close the syncWriter - it triggers the last sync
-	assert.NoError(t, syncer.Stop())
+	err := syncer.Stop()
+	if assert.Error(t, err) {
+		assert.Equal(t, "some flush error", err.Error())
+	}
 
 	// Check logs
 	tc.AssertLogs(`
@@ -763,7 +772,10 @@ func TestSyncWriter_SyncToCache_NoWait_Err(t *testing.T) {
 	assert.Equal(t, "data1data2data3", tc.Chain.Buffer.String())
 
 	// Close the syncWriter - it triggers the last sync
-	assert.NoError(t, syncer.Stop())
+	err = syncer.Stop()
+	if assert.Error(t, err) {
+		assert.Equal(t, "some flush error", err.Error())
+	}
 
 	// Check logs
 	tc.AssertLogs(`

--- a/internal/pkg/service/buffer/storage/local/writer/factory.go
+++ b/internal/pkg/service/buffer/storage/local/writer/factory.go
@@ -1,7 +1,20 @@
 package writer
 
 import (
+	"github.com/keboola/keboola-as-code/internal/pkg/service/buffer/storage"
 	"github.com/keboola/keboola-as-code/internal/pkg/service/buffer/storage/local/writer/base"
+	"github.com/keboola/keboola-as-code/internal/pkg/service/buffer/storage/local/writer/csv"
+	"github.com/keboola/keboola-as-code/internal/pkg/utils/errors"
 )
 
 type Factory func(w *base.Writer) (SliceWriter, error)
+
+func DefaultFactory(w *base.Writer) (SliceWriter, error) {
+	// Create writer according to the file type
+	switch w.Type() {
+	case storage.FileTypeCSV:
+		return csv.NewWriter(w)
+	default:
+		return nil, errors.Errorf(`unexpected file type "%s"`, w.Type())
+	}
+}

--- a/internal/pkg/service/buffer/storage/local/writer/factory_test.go
+++ b/internal/pkg/service/buffer/storage/local/writer/factory_test.go
@@ -1,0 +1,44 @@
+package writer
+
+import (
+	"github.com/keboola/keboola-as-code/internal/pkg/service/buffer/storage"
+	"github.com/keboola/keboola-as-code/internal/pkg/service/buffer/storage/local/writer/csv"
+	"github.com/stretchr/testify/assert"
+	"testing"
+)
+
+// TestDefaultFactory_FileTypeCSV tests that csv.Writer is created for the storage.FileTypeCSV.
+// Test for csv.Writer itself are in the "csv" package.
+func TestDefaultFactory_FileTypeCSV(t *testing.T) {
+	t.Parallel()
+	tc := newVolumeTestCase(t)
+
+	v, err := tc.OpenVolume(WithWriterFactory(DefaultFactory))
+	assert.NoError(t, err)
+
+	slice := newTestSlice(t)
+	slice.Type = storage.FileTypeCSV
+
+	w, err := v.NewWriterFor(slice)
+	assert.NoError(t, err)
+	assert.NotNil(t, w)
+
+	_, ok := w.(*csv.Writer)
+	assert.True(t, ok)
+}
+
+// TestDefaultFactory_FileTypeInvalid test handling of an invalid file type.
+func TestDefaultFactory_FileTypeInvalid(t *testing.T) {
+	t.Parallel()
+	tc := newVolumeTestCase(t)
+
+	v, err := tc.OpenVolume(WithWriterFactory(DefaultFactory))
+	assert.NoError(t, err)
+
+	slice := newTestSlice(t)
+	slice.Type = "invalid"
+	_, err = v.NewWriterFor(slice)
+	if assert.Error(t, err) {
+		assert.Equal(t, `unexpected file type "invalid"`, err.Error())
+	}
+}

--- a/internal/pkg/service/buffer/storage/local/writer/test/benchmark/benchmark.go
+++ b/internal/pkg/service/buffer/storage/local/writer/test/benchmark/benchmark.go
@@ -1,0 +1,161 @@
+package benchmark
+
+import (
+	"context"
+	"github.com/benbjohnson/clock"
+	"github.com/c2h5oh/datasize"
+	"github.com/keboola/keboola-as-code/internal/pkg/log"
+	"github.com/keboola/keboola-as-code/internal/pkg/service/buffer/storage"
+	"github.com/keboola/keboola-as-code/internal/pkg/service/buffer/storage/compression"
+	"github.com/keboola/keboola-as-code/internal/pkg/service/buffer/storage/local"
+	"github.com/keboola/keboola-as-code/internal/pkg/service/buffer/storage/local/writer"
+	"github.com/keboola/keboola-as-code/internal/pkg/service/buffer/storage/local/writer/disksync"
+	"github.com/keboola/keboola-as-code/internal/pkg/service/buffer/storage/staging"
+	"github.com/keboola/keboola-as-code/internal/pkg/service/buffer/store/key"
+	"github.com/keboola/keboola-as-code/internal/pkg/service/buffer/store/model/column"
+	"github.com/keboola/keboola-as-code/internal/pkg/service/common/utctime"
+	"github.com/keboola/keboola-as-code/internal/pkg/utils/testhelper"
+	"github.com/keboola/keboola-as-code/internal/pkg/validator"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	"go.uber.org/atomic"
+	"os"
+	"sync"
+	"testing"
+	"time"
+)
+
+// WriterBenchmark is a generic benchmark for writer.SliceWriter.
+type WriterBenchmark struct {
+	// Parallelism is number of parallel write operations.
+	Parallelism int
+	FileType    storage.FileType
+	Columns     column.Columns
+	Allocate    datasize.ByteSize
+	Sync        disksync.Config
+	Compression compression.Config
+
+	// DataChFactory must return the channel with table rows, the channel must be closed after the n reads.
+	DataChFactory func(ctx context.Context, n int, g *RandomStringGenerator) <-chan []any
+
+	latencySum   *atomic.Float64
+	latencyCount *atomic.Int64
+}
+
+func (wb *WriterBenchmark) Run(b *testing.B) {
+	ctx, cancel := context.WithCancel(context.Background())
+	defer cancel()
+
+	wb.latencySum = atomic.NewFloat64(0)
+	wb.latencyCount = atomic.NewInt64(0)
+
+	// Init random string generator
+	gen := newRandomStringGenerator()
+
+	// Setup logger
+	logger := log.NewDebugLogger()
+	logger.ConnectTo(testhelper.VerboseStdout())
+
+	// Open volume
+	volume, err := writer.OpenVolume(ctx, logger, clock.New(), b.TempDir())
+	require.NoError(b, err)
+
+	// Create writer
+	sliceWriter, err := volume.NewWriterFor(wb.newSlice(b, volume))
+	require.NoError(b, err)
+
+	// Create data channel
+	dataCh := wb.DataChFactory(ctx, b.N, gen)
+
+	// Run benchmark
+	b.ResetTimer()
+	start := time.Now()
+
+	// Write data in parallel, see Parallelism option.
+	wg := &sync.WaitGroup{}
+	wg.Add(1)
+	go func() {
+		defer wg.Done()
+
+		// Start wb.Parallelism goroutines
+		for i := 0; i < wb.Parallelism; i++ {
+			wg.Add(1)
+			go func() {
+				defer wg.Done()
+
+				var latencySum float64
+				var latencyCount int64
+
+				// Read from the channel until the N rows are processed, together by all goroutines
+				for row := range dataCh {
+					start := time.Now()
+					assert.NoError(b, sliceWriter.WriteRow(row))
+					latencySum += time.Since(start).Seconds()
+					latencyCount++
+				}
+
+				wb.latencySum.Add(latencySum)
+				wb.latencyCount.Add(latencyCount)
+			}()
+		}
+	}()
+	wg.Wait()
+	end := time.Now()
+
+	// Close volume
+	assert.NoError(b, volume.Close())
+
+	// Report extra metrics
+	duration := end.Sub(start)
+	b.ReportMetric(float64(b.N)/duration.Seconds(), "wr/s")
+	b.ReportMetric(wb.latencySum.Load()/float64(wb.latencyCount.Load())*1000, "ms/wr")
+	b.ReportMetric(sliceWriter.UncompressedSize().MBytes()/duration.Seconds(), "in_MB/s")
+	b.ReportMetric(sliceWriter.CompressedSize().MBytes()/duration.Seconds(), "out_MB/s")
+	b.ReportMetric(float64(sliceWriter.UncompressedSize())/float64(sliceWriter.CompressedSize()), "ratio")
+
+	// Check rows count
+	assert.Equal(b, uint64(b.N), sliceWriter.RowsCount())
+
+	// Check file real size
+	if wb.Compression.Type == compression.TypeNone {
+		assert.Equal(b, sliceWriter.CompressedSize(), sliceWriter.UncompressedSize())
+	}
+	stat, err := os.Stat(sliceWriter.FilePath())
+	assert.Equal(b, sliceWriter.CompressedSize(), datasize.ByteSize(stat.Size()))
+
+}
+
+func (wb *WriterBenchmark) newSlice(b *testing.B, volume *writer.Volume) *storage.Slice {
+	openedAt := utctime.From(time.Now())
+	s := &storage.Slice{
+		SliceKey: storage.SliceKey{
+			FileKey: storage.FileKey{
+				ExportKey: key.ExportKey{
+					ReceiverKey: key.ReceiverKey{ProjectID: 123, ReceiverID: "my-receiver"},
+					ExportID:    "my-export",
+				},
+				FileID: storage.FileID{OpenedAt: openedAt},
+			},
+			SliceID: storage.SliceID{VolumeID: volume.VolumeID(), OpenedAt: openedAt},
+		},
+		Type:    wb.FileType,
+		State:   storage.SliceWriting,
+		Columns: wb.Columns,
+		LocalStorage: local.Slice{
+			Dir:           openedAt.String(),
+			Filename:      "slice",
+			AllocateSpace: wb.Allocate,
+			Compression:   wb.Compression,
+			Sync:          wb.Sync,
+		},
+		StagingStorage: staging.Slice{
+			Path:        "slice",
+			Compression: wb.Compression,
+		},
+	}
+
+	// Slice definition must be valid
+	val := validator.New()
+	require.NoError(b, val.Validate(context.Background(), s))
+	return s
+}

--- a/internal/pkg/service/buffer/storage/local/writer/test/benchmark/randstr.go
+++ b/internal/pkg/service/buffer/storage/local/writer/test/benchmark/randstr.go
@@ -1,0 +1,49 @@
+package benchmark
+
+import (
+	"math/rand"
+	"strings"
+	"time"
+)
+
+const (
+	// letterAlphabet is list of allowed letters for the RandomStringGenerator.
+	// It's only 5 letters on purpose, because we want to test compression
+	// and it doesn't work on completely random data.
+	letterAlphabet = "abcde"
+	letterIdxBits  = 3                    // letterAlphabet length in bits 5="0b101" -> 3
+	letterIdxMask  = 1<<letterIdxBits - 1 // All 1-bits, as many as letterIdxBits
+	letterIdxMax   = 63 / letterIdxBits   // # of letter indices fitting in 63 bits
+)
+
+type RandomStringGenerator struct {
+	src rand.Source
+}
+
+func newRandomStringGenerator() *RandomStringGenerator {
+	return &RandomStringGenerator{
+		src: rand.NewSource(time.Now().UnixNano()),
+	}
+}
+
+// RandomString method is copied from:
+// https://stackoverflow.com/questions/22892120/how-to-generate-a-random-string-of-a-fixed-length-in-go
+// We need a fast way, with the custom alphabet, it doesn't have to be cryptographically strong.
+func (g *RandomStringGenerator) RandomString(n int) string {
+	sb := strings.Builder{}
+	sb.Grow(n)
+	// A src.Int63() generates 63 random bits, enough for letterIdxMax characters!
+	for i, cache, remain := n-1, g.src.Int63(), letterIdxMax; i >= 0; {
+		if remain == 0 {
+			cache, remain = g.src.Int63(), letterIdxMax
+		}
+		if idx := int(cache & letterIdxMask); idx < len(letterAlphabet) {
+			sb.WriteByte(letterAlphabet[idx])
+			i--
+		}
+		cache >>= letterIdxBits
+		remain--
+	}
+
+	return sb.String()
+}

--- a/internal/pkg/service/buffer/storage/local/writer/test/testcase/testcase.go
+++ b/internal/pkg/service/buffer/storage/local/writer/test/testcase/testcase.go
@@ -1,0 +1,181 @@
+package testcase
+
+import (
+	"context"
+	"fmt"
+	"github.com/benbjohnson/clock"
+	"github.com/c2h5oh/datasize"
+	"github.com/keboola/keboola-as-code/internal/pkg/log"
+	"github.com/keboola/keboola-as-code/internal/pkg/service/buffer/storage"
+	"github.com/keboola/keboola-as-code/internal/pkg/service/buffer/storage/compression"
+	"github.com/keboola/keboola-as-code/internal/pkg/service/buffer/storage/local"
+	"github.com/keboola/keboola-as-code/internal/pkg/service/buffer/storage/local/writer"
+	"github.com/keboola/keboola-as-code/internal/pkg/service/buffer/storage/local/writer/disksync"
+	"github.com/keboola/keboola-as-code/internal/pkg/service/buffer/storage/staging"
+	"github.com/keboola/keboola-as-code/internal/pkg/service/buffer/store/key"
+	"github.com/keboola/keboola-as-code/internal/pkg/service/buffer/store/model/column"
+	"github.com/keboola/keboola-as-code/internal/pkg/service/common/utctime"
+	"github.com/keboola/keboola-as-code/internal/pkg/utils/testhelper"
+	"github.com/keboola/keboola-as-code/internal/pkg/validator"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	"io"
+	"os"
+	"sync"
+	"testing"
+	"time"
+)
+
+type WriterTestCase struct {
+	Name        string
+	FileType    storage.FileType
+	Columns     column.Columns
+	Allocate    datasize.ByteSize
+	Sync        disksync.Config
+	Compression compression.Config
+
+	Data        []RowBatch
+	FileDecoder func(t *testing.T, r io.Reader) io.Reader
+	Validator   func(t *testing.T, fileContent string)
+}
+
+type RowBatch struct {
+	Parallel bool
+	Rows     [][]any
+}
+
+func (tc *WriterTestCase) Run(t *testing.T) {
+	ctx, cancel := context.WithTimeout(context.Background(), 10*time.Second)
+	defer cancel()
+
+	// Setup logger
+	logger := log.NewDebugLogger()
+	logger.ConnectTo(testhelper.VerboseStdout())
+
+	// Open volume
+	volume, err := writer.OpenVolume(ctx, logger, clock.New(), t.TempDir())
+	require.NoError(t, err)
+
+	// Create a test slice
+	slice := tc.newSlice(t, volume)
+
+	// Create writer
+	w, err := volume.NewWriterFor(slice)
+	require.NoError(t, err)
+
+	// Write all rows batches
+	for i, batch := range tc.Data {
+		batch := batch
+		done := make(chan struct{})
+
+		// There are two write modes
+		if batch.Parallel {
+			// Write rows from the set in parallel
+			wg := &sync.WaitGroup{}
+			for _, row := range batch.Rows {
+				row := row
+				wg.Add(1)
+				go func() {
+					defer wg.Done()
+					assert.NoError(t, w.WriteRow(row))
+				}()
+			}
+			go func() {
+				wg.Wait()
+				close(done)
+			}()
+		} else {
+			// Write rows from the set sequentially
+			go func() {
+				defer close(done)
+				for _, row := range batch.Rows {
+					assert.NoError(t, w.WriteRow(row))
+				}
+			}()
+		}
+
+		// Wait for all rows from the batch to be written
+		select {
+		case <-time.After(2 * time.Second):
+			require.Fail(t, fmt.Sprintf(`timeout when waiting for batch %d02`, i+1))
+		case <-done:
+			t.Logf(`set %02d written`, i+1)
+		}
+
+		// Simulate pod failure, restart writer
+		require.NoError(t, w.Close())
+		w, err = volume.NewWriterFor(slice)
+		require.NoError(t, err)
+	}
+
+	// Close the writer
+	require.NoError(t, w.Close())
+	assert.NotEmpty(t, w.RowsCount())
+	assert.NotEmpty(t, w.CompressedSize())
+	assert.NotEmpty(t, w.UncompressedSize())
+
+	// Check compressed size
+	stat, err := os.Stat(w.FilePath())
+	require.NoError(t, err)
+	assert.Equal(t, int64(w.CompressedSize().Bytes()), stat.Size(), "compressed file size doesn't match")
+
+	// Open file
+	f, err := os.OpenFile(w.FilePath(), os.O_RDONLY, 0o640)
+	require.NoError(t, err)
+
+	// Create file reader
+	var reader io.Reader = f
+	if tc.FileDecoder != nil {
+		reader = tc.FileDecoder(t, reader)
+	}
+
+	// Read file content
+	content, err := io.ReadAll(reader)
+	require.NoError(t, err)
+	assert.Equal(t, int(w.UncompressedSize().Bytes()), len(content), "uncompressed file size doesn't match")
+
+	// Check written data
+	tc.Validator(t, string(content))
+}
+
+func (tc *WriterTestCase) newSlice(t *testing.T, volume *writer.Volume) *storage.Slice {
+	s := NewTestSlice(volume)
+	s.Type = storage.FileTypeCSV
+	s.Columns = tc.Columns
+	s.LocalStorage.AllocateSpace = tc.Allocate
+	s.LocalStorage.Sync = tc.Sync
+	s.LocalStorage.Compression = tc.Compression
+	s.StagingStorage.Compression = tc.Compression
+
+	// Slice definition must be valid
+	val := validator.New()
+	require.NoError(t, val.Validate(context.Background(), s))
+	return s
+}
+
+func NewTestSlice(volume *writer.Volume) *storage.Slice {
+	openedAt := utctime.From(time.Now())
+	return &storage.Slice{
+		SliceKey: storage.SliceKey{
+			FileKey: storage.FileKey{
+				ExportKey: key.ExportKey{
+					ReceiverKey: key.ReceiverKey{ProjectID: 123, ReceiverID: "my-receiver"},
+					ExportID:    "my-export",
+				},
+				FileID: storage.FileID{OpenedAt: openedAt},
+			},
+			SliceID: storage.SliceID{VolumeID: volume.VolumeID(), OpenedAt: openedAt},
+		},
+		State: storage.SliceWriting,
+		LocalStorage: local.Slice{
+			Dir:         "dir",
+			Filename:    "slice",
+			Compression: compression.DefaultNoneConfig(),
+			Sync:        disksync.DefaultConfig(),
+		},
+		StagingStorage: staging.Slice{
+			Path:        "slice",
+			Compression: compression.DefaultNoneConfig(),
+		},
+	}
+}

--- a/internal/pkg/service/buffer/storage/local/writer/test/writer.go
+++ b/internal/pkg/service/buffer/storage/local/writer/test/writer.go
@@ -5,9 +5,9 @@ import (
 	"github.com/c2h5oh/datasize"
 	"github.com/keboola/keboola-as-code/internal/pkg/service/buffer/storage"
 	"github.com/keboola/keboola-as-code/internal/pkg/service/buffer/storage/local/writer/base"
+	"github.com/keboola/keboola-as-code/internal/pkg/service/buffer/storage/local/writer/count"
 	"github.com/spf13/cast"
 	"github.com/stretchr/testify/assert"
-	"go.uber.org/atomic"
 	"testing"
 	"time"
 )
@@ -21,7 +21,7 @@ type SliceWriter struct {
 	// UncompressedSizeValue defines value of the UncompressedSize getter.
 	UncompressedSizeValue datasize.ByteSize
 	// RowsCounter counts successfully written rows.
-	RowsCounter *atomic.Uint64
+	RowsCounter *count.Counter
 	// CloseError simulates error in the Close method.
 	CloseError error
 	// WriteDone signals completion of the write operation and the start of waiting for disk synchronization.
@@ -33,7 +33,7 @@ func NewSliceWriter(b *base.Writer) *SliceWriter {
 	return &SliceWriter{
 		base:        b,
 		WriteDone:   make(chan struct{}, 100),
-		RowsCounter: atomic.NewUint64(0),
+		RowsCounter: count.NewCounter(),
 	}
 }
 
@@ -61,7 +61,7 @@ func (w *SliceWriter) WriteRow(values []any) error {
 }
 
 func (w *SliceWriter) RowsCount() uint64 {
-	return w.RowsCounter.Load()
+	return w.RowsCounter.Count()
 }
 
 func (w *SliceWriter) CompressedSize() datasize.ByteSize {

--- a/internal/pkg/service/buffer/storage/local/writer/writechain/chain.go
+++ b/internal/pkg/service/buffer/storage/local/writer/writechain/chain.go
@@ -20,12 +20,10 @@ import (
 //
 // Add additional flusher or closer:
 //   - If you have a separate flusher or closer, you can add it using one of the following methods:
-//   - AppendFlusher
-//   - PrependFlusher
+//   - AppendFlusherCloser
+//   - PrependFlusherCloser
 //   - AppendFlushFn
 //   - PrependFlushFn
-//   - AppendCloser
-//   - PrependCloser
 //   - AppendCloseFn
 //   - PrependCloseFn
 //

--- a/internal/pkg/service/buffer/storage/local/writer/writechain/chain.go
+++ b/internal/pkg/service/buffer/storage/local/writer/writechain/chain.go
@@ -58,15 +58,17 @@ func New(logger log.Logger, file File) *Chain {
 	return &Chain{logger: logger, file: file, beginning: file}
 }
 
+// Write to the Chain beginning.
 func (c *Chain) Write(p []byte) (n int, err error) {
 	return c.beginning.Write(p)
 }
 
+// WriteString to the Chain beginning.
 func (c *Chain) WriteString(s string) (n int, err error) {
 	return c.beginning.WriteString(s)
 }
 
-// Flush data from writers to the file, see also Sync method.
+// Flush data from writers internal buffers, see also Sync method.
 func (c *Chain) Flush() error {
 	c.logger.Debug("flushing writers")
 	errs := errors.NewMultiError()
@@ -88,7 +90,8 @@ func (c *Chain) Flush() error {
 	return nil
 }
 
-// Sync method flushes data from writers to the file and then sync the in-memory copy of written data to disk.
+// Sync method flushes data from writers internal buffers and
+// then sync the in-memory copy of written data from the OS disk cache to the disk.
 func (c *Chain) Sync() error {
 	c.logger.Debug("syncing file")
 	errs := errors.NewMultiError()
@@ -145,8 +148,9 @@ func (c *Chain) Close() error {
 	return nil
 }
 
-// PrependWriter method adds writer to the Chain beginning.
+// PrependWriter method adds writer from the factory to the Chain beginning.
 // The factory can return the original writer without changes.
+// If the writer implements Flush or Close method, they are automatically registered.
 func (c *Chain) PrependWriter(factory func(Writer) io.Writer) (ok bool) {
 	ok, _ = c.PrependWriterOrErr(func(w Writer) (io.Writer, error) {
 		return factory(w), nil
@@ -154,8 +158,9 @@ func (c *Chain) PrependWriter(factory func(Writer) io.Writer) (ok bool) {
 	return ok
 }
 
-// PrependWriterOrErr method adds writer to the Chain beginning.
+// PrependWriterOrErr method adds writer from the factory to the Chain beginning.
 // The factory can return the original writer without changes.
+// If the writer implements Flush or Close method, they are automatically registered.
 func (c *Chain) PrependWriterOrErr(factory func(Writer) (io.Writer, error)) (ok bool, err error) {
 	// Wrap Chain with the new writer
 	oldWriter := c.beginning
@@ -170,15 +175,15 @@ func (c *Chain) PrependWriterOrErr(factory func(Writer) (io.Writer, error)) (ok 
 	if !same {
 		c.writers = append([]io.Writer{newWriter}, c.writers...)
 
-		// Protect asynchronous Flush with a lock
+		// Protect asynchronous Flush with a lock, add WriteString method if needed
 		safe := newSafeWriter(newWriter)
 
-		// Should be the writer flushed before the File.Sync?
+		// Register flusher for periodical sync
 		if _, ok := newWriter.(flusher); ok {
 			c.addFlusher(true, safe)
 		}
 
-		// Should be the writer closed/flushed before the File.Close?
+		// Register closer: use Close method if exists, or call Flush also on Close
 		if v, ok := newWriter.(io.Closer); ok {
 			c.addCloser(true, v)
 		} else if _, ok := newWriter.(flusher); ok {
@@ -189,6 +194,50 @@ func (c *Chain) PrependWriterOrErr(factory func(Writer) (io.Writer, error)) (ok 
 	}
 
 	return !same, nil
+}
+
+// AppendFlusherCloser adds
+// the Flush method if v implements it,
+// the Close method if v implements it,
+// to the Chain end.
+// At least one method must be implemented.
+func (c *Chain) AppendFlusherCloser(v any) {
+	c.addFlusherCloser(false, v)
+}
+
+// PrependFlusherCloser adds
+// the Flush method if v implements it,
+// the Close method if v implements it,
+// to the Chain beginning.
+// At least one method must be implemented.
+func (c *Chain) PrependFlusherCloser(v any) {
+	c.addFlusherCloser(true, v)
+}
+
+// AppendFlushFn adds the Flush function to the Chain end.
+// Info is a value used for identification of the function in the Chain.Dump, for example a related structure.
+func (c *Chain) AppendFlushFn(info any, fn func() error) {
+	c.addFlusher(false, newFlushFn(info, fn))
+	c.addCloser(false, newCloseFn(info, fn))
+}
+
+// PrependFlushFn adds the Flush function to the Chain beginning.
+// Info is a value used for identification of the function in the Chain.Dump, for example a related structure.
+func (c *Chain) PrependFlushFn(info any, fn func() error) {
+	c.addFlusher(true, newFlushFn(info, fn))
+	c.addCloser(true, newCloseFn(info, fn))
+}
+
+// AppendCloseFn adds the Close function to the Chain end.
+// Info is a value used for identification of the function in the Chain.Dump, for example a related structure.
+func (c *Chain) AppendCloseFn(info any, fn func() error) {
+	c.addCloser(false, newCloseFn(info, fn))
+}
+
+// PrependCloseFn adds the Close function to the Chain beginning.
+// Info is a value used for identification of the function in the Chain.Dump, for example a related structure.
+func (c *Chain) PrependCloseFn(info any, fn func() error) {
+	c.addCloser(true, newCloseFn(info, fn))
 }
 
 func (c *Chain) syncFile() error {
@@ -202,32 +251,6 @@ func (c *Chain) syncFile() error {
 
 	c.logger.Debug("file synced")
 	return nil
-}
-
-func (c *Chain) AppendFlusherCloser(v any) {
-	c.addFlusherCloser(false, v)
-}
-
-func (c *Chain) PrependFlusherCloser(v any) {
-	c.addFlusherCloser(true, v)
-}
-
-func (c *Chain) AppendFlushFn(info any, fn func() error) {
-	c.addFlusher(false, newFlushFn(info, fn))
-	c.addCloser(false, newCloseFn(info, fn))
-}
-
-func (c *Chain) PrependFlushFn(info any, fn func() error) {
-	c.addFlusher(true, newFlushFn(info, fn))
-	c.addCloser(true, newCloseFn(info, fn))
-}
-
-func (c *Chain) AppendCloseFn(info any, fn func() error) {
-	c.addCloser(false, newCloseFn(info, fn))
-}
-
-func (c *Chain) PrependCloseFn(info any, fn func() error) {
-	c.addCloser(true, newCloseFn(info, fn))
 }
 
 func (c *Chain) addFlusherCloser(prepend bool, v any) {

--- a/internal/pkg/service/buffer/storage/local/writer/writechain/closer.go
+++ b/internal/pkg/service/buffer/storage/local/writer/writechain/closer.go
@@ -10,8 +10,8 @@ type closeFn struct {
 	fn   func() error
 }
 
-// newCloseFn allows to a custom function in the io.Closer interface.
-// Info is a value used in the Chain.Dump, for example a related structure.
+// newCloseFn allows a custom function to be used as the io.Closer interface.
+// Info is a value used for identification of the function in the Chain.Dump, for example a related structure.
 func newCloseFn(info any, fn func() error) io.Closer {
 	return &closeFn{info: info, fn: fn}
 }

--- a/internal/pkg/service/buffer/storage/local/writer/writechain/flusher.go
+++ b/internal/pkg/service/buffer/storage/local/writer/writechain/flusher.go
@@ -10,8 +10,8 @@ type flushFn struct {
 	fn   func() error
 }
 
-// newFlushFn allows to a custom function in the flusher interface.
-// Info is a value used in the Chain.Dump, for example a related structure.
+// newFlushFn allows a custom function to be used as the flusher interface.
+// Info is a value used for identification of the function in the Chain.Dump, for example a related structure.
 func newFlushFn(info any, fn func() error) flusher {
 	return &flushFn{info: info, fn: fn}
 }

--- a/internal/pkg/service/buffer/storage/local/writer/writechain/writer.go
+++ b/internal/pkg/service/buffer/storage/local/writer/writechain/writer.go
@@ -29,7 +29,7 @@ func newStringWriterWrapper(w io.Writer) Writer {
 	return &stringWriterWrapper{Writer: w}
 }
 
-// safeWriter add locks to a io.Writer.
+// safeWriter add locks to an io.Writer.
 // Write, WriteString and Flush are protected by the lock, because Flush is triggered asynchronously.
 type safeWriter struct {
 	originalWriter io.Writer

--- a/internal/pkg/service/buffer/storage/local/writer/writechain/writer.go
+++ b/internal/pkg/service/buffer/storage/local/writer/writechain/writer.go
@@ -34,7 +34,8 @@ func newStringWriterWrapper(w io.Writer) Writer {
 type safeWriter struct {
 	originalWriter io.Writer
 	stringWriter   Writer
-	lock           *sync.Mutex
+	// lock synchronizes calls of the Write, WriteString, and Flush methods.
+	lock *sync.Mutex
 }
 
 func newSafeWriter(w io.Writer) *safeWriter {
@@ -46,7 +47,7 @@ func newSafeWriter(w io.Writer) *safeWriter {
 		sw = newStringWriterWrapper(w)
 	}
 
-	// Setup lock
+	// Setup Write/Flush lock
 	return &safeWriter{
 		originalWriter: w,
 		stringWriter:   sw,

--- a/internal/pkg/service/buffer/storage/local/writer/writer.go
+++ b/internal/pkg/service/buffer/storage/local/writer/writer.go
@@ -82,18 +82,26 @@ func (v *Volume) NewWriterFor(slice *storage.Slice) (w SliceWriter, err error) {
 		return nil, err
 	}
 
+	// Get file info
+	stat, err := file.Stat()
+	if err != nil {
+		return nil, err
+	}
+
 	// Allocate disk space
-	if size := slice.LocalStorage.AllocateSpace; size != 0 {
-		if ok, err := v.config.allocator.Allocate(file, size); ok {
-			logger.Debugf(`allocated disk space "%s"`, size)
-		} else if err != nil {
-			// The error is not fatal
-			logger.Errorf(`cannot allocate disk space "%s", allocation skipped: %s`, size, err)
+	if isNew := stat.Size() == 0; isNew {
+		if size := slice.LocalStorage.AllocateSpace; size != 0 && isNew {
+			if ok, err := v.config.allocator.Allocate(file, size); ok {
+				logger.Debugf(`allocated disk space "%s"`, size)
+			} else if err != nil {
+				// The error is not fatal
+				logger.Errorf(`cannot allocate disk space "%s", allocation skipped: %s`, size, err)
+			} else {
+				logger.Debug("disk space allocation is not supported")
+			}
 		} else {
-			logger.Debug("disk space allocation is not supported")
+			logger.Debug("disk space allocation is disabled")
 		}
-	} else {
-		logger.Debug("disk space allocation is disabled")
 	}
 
 	// Init writers chain

--- a/internal/pkg/service/buffer/storage/local/writer/writer.go
+++ b/internal/pkg/service/buffer/storage/local/writer/writer.go
@@ -78,7 +78,7 @@ func (v *Volume) NewWriterFor(slice *storage.Slice) (w SliceWriter, err error) {
 	if err == nil {
 		logger.Debug("opened file")
 	} else {
-		logger.Error(`cannot open file file "%s": %s`, filePath, err)
+		logger.Error(`cannot open file "%s": %s`, filePath, err)
 		return nil, err
 	}
 

--- a/internal/pkg/service/buffer/storage/local/writer/writer.go
+++ b/internal/pkg/service/buffer/storage/local/writer/writer.go
@@ -90,7 +90,7 @@ func (v *Volume) NewWriterFor(slice *storage.Slice) (w SliceWriter, err error) {
 
 	// Allocate disk space
 	if isNew := stat.Size() == 0; isNew {
-		if size := slice.LocalStorage.AllocateSpace; size != 0 && isNew {
+		if size := slice.LocalStorage.AllocateSpace; size != 0 {
 			if ok, err := v.config.allocator.Allocate(file, size); ok {
 				logger.Debugf(`allocated disk space "%s"`, size)
 			} else if err != nil {


### PR DESCRIPTION
Jira: https://keboola.atlassian.net/browse/PSGO-285

(PR contains 1 SVG image, so number of added lines is big)

Changes:
- Added `csv.Writer`, it converts table rows to bytes for the `writechain.Chain`.

--------------

CSV writer diagram:

![csv](https://github.com/keboola/keboola-as-code/assets/19371734/f8b66a10-d10c-474c-b28c-24f686baa1b3)



--------------------------
Benchmarks:

```
goos: linux
goarch: amd64
pkg: github.com/keboola/keboola-as-code/internal/pkg/service/buffer/storage/local/writer/csv
cpu: Intel(R) Core(TM) i7550U CPU @ 1.80GHz

sample=10 000x write, 1000 in parallel

                                                      │    writes/s     │   in_MB/s     │   ratio      │
None,NoSync                                               299.8k ± 10%      295.1 ± 10%     1.000 ± 0%
None,SyncToDisk,Wait                            <<<<<<<   198.5k ± 16%      195.3 ± 16%     1.000 ± 0%
None,SyncToDisk,NoWait                                    252.0k ± 15%      248.0 ± 15%     1.000 ± 0%
None,SyncToCache,Wait                                     254.8k ± 13%      250.8 ± 13%     1.000 ± 0%
None,SyncToCache,NoWait                                   295.8k ±  8%      291.1 ±  8%     1.000 ± 0%
GZIP_Standard,SyncToDisk,Wait,LevelBestSpeed               66.3k ± 10%       65.2 ± 10%     2.504 ± 0%
GZIP_Standard,SyncToDisk,NoWait,LevelBestSpeed             76.7k ±  7%       75.5 ±  7%     2.504 ± 0% 
GZIP_Parallel,SyncToDisk,Wait,LevelBestSpeed    <<<<<<<   179.7k ± 11%      176.9 ± 11%     2.629 ± 0%
GZIP_Parallel,SyncToDisk,NoWait,LevelBestSpeed            220.2k ± 11%      216.8 ± 11%     2.629 ± 0%
GZIP_Parallel,SyncToDisk,Wait,LevelDefCompression         143.3k ±  7%      141.0 ±  7%     2.694 ± 0%
GZIP_Parallel,SyncToDisk,NoWait,LevelDefCompression       153.6k ± 17%      151.2 ± 17%     2.695 ± 0%
ZSTD,SyncToDisk,Wait,LevelSpeedFastest                    117.2k ±  6%      115.3 ±  6%     2.651 ± 0%
ZSTD,SyncToDisk,NoWait,LevelSpeedFastest                  125.2k ±  8%      123.2 ±  8%     2.651 ± 0%
ZSTD,SyncToDisk,Wait,LevelSpeedDefault                     89.2k ±  5%       87.8 ±  5%     2.663 ± 0%
ZSTD,SyncToDisk,NoWait,LevelSpeedDefault                   87.6k ± 15%       86.3 ± 15%     2.663 ± 0%
```

--------------------------------

Coverage:

Potential errors when creating individual CSV writer components are not simulated/tested.

![image](https://github.com/keboola/keboola-as-code/assets/19371734/a2d15e78-7d39-41c7-a017-1cdd4ce5926d)



--------------------------------
