### PR TITLE
Counter: add FirstAt and LastAt methods

### DIFF
--- a/internal/pkg/service/buffer/storage/level/local/writer/csv/csv.go
+++ b/internal/pkg/service/buffer/storage/level/local/writer/csv/csv.go
@@ -120,14 +120,14 @@ func NewWriter(b *base.Writer) (w *Writer, err error) {
 }
 
 func (w *Writer) WriteRow(values []any) error {
+	// Block Close method
+	w.writeWg.Add(1)
+	defer w.writeWg.Done()
+
 	// Check if the writer is closed
 	if err := w.ctx.Err(); err != nil {
 		return errors.Errorf(`CSV writer is closed: %w`, err)
 	}
-
-	// Block Close method
-	w.writeWg.Add(1)
-	defer w.writeWg.Done()
 
 	// Check values count
 	if len(values) != len(w.columns) {

--- a/internal/pkg/service/buffer/storage/level/local/writer/csv/csv.go
+++ b/internal/pkg/service/buffer/storage/level/local/writer/csv/csv.go
@@ -7,6 +7,7 @@ import (
 	"io"
 	"path/filepath"
 	"sync"
+	"time"
 
 	"github.com/c2h5oh/datasize"
 	"github.com/spf13/cast"
@@ -19,6 +20,7 @@ import (
 	"github.com/keboola/keboola-as-code/internal/pkg/service/buffer/storage/level/local/writer/size"
 	"github.com/keboola/keboola-as-code/internal/pkg/service/buffer/storage/level/local/writer/writechain"
 	"github.com/keboola/keboola-as-code/internal/pkg/service/buffer/store/model/column"
+	"github.com/keboola/keboola-as-code/internal/pkg/service/common/utctime"
 	"github.com/keboola/keboola-as-code/internal/pkg/utils/errors"
 )
 
@@ -119,7 +121,7 @@ func NewWriter(b *base.Writer) (w *Writer, err error) {
 	return w, nil
 }
 
-func (w *Writer) WriteRow(values []any) error {
+func (w *Writer) WriteRow(timestamp time.Time, values []any) error {
 	// Block Close method
 	w.writeWg.Add(1)
 	defer w.writeWg.Done()
@@ -169,7 +171,7 @@ func (w *Writer) WriteRow(values []any) error {
 	}
 
 	// Increase the count of successful writes
-	w.rowsCounter.Add(1)
+	w.rowsCounter.Add(timestamp, 1)
 	return nil
 }
 
@@ -189,6 +191,16 @@ func (w *Writer) WaitingWriteOps() uint64 {
 // RowsCount returns count of successfully written rows.
 func (w *Writer) RowsCount() uint64 {
 	return w.rowsCounter.Count()
+}
+
+// FirstRowAt returns timestamp of receiving the first row for processing.
+func (w *Writer) FirstRowAt() utctime.UTCTime {
+	return w.rowsCounter.FirstAt()
+}
+
+// LastRowAt returns timestamp of receiving the last row for processing.
+func (w *Writer) LastRowAt() utctime.UTCTime {
+	return w.rowsCounter.LastAt()
 }
 
 // CompressedSize written to the file, measured after compression writer.

--- a/internal/pkg/service/buffer/storage/level/local/writer/disksync/disksync.go
+++ b/internal/pkg/service/buffer/storage/level/local/writer/disksync/disksync.go
@@ -119,7 +119,7 @@ func NewSyncer(logger log.Logger, clock clock.Clock, config Config, chain chain)
 	return w
 }
 
-// AddWriteOp increments number of high-level writer operations,
+// AddWriteOp increments number of high-level writer operations in progress,
 // for example writing one row of the table is one high-level write operation.
 func (s *Syncer) AddWriteOp(n uint) {
 	s.writeOpsCount.Add(uint64(n))
@@ -203,7 +203,7 @@ func (s *Syncer) Stop() error {
 	// Stop sync loop
 	s.cancel()
 
-	// Run last sync
+	// Run the last sync
 	err := s.TriggerSync(true).Wait()
 
 	// Wait for sync loop and running sync, if any

--- a/internal/pkg/service/buffer/storage/level/local/writer/test/benchmark/benchmark.go
+++ b/internal/pkg/service/buffer/storage/level/local/writer/test/benchmark/benchmark.go
@@ -61,7 +61,9 @@ func (wb *WriterBenchmark) Run(b *testing.B) {
 	logger.ConnectTo(testhelper.VerboseStdout())
 
 	// Open volume
-	vol, err := volume.Open(ctx, logger, clock.New(), volume.NewInfo(b.TempDir(), "hdd", "1"))
+	clk := clock.New()
+	now := clk.Now()
+	vol, err := volume.Open(ctx, logger, clk, volume.NewInfo(b.TempDir(), "hdd", "1"))
 	require.NoError(b, err)
 
 	// Create writer
@@ -93,7 +95,7 @@ func (wb *WriterBenchmark) Run(b *testing.B) {
 				// Read from the channel until the N rows are processed, together by all goroutines
 				for row := range dataCh {
 					start := time.Now()
-					assert.NoError(b, sliceWriter.WriteRow(row))
+					assert.NoError(b, sliceWriter.WriteRow(now, row))
 					latencySum += time.Since(start).Seconds()
 					latencyCount++
 				}

--- a/internal/pkg/service/buffer/storage/level/local/writer/test/testcase/testcase.go
+++ b/internal/pkg/service/buffer/storage/level/local/writer/test/testcase/testcase.go
@@ -59,7 +59,9 @@ func (tc *WriterTestCase) Run(t *testing.T) {
 
 	// Open volume
 	opts := []volume.Option{volume.WithWatchDrainFile(false)}
-	vol, err := volume.Open(ctx, logger, clock.New(), volume.NewInfo(t.TempDir(), "hdd", "1"), opts...)
+	clk := clock.New()
+	now := clk.Now()
+	vol, err := volume.Open(ctx, logger, clk, volume.NewInfo(t.TempDir(), "hdd", "1"), opts...)
 	require.NoError(t, err)
 
 	// Create a test slice
@@ -86,7 +88,7 @@ func (tc *WriterTestCase) Run(t *testing.T) {
 				wg.Add(1)
 				go func() {
 					defer wg.Done()
-					assert.NoError(t, w.WriteRow(row))
+					assert.NoError(t, w.WriteRow(now, row))
 				}()
 			}
 			go func() {
@@ -98,7 +100,7 @@ func (tc *WriterTestCase) Run(t *testing.T) {
 			go func() {
 				defer close(done)
 				for _, row := range batch.Rows {
-					assert.NoError(t, w.WriteRow(row))
+					assert.NoError(t, w.WriteRow(now, row))
 				}
 			}()
 		}

--- a/internal/pkg/service/buffer/storage/level/local/writer/volume/writer_test.go
+++ b/internal/pkg/service/buffer/storage/level/local/writer/volume/writer_test.go
@@ -124,12 +124,12 @@ func TestVolume_Writer_Sync_Enabled_Wait_ToDisk(t *testing.T) {
 	wg.Add(2)
 	go func() {
 		defer wg.Done()
-		assert.NoError(t, w.WriteRow([]any{"foo", "bar", 123}))
+		assert.NoError(t, w.WriteRow(tc.Clock.Now(), []any{"foo", "bar", 123}))
 		tc.Logger.Infof("TEST: write unblocked")
 	}()
 	go func() {
 		defer wg.Done()
-		assert.NoError(t, w.WriteRow([]any{"foo", "bar", 123}))
+		assert.NoError(t, w.WriteRow(tc.Clock.Now(), []any{"foo", "bar", 123}))
 		tc.Logger.Infof("TEST: write unblocked")
 	}()
 	w.ExpectWritesCount(t, 2)
@@ -140,7 +140,7 @@ func TestVolume_Writer_Sync_Enabled_Wait_ToDisk(t *testing.T) {
 	wg.Add(1)
 	go func() {
 		defer wg.Done()
-		assert.NoError(t, w.WriteRow([]any{"abc", "def", 456}))
+		assert.NoError(t, w.WriteRow(tc.Clock.Now(), []any{"abc", "def", 456}))
 		tc.Logger.Infof("TEST: write unblocked")
 	}()
 	w.ExpectWritesCount(t, 1)
@@ -151,7 +151,7 @@ func TestVolume_Writer_Sync_Enabled_Wait_ToDisk(t *testing.T) {
 	wg.Add(1)
 	go func() {
 		defer wg.Done()
-		assert.NoError(t, w.WriteRow([]any{"ghi", "jkl", 789}))
+		assert.NoError(t, w.WriteRow(tc.Clock.Now(), []any{"ghi", "jkl", 789}))
 	}()
 	w.ExpectWritesCount(t, 1)
 
@@ -228,12 +228,12 @@ func TestVolume_Writer_Sync_Enabled_Wait_ToDiskCache(t *testing.T) {
 	wg.Add(2)
 	go func() {
 		defer wg.Done()
-		assert.NoError(t, w.WriteRow([]any{"foo", "bar", 123}))
+		assert.NoError(t, w.WriteRow(tc.Clock.Now(), []any{"foo", "bar", 123}))
 		tc.Logger.Infof("TEST: write unblocked")
 	}()
 	go func() {
 		defer wg.Done()
-		assert.NoError(t, w.WriteRow([]any{"foo", "bar", 123}))
+		assert.NoError(t, w.WriteRow(tc.Clock.Now(), []any{"foo", "bar", 123}))
 		tc.Logger.Infof("TEST: write unblocked")
 	}()
 	w.ExpectWritesCount(t, 2)
@@ -244,7 +244,7 @@ func TestVolume_Writer_Sync_Enabled_Wait_ToDiskCache(t *testing.T) {
 	wg.Add(1)
 	go func() {
 		defer wg.Done()
-		assert.NoError(t, w.WriteRow([]any{"abc", "def", 456}))
+		assert.NoError(t, w.WriteRow(tc.Clock.Now(), []any{"abc", "def", 456}))
 		tc.Logger.Infof("TEST: write unblocked")
 	}()
 	w.ExpectWritesCount(t, 1)
@@ -255,7 +255,7 @@ func TestVolume_Writer_Sync_Enabled_Wait_ToDiskCache(t *testing.T) {
 	wg.Add(1)
 	go func() {
 		defer wg.Done()
-		assert.NoError(t, w.WriteRow([]any{"ghi", "jkl", 789}))
+		assert.NoError(t, w.WriteRow(tc.Clock.Now(), []any{"ghi", "jkl", 789}))
 	}()
 	w.ExpectWritesCount(t, 1)
 
@@ -317,18 +317,18 @@ func TestVolume_Writer_Sync_Enabled_NoWait_ToDisk(t *testing.T) {
 	// Writes are NOT BLOCKING, write doesn't wait for the next sync
 
 	// Write two rows and trigger sync
-	assert.NoError(t, w.WriteRow([]any{"foo", "bar", 123}))
-	assert.NoError(t, w.WriteRow([]any{"foo", "bar", 123}))
+	assert.NoError(t, w.WriteRow(tc.Clock.Now(), []any{"foo", "bar", 123}))
+	assert.NoError(t, w.WriteRow(tc.Clock.Now(), []any{"foo", "bar", 123}))
 	w.ExpectWritesCount(t, 2)
 	w.TriggerSync(t)
 
 	// Write one row and trigger sync
-	assert.NoError(t, w.WriteRow([]any{"abc", "def", 456}))
+	assert.NoError(t, w.WriteRow(tc.Clock.Now(), []any{"abc", "def", 456}))
 	w.ExpectWritesCount(t, 1)
 	w.TriggerSync(t)
 
 	// Last write
-	assert.NoError(t, w.WriteRow([]any{"ghi", "jkl", 789}))
+	assert.NoError(t, w.WriteRow(tc.Clock.Now(), []any{"ghi", "jkl", 789}))
 	w.ExpectWritesCount(t, 1)
 
 	// Close writer and volume - it triggers the last sync
@@ -394,18 +394,18 @@ func TestVolume_Writer_Sync_Enabled_NoWait_ToDiskCache(t *testing.T) {
 	// Writes are NOT BLOCKING, write doesn't wait for the next sync
 
 	// Write two rows and trigger sync
-	assert.NoError(t, w.WriteRow([]any{"foo", "bar", 123}))
-	assert.NoError(t, w.WriteRow([]any{"foo", "bar", 123}))
+	assert.NoError(t, w.WriteRow(tc.Clock.Now(), []any{"foo", "bar", 123}))
+	assert.NoError(t, w.WriteRow(tc.Clock.Now(), []any{"foo", "bar", 123}))
 	w.ExpectWritesCount(t, 2)
 	w.TriggerSync(t)
 
 	// Write one row and trigger sync
-	assert.NoError(t, w.WriteRow([]any{"abc", "def", 456}))
+	assert.NoError(t, w.WriteRow(tc.Clock.Now(), []any{"abc", "def", 456}))
 	w.ExpectWritesCount(t, 1)
 	w.TriggerSync(t)
 
 	// Last write
-	assert.NoError(t, w.WriteRow([]any{"ghi", "jkl", 789}))
+	assert.NoError(t, w.WriteRow(tc.Clock.Now(), []any{"ghi", "jkl", 789}))
 	w.ExpectWritesCount(t, 1)
 
 	// Close writer and volume - it triggers the last sync
@@ -461,16 +461,16 @@ func TestVolume_Writer_Sync_Disabled(t *testing.T) {
 	// Writes are NOT BLOCKING, sync is disabled completely
 
 	// Write two rows and trigger sync
-	assert.NoError(t, w.WriteRow([]any{"foo", "bar", 123}))
-	assert.NoError(t, w.WriteRow([]any{"foo", "bar", 123}))
+	assert.NoError(t, w.WriteRow(tc.Clock.Now(), []any{"foo", "bar", 123}))
+	assert.NoError(t, w.WriteRow(tc.Clock.Now(), []any{"foo", "bar", 123}))
 	w.ExpectWritesCount(t, 2)
 
 	// Write one row and trigger sync
-	assert.NoError(t, w.WriteRow([]any{"abc", "def", 456}))
+	assert.NoError(t, w.WriteRow(tc.Clock.Now(), []any{"abc", "def", 456}))
 	w.ExpectWritesCount(t, 1)
 
 	// Last write
-	assert.NoError(t, w.WriteRow([]any{"ghi", "jkl", 789}))
+	assert.NoError(t, w.WriteRow(tc.Clock.Now(), []any{"ghi", "jkl", 789}))
 	w.ExpectWritesCount(t, 1)
 
 	// Close writer and volume
@@ -601,7 +601,7 @@ func (tc *writerTestCase) OpenVolume(opts ...Option) (*Volume, error) {
 	return vol, err
 }
 
-func (tc *writerTestCase) NewWriter(opts ...Option) (*test.SliceWriter, error) {
+func (tc *writerTestCase) NewWriter(opts ...Option) (*test.Writer, error) {
 	if tc.Volume == nil {
 		// Write file with the VolumeID
 		require.NoError(tc.TB, os.WriteFile(filepath.Join(tc.VolumePath, volume.IDFile), []byte("my-volume"), 0o640))
@@ -620,7 +620,7 @@ func (tc *writerTestCase) NewWriter(opts ...Option) (*test.SliceWriter, error) {
 		return nil, err
 	}
 
-	return w.(*test.SliceWriter), nil
+	return w.(*test.Writer), nil
 }
 
 type testAllocator struct {

--- a/internal/pkg/service/buffer/storage/level/local/writer/writer.go
+++ b/internal/pkg/service/buffer/storage/level/local/writer/writer.go
@@ -5,9 +5,12 @@
 package writer
 
 import (
+	"time"
+
 	"github.com/c2h5oh/datasize"
 
 	"github.com/keboola/keboola-as-code/internal/pkg/service/buffer/storage"
+	"github.com/keboola/keboola-as-code/internal/pkg/service/common/utctime"
 )
 
 type Writer interface {
@@ -15,13 +18,17 @@ type Writer interface {
 
 	// RowsCount returns count of successfully written rows.
 	RowsCount() uint64
+	// FirstRowAt returns timestamp of receiving the first row for processing.
+	FirstRowAt() utctime.UTCTime
+	// LastRowAt returns timestamp of receiving the last row for processing.
+	LastRowAt() utctime.UTCTime
 	// CompressedSize written to the file, measured after compression writer.
 	CompressedSize() datasize.ByteSize
 	// UncompressedSize written to the file, measured before compression writer.
 	UncompressedSize() datasize.ByteSize
 
 	// WriteRow of tabular data.
-	WriteRow(values []any) error
+	WriteRow(timestamp time.Time, values []any) error
 	// Close the writer and sync data to the disk.
 	Close() error
 


### PR DESCRIPTION
Part of: https://keboola.atlassian.net/browse/PSGO-286

Changes:
- `count.Counter` and `counter.CounterWithBackup` have new methods `FirstAt` and `LastAt`.
  - Values from these methods are needed by the statistics package (next PR).

------------------

`100%` coverage

![image](https://github.com/keboola/keboola-as-code/assets/19371734/6355b99e-09a1-494b-9339-e5715322a38d)

![image](https://github.com/keboola/keboola-as-code/assets/19371734/fa789370-a934-4e2f-8bbd-9228634baa18)


------------------

Pre vyssie urovne apky potrebujem vediet timestamp prveho a posledneho row, ... bolo to tam aj predtym, ale v tejto novej verzii mi chybal sposob ako to zistit.