### PR TITLE
Fix coding standards, enable linter in CI

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -12,11 +12,11 @@ jobs:
     secrets: inherit
     uses: ./.github/workflows/check-licenses.yml
 
-#  test-lint:
-#    name: "Lint"
-#    secrets: inherit
-#    uses: ./.github/workflows/test-lint.yml
-#
+  test-lint:
+    name: "Lint"
+    secrets: inherit
+    uses: ./.github/workflows/test-lint.yml
+
 #  test-unit:
 #    name: "Unit Tests"
 #    secrets: inherit

--- a/build/ci/golangci.yml
+++ b/build/ci/golangci.yml
@@ -192,6 +192,15 @@ issues:
       text: "filepath."
       linters:
         - forbidigo
+    # Allow direct file operations in the Stream service
+    - path: internal/pkg/service/buffer/.*
+      text: "os."
+      linters:
+        - forbidigo
+    - path: internal/pkg/service/buffer/.*
+      text: "filepath."
+      linters:
+        - forbidigo
     # Allow direct printing to the console
     - path: internal/pkg/service/common/cliconfig/*
       text: "fmt."

--- a/internal/pkg/service/buffer/storage/compression/config.go
+++ b/internal/pkg/service/buffer/storage/compression/config.go
@@ -2,9 +2,10 @@ package compression
 
 import (
 	"compress/gzip"
+	"runtime"
+
 	"github.com/c2h5oh/datasize"
 	"github.com/klauspost/compress/zstd"
-	"runtime"
 )
 
 const (
@@ -25,13 +26,13 @@ type Config struct {
 type GZIPConfig struct {
 	Level       int                `json:"level" mapstructure:"level" validate:"min=1,max=9"  usage:"Default GZIP compression level."`
 	Impl        GZIPImplementation `json:"impl" mapstructure:"impl" validate:"required,oneof=standard fast parallel" usage:"Default GZIP implementation: standard, fast, parallel."`
-	BlockSize   datasize.ByteSize  `json:"blockSize" mapstructure:"block-size" validate:"required,min=16384,max=104857600" usage:"Default GZIP parallel block size."` //16kB-100MB
+	BlockSize   datasize.ByteSize  `json:"blockSize" mapstructure:"block-size" validate:"required,min=16384,max=104857600" usage:"Default GZIP parallel block size."` // 16kB-100MB
 	Concurrency int                `json:"concurrency" mapstructure:"concurrency" usage:"Default GZIP parallel concurrency, 0 = auto."`
 }
 
 type ZSTDConfig struct {
 	Level       zstd.EncoderLevel `json:"level" mapstructure:"level" validate:"min=1,max=4" usage:"Default ZSTD compression level."`
-	WindowSize  datasize.ByteSize `json:"windowSize" mapstructure:"window-size" validate:"required,min=1024,max=536870912" usage:"Default ZSTD window size."` //1kB-512MB
+	WindowSize  datasize.ByteSize `json:"windowSize" mapstructure:"window-size" validate:"required,min=1024,max=536870912" usage:"Default ZSTD window size."` // 1kB-512MB
 	Concurrency int               `json:"concurrency" mapstructure:"concurrency" usage:"Default ZSTD concurrency, 0 = auto"`
 }
 

--- a/internal/pkg/service/buffer/storage/compression/config_test.go
+++ b/internal/pkg/service/buffer/storage/compression/config_test.go
@@ -2,10 +2,12 @@ package compression
 
 import (
 	"context"
-	"github.com/keboola/keboola-as-code/internal/pkg/validator"
-	"github.com/stretchr/testify/assert"
 	"strings"
 	"testing"
+
+	"github.com/stretchr/testify/assert"
+
+	"github.com/keboola/keboola-as-code/internal/pkg/validator"
 )
 
 func TestConfig_Validation(t *testing.T) {

--- a/internal/pkg/service/buffer/storage/compression/filename_test.go
+++ b/internal/pkg/service/buffer/storage/compression/filename_test.go
@@ -1,8 +1,9 @@
 package compression
 
 import (
-	"github.com/stretchr/testify/assert"
 	"testing"
+
+	"github.com/stretchr/testify/assert"
 )
 
 func TestFilename(t *testing.T) {

--- a/internal/pkg/service/buffer/storage/compression/reader/reader.go
+++ b/internal/pkg/service/buffer/storage/compression/reader/reader.go
@@ -3,12 +3,14 @@ package reader
 
 import (
 	"compress/gzip"
-	"github.com/keboola/keboola-as-code/internal/pkg/service/buffer/storage/compression"
-	"github.com/keboola/keboola-as-code/internal/pkg/utils/errors"
+	"io"
+
 	fastGzip "github.com/klauspost/compress/gzip"
 	"github.com/klauspost/compress/zstd"
 	"github.com/klauspost/pgzip"
-	"io"
+
+	"github.com/keboola/keboola-as-code/internal/pkg/service/buffer/storage/compression"
+	"github.com/keboola/keboola-as-code/internal/pkg/utils/errors"
 )
 
 // New wraps the specified reader with the compression reader.

--- a/internal/pkg/service/buffer/storage/compression/reader/reader_test.go
+++ b/internal/pkg/service/buffer/storage/compression/reader/reader_test.go
@@ -4,15 +4,17 @@ import (
 	"bytes"
 	"compress/gzip"
 	"crypto/md5"
-	"github.com/c2h5oh/datasize"
-	"github.com/keboola/keboola-as-code/internal/pkg/service/buffer/storage/compression"
-	"github.com/klauspost/compress/zstd"
-	"github.com/stretchr/testify/assert"
-	"github.com/stretchr/testify/require"
 	"io"
 	"math/rand"
 	"testing"
 	"time"
+
+	"github.com/c2h5oh/datasize"
+	"github.com/klauspost/compress/zstd"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+
+	"github.com/keboola/keboola-as-code/internal/pkg/service/buffer/storage/compression"
 )
 
 func TestReader(t *testing.T) {

--- a/internal/pkg/service/buffer/storage/compression/reader/reader_test.go
+++ b/internal/pkg/service/buffer/storage/compression/reader/reader_test.go
@@ -22,13 +22,16 @@ func TestReader(t *testing.T) {
 
 	// Encoders to compressed data before test
 	noneDecoder := func(t *testing.T, w io.Writer) io.Writer {
+		t.Helper()
 		return w
 	}
 	gzipEncoder := func(t *testing.T, w io.Writer) io.Writer {
+		t.Helper()
 		// The standard gzip implementation is used to encode data.
 		return gzip.NewWriter(w)
 	}
 	zstdEncoder := func(t *testing.T, w io.Writer) io.Writer {
+		t.Helper()
 		r, err := zstd.NewWriter(w)
 		require.NoError(t, err)
 		return r

--- a/internal/pkg/service/buffer/storage/compression/writer/writer.go
+++ b/internal/pkg/service/buffer/storage/compression/writer/writer.go
@@ -3,12 +3,14 @@ package writer
 
 import (
 	"compress/gzip"
-	"github.com/keboola/keboola-as-code/internal/pkg/service/buffer/storage/compression"
-	"github.com/keboola/keboola-as-code/internal/pkg/utils/errors"
+	"io"
+
 	fastGzip "github.com/klauspost/compress/gzip"
 	"github.com/klauspost/compress/zstd"
 	"github.com/klauspost/pgzip"
-	"io"
+
+	"github.com/keboola/keboola-as-code/internal/pkg/service/buffer/storage/compression"
+	"github.com/keboola/keboola-as-code/internal/pkg/utils/errors"
 )
 
 // New wraps the specified writer with the compression writer.

--- a/internal/pkg/service/buffer/storage/compression/writer/writer.go
+++ b/internal/pkg/service/buffer/storage/compression/writer/writer.go
@@ -63,7 +63,7 @@ func newParallelGZIPWriter(w io.Writer, cfg compression.Config) (io.WriteCloser,
 func newZstdWriter(w io.Writer, cfg compression.Config) (io.WriteCloser, error) {
 	return zstd.NewWriter(
 		w,
-		zstd.WithEncoderLevel(zstd.EncoderLevel(cfg.ZSTD.Level)),
+		zstd.WithEncoderLevel(cfg.ZSTD.Level),
 		zstd.WithEncoderConcurrency(cfg.ZSTD.Concurrency),
 		zstd.WithWindowSize(nextPowOf2(int(cfg.ZSTD.WindowSize.Bytes()))),
 	)

--- a/internal/pkg/service/buffer/storage/compression/writer/writer_test.go
+++ b/internal/pkg/service/buffer/storage/compression/writer/writer_test.go
@@ -22,15 +22,18 @@ func TestWriter(t *testing.T) {
 
 	// Decoders to validate compressed data
 	noneDecoder := func(t *testing.T, r io.Reader) io.Reader {
+		t.Helper()
 		return r
 	}
 	gzipDecoder := func(t *testing.T, r io.Reader) io.Reader {
+		t.Helper()
 		// The standard gzip implementation is used to decode data.
 		r, err := gzip.NewReader(r)
 		require.NoError(t, err)
 		return r
 	}
 	zstdDecoder := func(t *testing.T, r io.Reader) io.Reader {
+		t.Helper()
 		r, err := zstd.NewReader(r)
 		require.NoError(t, err)
 		return r

--- a/internal/pkg/service/buffer/storage/compression/writer/writer_test.go
+++ b/internal/pkg/service/buffer/storage/compression/writer/writer_test.go
@@ -4,15 +4,17 @@ import (
 	"bytes"
 	"compress/gzip"
 	"crypto/md5"
-	"github.com/c2h5oh/datasize"
-	"github.com/keboola/keboola-as-code/internal/pkg/service/buffer/storage/compression"
-	"github.com/klauspost/compress/zstd"
-	"github.com/stretchr/testify/assert"
-	"github.com/stretchr/testify/require"
 	"io"
 	"math/rand"
 	"testing"
 	"time"
+
+	"github.com/c2h5oh/datasize"
+	"github.com/klauspost/compress/zstd"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+
+	"github.com/keboola/keboola-as-code/internal/pkg/service/buffer/storage/compression"
 )
 
 func TestWriter(t *testing.T) {

--- a/internal/pkg/service/buffer/storage/file_test.go
+++ b/internal/pkg/service/buffer/storage/file_test.go
@@ -2,7 +2,12 @@ package storage
 
 import (
 	"context"
+	"strings"
+	"testing"
+
 	"github.com/keboola/go-client/pkg/keboola"
+	"github.com/stretchr/testify/assert"
+
 	"github.com/keboola/keboola-as-code/internal/pkg/service/buffer/storage/compression"
 	"github.com/keboola/keboola-as-code/internal/pkg/service/buffer/storage/local"
 	"github.com/keboola/keboola-as-code/internal/pkg/service/buffer/storage/local/writer/disksync"
@@ -12,9 +17,6 @@ import (
 	"github.com/keboola/keboola-as-code/internal/pkg/service/buffer/store/model/column"
 	"github.com/keboola/keboola-as-code/internal/pkg/service/common/utctime"
 	"github.com/keboola/keboola-as-code/internal/pkg/validator"
-	"github.com/stretchr/testify/assert"
-	"strings"
-	"testing"
 )
 
 func TestFileID_Validation(t *testing.T) {

--- a/internal/pkg/service/buffer/storage/file_test.go
+++ b/internal/pkg/service/buffer/storage/file_test.go
@@ -83,6 +83,8 @@ func TestFileKey_OpenedAt(t *testing.T) {
 }
 
 func TestFile_Validation(t *testing.T) {
+	t.Parallel()
+
 	// Following values have own validation
 	localStorage := local.File{
 		Dir:         "my-dir",

--- a/internal/pkg/service/buffer/storage/local/file_test.go
+++ b/internal/pkg/service/buffer/storage/local/file_test.go
@@ -2,12 +2,14 @@ package local
 
 import (
 	"context"
+	"strings"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+
 	"github.com/keboola/keboola-as-code/internal/pkg/service/buffer/storage/compression"
 	"github.com/keboola/keboola-as-code/internal/pkg/service/buffer/storage/local/writer/disksync"
 	"github.com/keboola/keboola-as-code/internal/pkg/validator"
-	"github.com/stretchr/testify/assert"
-	"strings"
-	"testing"
 )
 
 func TestFile_Validation(t *testing.T) {

--- a/internal/pkg/service/buffer/storage/local/reader/config.go
+++ b/internal/pkg/service/buffer/storage/local/reader/config.go
@@ -1,8 +1,9 @@
 package reader
 
 import (
-	"github.com/keboola/keboola-as-code/internal/pkg/utils/errors"
 	"time"
+
+	"github.com/keboola/keboola-as-code/internal/pkg/utils/errors"
 )
 
 const (

--- a/internal/pkg/service/buffer/storage/local/reader/file_test.go
+++ b/internal/pkg/service/buffer/storage/local/reader/file_test.go
@@ -1,8 +1,9 @@
 package reader
 
 import (
-	"github.com/keboola/keboola-as-code/internal/pkg/utils/errors"
 	"io"
+
+	"github.com/keboola/keboola-as-code/internal/pkg/utils/errors"
 )
 
 // testFile provides implementation of the File interface for tests.

--- a/internal/pkg/service/buffer/storage/local/reader/readchain/chain.go
+++ b/internal/pkg/service/buffer/storage/local/reader/readchain/chain.go
@@ -2,10 +2,11 @@
 package readchain
 
 import (
-	"github.com/keboola/keboola-as-code/internal/pkg/log"
-	"github.com/keboola/keboola-as-code/internal/pkg/utils/errors"
 	"io"
 	"os"
+
+	"github.com/keboola/keboola-as-code/internal/pkg/log"
+	"github.com/keboola/keboola-as-code/internal/pkg/utils/errors"
 )
 
 // Chain of readers with support for the Close method.

--- a/internal/pkg/service/buffer/storage/local/reader/readchain/chain_test.go
+++ b/internal/pkg/service/buffer/storage/local/reader/readchain/chain_test.go
@@ -1,15 +1,17 @@
 package readchain
 
 import (
-	"github.com/keboola/go-utils/pkg/wildcards"
-	"github.com/keboola/keboola-as-code/internal/pkg/log"
-	"github.com/keboola/keboola-as-code/internal/pkg/utils/errors"
-	"github.com/stretchr/testify/assert"
 	"io"
 	"os"
 	"path/filepath"
 	"strings"
 	"testing"
+
+	"github.com/keboola/go-utils/pkg/wildcards"
+	"github.com/stretchr/testify/assert"
+
+	"github.com/keboola/keboola-as-code/internal/pkg/log"
+	"github.com/keboola/keboola-as-code/internal/pkg/utils/errors"
 )
 
 // TestChain_Empty tests that an empty Chain with only one reader.

--- a/internal/pkg/service/buffer/storage/local/reader/readchain/chain_test.go
+++ b/internal/pkg/service/buffer/storage/local/reader/readchain/chain_test.go
@@ -21,8 +21,8 @@ func TestChain_Empty(t *testing.T) {
 
 	// Read all from the Chain
 	content, err := io.ReadAll(tc.Chain)
-	if assert.NoError(tc.T, err) {
-		assert.Equal(tc.T, "foo bar", string(content))
+	if assert.NoError(tc.TB, err) {
+		assert.Equal(tc.TB, "foo bar", string(content))
 	}
 
 	// Close the chain
@@ -169,8 +169,8 @@ func TestChain_ReadAndCloseOk(t *testing.T) {
 
 	// Read all from the Chain
 	content, err := io.ReadAll(tc.Chain)
-	if assert.NoError(tc.T, err) {
-		assert.Equal(tc.T, "foo bar", string(content))
+	if assert.NoError(tc.TB, err) {
+		assert.Equal(tc.TB, "foo bar", string(content))
 	}
 
 	// Close the chain
@@ -209,8 +209,8 @@ func TestChain_ReadError(t *testing.T) {
 
 	// Read all from the Chain
 	_, err := io.ReadAll(tc.Chain)
-	if assert.Error(tc.T, err) {
-		assert.Equal(tc.T, "some error", err.Error())
+	if assert.Error(tc.TB, err) {
+		assert.Equal(tc.TB, "some error", err.Error())
 	}
 
 	// 1st read is the string, 2nd is EOF error
@@ -234,14 +234,14 @@ func TestChain_CloseError(t *testing.T) {
 
 	// Read all from the Chain
 	content, err := io.ReadAll(tc.Chain)
-	if assert.NoError(tc.T, err) {
-		assert.Equal(tc.T, "foo bar", string(content))
+	if assert.NoError(tc.TB, err) {
+		assert.Equal(tc.TB, "foo bar", string(content))
 	}
 
 	// Read all from the Chain
 	err = tc.Chain.Close()
-	if assert.Error(tc.T, err) {
-		assert.Equal(tc.T, "chain close error: cannot close \"RC2\": some error", err.Error())
+	if assert.Error(tc.TB, err) {
+		assert.Equal(tc.TB, "chain close error: cannot close \"RC2\": some error", err.Error())
 	}
 
 	// 1st read is the content, 2nd is EOF error
@@ -262,21 +262,21 @@ DEBUG  chain closed
 }
 
 type chainTestCase struct {
-	T      testing.TB
+	TB     testing.TB
 	Logger log.DebugLogger
 	Chain  *Chain
 }
 
-func newChainTestCase(t testing.TB) *chainTestCase {
-	t.Helper()
+func newChainTestCase(tb testing.TB) *chainTestCase {
+	tb.Helper()
 	logger := log.NewDebugLogger()
 	testFile := &testReadCloser{inner: strings.NewReader("foo bar"), Logger: logger, Name: "file"}
 	chain := New(logger, testFile)
-	return &chainTestCase{T: t, Logger: logger, Chain: chain}
+	return &chainTestCase{TB: tb, Logger: logger, Chain: chain}
 }
 
 func (tc *chainTestCase) AssertLogs(expected string) bool {
-	return wildcards.Assert(tc.T, strings.TrimSpace(expected), strings.TrimSpace(tc.Logger.AllMessages()))
+	return wildcards.Assert(tc.TB, strings.TrimSpace(expected), strings.TrimSpace(tc.Logger.AllMessages()))
 }
 
 type testReader struct {

--- a/internal/pkg/service/buffer/storage/local/reader/readchain/dump_test.go
+++ b/internal/pkg/service/buffer/storage/local/reader/readchain/dump_test.go
@@ -1,8 +1,9 @@
 package readchain
 
 import (
-	"github.com/stretchr/testify/assert"
 	"testing"
+
+	"github.com/stretchr/testify/assert"
 )
 
 func TestStringOrType(t *testing.T) {

--- a/internal/pkg/service/buffer/storage/local/reader/reader.go
+++ b/internal/pkg/service/buffer/storage/local/reader/reader.go
@@ -3,6 +3,9 @@
 package reader
 
 import (
+	"io"
+	"os"
+
 	"github.com/keboola/keboola-as-code/internal/pkg/filesystem"
 	"github.com/keboola/keboola-as-code/internal/pkg/service/buffer/storage"
 	"github.com/keboola/keboola-as-code/internal/pkg/service/buffer/storage/compression"
@@ -10,8 +13,6 @@ import (
 	compressionWriter "github.com/keboola/keboola-as-code/internal/pkg/service/buffer/storage/compression/writer"
 	"github.com/keboola/keboola-as-code/internal/pkg/service/buffer/storage/local/reader/readchain"
 	"github.com/keboola/keboola-as-code/internal/pkg/utils/errors"
-	"io"
-	"os"
 )
 
 type SliceReader interface {

--- a/internal/pkg/service/buffer/storage/local/reader/reader_test.go
+++ b/internal/pkg/service/buffer/storage/local/reader/reader_test.go
@@ -3,7 +3,16 @@ package reader
 import (
 	"bytes"
 	"context"
+	"io"
+	"os"
+	"path/filepath"
+	"testing"
+	"time"
+
 	"github.com/c2h5oh/datasize"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+
 	"github.com/keboola/keboola-as-code/internal/pkg/service/buffer/storage"
 	"github.com/keboola/keboola-as-code/internal/pkg/service/buffer/storage/compression"
 	compressionReader "github.com/keboola/keboola-as-code/internal/pkg/service/buffer/storage/compression/reader"
@@ -16,13 +25,6 @@ import (
 	"github.com/keboola/keboola-as-code/internal/pkg/service/common/utctime"
 	"github.com/keboola/keboola-as-code/internal/pkg/utils/errors"
 	"github.com/keboola/keboola-as-code/internal/pkg/validator"
-	"github.com/stretchr/testify/assert"
-	"github.com/stretchr/testify/require"
-	"io"
-	"os"
-	"path/filepath"
-	"testing"
-	"time"
 )
 
 // TestVolume_NewReaderFor_Ok tests Volume.NewReaderFor method and SliceReader getters.

--- a/internal/pkg/service/buffer/storage/local/reader/volume.go
+++ b/internal/pkg/service/buffer/storage/local/reader/volume.go
@@ -2,22 +2,24 @@ package reader
 
 import (
 	"context"
-	"github.com/benbjohnson/clock"
-	"github.com/gofrs/flock"
-	"github.com/keboola/keboola-as-code/internal/pkg/log"
-	"github.com/keboola/keboola-as-code/internal/pkg/service/buffer/storage"
-	"github.com/keboola/keboola-as-code/internal/pkg/service/buffer/storage/local"
-	"github.com/keboola/keboola-as-code/internal/pkg/utils/errors"
 	"os"
 	"path/filepath"
 	"sort"
 	"strings"
 	"sync"
 	"time"
+
+	"github.com/benbjohnson/clock"
+	"github.com/gofrs/flock"
+
+	"github.com/keboola/keboola-as-code/internal/pkg/log"
+	"github.com/keboola/keboola-as-code/internal/pkg/service/buffer/storage"
+	"github.com/keboola/keboola-as-code/internal/pkg/service/buffer/storage/local"
+	"github.com/keboola/keboola-as-code/internal/pkg/utils/errors"
 )
 
 const (
-	// lockFile ensures only one opening of the volume for reading
+	// lockFile ensures only one opening of the volume for reading.
 	lockFile                = "reader.lock"
 	waitForVolumeIDInterval = 500 * time.Millisecond
 )

--- a/internal/pkg/service/buffer/storage/local/reader/volume_test.go
+++ b/internal/pkg/service/buffer/storage/local/reader/volume_test.go
@@ -276,24 +276,26 @@ func TestVolume_Close_Errors(t *testing.T) {
 }
 
 type volumeTestCase struct {
-	T          testing.TB
+	TB         testing.TB
 	Ctx        context.Context
 	Logger     log.DebugLogger
 	Clock      *clock.Mock
 	VolumePath string
 }
 
-func newVolumeTestCase(t testing.TB) *volumeTestCase {
+func newVolumeTestCase(tb testing.TB) *volumeTestCase {
+	tb.Helper()
+
 	ctx, cancel := context.WithTimeout(context.Background(), 10*time.Second)
-	t.Cleanup(func() {
+	tb.Cleanup(func() {
 		cancel()
 	})
 
 	logger := log.NewDebugLogger()
-	tmpDir := t.TempDir()
+	tmpDir := tb.TempDir()
 
 	return &volumeTestCase{
-		T:          t,
+		TB:         tb,
 		Ctx:        ctx,
 		Logger:     logger,
 		Clock:      clock.NewMock(),
@@ -306,5 +308,5 @@ func (tc *volumeTestCase) OpenVolume(opts ...Option) (*Volume, error) {
 }
 
 func (tc *volumeTestCase) AssertLogs(expected string) bool {
-	return wildcards.Assert(tc.T, strings.TrimSpace(expected), strings.TrimSpace(tc.Logger.AllMessages()))
+	return wildcards.Assert(tc.TB, strings.TrimSpace(expected), strings.TrimSpace(tc.Logger.AllMessages()))
 }

--- a/internal/pkg/service/buffer/storage/local/reader/volume_test.go
+++ b/internal/pkg/service/buffer/storage/local/reader/volume_test.go
@@ -3,21 +3,23 @@ package reader
 import (
 	"context"
 	"fmt"
-	"github.com/benbjohnson/clock"
-	"github.com/gofrs/flock"
-	"github.com/keboola/go-utils/pkg/wildcards"
-	"github.com/keboola/keboola-as-code/internal/pkg/filesystem"
-	"github.com/keboola/keboola-as-code/internal/pkg/log"
-	"github.com/keboola/keboola-as-code/internal/pkg/service/buffer/storage"
-	"github.com/keboola/keboola-as-code/internal/pkg/service/buffer/storage/local"
-	"github.com/keboola/keboola-as-code/internal/pkg/utils/errors"
-	"github.com/stretchr/testify/assert"
-	"github.com/stretchr/testify/require"
 	"os"
 	"path/filepath"
 	"strings"
 	"testing"
 	"time"
+
+	"github.com/benbjohnson/clock"
+	"github.com/gofrs/flock"
+	"github.com/keboola/go-utils/pkg/wildcards"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+
+	"github.com/keboola/keboola-as-code/internal/pkg/filesystem"
+	"github.com/keboola/keboola-as-code/internal/pkg/log"
+	"github.com/keboola/keboola-as-code/internal/pkg/service/buffer/storage"
+	"github.com/keboola/keboola-as-code/internal/pkg/service/buffer/storage/local"
+	"github.com/keboola/keboola-as-code/internal/pkg/utils/errors"
 )
 
 // TestOpenVolume_NonExistentPath tests that an error should occur if the volume directory not exists.

--- a/internal/pkg/service/buffer/storage/local/slice.go
+++ b/internal/pkg/service/buffer/storage/local/slice.go
@@ -2,6 +2,7 @@ package local
 
 import (
 	"github.com/c2h5oh/datasize"
+
 	"github.com/keboola/keboola-as-code/internal/pkg/service/buffer/storage/compression"
 	"github.com/keboola/keboola-as-code/internal/pkg/service/buffer/storage/local/writer/disksync"
 )

--- a/internal/pkg/service/buffer/storage/local/slice_test.go
+++ b/internal/pkg/service/buffer/storage/local/slice_test.go
@@ -2,13 +2,15 @@ package local
 
 import (
 	"context"
+	"strings"
+	"testing"
+
 	"github.com/c2h5oh/datasize"
+	"github.com/stretchr/testify/assert"
+
 	"github.com/keboola/keboola-as-code/internal/pkg/service/buffer/storage/compression"
 	"github.com/keboola/keboola-as-code/internal/pkg/service/buffer/storage/local/writer/disksync"
 	"github.com/keboola/keboola-as-code/internal/pkg/validator"
-	"github.com/stretchr/testify/assert"
-	"strings"
-	"testing"
 )
 
 func TestSlice_Validation(t *testing.T) {

--- a/internal/pkg/service/buffer/storage/local/volume.go
+++ b/internal/pkg/service/buffer/storage/local/volume.go
@@ -1,15 +1,15 @@
 package local
 
 import (
-	"github.com/keboola/keboola-as-code/internal/pkg/utils/errors"
 	"os"
+
+	"github.com/keboola/keboola-as-code/internal/pkg/utils/errors"
 )
 
 const VolumeIDFile = "volume-id.txt"
 
 func CheckVolumeDir(path string) error {
 	info, err := os.Stat(path)
-
 	// Path must exist
 	if err != nil {
 		return errors.Errorf(`cannot open volume "%s": %w`, path, err)

--- a/internal/pkg/service/buffer/storage/local/volume_test.go
+++ b/internal/pkg/service/buffer/storage/local/volume_test.go
@@ -2,11 +2,13 @@ package local
 
 import (
 	"fmt"
-	"github.com/keboola/keboola-as-code/internal/pkg/filesystem"
-	"github.com/keboola/keboola-as-code/internal/pkg/utils/errors"
-	"github.com/stretchr/testify/assert"
 	"os"
 	"testing"
+
+	"github.com/stretchr/testify/assert"
+
+	"github.com/keboola/keboola-as-code/internal/pkg/filesystem"
+	"github.com/keboola/keboola-as-code/internal/pkg/utils/errors"
 )
 
 func TestCheckVolumeDir_Ok(t *testing.T) {

--- a/internal/pkg/service/buffer/storage/local/writer/allocate/allocate_linux.go
+++ b/internal/pkg/service/buffer/storage/local/writer/allocate/allocate_linux.go
@@ -3,10 +3,11 @@
 package allocate
 
 import (
-	"github.com/c2h5oh/datasize"
-	"golang.org/x/sys/unix"
 	"os"
 	"syscall"
+
+	"github.com/c2h5oh/datasize"
+	"golang.org/x/sys/unix"
 )
 
 func (a DefaultAllocator) Allocate(f File, size datasize.ByteSize) (bool, error) {

--- a/internal/pkg/service/buffer/storage/local/writer/allocate/allocate_linux_test.go
+++ b/internal/pkg/service/buffer/storage/local/writer/allocate/allocate_linux_test.go
@@ -3,12 +3,13 @@
 package allocate
 
 import (
-	"github.com/c2h5oh/datasize"
-	"github.com/stretchr/testify/assert"
-	"github.com/stretchr/testify/require"
 	"os"
 	"path/filepath"
 	"testing"
+
+	"github.com/c2h5oh/datasize"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
 )
 
 func TestAllocate(t *testing.T) {

--- a/internal/pkg/service/buffer/storage/local/writer/allocate/allocate_other.go
+++ b/internal/pkg/service/buffer/storage/local/writer/allocate/allocate_other.go
@@ -3,8 +3,9 @@
 package allocate
 
 import (
-	"github.com/c2h5oh/datasize"
 	"os"
+
+	"github.com/c2h5oh/datasize"
 )
 
 func (a DefaultAllocator) AllocateSpace(f *os.File, size datasize.ByteSize) (bool, error) {

--- a/internal/pkg/service/buffer/storage/local/writer/base/base.go
+++ b/internal/pkg/service/buffer/storage/local/writer/base/base.go
@@ -2,6 +2,7 @@ package base
 
 import (
 	"github.com/benbjohnson/clock"
+
 	"github.com/keboola/keboola-as-code/internal/pkg/log"
 	"github.com/keboola/keboola-as-code/internal/pkg/service/buffer/storage"
 	"github.com/keboola/keboola-as-code/internal/pkg/service/buffer/storage/compression"

--- a/internal/pkg/service/buffer/storage/local/writer/base/base_test.go
+++ b/internal/pkg/service/buffer/storage/local/writer/base/base_test.go
@@ -2,8 +2,15 @@ package base_test
 
 import (
 	"context"
+	"os"
+	"path/filepath"
+	"testing"
+
 	"github.com/benbjohnson/clock"
 	"github.com/c2h5oh/datasize"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+
 	"github.com/keboola/keboola-as-code/internal/pkg/log"
 	"github.com/keboola/keboola-as-code/internal/pkg/service/buffer/storage"
 	"github.com/keboola/keboola-as-code/internal/pkg/service/buffer/storage/compression"
@@ -17,11 +24,6 @@ import (
 	"github.com/keboola/keboola-as-code/internal/pkg/service/common/utctime"
 	"github.com/keboola/keboola-as-code/internal/pkg/utils/errors"
 	"github.com/keboola/keboola-as-code/internal/pkg/validator"
-	"github.com/stretchr/testify/assert"
-	"github.com/stretchr/testify/require"
-	"os"
-	"path/filepath"
-	"testing"
 )
 
 func TestBaseWriter(t *testing.T) {

--- a/internal/pkg/service/buffer/storage/local/writer/base/base_test.go
+++ b/internal/pkg/service/buffer/storage/local/writer/base/base_test.go
@@ -110,7 +110,9 @@ func TestBaseWriter_CloseError(t *testing.T) {
 	}
 }
 
-func newTestSlice(t testing.TB) *storage.Slice {
+func newTestSlice(tb testing.TB) *storage.Slice {
+	tb.Helper()
+
 	s := &storage.Slice{
 		SliceKey: storage.SliceKey{
 			FileKey: storage.FileKey{
@@ -152,6 +154,6 @@ func newTestSlice(t testing.TB) *storage.Slice {
 
 	// Slice definition must be valid
 	val := validator.New()
-	require.NoError(t, val.Validate(context.Background(), s))
+	require.NoError(tb, val.Validate(context.Background(), s))
 	return s
 }

--- a/internal/pkg/service/buffer/storage/local/writer/count/counter.go
+++ b/internal/pkg/service/buffer/storage/local/writer/count/counter.go
@@ -2,13 +2,15 @@
 package count
 
 import (
-	"github.com/keboola/keboola-as-code/internal/pkg/utils/errors"
-	"github.com/keboola/keboola-as-code/internal/pkg/utils/strhelper"
-	"go.uber.org/atomic"
 	"io"
 	"os"
 	"strconv"
 	"strings"
+
+	"go.uber.org/atomic"
+
+	"github.com/keboola/keboola-as-code/internal/pkg/utils/errors"
+	"github.com/keboola/keboola-as-code/internal/pkg/utils/strhelper"
 )
 
 // Counter is an atomic counter.

--- a/internal/pkg/service/buffer/storage/local/writer/count/counter_test.go
+++ b/internal/pkg/service/buffer/storage/local/writer/count/counter_test.go
@@ -2,12 +2,14 @@ package count
 
 import (
 	"bytes"
-	"github.com/keboola/keboola-as-code/internal/pkg/utils/errors"
-	"github.com/stretchr/testify/assert"
 	"io"
 	"os"
 	"path/filepath"
 	"testing"
+
+	"github.com/stretchr/testify/assert"
+
+	"github.com/keboola/keboola-as-code/internal/pkg/utils/errors"
 )
 
 func TestCounter(t *testing.T) {

--- a/internal/pkg/service/buffer/storage/local/writer/csv/csv.go
+++ b/internal/pkg/service/buffer/storage/local/writer/csv/csv.go
@@ -4,7 +4,13 @@ import (
 	"bufio"
 	"context"
 	"encoding/csv"
+	"io"
+	"path/filepath"
+	"sync"
+
 	"github.com/c2h5oh/datasize"
+	"github.com/spf13/cast"
+
 	"github.com/keboola/keboola-as-code/internal/pkg/service/buffer/storage"
 	"github.com/keboola/keboola-as-code/internal/pkg/service/buffer/storage/compression"
 	compressionWriter "github.com/keboola/keboola-as-code/internal/pkg/service/buffer/storage/compression/writer"
@@ -14,10 +20,6 @@ import (
 	"github.com/keboola/keboola-as-code/internal/pkg/service/buffer/storage/local/writer/writechain"
 	"github.com/keboola/keboola-as-code/internal/pkg/service/buffer/store/model/column"
 	"github.com/keboola/keboola-as-code/internal/pkg/utils/errors"
-	"github.com/spf13/cast"
-	"io"
-	"path/filepath"
-	"sync"
 )
 
 const (
@@ -152,7 +154,6 @@ func (w *Writer) WriteRow(values []any) error {
 		w.csvWriterLock.Unlock()
 		return err
 	})
-
 	// Return writer error
 	if err != nil {
 		return err

--- a/internal/pkg/service/buffer/storage/local/writer/csv/csv_benchmark_test.go
+++ b/internal/pkg/service/buffer/storage/local/writer/csv/csv_benchmark_test.go
@@ -3,15 +3,17 @@ package csv_test
 import (
 	"compress/gzip"
 	"context"
+	"testing"
+	"time"
+
 	"github.com/c2h5oh/datasize"
+	"github.com/klauspost/compress/zstd"
+
 	"github.com/keboola/keboola-as-code/internal/pkg/service/buffer/storage"
 	"github.com/keboola/keboola-as-code/internal/pkg/service/buffer/storage/compression"
 	"github.com/keboola/keboola-as-code/internal/pkg/service/buffer/storage/local/writer/disksync"
 	"github.com/keboola/keboola-as-code/internal/pkg/service/buffer/storage/local/writer/test/benchmark"
 	"github.com/keboola/keboola-as-code/internal/pkg/service/buffer/store/model/column"
-	"github.com/klauspost/compress/zstd"
-	"testing"
-	"time"
 )
 
 const (

--- a/internal/pkg/service/buffer/storage/local/writer/csv/csv_test.go
+++ b/internal/pkg/service/buffer/storage/local/writer/csv/csv_test.go
@@ -4,8 +4,19 @@ import (
 	"compress/gzip"
 	"context"
 	"fmt"
+	"io"
+	"os"
+	"strings"
+	"sync"
+	"testing"
+	"time"
+
 	"github.com/benbjohnson/clock"
 	"github.com/c2h5oh/datasize"
+	"github.com/klauspost/compress/zstd"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+
 	"github.com/keboola/keboola-as-code/internal/pkg/filesystem"
 	"github.com/keboola/keboola-as-code/internal/pkg/log"
 	"github.com/keboola/keboola-as-code/internal/pkg/service/buffer/storage"
@@ -17,15 +28,6 @@ import (
 	"github.com/keboola/keboola-as-code/internal/pkg/service/buffer/store/model/column"
 	"github.com/keboola/keboola-as-code/internal/pkg/utils/errors"
 	"github.com/keboola/keboola-as-code/internal/pkg/validator"
-	"github.com/klauspost/compress/zstd"
-	"github.com/stretchr/testify/assert"
-	"github.com/stretchr/testify/require"
-	"io"
-	"os"
-	"strings"
-	"sync"
-	"testing"
-	"time"
 )
 
 type fileCompression struct {

--- a/internal/pkg/service/buffer/storage/local/writer/disksync/config.go
+++ b/internal/pkg/service/buffer/storage/local/writer/disksync/config.go
@@ -1,8 +1,9 @@
 package disksync
 
 import (
-	"github.com/c2h5oh/datasize"
 	"time"
+
+	"github.com/c2h5oh/datasize"
 )
 
 const (

--- a/internal/pkg/service/buffer/storage/local/writer/disksync/config_test.go
+++ b/internal/pkg/service/buffer/storage/local/writer/disksync/config_test.go
@@ -2,12 +2,14 @@ package disksync
 
 import (
 	"context"
-	"github.com/c2h5oh/datasize"
-	"github.com/keboola/keboola-as-code/internal/pkg/validator"
-	"github.com/stretchr/testify/assert"
 	"strings"
 	"testing"
 	"time"
+
+	"github.com/c2h5oh/datasize"
+	"github.com/stretchr/testify/assert"
+
+	"github.com/keboola/keboola-as-code/internal/pkg/validator"
 )
 
 func TestConfig(t *testing.T) {

--- a/internal/pkg/service/buffer/storage/local/writer/disksync/disksync.go
+++ b/internal/pkg/service/buffer/storage/local/writer/disksync/disksync.go
@@ -4,14 +4,16 @@ package disksync
 
 import (
 	"context"
+	"io"
+	"sync"
+
 	"github.com/benbjohnson/clock"
 	"github.com/c2h5oh/datasize"
+	"go.uber.org/atomic"
+
 	"github.com/keboola/keboola-as-code/internal/pkg/log"
 	"github.com/keboola/keboola-as-code/internal/pkg/service/buffer/storage/local/writer/notify"
 	"github.com/keboola/keboola-as-code/internal/pkg/utils/errors"
-	"go.uber.org/atomic"
-	"io"
-	"sync"
 )
 
 // Syncer writes data to the underlying writer and according to the Config it calls the chain.Flush() or chain.Sync().

--- a/internal/pkg/service/buffer/storage/local/writer/disksync/disksync_test.go
+++ b/internal/pkg/service/buffer/storage/local/writer/disksync/disksync_test.go
@@ -114,6 +114,7 @@ func TestSyncWriter_WriteString_Error(t *testing.T) {
 
 func TestSyncWriter_StopStoppedSyncer(t *testing.T) {
 	t.Parallel()
+
 	tc := newWriterTestCase(t)
 	syncer := tc.NewSyncer()
 
@@ -1122,7 +1123,7 @@ DEBUG  syncer stopped
 }
 
 type writerTestCase struct {
-	T      testing.TB
+	TB     testing.TB
 	Ctx    context.Context
 	Logger log.DebugLogger
 	Clock  *clock.Mock
@@ -1173,11 +1174,11 @@ func (c *testChain) Sync() error {
 	return c.SyncError
 }
 
-func newWriterTestCase(t testing.TB) *writerTestCase {
-	t.Helper()
+func newWriterTestCase(tb testing.TB) *writerTestCase {
+	tb.Helper()
 
 	ctx, cancel := context.WithTimeout(context.Background(), 10*time.Second)
-	t.Cleanup(func() {
+	tb.Cleanup(func() {
 		cancel()
 	})
 
@@ -1191,11 +1192,11 @@ func newWriterTestCase(t testing.TB) *writerTestCase {
 		IntervalTrigger: 10 * time.Millisecond,
 	}
 	val := validator.New()
-	require.NoError(t, val.Validate(ctx, config))
+	require.NoError(tb, val.Validate(ctx, config))
 
 	logger := log.NewDebugLogger()
 	return &writerTestCase{
-		T:      t,
+		TB:     tb,
 		Ctx:    ctx,
 		Logger: logger,
 		Clock:  clock.NewMock(),
@@ -1212,5 +1213,5 @@ func (tc *writerTestCase) NewSyncer() *Syncer {
 }
 
 func (tc *writerTestCase) AssertLogs(expected string) bool {
-	return wildcards.Assert(tc.T, strings.TrimSpace(expected), strings.TrimSpace(tc.Logger.AllMessages()))
+	return wildcards.Assert(tc.TB, strings.TrimSpace(expected), strings.TrimSpace(tc.Logger.AllMessages()))
 }

--- a/internal/pkg/service/buffer/storage/local/writer/disksync/disksync_test.go
+++ b/internal/pkg/service/buffer/storage/local/writer/disksync/disksync_test.go
@@ -4,19 +4,21 @@ import (
 	"bytes"
 	"context"
 	"fmt"
-	"github.com/benbjohnson/clock"
-	"github.com/c2h5oh/datasize"
-	"github.com/keboola/go-utils/pkg/wildcards"
-	"github.com/keboola/keboola-as-code/internal/pkg/log"
-	"github.com/keboola/keboola-as-code/internal/pkg/utils/errors"
-	"github.com/keboola/keboola-as-code/internal/pkg/utils/strhelper"
-	"github.com/keboola/keboola-as-code/internal/pkg/validator"
-	"github.com/stretchr/testify/assert"
-	"github.com/stretchr/testify/require"
 	"strings"
 	"sync"
 	"testing"
 	"time"
+
+	"github.com/benbjohnson/clock"
+	"github.com/c2h5oh/datasize"
+	"github.com/keboola/go-utils/pkg/wildcards"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+
+	"github.com/keboola/keboola-as-code/internal/pkg/log"
+	"github.com/keboola/keboola-as-code/internal/pkg/utils/errors"
+	"github.com/keboola/keboola-as-code/internal/pkg/utils/strhelper"
+	"github.com/keboola/keboola-as-code/internal/pkg/validator"
 )
 
 const (

--- a/internal/pkg/service/buffer/storage/local/writer/factory_test.go
+++ b/internal/pkg/service/buffer/storage/local/writer/factory_test.go
@@ -1,10 +1,12 @@
 package writer
 
 import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+
 	"github.com/keboola/keboola-as-code/internal/pkg/service/buffer/storage"
 	"github.com/keboola/keboola-as-code/internal/pkg/service/buffer/storage/local/writer/csv"
-	"github.com/stretchr/testify/assert"
-	"testing"
 )
 
 // TestDefaultFactory_FileTypeCSV tests that csv.Writer is created for the storage.FileTypeCSV.

--- a/internal/pkg/service/buffer/storage/local/writer/file_test.go
+++ b/internal/pkg/service/buffer/storage/local/writer/file_test.go
@@ -1,9 +1,10 @@
 package writer
 
 import (
-	"github.com/stretchr/testify/require"
 	"os"
 	"testing"
+
+	"github.com/stretchr/testify/require"
 )
 
 // testFile provides implementation of the File interface for tests.

--- a/internal/pkg/service/buffer/storage/local/writer/file_test.go
+++ b/internal/pkg/service/buffer/storage/local/writer/file_test.go
@@ -14,6 +14,7 @@ type testFile struct {
 }
 
 func newTestFile(t *testing.T, filePath string) *testFile {
+	t.Helper()
 	file, err := os.OpenFile(filePath, sliceFileFlags, sliceFilePerm)
 	require.NoError(t, err)
 	return &testFile{file: file}

--- a/internal/pkg/service/buffer/storage/local/writer/notify/notify.go
+++ b/internal/pkg/service/buffer/storage/local/writer/notify/notify.go
@@ -1,8 +1,9 @@
 package notify
 
 import (
-	"github.com/keboola/keboola-as-code/internal/pkg/utils/errors"
 	"time"
+
+	"github.com/keboola/keboola-as-code/internal/pkg/utils/errors"
 )
 
 // Notifier allows multiple listeners to Wait for the completion of an operation that may end with an error.
@@ -46,6 +47,6 @@ func (n *Notifier) WaitWithTimeout(timeout time.Duration) error {
 	case <-time.After(timeout):
 		return errors.Errorf(`timeout after %s`, timeout)
 	}
-	
+
 	return n.error
 }

--- a/internal/pkg/service/buffer/storage/local/writer/notify/notify_test.go
+++ b/internal/pkg/service/buffer/storage/local/writer/notify/notify_test.go
@@ -1,13 +1,15 @@
 package notify
 
 import (
-	"github.com/keboola/keboola-as-code/internal/pkg/utils/errors"
-	"github.com/keboola/keboola-as-code/internal/pkg/utils/ioutil"
-	"github.com/stretchr/testify/assert"
 	"strings"
 	"sync"
 	"testing"
 	"time"
+
+	"github.com/stretchr/testify/assert"
+
+	"github.com/keboola/keboola-as-code/internal/pkg/utils/errors"
+	"github.com/keboola/keboola-as-code/internal/pkg/utils/ioutil"
 )
 
 const (

--- a/internal/pkg/service/buffer/storage/local/writer/size/size.go
+++ b/internal/pkg/service/buffer/storage/local/writer/size/size.go
@@ -2,13 +2,15 @@
 package size
 
 import (
-	"github.com/c2h5oh/datasize"
-	"github.com/keboola/keboola-as-code/internal/pkg/utils/errors"
-	"github.com/keboola/keboola-as-code/internal/pkg/utils/strhelper"
 	"io"
 	"os"
 	"strconv"
 	"strings"
+
+	"github.com/c2h5oh/datasize"
+
+	"github.com/keboola/keboola-as-code/internal/pkg/utils/errors"
+	"github.com/keboola/keboola-as-code/internal/pkg/utils/strhelper"
 )
 
 // Meter implements io.Writer interface to measure size of the data written to the underlying writer.

--- a/internal/pkg/service/buffer/storage/local/writer/size/size_test.go
+++ b/internal/pkg/service/buffer/storage/local/writer/size/size_test.go
@@ -2,13 +2,15 @@ package size
 
 import (
 	"bytes"
-	"github.com/c2h5oh/datasize"
-	"github.com/keboola/keboola-as-code/internal/pkg/utils/errors"
-	"github.com/stretchr/testify/assert"
 	"io"
 	"os"
 	"path/filepath"
 	"testing"
+
+	"github.com/c2h5oh/datasize"
+	"github.com/stretchr/testify/assert"
+
+	"github.com/keboola/keboola-as-code/internal/pkg/utils/errors"
 )
 
 func TestMeter(t *testing.T) {

--- a/internal/pkg/service/buffer/storage/local/writer/test/benchmark/benchmark.go
+++ b/internal/pkg/service/buffer/storage/local/writer/test/benchmark/benchmark.go
@@ -45,6 +45,8 @@ type WriterBenchmark struct {
 }
 
 func (wb *WriterBenchmark) Run(b *testing.B) {
+	b.Helper()
+
 	ctx, cancel := context.WithCancel(context.Background())
 	defer cancel()
 
@@ -123,10 +125,13 @@ func (wb *WriterBenchmark) Run(b *testing.B) {
 		assert.Equal(b, sliceWriter.CompressedSize(), sliceWriter.UncompressedSize())
 	}
 	stat, err := os.Stat(sliceWriter.FilePath())
+	assert.NoError(b, err)
 	assert.Equal(b, sliceWriter.CompressedSize(), datasize.ByteSize(stat.Size()))
 }
 
 func (wb *WriterBenchmark) newSlice(b *testing.B, volume *writer.Volume) *storage.Slice {
+	b.Helper()
+
 	openedAt := utctime.From(time.Now())
 	s := &storage.Slice{
 		SliceKey: storage.SliceKey{

--- a/internal/pkg/service/buffer/storage/local/writer/test/benchmark/benchmark.go
+++ b/internal/pkg/service/buffer/storage/local/writer/test/benchmark/benchmark.go
@@ -2,8 +2,17 @@ package benchmark
 
 import (
 	"context"
+	"os"
+	"sync"
+	"testing"
+	"time"
+
 	"github.com/benbjohnson/clock"
 	"github.com/c2h5oh/datasize"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	"go.uber.org/atomic"
+
 	"github.com/keboola/keboola-as-code/internal/pkg/log"
 	"github.com/keboola/keboola-as-code/internal/pkg/service/buffer/storage"
 	"github.com/keboola/keboola-as-code/internal/pkg/service/buffer/storage/compression"
@@ -16,13 +25,6 @@ import (
 	"github.com/keboola/keboola-as-code/internal/pkg/service/common/utctime"
 	"github.com/keboola/keboola-as-code/internal/pkg/utils/testhelper"
 	"github.com/keboola/keboola-as-code/internal/pkg/validator"
-	"github.com/stretchr/testify/assert"
-	"github.com/stretchr/testify/require"
-	"go.uber.org/atomic"
-	"os"
-	"sync"
-	"testing"
-	"time"
 )
 
 // WriterBenchmark is a generic benchmark for writer.SliceWriter.
@@ -122,7 +124,6 @@ func (wb *WriterBenchmark) Run(b *testing.B) {
 	}
 	stat, err := os.Stat(sliceWriter.FilePath())
 	assert.Equal(b, sliceWriter.CompressedSize(), datasize.ByteSize(stat.Size()))
-
 }
 
 func (wb *WriterBenchmark) newSlice(b *testing.B, volume *writer.Volume) *storage.Slice {

--- a/internal/pkg/service/buffer/storage/local/writer/test/testcase/testcase.go
+++ b/internal/pkg/service/buffer/storage/local/writer/test/testcase/testcase.go
@@ -3,8 +3,17 @@ package testcase
 import (
 	"context"
 	"fmt"
+	"io"
+	"os"
+	"sync"
+	"testing"
+	"time"
+
 	"github.com/benbjohnson/clock"
 	"github.com/c2h5oh/datasize"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+
 	"github.com/keboola/keboola-as-code/internal/pkg/log"
 	"github.com/keboola/keboola-as-code/internal/pkg/service/buffer/storage"
 	"github.com/keboola/keboola-as-code/internal/pkg/service/buffer/storage/compression"
@@ -17,13 +26,6 @@ import (
 	"github.com/keboola/keboola-as-code/internal/pkg/service/common/utctime"
 	"github.com/keboola/keboola-as-code/internal/pkg/utils/testhelper"
 	"github.com/keboola/keboola-as-code/internal/pkg/validator"
-	"github.com/stretchr/testify/assert"
-	"github.com/stretchr/testify/require"
-	"io"
-	"os"
-	"sync"
-	"testing"
-	"time"
 )
 
 type WriterTestCase struct {

--- a/internal/pkg/service/buffer/storage/local/writer/test/testcase/testcase.go
+++ b/internal/pkg/service/buffer/storage/local/writer/test/testcase/testcase.go
@@ -46,7 +46,10 @@ type RowBatch struct {
 	Rows     [][]any
 }
 
+// nolint:thelper // false positive
 func (tc *WriterTestCase) Run(t *testing.T) {
+	t.Parallel()
+
 	ctx, cancel := context.WithTimeout(context.Background(), 10*time.Second)
 	defer cancel()
 
@@ -144,6 +147,8 @@ func (tc *WriterTestCase) Run(t *testing.T) {
 }
 
 func (tc *WriterTestCase) newSlice(t *testing.T, volume *writer.Volume) *storage.Slice {
+	t.Helper()
+
 	s := NewTestSlice(volume)
 	s.Type = storage.FileTypeCSV
 	s.Columns = tc.Columns

--- a/internal/pkg/service/buffer/storage/local/writer/test/writer.go
+++ b/internal/pkg/service/buffer/storage/local/writer/test/writer.go
@@ -113,22 +113,24 @@ func (w *SliceWriter) Close() error {
 	return w.CloseError
 }
 
-func (w *SliceWriter) ExpectWritesCount(t testing.TB, n int) {
-	t.Logf(`waiting for %d writes`, n)
+func (w *SliceWriter) ExpectWritesCount(tb testing.TB, n int) {
+	tb.Helper()
+	tb.Logf(`waiting for %d writes`, n)
 	for i := 0; i < n; i++ {
 		select {
 		case <-w.WriteDone:
-			t.Logf(`write %d done`, i+1)
+			tb.Logf(`write %d done`, i+1)
 		case <-time.After(2 * time.Second):
-			assert.FailNow(t, "timeout")
+			assert.FailNow(tb, "timeout")
 			return
 		}
 	}
-	t.Logf(`all writes done`)
+	tb.Logf(`all writes done`)
 }
 
-func (w *SliceWriter) TriggerSync(t testing.TB) {
-	t.Logf("trigger sync")
-	assert.NoError(t, w.base.TriggerSync(true).Wait())
-	t.Logf("sync done")
+func (w *SliceWriter) TriggerSync(tb testing.TB) {
+	tb.Helper()
+	tb.Logf("trigger sync")
+	assert.NoError(tb, w.base.TriggerSync(true).Wait())
+	tb.Logf("sync done")
 }

--- a/internal/pkg/service/buffer/storage/local/writer/test/writer.go
+++ b/internal/pkg/service/buffer/storage/local/writer/test/writer.go
@@ -68,7 +68,7 @@ func (w *SliceWriter) WriteRow(values []any) error {
 	w.WriteDone <- struct{}{}
 
 	// Wait for sync and return sync error, if any
-	if err = notifier.Wait(); err == nil {
+	if err = notifier.Wait(); err != nil {
 		return err
 	}
 

--- a/internal/pkg/service/buffer/storage/local/writer/test/writer.go
+++ b/internal/pkg/service/buffer/storage/local/writer/test/writer.go
@@ -2,15 +2,17 @@ package test
 
 import (
 	"bytes"
-	"github.com/c2h5oh/datasize"
-	"github.com/keboola/keboola-as-code/internal/pkg/service/buffer/storage"
-	"github.com/keboola/keboola-as-code/internal/pkg/service/buffer/storage/local/writer/base"
-	"github.com/keboola/keboola-as-code/internal/pkg/service/buffer/storage/local/writer/count"
-	"github.com/spf13/cast"
-	"github.com/stretchr/testify/assert"
 	"sync"
 	"testing"
 	"time"
+
+	"github.com/c2h5oh/datasize"
+	"github.com/spf13/cast"
+	"github.com/stretchr/testify/assert"
+
+	"github.com/keboola/keboola-as-code/internal/pkg/service/buffer/storage"
+	"github.com/keboola/keboola-as-code/internal/pkg/service/buffer/storage/local/writer/base"
+	"github.com/keboola/keboola-as-code/internal/pkg/service/buffer/storage/local/writer/count"
 )
 
 // SliceWriter implements a simple writer implementing writer.SliceWriter for tests.

--- a/internal/pkg/service/buffer/storage/local/writer/volume.go
+++ b/internal/pkg/service/buffer/storage/local/writer/volume.go
@@ -3,23 +3,25 @@ package writer
 import (
 	"bytes"
 	"context"
+	"os"
+	"path/filepath"
+	"sort"
+	"sync"
+
 	"github.com/benbjohnson/clock"
 	"github.com/gofrs/flock"
+
 	"github.com/keboola/keboola-as-code/internal/pkg/filesystem"
 	"github.com/keboola/keboola-as-code/internal/pkg/log"
 	"github.com/keboola/keboola-as-code/internal/pkg/service/buffer/storage"
 	"github.com/keboola/keboola-as-code/internal/pkg/service/buffer/storage/local"
 	"github.com/keboola/keboola-as-code/internal/pkg/utils/errors"
-	"os"
-	"path/filepath"
-	"sort"
-	"sync"
 )
 
 const (
-	// drainFile blocks opening of the volume for writing
+	// drainFile blocks opening of the volume for writing.
 	drainFile = "drain"
-	// lockFile ensures only one opening of the volume for writing
+	// lockFile ensures only one opening of the volume for writing.
 	lockFile          = "writer.lock"
 	volumeIDFileFlags = os.O_WRONLY | os.O_CREATE | os.O_EXCL
 	volumeIDFilePerm  = 0o640

--- a/internal/pkg/service/buffer/storage/local/writer/volume_test.go
+++ b/internal/pkg/service/buffer/storage/local/writer/volume_test.go
@@ -3,9 +3,18 @@ package writer
 import (
 	"context"
 	"fmt"
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+	"time"
+
 	"github.com/benbjohnson/clock"
 	"github.com/gofrs/flock"
 	"github.com/keboola/go-utils/pkg/wildcards"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+
 	"github.com/keboola/keboola-as-code/internal/pkg/filesystem"
 	"github.com/keboola/keboola-as-code/internal/pkg/log"
 	"github.com/keboola/keboola-as-code/internal/pkg/service/buffer/storage"
@@ -13,13 +22,6 @@ import (
 	"github.com/keboola/keboola-as-code/internal/pkg/service/buffer/storage/local/writer/base"
 	"github.com/keboola/keboola-as-code/internal/pkg/service/buffer/storage/local/writer/test"
 	"github.com/keboola/keboola-as-code/internal/pkg/utils/errors"
-	"github.com/stretchr/testify/assert"
-	"github.com/stretchr/testify/require"
-	"os"
-	"path/filepath"
-	"strings"
-	"testing"
-	"time"
 )
 
 func TestOpenVolume_NonExistentPath(t *testing.T) {

--- a/internal/pkg/service/buffer/storage/local/writer/volume_test.go
+++ b/internal/pkg/service/buffer/storage/local/writer/volume_test.go
@@ -230,7 +230,7 @@ func TestVolume_Close_Errors(t *testing.T) {
 }
 
 type volumeTestCase struct {
-	T          testing.TB
+	TB         testing.TB
 	Ctx        context.Context
 	Logger     log.DebugLogger
 	Clock      *clock.Mock
@@ -238,17 +238,18 @@ type volumeTestCase struct {
 	VolumePath string
 }
 
-func newVolumeTestCase(t testing.TB) *volumeTestCase {
+func newVolumeTestCase(tb testing.TB) *volumeTestCase {
+	tb.Helper()
 	ctx, cancel := context.WithTimeout(context.Background(), 10*time.Second)
-	t.Cleanup(func() {
+	tb.Cleanup(func() {
 		cancel()
 	})
 
 	logger := log.NewDebugLogger()
-	tmpDir := t.TempDir()
+	tmpDir := tb.TempDir()
 
 	return &volumeTestCase{
-		T:          t,
+		TB:         tb,
 		Ctx:        ctx,
 		Logger:     logger,
 		Clock:      clock.NewMock(),
@@ -269,5 +270,5 @@ func (tc *volumeTestCase) OpenVolume(opts ...Option) (*Volume, error) {
 }
 
 func (tc *volumeTestCase) AssertLogs(expected string) bool {
-	return wildcards.Assert(tc.T, strings.TrimSpace(expected), strings.TrimSpace(tc.Logger.AllMessages()))
+	return wildcards.Assert(tc.TB, strings.TrimSpace(expected), strings.TrimSpace(tc.Logger.AllMessages()))
 }

--- a/internal/pkg/service/buffer/storage/local/writer/writechain/chain.go
+++ b/internal/pkg/service/buffer/storage/local/writer/writechain/chain.go
@@ -2,9 +2,10 @@
 package writechain
 
 import (
+	"io"
+
 	"github.com/keboola/keboola-as-code/internal/pkg/log"
 	"github.com/keboola/keboola-as-code/internal/pkg/utils/errors"
-	"io"
 )
 
 // Chain of writers at the end of which is the File.

--- a/internal/pkg/service/buffer/storage/local/writer/writechain/chain_test.go
+++ b/internal/pkg/service/buffer/storage/local/writer/writechain/chain_test.go
@@ -2,16 +2,18 @@ package writechain
 
 import (
 	"bufio"
-	"github.com/keboola/go-utils/pkg/wildcards"
-	"github.com/keboola/keboola-as-code/internal/pkg/log"
-	"github.com/keboola/keboola-as-code/internal/pkg/utils/errors"
-	"github.com/stretchr/testify/assert"
-	"github.com/stretchr/testify/require"
 	"io"
 	"os"
 	"path/filepath"
 	"strings"
 	"testing"
+
+	"github.com/keboola/go-utils/pkg/wildcards"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+
+	"github.com/keboola/keboola-as-code/internal/pkg/log"
+	"github.com/keboola/keboola-as-code/internal/pkg/utils/errors"
 )
 
 // TestChain_Empty tests that an empty Chain writes directly to the File.
@@ -667,7 +669,7 @@ func (tc *chainTestCase) WriteData(items []string) {
 }
 
 // SetupSimpleChain creates following chain:
-// simple -> flusher-closer -> buffer -> file
+// simple -> flusher-closer -> buffer -> file.
 func (tc *chainTestCase) SetupSimpleChain() *simpleChain {
 	out := &simpleChain{}
 	tc.Chain.PrependWriter(func(w Writer) io.Writer {
@@ -702,7 +704,7 @@ Closers:
 }
 
 // SetupComplexChain creates following chain:
-// simple -> flusher-closer -> flusher -> closer -> flush func -> close func -> buffer1 -> buffer2 -> last -> file
+// simple -> flusher-closer -> flusher -> closer -> flush func -> close func -> buffer1 -> buffer2 -> last -> file.
 func (tc *chainTestCase) SetupComplexChain() *complexChain {
 	out := &complexChain{}
 	tc.Chain.PrependWriter(func(w Writer) io.Writer {

--- a/internal/pkg/service/buffer/storage/local/writer/writechain/chain_test.go
+++ b/internal/pkg/service/buffer/storage/local/writer/writechain/chain_test.go
@@ -605,7 +605,7 @@ func (w *testFlusherCloser) Close() error {
 }
 
 type chainTestCase struct {
-	T      testing.TB
+	TB     testing.TB
 	Logger log.DebugLogger
 	Path   string
 	File   *testFile
@@ -628,29 +628,29 @@ type simpleChain struct {
 	Buffer        *testBuffer
 }
 
-func newChainTestCase(t testing.TB) *chainTestCase {
-	t.Helper()
+func newChainTestCase(tb testing.TB) *chainTestCase {
+	tb.Helper()
 
 	logger := log.NewDebugLogger()
-	path := filepath.Join(t.TempDir(), "file")
+	path := filepath.Join(tb.TempDir(), "file")
 	osFile, err := os.OpenFile(path, os.O_WRONLY|os.O_CREATE|os.O_EXCL, 0o640)
-	require.NoError(t, err)
+	require.NoError(tb, err)
 
 	file := &testFile{OsFile: osFile, Logger: logger}
 	chain := New(logger, file)
 
-	return &chainTestCase{T: t, Logger: logger, Path: path, File: file, Chain: chain}
+	return &chainTestCase{TB: tb, Logger: logger, Path: path, File: file, Chain: chain}
 }
 
 func (tc *chainTestCase) AssertFileContent(expected string) {
 	content, err := os.ReadFile(tc.Path)
-	if assert.NoError(tc.T, err) {
-		assert.Equal(tc.T, expected, string(content))
+	if assert.NoError(tc.TB, err) {
+		assert.Equal(tc.TB, expected, string(content))
 	}
 }
 
 func (tc *chainTestCase) AssertLogs(expected string) bool {
-	return wildcards.Assert(tc.T, strings.TrimSpace(expected), strings.TrimSpace(tc.Logger.AllMessages()))
+	return wildcards.Assert(tc.TB, strings.TrimSpace(expected), strings.TrimSpace(tc.Logger.AllMessages()))
 }
 
 // WriteData writes alternately using Write and WriteString methods.
@@ -658,12 +658,12 @@ func (tc *chainTestCase) WriteData(items []string) {
 	for i, str := range items {
 		if i%2 == 0 {
 			n, err := tc.Chain.Write([]byte(str))
-			assert.Equal(tc.T, 3, n)
-			assert.NoError(tc.T, err)
+			assert.Equal(tc.TB, 3, n)
+			assert.NoError(tc.TB, err)
 		} else {
 			n, err := tc.Chain.WriteString(str)
-			assert.Equal(tc.T, 3, n)
-			assert.NoError(tc.T, err)
+			assert.Equal(tc.TB, 3, n)
+			assert.NoError(tc.TB, err)
 		}
 	}
 }
@@ -685,7 +685,7 @@ func (tc *chainTestCase) SetupSimpleChain() *simpleChain {
 		return out.Simple
 	})
 
-	assert.Equal(tc.T, `
+	assert.Equal(tc.TB, `
 Writers:
   simple writer
   flusher-closer writer
@@ -748,7 +748,7 @@ func (tc *chainTestCase) SetupComplexChain() *complexChain {
 		return out.Simple
 	})
 
-	assert.Equal(tc.T, `
+	assert.Equal(tc.TB, `
 Writers:
   simple writer
   flusher-closer writer

--- a/internal/pkg/service/buffer/storage/local/writer/writechain/dump_test.go
+++ b/internal/pkg/service/buffer/storage/local/writer/writechain/dump_test.go
@@ -1,8 +1,9 @@
 package writechain
 
 import (
-	"github.com/stretchr/testify/assert"
 	"testing"
+
+	"github.com/stretchr/testify/assert"
 )
 
 func TestStringOrType(t *testing.T) {

--- a/internal/pkg/service/buffer/storage/local/writer/writer.go
+++ b/internal/pkg/service/buffer/storage/local/writer/writer.go
@@ -2,13 +2,15 @@
 package writer
 
 import (
+	"os"
+
 	"github.com/c2h5oh/datasize"
+
 	"github.com/keboola/keboola-as-code/internal/pkg/filesystem"
 	"github.com/keboola/keboola-as-code/internal/pkg/service/buffer/storage"
 	"github.com/keboola/keboola-as-code/internal/pkg/service/buffer/storage/local/writer/base"
 	"github.com/keboola/keboola-as-code/internal/pkg/service/buffer/storage/local/writer/writechain"
 	"github.com/keboola/keboola-as-code/internal/pkg/utils/errors"
-	"os"
 )
 
 const (

--- a/internal/pkg/service/buffer/storage/local/writer/writer_linux_test.go
+++ b/internal/pkg/service/buffer/storage/local/writer/writer_linux_test.go
@@ -3,11 +3,13 @@
 package writer
 
 import (
+	"testing"
+
 	"github.com/c2h5oh/datasize"
-	"github.com/keboola/keboola-as-code/internal/pkg/service/buffer/storage/local/writer/allocate"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
-	"testing"
+
+	"github.com/keboola/keboola-as-code/internal/pkg/service/buffer/storage/local/writer/allocate"
 )
 
 func TestVolume_Writer_AllocateSpace_Enabled(t *testing.T) {

--- a/internal/pkg/service/buffer/storage/local/writer/writer_test.go
+++ b/internal/pkg/service/buffer/storage/local/writer/writer_test.go
@@ -2,7 +2,17 @@ package writer
 
 import (
 	"context"
+	"os"
+	"path/filepath"
+	"strings"
+	"sync"
+	"testing"
+	"time"
+
 	"github.com/c2h5oh/datasize"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+
 	"github.com/keboola/keboola-as-code/internal/pkg/service/buffer/storage"
 	"github.com/keboola/keboola-as-code/internal/pkg/service/buffer/storage/compression"
 	"github.com/keboola/keboola-as-code/internal/pkg/service/buffer/storage/local"
@@ -15,14 +25,6 @@ import (
 	"github.com/keboola/keboola-as-code/internal/pkg/service/common/utctime"
 	"github.com/keboola/keboola-as-code/internal/pkg/utils/errors"
 	"github.com/keboola/keboola-as-code/internal/pkg/validator"
-	"github.com/stretchr/testify/assert"
-	"github.com/stretchr/testify/require"
-	"os"
-	"path/filepath"
-	"strings"
-	"sync"
-	"testing"
-	"time"
 )
 
 func TestVolume_NewWriterFor_Ok(t *testing.T) {
@@ -55,7 +57,6 @@ func TestVolume_NewWriterFor_Duplicate(t *testing.T) {
 
 	assert.NoError(t, w.Close())
 	assert.Len(t, tc.Volume.writers, 0)
-
 }
 
 func TestVolume_NewWriterFor_ClosedVolume(t *testing.T) {

--- a/internal/pkg/service/buffer/storage/local/writer/writer_test.go
+++ b/internal/pkg/service/buffer/storage/local/writer/writer_test.go
@@ -649,9 +649,10 @@ type writerTestCase struct {
 	Slice  *storage.Slice
 }
 
-func newWriterTestCase(t testing.TB) *writerTestCase {
+func newWriterTestCase(tb testing.TB) *writerTestCase {
+	tb.Helper()
 	tc := &writerTestCase{}
-	tc.volumeTestCase = newVolumeTestCase(t)
+	tc.volumeTestCase = newVolumeTestCase(tb)
 	tc.Slice = newTestSlice()
 	return tc
 }
@@ -665,16 +666,16 @@ func (tc *writerTestCase) OpenVolume(opts ...Option) (*Volume, error) {
 func (tc *writerTestCase) NewWriter(opts ...Option) (*test.SliceWriter, error) {
 	if tc.Volume == nil {
 		// Write file with the VolumeID
-		require.NoError(tc.T, os.WriteFile(filepath.Join(tc.VolumePath, local.VolumeIDFile), []byte("my-volume"), 0o640))
+		require.NoError(tc.TB, os.WriteFile(filepath.Join(tc.VolumePath, local.VolumeIDFile), []byte("my-volume"), 0o640))
 
 		// Open volume
 		_, err := tc.OpenVolume(opts...)
-		require.NoError(tc.T, err)
+		require.NoError(tc.TB, err)
 	}
 
 	// Slice definition must be valid
 	val := validator.New()
-	require.NoError(tc.T, val.Validate(context.Background(), tc.Slice))
+	require.NoError(tc.TB, val.Validate(context.Background(), tc.Slice))
 
 	w, err := tc.Volume.NewWriterFor(tc.Slice)
 	if err != nil {
@@ -693,8 +694,9 @@ func (a *testAllocator) Allocate(_ allocate.File, _ datasize.ByteSize) (bool, er
 	return a.Ok, a.Error
 }
 
-func AssertFileContent(t testing.TB, path, expected string) {
+func AssertFileContent(tb testing.TB, path, expected string) {
+	tb.Helper()
 	content, err := os.ReadFile(path)
-	assert.NoError(t, err)
-	assert.Equal(t, strings.TrimSpace(expected), strings.TrimSpace(string(content)))
+	assert.NoError(tb, err)
+	assert.Equal(tb, strings.TrimSpace(expected), strings.TrimSpace(string(content)))
 }

--- a/internal/pkg/service/buffer/storage/naming_test.go
+++ b/internal/pkg/service/buffer/storage/naming_test.go
@@ -1,9 +1,11 @@
 package storage
 
 import (
-	"github.com/keboola/keboola-as-code/internal/pkg/service/buffer/storage/compression"
-	"github.com/stretchr/testify/assert"
 	"testing"
+
+	"github.com/stretchr/testify/assert"
+
+	"github.com/keboola/keboola-as-code/internal/pkg/service/buffer/storage/compression"
 )
 
 func TestSliceFilename(t *testing.T) {

--- a/internal/pkg/service/buffer/storage/retry_test.go
+++ b/internal/pkg/service/buffer/storage/retry_test.go
@@ -2,11 +2,13 @@ package storage
 
 import (
 	"context"
-	"github.com/keboola/keboola-as-code/internal/pkg/service/common/utctime"
-	"github.com/keboola/keboola-as-code/internal/pkg/validator"
-	"github.com/stretchr/testify/assert"
 	"strings"
 	"testing"
+
+	"github.com/stretchr/testify/assert"
+
+	"github.com/keboola/keboola-as-code/internal/pkg/service/common/utctime"
+	"github.com/keboola/keboola-as-code/internal/pkg/validator"
 )
 
 func TestRetryable_Validation(t *testing.T) {

--- a/internal/pkg/service/buffer/storage/retry_test.go
+++ b/internal/pkg/service/buffer/storage/retry_test.go
@@ -12,6 +12,8 @@ import (
 )
 
 func TestRetryable_Validation(t *testing.T) {
+	t.Parallel()
+
 	cases := []struct {
 		Name          string
 		ExpectedError string

--- a/internal/pkg/service/buffer/storage/slice.go
+++ b/internal/pkg/service/buffer/storage/slice.go
@@ -32,7 +32,7 @@ type SliceKey struct {
 }
 
 type SliceID struct {
-	VolumeID VolumeID        `json:"volumeID" validate:"required"`
+	VolumeID VolumeID        `json:"volumeId" validate:"required"`
 	OpenedAt utctime.UTCTime `json:"openedAt" validate:"required"`
 }
 
@@ -40,7 +40,7 @@ func (v SliceID) String() string {
 	if v.OpenedAt.IsZero() {
 		panic(errors.New("storage.SliceID.OpenedAt cannot be empty"))
 	}
-	return string(v.VolumeID.String()) + "/" + v.OpenedAt.String()
+	return v.VolumeID.String() + "/" + v.OpenedAt.String()
 }
 
 func (v SliceKey) String() string {

--- a/internal/pkg/service/buffer/storage/slice_test.go
+++ b/internal/pkg/service/buffer/storage/slice_test.go
@@ -2,6 +2,11 @@ package storage
 
 import (
 	"context"
+	"strings"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+
 	"github.com/keboola/keboola-as-code/internal/pkg/service/buffer/storage/compression"
 	"github.com/keboola/keboola-as-code/internal/pkg/service/buffer/storage/local"
 	"github.com/keboola/keboola-as-code/internal/pkg/service/buffer/storage/local/writer/disksync"
@@ -10,9 +15,6 @@ import (
 	"github.com/keboola/keboola-as-code/internal/pkg/service/buffer/store/model/column"
 	"github.com/keboola/keboola-as-code/internal/pkg/service/common/utctime"
 	"github.com/keboola/keboola-as-code/internal/pkg/validator"
-	"github.com/stretchr/testify/assert"
-	"strings"
-	"testing"
 )
 
 func TestSliceID_Validation(t *testing.T) {

--- a/internal/pkg/service/buffer/storage/slice_test.go
+++ b/internal/pkg/service/buffer/storage/slice_test.go
@@ -109,6 +109,8 @@ func TestSliceKey_OpenedAt(t *testing.T) {
 }
 
 func TestSlice_Validation(t *testing.T) {
+	t.Parallel()
+
 	// Following values have own validation
 	localStorage := local.Slice{
 		Dir:         "my-dir",

--- a/internal/pkg/service/buffer/storage/staging/file.go
+++ b/internal/pkg/service/buffer/storage/staging/file.go
@@ -2,6 +2,7 @@ package staging
 
 import (
 	"github.com/keboola/go-client/pkg/keboola"
+
 	"github.com/keboola/keboola-as-code/internal/pkg/service/buffer/storage/compression"
 	"github.com/keboola/keboola-as-code/internal/pkg/service/common/utctime"
 )

--- a/internal/pkg/service/buffer/storage/staging/file_test.go
+++ b/internal/pkg/service/buffer/storage/staging/file_test.go
@@ -14,6 +14,8 @@ import (
 )
 
 func TestFile_Validation(t *testing.T) {
+	t.Parallel()
+
 	cases := []struct {
 		Name          string
 		ExpectedError string

--- a/internal/pkg/service/buffer/storage/staging/file_test.go
+++ b/internal/pkg/service/buffer/storage/staging/file_test.go
@@ -2,13 +2,15 @@ package staging
 
 import (
 	"context"
+	"strings"
+	"testing"
+
 	"github.com/keboola/go-client/pkg/keboola"
+	"github.com/stretchr/testify/assert"
+
 	"github.com/keboola/keboola-as-code/internal/pkg/service/buffer/storage/compression"
 	"github.com/keboola/keboola-as-code/internal/pkg/service/common/utctime"
 	"github.com/keboola/keboola-as-code/internal/pkg/validator"
-	"github.com/stretchr/testify/assert"
-	"strings"
-	"testing"
 )
 
 func TestFile_Validation(t *testing.T) {

--- a/internal/pkg/service/buffer/storage/staging/slice_test.go
+++ b/internal/pkg/service/buffer/storage/staging/slice_test.go
@@ -2,11 +2,13 @@ package staging
 
 import (
 	"context"
-	"github.com/keboola/keboola-as-code/internal/pkg/service/buffer/storage/compression"
-	"github.com/keboola/keboola-as-code/internal/pkg/validator"
-	"github.com/stretchr/testify/assert"
 	"strings"
 	"testing"
+
+	"github.com/stretchr/testify/assert"
+
+	"github.com/keboola/keboola-as-code/internal/pkg/service/buffer/storage/compression"
+	"github.com/keboola/keboola-as-code/internal/pkg/validator"
 )
 
 func TestSlice_Validation(t *testing.T) {

--- a/internal/pkg/service/buffer/storage/staging/slice_test.go
+++ b/internal/pkg/service/buffer/storage/staging/slice_test.go
@@ -12,6 +12,8 @@ import (
 )
 
 func TestSlice_Validation(t *testing.T) {
+	t.Parallel()
+
 	cases := []struct {
 		Name          string
 		ExpectedError string

--- a/internal/pkg/service/buffer/storage/target/file_test.go
+++ b/internal/pkg/service/buffer/storage/target/file_test.go
@@ -2,11 +2,13 @@ package target
 
 import (
 	"context"
-	"github.com/keboola/go-client/pkg/keboola"
-	"github.com/keboola/keboola-as-code/internal/pkg/validator"
-	"github.com/stretchr/testify/assert"
 	"strings"
 	"testing"
+
+	"github.com/keboola/go-client/pkg/keboola"
+	"github.com/stretchr/testify/assert"
+
+	"github.com/keboola/keboola-as-code/internal/pkg/validator"
 )
 
 func TestFile_Validation(t *testing.T) {

--- a/internal/pkg/service/buffer/storage/volume_test.go
+++ b/internal/pkg/service/buffer/storage/volume_test.go
@@ -1,8 +1,9 @@
 package storage
 
 import (
-	"github.com/stretchr/testify/assert"
 	"testing"
+
+	"github.com/stretchr/testify/assert"
 )
 
 func TestGenerateVolumeID(t *testing.T) {


### PR DESCRIPTION
Jira: https://keboola.atlassian.net/browse/PSGO-286

Changes:
- Enabled linter in CI (tests are still disabled).
- Automatically and manually fixed  linter issues.
- Fixed bug/typo in test writer.

--------------

Uz sme v stave, ze by bolo fajn zapnut spat aspon linter.
Balicky uz nie su az tak rozbite, ze by linter nepresiel.

--------------------

![image](https://github.com/keboola/keboola-as-code/assets/19371734/1a405115-ec41-4c3c-94f6-5df8c2a1350c)
