### PR TITLE
GCP provisioning: deploy templates api

### DIFF
--- a/provisioning/templates-api/gcp.sh
+++ b/provisioning/templates-api/gcp.sh
@@ -1,0 +1,62 @@
+#!/usr/bin/env bash
+set -Eeuo pipefail
+
+terraform_output () {
+  terraform -chdir=./gcp output -raw $1
+}
+
+SCRIPT_PATH="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+cd "${SCRIPT_PATH}"
+
+
+if [ -n "${TF_INIT_ONLY:-}" ]; then
+  terraform init -no-color -backend=false
+  exit 0
+fi
+
+echo ""
+echo "Terraform backend configuration:"
+echo "bucket=${TERRAFORM_REMOTE_STATE_BUCKET}"
+echo ""
+
+terraform -chdir=./gcp  init -input=false -no-color \
+  -backend-config="bucket=${TERRAFORM_REMOTE_STATE_BUCKET}" \
+  -backend-config="prefix=keboola-as-code/templates-api"
+
+echo "=> Validating configuration"
+terraform validate -no-color
+
+echo "=> Planning changes"
+terraform -chdir=./gcp plan -input=false -no-color  -out=terraform.tfplan \
+  -var "terraform_remote_state_bucket=${TERRAFORM_REMOTE_STATE_BUCKET}"
+
+echo "=> Applying changes"
+terraform -chdir=./gcp apply -no-color terraform.tfplan
+
+# Authorize to GKE
+GKE_CLUSTER_NAME=$(terraform_output main_gke_cluster_name)
+GKE_CLUSTER_LOCATION=$(terraform_output main_gke_cluster_location)
+
+echo $GKE_CLUSTER_NAME
+echo $GKE_CLUSTER_LOCATION
+
+gcloud auth login --cred-file=$GOOGLE_APPLICATION_CREDENTIALS
+
+# https://cloud.google.com/blog/products/containers-kubernetes/kubectl-auth-changes-in-gke
+echo "deb [signed-by=/usr/share/keyrings/cloud.google.gpg] https://packages.cloud.google.com/apt cloud-sdk main" | sudo tee -a /etc/apt/sources.list.d/google-cloud-sdk.list
+curl https://packages.cloud.google.com/apt/doc/apt-key.gpg | sudo apt-key --keyring /usr/share/keyrings/cloud.google.gpg add -
+sudo apt update
+sudo apt-get install google-cloud-sdk-gke-gcloud-auth-plugin
+
+gcloud container clusters get-credentials $GKE_CLUSTER_NAME --region $GKE_CLUSTER_LOCATION --project $GCP_PROJECT
+
+# Common part of the deploy
+export ETCD_STORAGE_CLASS_NAME=
+. ./common.sh
+
+# GCP specific part of the deploy
+kubectl apply -f ./kubernetes/deploy/cloud/gcp/service.yaml
+kubectl apply -f ./kubernetes/deploy/cloud/gcp/ingress.yaml
+
+# Wait for the rollout
+. ./wait.sh

--- a/provisioning/templates-api/gcp/.gitignore
+++ b/provisioning/templates-api/gcp/.gitignore
@@ -1,0 +1,38 @@
+# Local .terraform directories
+**/.terraform/*
+
+# .tfstate files
+*.tfstate
+*.tfstate.*
+
+# Crash log files
+crash.log
+
+# Exclude all .tfvars files, which are likely to contain sentitive data, such as
+# password, private keys, and other secrets. These should not be part of version
+# control as they are data points which are potentially sensitive and subject
+# to change depending on the environment.
+#
+*.tfvars
+
+# Ignore override files as they are usually used to override resources locally and so
+# are not checked in
+override.tf
+override.tf.json
+*_override.tf
+*_override.tf.json
+
+# Include override files you do wish to add to version control using negated pattern
+#
+# !example_override.tf
+
+# Include tfplan files to ignore the plan output of command: terraform plan -out=tfplan
+# example: *tfplan*
+
+# Ignore CLI configuration files
+.terraformrc
+terraform.rc
+
+terraform.tfplan
+
+.env

--- a/provisioning/templates-api/gcp/main.tf
+++ b/provisioning/templates-api/gcp/main.tf
@@ -1,0 +1,22 @@
+terraform {
+  required_version = "~> 1.1"
+  backend "gcs" {}
+}
+
+# Read shared infrastructure outputs
+data "terraform_remote_state" "infrastructure" {
+  backend = "gcs"
+
+  config = {
+    bucket = var.terraform_remote_state_bucket
+    prefix = "infrastructure/output"
+  }
+}
+
+output "main_gke_cluster_name" {
+  value = data.terraform_remote_state.infrastructure.outputs.main_gke_cluster_name
+}
+
+output "main_gke_cluster_location" {
+  value = data.terraform_remote_state.infrastructure.outputs.main_gke_cluster_location
+}

--- a/provisioning/templates-api/gcp/variables.tf
+++ b/provisioning/templates-api/gcp/variables.tf
@@ -1,0 +1,3 @@
+variable "terraform_remote_state_bucket" {
+  type = string
+}

--- a/provisioning/templates-api/kubernetes/build.sh
+++ b/provisioning/templates-api/kubernetes/build.sh
@@ -34,6 +34,9 @@ if [[ "$CLOUD_PROVIDER" == "aws" ]]; then
   envsubst < templates/cloud/aws/ingress.yaml > deploy/cloud/aws/ingress.yaml
 elif [[ "$CLOUD_PROVIDER" == "azure" ]]; then
   envsubst < templates/cloud/azure/service.yaml > deploy/cloud/azure/service.yaml
+elif [[ "$CLOUD_PROVIDER" == "gcp" ]]; then
+  envsubst < templates/cloud/gcp/service.yaml > deploy/cloud/gcp/service.yaml
+  envsubst < templates/cloud/gcp/ingress.yaml > deploy/cloud/gcp/ingress.yaml
 elif [[ "$CLOUD_PROVIDER" == "local" ]]; then
   envsubst < templates/cloud/local/service.yaml > deploy/cloud/local/service.yaml
 fi

--- a/provisioning/templates-api/kubernetes/deploy/cloud/gcp/.gitignore
+++ b/provisioning/templates-api/kubernetes/deploy/cloud/gcp/.gitignore
@@ -1,0 +1,2 @@
+*
+!.gitignore

--- a/provisioning/templates-api/kubernetes/templates/cloud/gcp/ingress.yaml
+++ b/provisioning/templates-api/kubernetes/templates/cloud/gcp/ingress.yaml
@@ -1,0 +1,22 @@
+---
+apiVersion: networking.k8s.io/v1
+kind: Ingress
+metadata:
+  name: templates-api
+  namespace: $NAMESPACE
+  labels:
+    app: templates-api
+  annotations:
+    kubernetes.io/ingress.class: "nginx"
+spec:
+  rules:
+    - host: "templates.${HOSTNAME_SUFFIX}"
+      http:
+        paths:
+          - backend:
+              service:
+                name: templates-api
+                port:
+                  number: 80
+            path: /
+            pathType: Prefix

--- a/provisioning/templates-api/kubernetes/templates/cloud/gcp/service.yaml
+++ b/provisioning/templates-api/kubernetes/templates/cloud/gcp/service.yaml
@@ -1,0 +1,17 @@
+---
+kind: Service
+apiVersion: v1
+metadata:
+  name: templates-api
+  namespace: $NAMESPACE
+  labels:
+    app: templates-api
+spec:
+  type: ClusterIP
+  selector:
+    app: templates-api
+  ports:
+    - port: 80
+      targetPort: 8000
+      protocol: TCP
+      name: http


### PR DESCRIPTION
fixes https://keboola.atlassian.net/browse/GCP-187
Tato uprava nasadzuje templates api na GCP based stacks.

## Test
Vytvoril som infra pipeline a nasadil templates api na GCP Dev stack: https://dev.azure.com/keboola-prod/Keboola%20Connection%20GCP/_releaseProgress?_a=release-pipeline-progress&releaseId=508
sluzba je potom dostupna pod URL: https://templates.us-central1.gcp.keboola.dev
![image](https://github.com/keboola/keboola-as-code/assets/1412120/1e57d3d9-9c09-4923-8cce-884f83a3323b)

Podla logov podu by som tiez povedal ze to funguje:
![image](https://github.com/keboola/keboola-as-code/assets/1412120/8570fd87-6f49-46ff-ab89-dbb626b130b9)

