### PR TITLE
Bug fixes in csv.Writer.Close, wait for write operations in progress

### DIFF
--- a/internal/pkg/service/buffer/storage/local/reader/volume_test.go
+++ b/internal/pkg/service/buffer/storage/local/reader/volume_test.go
@@ -263,10 +263,11 @@ func TestVolume_Close_Errors(t *testing.T) {
 	// Close volume, expect close errors from the writers
 	err = volume.Close()
 	if assert.Error(t, err) {
-		assert.Equal(t, strings.TrimSpace(`
-- cannot close reader for slice "123/my-receiver/my-export/2000-01-01T19:00:00.000Z/my-volume/2000-01-01T20:00:00.000Z": chain close error:
+		// Order of the errors is random, writers are closed in parallel
+		wildcards.Assert(t, strings.TrimSpace(`
+- cannot close reader for slice "123/my-receiver/my-export/2000-01-01T19:00:00.000Z/my-volume/2000-01-01T%s": chain close error:
   - cannot close "*reader.testFile": some close error
-- cannot close reader for slice "123/my-receiver/my-export/2000-01-01T19:00:00.000Z/my-volume/2000-01-01T21:00:00.000Z": chain close error:
+- cannot close reader for slice "123/my-receiver/my-export/2000-01-01T19:00:00.000Z/my-volume/2000-01-01T%s": chain close error:
   - cannot close "*reader.testFile": some close error
 `), err.Error())
 	}

--- a/internal/pkg/service/buffer/storage/local/reader/volume_test.go
+++ b/internal/pkg/service/buffer/storage/local/reader/volume_test.go
@@ -263,7 +263,7 @@ func TestVolume_Close_Errors(t *testing.T) {
 	// Close volume, expect close errors from the writers
 	err = volume.Close()
 	if assert.Error(t, err) {
-		// Order of the errors is random, writers are closed in parallel
+		// Order of the errors is random, readers are closed in parallel
 		wildcards.Assert(t, strings.TrimSpace(`
 - cannot close reader for slice "123/my-receiver/my-export/2000-01-01T19:00:00.000Z/my-volume/2000-01-01T%s": chain close error:
   - cannot close "*reader.testFile": some close error

--- a/internal/pkg/service/buffer/storage/local/writer/csv/csv.go
+++ b/internal/pkg/service/buffer/storage/local/writer/csv/csv.go
@@ -20,9 +20,9 @@ import (
 )
 
 const (
-	rowsCounterFile      = "rows_count"
-	compressedSizeFile   = "compressed_size"
-	uncompressedSizeFile = "uncompressed_size"
+	RowsCounterFile      = "rows_count"
+	CompressedSizeFile   = "compressed_size"
+	UncompressedSizeFile = "uncompressed_size"
 	fileBufferSize       = 64 * datasize.KB
 )
 
@@ -50,7 +50,7 @@ func NewWriter(b *base.Writer) (w *Writer, err error) {
 
 	// Measure size of compressed data
 	_, err = w.base.PrependWriterOrErr(func(writer writechain.Writer) (out io.Writer, err error) {
-		w.compressedMeter, err = size.NewMeterWithBackupFile(writer, filepath.Join(w.base.DirPath(), compressedSizeFile))
+		w.compressedMeter, err = size.NewMeterWithBackupFile(writer, filepath.Join(w.base.DirPath(), CompressedSizeFile))
 		return w.compressedMeter, err
 	})
 	if err != nil {
@@ -69,7 +69,7 @@ func NewWriter(b *base.Writer) (w *Writer, err error) {
 
 		// Measure size of uncompressed CSV data
 		_, err = w.base.PrependWriterOrErr(func(writer writechain.Writer) (_ io.Writer, err error) {
-			w.uncompressedMeter, err = size.NewMeterWithBackupFile(writer, filepath.Join(w.base.DirPath(), uncompressedSizeFile))
+			w.uncompressedMeter, err = size.NewMeterWithBackupFile(writer, filepath.Join(w.base.DirPath(), UncompressedSizeFile))
 			return w.uncompressedMeter, err
 		})
 		if err != nil {
@@ -86,7 +86,7 @@ func NewWriter(b *base.Writer) (w *Writer, err error) {
 	}
 
 	// Setup rows counter
-	w.rowsCounter, err = count.NewCounterWithBackupFile(filepath.Join(w.base.DirPath(), rowsCounterFile))
+	w.rowsCounter, err = count.NewCounterWithBackupFile(filepath.Join(w.base.DirPath(), RowsCounterFile))
 	if err == nil {
 		// Backup the counter value on Flush and Close
 		w.base.PrependFlusherCloser(w.rowsCounter)

--- a/internal/pkg/service/buffer/storage/local/writer/csv/csv.go
+++ b/internal/pkg/service/buffer/storage/local/writer/csv/csv.go
@@ -154,6 +154,11 @@ func (w *Writer) DumpChain() string {
 	return w.base.Dump()
 }
 
+
+// WaitingWriteOps returns count of write operations waiting for the sync, for tests.
+func (w *Writer) WaitingWriteOps() uint64 {
+	return w.base.WaitingWriteOps()
+}
 func (w *Writer) RowsCount() uint64 {
 	return w.rowsCounter.Count()
 }

--- a/internal/pkg/service/buffer/storage/local/writer/csv/csv.go
+++ b/internal/pkg/service/buffer/storage/local/writer/csv/csv.go
@@ -150,7 +150,6 @@ func (w *Writer) WriteRow(values []any) error {
 		w.csvWriterLock.Lock()
 		err = w.csvWriter.Write(strings)
 		w.csvWriterLock.Unlock()
-		w.base.AddWriteOp(1)
 		return err
 	})
 
@@ -159,7 +158,9 @@ func (w *Writer) WriteRow(values []any) error {
 		return err
 	}
 
-	// Wait for sync to disk, return sync error, if any
+	// Increments number of high-level writes in progress
+	w.base.AddWriteOp(1)
+
 	err = notifier.Wait()
 	if err != nil {
 		return err

--- a/internal/pkg/service/buffer/storage/local/writer/csv/csv.go
+++ b/internal/pkg/service/buffer/storage/local/writer/csv/csv.go
@@ -161,11 +161,13 @@ func (w *Writer) WriteRow(values []any) error {
 	// Increments number of high-level writes in progress
 	w.base.AddWriteOp(1)
 
+	// Wait for sync and return sync error, if any
 	err = notifier.Wait()
 	if err != nil {
 		return err
 	}
 
+	// Increase the count of successful writes
 	w.rowsCounter.Add(1)
 	return nil
 }
@@ -174,25 +176,28 @@ func (w *Writer) DumpChain() string {
 	return w.base.Dump()
 }
 
+func (w *Writer) SliceKey() storage.SliceKey {
+	return w.base.SliceKey()
+}
 
 // WaitingWriteOps returns count of write operations waiting for the sync, for tests.
 func (w *Writer) WaitingWriteOps() uint64 {
 	return w.base.WaitingWriteOps()
 }
+
+// RowsCount returns count of successfully written rows.
 func (w *Writer) RowsCount() uint64 {
 	return w.rowsCounter.Count()
 }
 
+// CompressedSize written to the file, measured after compression writer.
 func (w *Writer) CompressedSize() datasize.ByteSize {
 	return w.compressedMeter.Size()
 }
 
+// UncompressedSize written to the file, measured before compression writer.
 func (w *Writer) UncompressedSize() datasize.ByteSize {
 	return w.uncompressedMeter.Size()
-}
-
-func (w *Writer) SliceKey() storage.SliceKey {
-	return w.base.SliceKey()
 }
 
 func (w *Writer) DirPath() string {

--- a/internal/pkg/service/buffer/storage/local/writer/disksync/disksync.go
+++ b/internal/pkg/service/buffer/storage/local/writer/disksync/disksync.go
@@ -123,6 +123,11 @@ func (s *Syncer) AddWriteOp(n uint) {
 	s.writeOpsCount.Add(uint64(n))
 }
 
+// WaitingWriteOps returns count of write operations waiting for the sync, for tests.
+func (s *Syncer) WaitingWriteOps() uint64 {
+	return s.writeOpsCount.Load()
+}
+
 // DoWithNotify provides wrapping for multiple write operations and waiting for them to be synced to disk.
 // This is ensured by shared notifierLock, so notifier cannot be swapped during the method,
 // but parallel writes are not blocked. The lock blocks the TriggerSync method,

--- a/internal/pkg/service/buffer/storage/local/writer/disksync/disksync_test.go
+++ b/internal/pkg/service/buffer/storage/local/writer/disksync/disksync_test.go
@@ -829,7 +829,7 @@ func TestSyncWriter_WriteDuringSync(t *testing.T) {
 
 	// Wait for sync start
 	assert.Eventually(t, func() bool {
-		return strings.Contains(tc.Logger.AllMessages(), `starting sync`)
+		return strings.Contains(tc.Logger.AllMessages(), `INFO  TEST: sync started`)
 	}, time.Second, 10*time.Millisecond)
 
 	// Write more data

--- a/internal/pkg/service/buffer/storage/local/writer/test/testcase/testcase.go
+++ b/internal/pkg/service/buffer/storage/local/writer/test/testcase/testcase.go
@@ -64,8 +64,11 @@ func (tc *WriterTestCase) Run(t *testing.T) {
 	require.NoError(t, err)
 
 	// Write all rows batches
+	rowsCount := 0
 	for i, batch := range tc.Data {
 		batch := batch
+		rowsCount += len(batch.Rows)
+
 		done := make(chan struct{})
 
 		// There are two write modes
@@ -110,7 +113,7 @@ func (tc *WriterTestCase) Run(t *testing.T) {
 
 	// Close the writer
 	require.NoError(t, w.Close())
-	assert.NotEmpty(t, w.RowsCount())
+	assert.Equal(t, uint64(rowsCount), w.RowsCount())
 	assert.NotEmpty(t, w.CompressedSize())
 	assert.NotEmpty(t, w.UncompressedSize())
 

--- a/internal/pkg/service/buffer/storage/local/writer/volume_test.go
+++ b/internal/pkg/service/buffer/storage/local/writer/volume_test.go
@@ -219,9 +219,10 @@ func TestVolume_Close_Errors(t *testing.T) {
 	// Close volume, expect close errors from the writers
 	err = volume.Close()
 	if assert.Error(t, err) {
-		assert.Equal(t, strings.TrimSpace(`
-- cannot close writer for slice "123/my-receiver/my-export/2000-01-01T19:00:00.000Z/my-volume/2000-01-01T20:00:00.000Z": chain close error: cannot close file: some close error
-- cannot close writer for slice "123/my-receiver/my-export/2000-01-01T19:00:00.000Z/my-volume/2000-01-01T21:00:00.000Z": chain close error: cannot close file: some close error
+		// Order of the errors is random, writers are closed in parallel
+		wildcards.Assert(t, strings.TrimSpace(`
+- cannot close writer for slice "123/my-receiver/my-export/2000-01-01T19:00:00.000Z/my-volume/2000-01-01T%s": chain close error: cannot close file: some close error
+- cannot close writer for slice "123/my-receiver/my-export/2000-01-01T19:00:00.000Z/my-volume/2000-01-01T%s": chain close error: cannot close file: some close error
 `), err.Error())
 	}
 }

--- a/internal/pkg/service/buffer/storage/local/writer/writer.go
+++ b/internal/pkg/service/buffer/storage/local/writer/writer.go
@@ -16,12 +16,17 @@ const (
 )
 
 type SliceWriter interface {
-	SliceKey() storage.SliceKey
-	DirPath() string
-	FilePath() string
 	WriteRow(values []any) error
+	SliceKey() storage.SliceKey
+	// DirPath is absolute path to the slice directory. It contains slice file and optionally an auxiliary files.
+	DirPath() string
+	// FilePath is absolute path to the slice file.
+	FilePath() string
+	// RowsCount returns count of successfully written rows.
 	RowsCount() uint64
+	// CompressedSize written to the file, measured after compression writer.
 	CompressedSize() datasize.ByteSize
+	// UncompressedSize written to the file, measured before compression writer.
 	UncompressedSize() datasize.ByteSize
 	Close() error
 }


### PR DESCRIPTION
Jira: https://keboola.atlassian.net/browse/PSGO-286

Changes:
- Writers and readers are closed in parallel, there may be 100x+ slices (=writers/readers).
- `csv.Writer.Close` method waits for all `csv.Writer.WriterRow` operations in progress.
  - `rowsCounter` is closed after all write operations, so content of the backup file contains right value.
  
---------------------
Coverage is same:

![image](https://github.com/keboola/keboola-as-code/assets/19371734/bb3d75ca-9ad5-48e3-8b19-07d11e7f9b8d)


-------------------