### PR TITLE
Add local/writer.Events

### DIFF
--- a/internal/pkg/service/buffer/storage/level/local/volume/volumes.go
+++ b/internal/pkg/service/buffer/storage/level/local/volume/volumes.go
@@ -114,6 +114,8 @@ func (v *Volumes[V]) Close() error {
 // detect volumes in the volumesPath.
 // Relative path of each Volume has format: {type}/{label}.
 func (v *Volumes[V]) detect() error {
+	v.logger.Infof(`searching for volumes in "%s"`, v.path)
+
 	lock := &sync.Mutex{}
 	errs := errors.NewMultiError()
 	wg := &sync.WaitGroup{}
@@ -197,6 +199,7 @@ func (v *Volumes[V]) detect() error {
 		return errors.New("no volume found")
 	}
 
+	v.logger.Infof(`found "%d" volumes`, len(v.byID))
 	return nil
 }
 

--- a/internal/pkg/service/buffer/storage/level/local/writer/base.go
+++ b/internal/pkg/service/buffer/storage/level/local/writer/base.go
@@ -1,4 +1,4 @@
-package base
+package writer
 
 import (
 	"github.com/benbjohnson/clock"
@@ -15,7 +15,8 @@ type chain = writechain.Chain
 
 type syncer = disksync.Syncer
 
-type Writer struct {
+// BaseWriter implements common logic for all file types.
+type BaseWriter struct {
 	*chain
 	*syncer
 	logger   log.Logger
@@ -24,8 +25,8 @@ type Writer struct {
 	filePath string
 }
 
-func NewWriter(logger log.Logger, clock clock.Clock, slice *storage.Slice, dirPath string, filePath string, chain *writechain.Chain) *Writer {
-	return &Writer{
+func NewBaseWriter(logger log.Logger, clock clock.Clock, slice *storage.Slice, dirPath string, filePath string, chain *writechain.Chain) *BaseWriter {
+	return &BaseWriter{
 		chain:    chain,
 		syncer:   disksync.NewSyncer(logger, clock, slice.LocalStorage.Sync, chain),
 		logger:   logger,
@@ -35,50 +36,50 @@ func NewWriter(logger log.Logger, clock clock.Clock, slice *storage.Slice, dirPa
 	}
 }
 
-func (w *Writer) Logger() log.Logger {
+func (w *BaseWriter) Logger() log.Logger {
 	return w.logger
 }
 
-func (w *Writer) SliceKey() storage.SliceKey {
+func (w *BaseWriter) SliceKey() storage.SliceKey {
 	return w.slice.SliceKey
 }
 
-func (w *Writer) Columns() column.Columns {
+func (w *BaseWriter) Columns() column.Columns {
 	out := make(column.Columns, len(w.slice.Columns))
 	copy(out, w.slice.Columns)
 	return out
 }
 
-func (w *Writer) Type() storage.FileType {
+func (w *BaseWriter) Type() storage.FileType {
 	return w.slice.Type
 }
 
 // Compression config.
-func (w *Writer) Compression() compression.Config {
+func (w *BaseWriter) Compression() compression.Config {
 	return w.slice.LocalStorage.Compression
 }
 
 // DirPath to the directory with slice files.
 // It is an absolute path.
-func (w *Writer) DirPath() string {
+func (w *BaseWriter) DirPath() string {
 	return w.dirPath
 }
 
 // FilePath to the slice data.
 // It is an absolute path.
-func (w *Writer) FilePath() string {
+func (w *BaseWriter) FilePath() string {
 	return w.filePath
 }
 
-func (w *Writer) Write(p []byte) (int, error) {
+func (w *BaseWriter) Write(p []byte) (int, error) {
 	return w.syncer.Write(p)
 }
 
-func (w *Writer) WriteString(s string) (int, error) {
+func (w *BaseWriter) WriteString(s string) (int, error) {
 	return w.syncer.WriteString(s)
 }
 
-func (w *Writer) Close() error {
+func (w *BaseWriter) Close() error {
 	w.logger.Debug("closing file")
 
 	// Stop syncer, it triggers also the last sync

--- a/internal/pkg/service/buffer/storage/level/local/writer/base.go
+++ b/internal/pkg/service/buffer/storage/level/local/writer/base.go
@@ -19,16 +19,18 @@ type syncer = disksync.Syncer
 type BaseWriter struct {
 	*chain
 	*syncer
+	events   *Events
 	logger   log.Logger
 	slice    *storage.Slice
 	dirPath  string
 	filePath string
 }
 
-func NewBaseWriter(logger log.Logger, clock clock.Clock, slice *storage.Slice, dirPath string, filePath string, chain *writechain.Chain) *BaseWriter {
+func NewBaseWriter(logger log.Logger, clock clock.Clock, slice *storage.Slice, dirPath string, filePath string, chain *writechain.Chain, events *Events) *BaseWriter {
 	return &BaseWriter{
 		chain:    chain,
 		syncer:   disksync.NewSyncer(logger, clock, slice.LocalStorage.Sync, chain),
+		events:   events,
 		logger:   logger,
 		slice:    slice,
 		dirPath:  dirPath,
@@ -38,6 +40,10 @@ func NewBaseWriter(logger log.Logger, clock clock.Clock, slice *storage.Slice, d
 
 func (w *BaseWriter) Logger() log.Logger {
 	return w.logger
+}
+
+func (w *BaseWriter) Events() *Events {
+	return w.events
 }
 
 func (w *BaseWriter) SliceKey() storage.SliceKey {

--- a/internal/pkg/service/buffer/storage/level/local/writer/base_test.go
+++ b/internal/pkg/service/buffer/storage/level/local/writer/base_test.go
@@ -1,4 +1,4 @@
-package base_test
+package writer
 
 import (
 	"context"
@@ -15,7 +15,6 @@ import (
 	"github.com/keboola/keboola-as-code/internal/pkg/service/buffer/storage"
 	"github.com/keboola/keboola-as-code/internal/pkg/service/buffer/storage/compression"
 	"github.com/keboola/keboola-as-code/internal/pkg/service/buffer/storage/level/local"
-	"github.com/keboola/keboola-as-code/internal/pkg/service/buffer/storage/level/local/writer/base"
 	"github.com/keboola/keboola-as-code/internal/pkg/service/buffer/storage/level/local/writer/disksync"
 	"github.com/keboola/keboola-as-code/internal/pkg/service/buffer/storage/level/local/writer/writechain"
 	"github.com/keboola/keboola-as-code/internal/pkg/service/buffer/storage/level/staging"
@@ -38,7 +37,7 @@ func TestBaseWriter(t *testing.T) {
 	file, err := os.OpenFile(filePath, os.O_WRONLY|os.O_CREATE|os.O_APPEND, 0o644)
 	assert.NoError(t, err)
 	chain := writechain.New(logger, file)
-	w := base.NewWriter(logger, clk, slice, dirPath, filePath, chain)
+	w := NewBaseWriter(logger, clk, slice, dirPath, filePath, chain)
 
 	// Test getters
 	assert.Equal(t, logger, w.Logger())
@@ -97,7 +96,7 @@ func TestBaseWriter_CloseError(t *testing.T) {
 	file, err := os.OpenFile(filePath, os.O_WRONLY|os.O_CREATE|os.O_APPEND, 0o644)
 	assert.NoError(t, err)
 	chain := writechain.New(logger, file)
-	w := base.NewWriter(logger, clk, slice, dirPath, filePath, chain)
+	w := NewBaseWriter(logger, clk, slice, dirPath, filePath, chain)
 
 	w.AppendCloseFn("my-closer", func() error {
 		return errors.New("some error")

--- a/internal/pkg/service/buffer/storage/level/local/writer/base_test.go
+++ b/internal/pkg/service/buffer/storage/level/local/writer/base_test.go
@@ -36,8 +36,7 @@ func TestBaseWriter(t *testing.T) {
 
 	file, err := os.OpenFile(filePath, os.O_WRONLY|os.O_CREATE|os.O_APPEND, 0o644)
 	assert.NoError(t, err)
-	chain := writechain.New(logger, file)
-	w := NewBaseWriter(logger, clk, slice, dirPath, filePath, chain)
+	w := NewBaseWriter(logger, clk, slice, dirPath, filePath, writechain.New(logger, file), NewEvents())
 
 	// Test getters
 	assert.Equal(t, logger, w.Logger())
@@ -95,8 +94,7 @@ func TestBaseWriter_CloseError(t *testing.T) {
 
 	file, err := os.OpenFile(filePath, os.O_WRONLY|os.O_CREATE|os.O_APPEND, 0o644)
 	assert.NoError(t, err)
-	chain := writechain.New(logger, file)
-	w := NewBaseWriter(logger, clk, slice, dirPath, filePath, chain)
+	w := NewBaseWriter(logger, clk, slice, dirPath, filePath, writechain.New(logger, file), NewEvents())
 
 	w.AppendCloseFn("my-closer", func() error {
 		return errors.New("some error")

--- a/internal/pkg/service/buffer/storage/level/local/writer/csv/csv.go
+++ b/internal/pkg/service/buffer/storage/level/local/writer/csv/csv.go
@@ -15,7 +15,7 @@ import (
 	"github.com/keboola/keboola-as-code/internal/pkg/service/buffer/storage"
 	"github.com/keboola/keboola-as-code/internal/pkg/service/buffer/storage/compression"
 	compressionWriter "github.com/keboola/keboola-as-code/internal/pkg/service/buffer/storage/compression/writer"
-	"github.com/keboola/keboola-as-code/internal/pkg/service/buffer/storage/level/local/writer/base"
+	"github.com/keboola/keboola-as-code/internal/pkg/service/buffer/storage/level/local/writer"
 	"github.com/keboola/keboola-as-code/internal/pkg/service/buffer/storage/level/local/writer/count"
 	"github.com/keboola/keboola-as-code/internal/pkg/service/buffer/storage/level/local/writer/size"
 	"github.com/keboola/keboola-as-code/internal/pkg/service/buffer/storage/level/local/writer/writechain"
@@ -32,7 +32,7 @@ const (
 )
 
 type Writer struct {
-	base    *base.Writer
+	base    *writer.BaseWriter
 	columns column.Columns
 	writeWg *sync.WaitGroup
 
@@ -51,7 +51,7 @@ type Writer struct {
 	uncompressedMeter *size.MeterWithBackup
 }
 
-func NewWriter(b *base.Writer) (w *Writer, err error) {
+func NewWriter(b *writer.BaseWriter) (w *Writer, err error) {
 	w = &Writer{
 		base:          b,
 		columns:       b.Columns(),

--- a/internal/pkg/service/buffer/storage/level/local/writer/csv/csv.go
+++ b/internal/pkg/service/buffer/storage/level/local/writer/csv/csv.go
@@ -213,6 +213,10 @@ func (w *Writer) UncompressedSize() datasize.ByteSize {
 	return w.uncompressedMeter.Size()
 }
 
+func (w *Writer) Events() *writer.Events {
+	return w.base.Events()
+}
+
 func (w *Writer) DirPath() string {
 	return w.base.DirPath()
 }

--- a/internal/pkg/service/buffer/storage/level/local/writer/event.go
+++ b/internal/pkg/service/buffer/storage/level/local/writer/event.go
@@ -1,0 +1,109 @@
+package writer
+
+import (
+	"github.com/keboola/keboola-as-code/internal/pkg/utils/errors"
+)
+
+type writer = Writer
+
+// EventWriter adds dispatching of the Events for the underlying writer.
+type EventWriter struct {
+	writer
+	events *Events
+}
+
+// Events provides listening to the writer lifecycle.
+type Events struct {
+	parent           *Events
+	onWriterCreation []func(w Writer) error
+	onWriterClose    []func(w Writer, closeErr error) error
+}
+
+// NewEventWriter wraps the Writer to the EventWriter and dispatch "open" event.
+func NewEventWriter(w Writer, events *Events) (*EventWriter, error) {
+	// Dispatch "open" event
+	if err := events.dispatchOnWriterOpen(w); err != nil {
+		return nil, err
+	}
+
+	// Wrap the Close method
+	return &EventWriter{writer: w, events: events}, nil
+}
+
+func NewEvents() *Events {
+	return &Events{}
+}
+
+// Close overwrites the original Close method to dispatch "close" event.
+func (w *EventWriter) Close() error {
+	errs := errors.NewMultiError()
+
+	cErr := w.writer.Close()
+	if cErr != nil {
+		errs.Append(cErr)
+	}
+
+	if eErr := w.events.dispatchOnWriterClose(w, cErr); eErr != nil {
+		errs.Append(eErr)
+	}
+
+	return errs.ErrorOrNil()
+}
+
+// Unwrap returns underlying writer, used in tests.
+func (w *EventWriter) Unwrap() Writer {
+	return w.writer
+}
+
+// OnWriterOpen registers a callback that is invoked in the LIFO order when a new writer is created.
+func (e *Events) OnWriterOpen(fn func(Writer) error) {
+	e.onWriterCreation = append(e.onWriterCreation, fn)
+}
+
+// OnWriterClose registers a callback that is invoked in the LIFO order when a writer is closed.
+func (e *Events) OnWriterClose(fn func(Writer, error) error) {
+	e.onWriterClose = append(e.onWriterClose, fn)
+}
+
+// Clone returns a new independent instance of the Events with reference to the parent value.
+func (e *Events) Clone() *Events {
+	return &Events{parent: e}
+}
+
+func (e *Events) dispatchOnWriterOpen(w Writer) error {
+	errs := errors.NewMultiError()
+
+	// Invoke listeners in the LIFO order
+	node := e
+	for node != nil {
+		listeners := node.onWriterCreation
+		for i := len(listeners) - 1; i >= 0; i-- {
+			if err := listeners[i](w); err != nil {
+				errs.Append(err)
+			}
+		}
+
+		node = node.parent
+	}
+
+	return errs.ErrorOrNil()
+}
+
+func (e *Events) dispatchOnWriterClose(w Writer, closeErr error) error {
+	errs := errors.NewMultiError()
+
+	// Invoke listeners in the LIFO order
+	node := e
+	for node != nil {
+		listeners := node.onWriterClose
+		for i := len(listeners) - 1; i >= 0; i-- {
+			if err := listeners[i](w, closeErr); err != nil {
+				errs.Append(err)
+			}
+		}
+
+		node = node.parent
+	}
+
+	return errs.ErrorOrNil()
+}

--- a/internal/pkg/service/buffer/storage/level/local/writer/event_test.go
+++ b/internal/pkg/service/buffer/storage/level/local/writer/event_test.go
@@ -1,0 +1,239 @@
+package writer_test
+
+import (
+	"context"
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+	"time"
+
+	"github.com/benbjohnson/clock"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+
+	"github.com/keboola/keboola-as-code/internal/pkg/log"
+	"github.com/keboola/keboola-as-code/internal/pkg/service/buffer/storage/level/local/volume"
+	"github.com/keboola/keboola-as-code/internal/pkg/service/buffer/storage/level/local/writer"
+	"github.com/keboola/keboola-as-code/internal/pkg/service/buffer/storage/level/local/writer/test"
+	writerVolume "github.com/keboola/keboola-as-code/internal/pkg/service/buffer/storage/level/local/writer/volume"
+	"github.com/keboola/keboola-as-code/internal/pkg/utils/errors"
+	"github.com/keboola/keboola-as-code/internal/pkg/utils/strhelper"
+)
+
+func TestEventWriter(t *testing.T) {
+	t.Parallel()
+
+	ctx, cancel := context.WithTimeout(context.Background(), 10*time.Second)
+	defer cancel()
+
+	logger := log.NewDebugLogger()
+	clk := clock.New()
+
+	// There are 2 volumes
+	volumesPath := t.TempDir()
+	assert.NoError(t, os.MkdirAll(filepath.Join(volumesPath, "hdd", "1"), 0o750))
+	assert.NoError(t, os.MkdirAll(filepath.Join(volumesPath, "hdd", "2"), 0o750))
+	assert.NoError(t, os.WriteFile(filepath.Join(volumesPath, "hdd", "1", volume.IDFile), []byte("HDD_1"), 0o640))
+	assert.NoError(t, os.WriteFile(filepath.Join(volumesPath, "hdd", "2", volume.IDFile), []byte("HDD_2"), 0o640))
+
+	// Detect volumes
+	volumes, err := writerVolume.DetectVolumes(ctx, logger, clk, volumesPath, writerVolume.WithWriterFactory(volumeFactory))
+	assert.NoError(t, err)
+
+	// Register "OnWriterOpen" and "OnWriterClose" events on the "volumes" level
+	volumes.Events().OnWriterOpen(func(w writer.Writer) error {
+		logger.Infof(`EVENT: slice: "%s", event: OPEN (1), level: volumes`, w.SliceKey().OpenedAt())
+		return nil
+	})
+	volumes.Events().OnWriterOpen(func(w writer.Writer) error {
+		logger.Infof(`EVENT: slice: "%s", event: OPEN (2), level: volumes`, w.SliceKey().OpenedAt())
+		return nil
+	})
+	volumes.Events().OnWriterClose(func(w writer.Writer, _ error) error {
+		logger.Infof(`EVENT: slice: "%s", event: CLOSE (1), level: volumes`, w.SliceKey().OpenedAt())
+		return nil
+	})
+	volumes.Events().OnWriterClose(func(w writer.Writer, _ error) error {
+		logger.Infof(`EVENT: slice: "%s", event: CLOSE (2), level: volumes`, w.SliceKey().OpenedAt())
+		return nil
+	})
+
+	// Register "OnWriterOpen" and "OnWriterClose" events on the "volume" level
+	vol1, err := volumes.Volume("HDD_1")
+	assert.NoError(t, err)
+	vol2, err := volumes.Volume("HDD_2")
+	assert.NoError(t, err)
+	vol1.Events().OnWriterOpen(func(w writer.Writer) error {
+		logger.Infof(`EVENT: slice: "%s", event: OPEN (3), level: volume1`, w.SliceKey().OpenedAt())
+		return nil
+	})
+	vol1.Events().OnWriterOpen(func(w writer.Writer) error {
+		logger.Infof(`EVENT: slice: "%s", event: OPEN (4), level: volume1`, w.SliceKey().OpenedAt())
+		return nil
+	})
+	vol1.Events().OnWriterClose(func(w writer.Writer, _ error) error {
+		logger.Infof(`EVENT: slice: "%s", event: CLOSE (3), level: volume1`, w.SliceKey().OpenedAt())
+		return nil
+	})
+	vol1.Events().OnWriterClose(func(w writer.Writer, _ error) error {
+		logger.Infof(`EVENT: slice: "%s", event: CLOSE (4), level: volume1`, w.SliceKey().OpenedAt())
+		return nil
+	})
+	vol2.Events().OnWriterOpen(func(w writer.Writer) error {
+		logger.Infof(`EVENT: slice: "%s", event: OPEN (3), level: volume2`, w.SliceKey().OpenedAt())
+		return nil
+	})
+	vol2.Events().OnWriterOpen(func(w writer.Writer) error {
+		logger.Infof(`EVENT: slice: "%s", event: OPEN (4), level: volume2`, w.SliceKey().OpenedAt())
+		return nil
+	})
+	vol2.Events().OnWriterClose(func(w writer.Writer, _ error) error {
+		logger.Infof(`EVENT: slice: "%s", event: CLOSE (3), level: volume2`, w.SliceKey().OpenedAt())
+		return nil
+	})
+	vol2.Events().OnWriterClose(func(w writer.Writer, _ error) error {
+		logger.Infof(`EVENT: slice: "%s", event: CLOSE (4), level: volume2`, w.SliceKey().OpenedAt())
+		return nil
+	})
+
+	// Register "OnWriterClose" event on the "writer" level
+	slice1 := test.NewSliceOpenedAt("2001-01-01T00:00:00.000Z")
+	slice2 := test.NewSliceOpenedAt("2002-01-01T00:00:00.000Z")
+	writer1, err := vol1.NewWriterFor(slice1)
+	require.NoError(t, err)
+	writer2, err := vol2.NewWriterFor(slice2)
+	require.NoError(t, err)
+	writer1.Events().OnWriterClose(func(w writer.Writer, _ error) error {
+		logger.Infof(`EVENT: slice: "%s", event: CLOSE (5), level: writer1`, w.SliceKey().OpenedAt())
+		return nil
+	})
+	writer1.Events().OnWriterClose(func(w writer.Writer, _ error) error {
+		logger.Infof(`EVENT: slice: "%s", event: CLOSE (6), level: writer1`, w.SliceKey().OpenedAt())
+		return nil
+	})
+	writer2.Events().OnWriterClose(func(w writer.Writer, _ error) error {
+		logger.Infof(`EVENT: slice: "%s", event: CLOSE (5), level: writer2`, w.SliceKey().OpenedAt())
+		return nil
+	})
+	writer2.Events().OnWriterClose(func(w writer.Writer, _ error) error {
+		logger.Infof(`EVENT: slice: "%s", event: CLOSE (6), level: writer2`, w.SliceKey().OpenedAt())
+		return nil
+	})
+
+	// Close all
+	assert.NoError(t, volumes.Close())
+
+	// Check logs, closing is parallel, so writers logs are checked separately
+	assert.Equal(t, strings.TrimSpace(`
+INFO  EVENT: slice: "2001-01-01T00:00:00.000Z", event: OPEN (4), level: volume1
+INFO  EVENT: slice: "2001-01-01T00:00:00.000Z", event: OPEN (3), level: volume1
+INFO  EVENT: slice: "2001-01-01T00:00:00.000Z", event: OPEN (2), level: volumes
+INFO  EVENT: slice: "2001-01-01T00:00:00.000Z", event: OPEN (1), level: volumes
+INFO  EVENT: slice: "2001-01-01T00:00:00.000Z", event: CLOSE (6), level: writer1
+INFO  EVENT: slice: "2001-01-01T00:00:00.000Z", event: CLOSE (5), level: writer1
+INFO  EVENT: slice: "2001-01-01T00:00:00.000Z", event: CLOSE (4), level: volume1
+INFO  EVENT: slice: "2001-01-01T00:00:00.000Z", event: CLOSE (3), level: volume1
+INFO  EVENT: slice: "2001-01-01T00:00:00.000Z", event: CLOSE (2), level: volumes
+INFO  EVENT: slice: "2001-01-01T00:00:00.000Z", event: CLOSE (1), level: volumes
+`), strings.TrimSpace(strhelper.FilterLines(`^INFO  EVENT: slice: "2001`, logger.InfoMessages())))
+	assert.Equal(t, strings.TrimSpace(`
+INFO  EVENT: slice: "2002-01-01T00:00:00.000Z", event: OPEN (4), level: volume2
+INFO  EVENT: slice: "2002-01-01T00:00:00.000Z", event: OPEN (3), level: volume2
+INFO  EVENT: slice: "2002-01-01T00:00:00.000Z", event: OPEN (2), level: volumes
+INFO  EVENT: slice: "2002-01-01T00:00:00.000Z", event: OPEN (1), level: volumes
+INFO  EVENT: slice: "2002-01-01T00:00:00.000Z", event: CLOSE (6), level: writer2
+INFO  EVENT: slice: "2002-01-01T00:00:00.000Z", event: CLOSE (5), level: writer2
+INFO  EVENT: slice: "2002-01-01T00:00:00.000Z", event: CLOSE (4), level: volume2
+INFO  EVENT: slice: "2002-01-01T00:00:00.000Z", event: CLOSE (3), level: volume2
+INFO  EVENT: slice: "2002-01-01T00:00:00.000Z", event: CLOSE (2), level: volumes
+INFO  EVENT: slice: "2002-01-01T00:00:00.000Z", event: CLOSE (1), level: volumes
+`), strings.TrimSpace(strhelper.FilterLines(`^INFO  EVENT: slice: "2002`, logger.InfoMessages())))
+}
+
+func TestEventWriter_OpenError(t *testing.T) {
+	t.Parallel()
+
+	ctx, cancel := context.WithTimeout(context.Background(), 10*time.Second)
+	defer cancel()
+
+	logger := log.NewDebugLogger()
+	clk := clock.New()
+
+	// There are 2 volumes
+	volumesPath := t.TempDir()
+	assert.NoError(t, os.MkdirAll(filepath.Join(volumesPath, "hdd", "1"), 0o750))
+	assert.NoError(t, os.WriteFile(filepath.Join(volumesPath, "hdd", "1", volume.IDFile), []byte("HDD_1"), 0o640))
+
+	// Detect volumes
+	volumes, err := writerVolume.DetectVolumes(ctx, logger, clk, volumesPath, writerVolume.WithWriterFactory(volumeFactory))
+	assert.NoError(t, err)
+
+	// Register "OnWriterOpen" event on the "volumes" level
+	volumes.Events().OnWriterOpen(func(w writer.Writer) error {
+		return errors.New("error (1)")
+	})
+
+	// Register "OnWriterOpen" event on the "volume" level
+	vol, err := volumes.Volume("HDD_1")
+	assert.NoError(t, err)
+	vol.Events().OnWriterOpen(func(w writer.Writer) error {
+		return errors.New("error (2)")
+	})
+
+	// Check error
+	_, err = vol.NewWriterFor(test.NewSlice())
+	if assert.Error(t, err) {
+		assert.Equal(t, "- error (2)\n- error (1)", err.Error())
+	}
+}
+
+func TestEventWriter_CloseError(t *testing.T) {
+	t.Parallel()
+
+	ctx, cancel := context.WithTimeout(context.Background(), 10*time.Second)
+	defer cancel()
+
+	logger := log.NewDebugLogger()
+	clk := clock.New()
+
+	// There are 2 volumes
+	volumesPath := t.TempDir()
+	assert.NoError(t, os.MkdirAll(filepath.Join(volumesPath, "hdd", "1"), 0o750))
+	assert.NoError(t, os.WriteFile(filepath.Join(volumesPath, "hdd", "1", volume.IDFile), []byte("HDD_1"), 0o640))
+
+	// Detect volumes
+	volumes, err := writerVolume.DetectVolumes(ctx, logger, clk, volumesPath, writerVolume.WithWriterFactory(volumeFactory))
+	assert.NoError(t, err)
+
+	// Register "OnWriterClose" event on the "volumes" level
+	volumes.Events().OnWriterClose(func(w writer.Writer, _ error) error {
+		return errors.New("error (1)")
+	})
+
+	// Register "OnWriterClose" event on the "volume" level
+	vol, err := volumes.Volume("HDD_1")
+	assert.NoError(t, err)
+	vol.Events().OnWriterClose(func(w writer.Writer, _ error) error {
+		return errors.New("error (2)")
+	})
+
+	// Create writer
+	w, err := vol.NewWriterFor(test.NewSlice())
+	require.NoError(t, err)
+
+	// Register "OnWriterClose" event on the "writer" level
+	w.Events().OnWriterClose(func(w writer.Writer, _ error) error {
+		return errors.New("error (3)")
+	})
+
+	// Check error
+	err = w.Close()
+	if assert.Error(t, err) {
+		assert.Equal(t, "- error (3)\n- error (2)\n- error (1)", err.Error())
+	}
+}
+
+func volumeFactory(w *writer.BaseWriter) (writer.Writer, error) {
+	return test.NewWriter(test.NewWriterHelper(), w), nil
+}

--- a/internal/pkg/service/buffer/storage/level/local/writer/factory/factory.go
+++ b/internal/pkg/service/buffer/storage/level/local/writer/factory/factory.go
@@ -1,15 +1,16 @@
-package writer
+// Package factory create a slice writer according to the specified file type.
+package factory
 
 import (
 	"github.com/keboola/keboola-as-code/internal/pkg/service/buffer/storage"
-	"github.com/keboola/keboola-as-code/internal/pkg/service/buffer/storage/level/local/writer/base"
+	"github.com/keboola/keboola-as-code/internal/pkg/service/buffer/storage/level/local/writer"
 	"github.com/keboola/keboola-as-code/internal/pkg/service/buffer/storage/level/local/writer/csv"
 	"github.com/keboola/keboola-as-code/internal/pkg/utils/errors"
 )
 
-type Factory func(w *base.Writer) (Writer, error)
+type Factory func(w *writer.BaseWriter) (writer.Writer, error)
 
-func DefaultFactory(w *base.Writer) (Writer, error) {
+func Default(w *writer.BaseWriter) (writer.Writer, error) {
 	// Create writer according to the file type
 	switch w.Type() {
 	case storage.FileTypeCSV:

--- a/internal/pkg/service/buffer/storage/level/local/writer/factory/factory_test.go
+++ b/internal/pkg/service/buffer/storage/level/local/writer/factory/factory_test.go
@@ -9,6 +9,7 @@ import (
 
 	"github.com/keboola/keboola-as-code/internal/pkg/log"
 	"github.com/keboola/keboola-as-code/internal/pkg/service/buffer/storage"
+	"github.com/keboola/keboola-as-code/internal/pkg/service/buffer/storage/level/local/writer"
 	"github.com/keboola/keboola-as-code/internal/pkg/service/buffer/storage/level/local/writer/csv"
 	"github.com/keboola/keboola-as-code/internal/pkg/service/buffer/storage/level/local/writer/factory"
 	"github.com/keboola/keboola-as-code/internal/pkg/service/buffer/storage/level/local/writer/test"
@@ -25,7 +26,7 @@ func TestDefaultFactory_FileTypeCSV(t *testing.T) {
 	clk := clock.New()
 	info := volume.NewInfo(t.TempDir(), "hdd", "1")
 
-	v, err := volume.Open(ctx, logger, clk, info, volume.WithWriterFactory(factory.Default))
+	v, err := volume.Open(ctx, logger, clk, writer.NewEvents(), info, volume.WithWriterFactory(factory.Default))
 	assert.NoError(t, err)
 
 	slice := test.NewSlice()
@@ -35,7 +36,7 @@ func TestDefaultFactory_FileTypeCSV(t *testing.T) {
 	assert.NoError(t, err)
 	assert.NotNil(t, w)
 
-	_, ok := w.(*csv.Writer)
+	_, ok := w.Unwrap().(*csv.Writer)
 	assert.True(t, ok)
 }
 
@@ -48,7 +49,7 @@ func TestDefaultFactory_FileTypeInvalid(t *testing.T) {
 	clk := clock.New()
 	info := volume.NewInfo(t.TempDir(), "hdd", "1")
 
-	v, err := volume.Open(ctx, logger, clk, info, volume.WithWriterFactory(factory.Default))
+	v, err := volume.Open(ctx, logger, clk, writer.NewEvents(), info, volume.WithWriterFactory(factory.Default))
 	assert.NoError(t, err)
 
 	slice := test.NewSlice()

--- a/internal/pkg/service/buffer/storage/level/local/writer/factory/factory_test.go
+++ b/internal/pkg/service/buffer/storage/level/local/writer/factory/factory_test.go
@@ -1,4 +1,4 @@
-package writer_test
+package factory_test
 
 import (
 	"context"
@@ -9,8 +9,8 @@ import (
 
 	"github.com/keboola/keboola-as-code/internal/pkg/log"
 	"github.com/keboola/keboola-as-code/internal/pkg/service/buffer/storage"
-	"github.com/keboola/keboola-as-code/internal/pkg/service/buffer/storage/level/local/writer"
 	"github.com/keboola/keboola-as-code/internal/pkg/service/buffer/storage/level/local/writer/csv"
+	"github.com/keboola/keboola-as-code/internal/pkg/service/buffer/storage/level/local/writer/factory"
 	"github.com/keboola/keboola-as-code/internal/pkg/service/buffer/storage/level/local/writer/test"
 	"github.com/keboola/keboola-as-code/internal/pkg/service/buffer/storage/level/local/writer/volume"
 )
@@ -25,7 +25,7 @@ func TestDefaultFactory_FileTypeCSV(t *testing.T) {
 	clk := clock.New()
 	info := volume.NewInfo(t.TempDir(), "hdd", "1")
 
-	v, err := volume.Open(ctx, logger, clk, info, volume.WithWriterFactory(writer.DefaultFactory))
+	v, err := volume.Open(ctx, logger, clk, info, volume.WithWriterFactory(factory.Default))
 	assert.NoError(t, err)
 
 	slice := test.NewSlice()
@@ -48,7 +48,7 @@ func TestDefaultFactory_FileTypeInvalid(t *testing.T) {
 	clk := clock.New()
 	info := volume.NewInfo(t.TempDir(), "hdd", "1")
 
-	v, err := volume.Open(ctx, logger, clk, info, volume.WithWriterFactory(writer.DefaultFactory))
+	v, err := volume.Open(ctx, logger, clk, info, volume.WithWriterFactory(factory.Default))
 	assert.NoError(t, err)
 
 	slice := test.NewSlice()

--- a/internal/pkg/service/buffer/storage/level/local/writer/test/benchmark/benchmark.go
+++ b/internal/pkg/service/buffer/storage/level/local/writer/test/benchmark/benchmark.go
@@ -17,6 +17,7 @@ import (
 	"github.com/keboola/keboola-as-code/internal/pkg/service/buffer/storage"
 	"github.com/keboola/keboola-as-code/internal/pkg/service/buffer/storage/compression"
 	"github.com/keboola/keboola-as-code/internal/pkg/service/buffer/storage/level/local"
+	"github.com/keboola/keboola-as-code/internal/pkg/service/buffer/storage/level/local/writer"
 	"github.com/keboola/keboola-as-code/internal/pkg/service/buffer/storage/level/local/writer/disksync"
 	"github.com/keboola/keboola-as-code/internal/pkg/service/buffer/storage/level/local/writer/volume"
 	"github.com/keboola/keboola-as-code/internal/pkg/service/buffer/storage/level/staging"
@@ -63,7 +64,7 @@ func (wb *WriterBenchmark) Run(b *testing.B) {
 	// Open volume
 	clk := clock.New()
 	now := clk.Now()
-	vol, err := volume.Open(ctx, logger, clk, volume.NewInfo(b.TempDir(), "hdd", "1"))
+	vol, err := volume.Open(ctx, logger, clk, writer.NewEvents(), volume.NewInfo(b.TempDir(), "hdd", "1"))
 	require.NoError(b, err)
 
 	// Create writer

--- a/internal/pkg/service/buffer/storage/level/local/writer/test/testcase/testcase.go
+++ b/internal/pkg/service/buffer/storage/level/local/writer/test/testcase/testcase.go
@@ -18,6 +18,7 @@ import (
 	"github.com/keboola/keboola-as-code/internal/pkg/service/buffer/storage"
 	"github.com/keboola/keboola-as-code/internal/pkg/service/buffer/storage/compression"
 	"github.com/keboola/keboola-as-code/internal/pkg/service/buffer/storage/level/local"
+	"github.com/keboola/keboola-as-code/internal/pkg/service/buffer/storage/level/local/writer"
 	"github.com/keboola/keboola-as-code/internal/pkg/service/buffer/storage/level/local/writer/disksync"
 	"github.com/keboola/keboola-as-code/internal/pkg/service/buffer/storage/level/local/writer/volume"
 	"github.com/keboola/keboola-as-code/internal/pkg/service/buffer/storage/level/staging"
@@ -61,7 +62,7 @@ func (tc *WriterTestCase) Run(t *testing.T) {
 	opts := []volume.Option{volume.WithWatchDrainFile(false)}
 	clk := clock.New()
 	now := clk.Now()
-	vol, err := volume.Open(ctx, logger, clk, volume.NewInfo(t.TempDir(), "hdd", "1"), opts...)
+	vol, err := volume.Open(ctx, logger, clk, writer.NewEvents(), volume.NewInfo(t.TempDir(), "hdd", "1"), opts...)
 	require.NoError(t, err)
 
 	// Create a test slice

--- a/internal/pkg/service/buffer/storage/level/local/writer/test/writer.go
+++ b/internal/pkg/service/buffer/storage/level/local/writer/test/writer.go
@@ -126,6 +126,10 @@ func (w *Writer) FilePath() string {
 	return w.base.FilePath()
 }
 
+func (w *Writer) Events() *writer.Events {
+	return w.base.Events()
+}
+
 func (w *Writer) Close() error {
 	// Prevent new writes
 	w.cancel()

--- a/internal/pkg/service/buffer/storage/level/local/writer/test/writer.go
+++ b/internal/pkg/service/buffer/storage/level/local/writer/test/writer.go
@@ -12,7 +12,7 @@ import (
 	"github.com/stretchr/testify/assert"
 
 	"github.com/keboola/keboola-as-code/internal/pkg/service/buffer/storage"
-	"github.com/keboola/keboola-as-code/internal/pkg/service/buffer/storage/level/local/writer/base"
+	"github.com/keboola/keboola-as-code/internal/pkg/service/buffer/storage/level/local/writer"
 	"github.com/keboola/keboola-as-code/internal/pkg/service/buffer/storage/level/local/writer/count"
 	"github.com/keboola/keboola-as-code/internal/pkg/service/common/utctime"
 	"github.com/keboola/keboola-as-code/internal/pkg/utils/errors"
@@ -21,7 +21,7 @@ import (
 // Writer implements a simple writer implementing writer.Writer for tests.
 // The writer writes row values to one line as strings, separated by comma.
 type Writer struct {
-	base    *base.Writer
+	base    *writer.BaseWriter
 	writeWg *sync.WaitGroup
 
 	ctx    context.Context
@@ -40,7 +40,7 @@ type Writer struct {
 	WriteDone chan struct{}
 }
 
-func NewSliceWriter(b *base.Writer) *Writer {
+func NewSliceWriter(b *writer.BaseWriter) *Writer {
 	w := &Writer{
 		base:        b,
 		writeWg:     &sync.WaitGroup{},

--- a/internal/pkg/service/buffer/storage/level/local/writer/volume/config.go
+++ b/internal/pkg/service/buffer/storage/level/local/writer/volume/config.go
@@ -1,8 +1,8 @@
 package volume
 
 import (
-	"github.com/keboola/keboola-as-code/internal/pkg/service/buffer/storage/level/local/writer"
 	"github.com/keboola/keboola-as-code/internal/pkg/service/buffer/storage/level/local/writer/allocate"
+	"github.com/keboola/keboola-as-code/internal/pkg/service/buffer/storage/level/local/writer/factory"
 	"github.com/keboola/keboola-as-code/internal/pkg/utils/errors"
 )
 
@@ -10,7 +10,7 @@ type config struct {
 	// allocator allocates a free disk space for a file.
 	allocator allocate.Allocator
 	// writerFactory creates a high-level writer for the storage.FileType, for example storage.FileTypeCSV.
-	writerFactory writer.Factory
+	writerFactory factory.Factory
 	// fileOpener provides file opening, a custom implementation can be useful for tests.
 	fileOpener FileOpener
 	// watchDrainFile activates watching for drainFile changes (creation/deletion),
@@ -25,7 +25,7 @@ type Option func(config *config)
 func newConfig(opts []Option) config {
 	cfg := config{
 		allocator:      allocate.DefaultAllocator{},
-		writerFactory:  writer.DefaultFactory,
+		writerFactory:  factory.Default,
 		fileOpener:     DefaultFileOpener,
 		watchDrainFile: true,
 	}
@@ -46,7 +46,7 @@ func WithAllocator(v allocate.Allocator) Option {
 	}
 }
 
-func WithWriterFactory(v writer.Factory) Option {
+func WithWriterFactory(v factory.Factory) Option {
 	return func(c *config) {
 		if v == nil {
 			panic(errors.New(`value must not be nil`))

--- a/internal/pkg/service/buffer/storage/level/local/writer/volume/volume_test.go
+++ b/internal/pkg/service/buffer/storage/level/local/writer/volume/volume_test.go
@@ -20,7 +20,6 @@ import (
 	"github.com/keboola/keboola-as-code/internal/pkg/service/buffer/storage"
 	"github.com/keboola/keboola-as-code/internal/pkg/service/buffer/storage/level/local/volume"
 	"github.com/keboola/keboola-as-code/internal/pkg/service/buffer/storage/level/local/writer"
-	"github.com/keboola/keboola-as-code/internal/pkg/service/buffer/storage/level/local/writer/base"
 	"github.com/keboola/keboola-as-code/internal/pkg/service/buffer/storage/level/local/writer/test"
 	"github.com/keboola/keboola-as-code/internal/pkg/utils/errors"
 )
@@ -251,7 +250,7 @@ func newVolumeTestCase(tb testing.TB) *volumeTestCase {
 func (tc *volumeTestCase) OpenVolume(opts ...Option) (*Volume, error) {
 	opts = append([]Option{
 		WithAllocator(tc.Allocator),
-		WithWriterFactory(func(w *base.Writer) (writer.Writer, error) {
+		WithWriterFactory(func(w *writer.BaseWriter) (writer.Writer, error) {
 			return test.NewSliceWriter(w), nil
 		}),
 		WithWatchDrainFile(false),

--- a/internal/pkg/service/buffer/storage/level/local/writer/volume/volumes.go
+++ b/internal/pkg/service/buffer/storage/level/local/writer/volume/volumes.go
@@ -10,24 +10,31 @@ import (
 	"github.com/keboola/keboola-as-code/internal/pkg/log"
 	"github.com/keboola/keboola-as-code/internal/pkg/service/buffer/storage"
 	"github.com/keboola/keboola-as-code/internal/pkg/service/buffer/storage/level/local/volume"
+	"github.com/keboola/keboola-as-code/internal/pkg/service/buffer/storage/level/local/writer"
 )
 
 type baseVolumes = volume.Volumes[*Volume]
 
 type Volumes struct {
 	*baseVolumes
+	events *writer.Events
 }
 
 // DetectVolumes function detects and opens all volumes in the path.
-func DetectVolumes(ctx context.Context, logger log.Logger, clock clock.Clock, path string, opts ...Option) (*Volumes, error) {
-	v, err := volume.DetectVolumes(logger, path, func(info volumeInfo) (*Volume, error) {
-		return Open(ctx, logger, clock, info, opts...)
+func DetectVolumes(ctx context.Context, logger log.Logger, clock clock.Clock, path string, opts ...Option) (out *Volumes, err error) {
+	events := writer.NewEvents()
+	out = &Volumes{events: events}
+	out.baseVolumes, err = volume.DetectVolumes(logger, path, func(info volumeInfo) (*Volume, error) {
+		return Open(ctx, logger, clock, events.Clone(), info, opts...)
 	})
 	if err != nil {
 		return nil, err
 	}
+	return out, nil
+}
 
-	return &Volumes{baseVolumes: v}, nil
+func (v *Volumes) Events() *writer.Events {
+	return v.events
 }
 
 // VolumesFor returns volumes list according to the file settings.

--- a/internal/pkg/service/buffer/storage/level/local/writer/volume/writer.go
+++ b/internal/pkg/service/buffer/storage/level/local/writer/volume/writer.go
@@ -7,7 +7,6 @@ import (
 	"github.com/keboola/keboola-as-code/internal/pkg/filesystem"
 	"github.com/keboola/keboola-as-code/internal/pkg/service/buffer/storage"
 	"github.com/keboola/keboola-as-code/internal/pkg/service/buffer/storage/level/local/writer"
-	"github.com/keboola/keboola-as-code/internal/pkg/service/buffer/storage/level/local/writer/base"
 	"github.com/keboola/keboola-as-code/internal/pkg/service/buffer/storage/level/local/writer/writechain"
 	"github.com/keboola/keboola-as-code/internal/pkg/utils/errors"
 )
@@ -102,7 +101,7 @@ func (v *Volume) NewWriterFor(slice *storage.Slice) (w writer.Writer, err error)
 	})
 
 	// Create writer via factory
-	return v.config.writerFactory(base.NewWriter(logger, v.clock, slice, dirPath, filePath, chain))
+	return v.config.writerFactory(writer.NewBaseWriter(logger, v.clock, slice, dirPath, filePath, chain))
 }
 
 func (v *Volume) Writers() (out []writer.Writer) {

--- a/internal/pkg/service/buffer/storage/level/local/writer/volume/writer.go
+++ b/internal/pkg/service/buffer/storage/level/local/writer/volume/writer.go
@@ -19,7 +19,7 @@ type writerRef struct {
 	writer.Writer
 }
 
-func (v *Volume) NewWriterFor(slice *storage.Slice) (w writer.Writer, err error) {
+func (v *Volume) NewWriterFor(slice *storage.Slice) (out *writer.EventWriter, err error) {
 	// Check context
 	if err := v.ctx.Err(); err != nil {
 		return nil, errors.Errorf(`writer for slice "%s cannot be created, volume is closed: %w`, slice.SliceKey.String(), err)
@@ -28,11 +28,20 @@ func (v *Volume) NewWriterFor(slice *storage.Slice) (w writer.Writer, err error)
 	// Setup logger
 	logger := v.logger
 
+	// Setup events
+	events := v.events.Clone()
+
 	// Check if the writer already exists, if not, register an empty reference to unlock immediately
-	ref, exists := v.addWriterFor(slice.SliceKey)
+	ref, exists := v.addWriter(slice.SliceKey)
 	if exists {
 		return nil, errors.Errorf(`writer for slice "%s" already exists`, slice.SliceKey.String())
 	}
+
+	// Register writer close callback
+	events.OnWriterClose(func(_ writer.Writer, _ error) error {
+		v.removeWriter(slice.SliceKey)
+		return nil
+	})
 
 	// Close resources on a creation error
 	var file File
@@ -40,7 +49,7 @@ func (v *Volume) NewWriterFor(slice *storage.Slice) (w writer.Writer, err error)
 	defer func() {
 		if err == nil {
 			// Update reference
-			ref.Writer = w
+			ref.Writer = out
 		} else {
 			// Close resources
 			if chain != nil {
@@ -94,14 +103,14 @@ func (v *Volume) NewWriterFor(slice *storage.Slice) (w writer.Writer, err error)
 	// Init writers chain
 	chain = writechain.New(logger, file)
 
-	// Unregister the writer on close
-	chain.AppendCloseFn("unregister", func() error {
-		v.removeWriter(slice.SliceKey)
-		return nil
-	})
-
 	// Create writer via factory
-	return v.config.writerFactory(writer.NewBaseWriter(logger, v.clock, slice, dirPath, filePath, chain))
+	w, err := v.config.writerFactory(writer.NewBaseWriter(logger, v.clock, slice, dirPath, filePath, chain, events))
+	if err != nil {
+		return nil, err
+	}
+
+	// Wrap the writer to add events dispatching
+	return writer.NewEventWriter(w, events)
 }
 
 func (v *Volume) Writers() (out []writer.Writer) {
@@ -120,7 +129,7 @@ func (v *Volume) Writers() (out []writer.Writer) {
 	return out
 }
 
-func (v *Volume) addWriterFor(k storage.SliceKey) (ref *writerRef, exists bool) {
+func (v *Volume) addWriter(k storage.SliceKey) (ref *writerRef, exists bool) {
 	v.writersLock.Lock()
 	defer v.writersLock.Unlock()
 

--- a/internal/pkg/service/buffer/storage/level/local/writer/volume/writer_test.go
+++ b/internal/pkg/service/buffer/storage/level/local/writer/volume/writer_test.go
@@ -14,6 +14,7 @@ import (
 
 	"github.com/keboola/keboola-as-code/internal/pkg/service/buffer/storage"
 	"github.com/keboola/keboola-as-code/internal/pkg/service/buffer/storage/level/local/volume"
+	"github.com/keboola/keboola-as-code/internal/pkg/service/buffer/storage/level/local/writer"
 	"github.com/keboola/keboola-as-code/internal/pkg/service/buffer/storage/level/local/writer/allocate"
 	"github.com/keboola/keboola-as-code/internal/pkg/service/buffer/storage/level/local/writer/disksync"
 	"github.com/keboola/keboola-as-code/internal/pkg/service/buffer/storage/level/local/writer/test"
@@ -132,8 +133,8 @@ func TestVolume_Writer_Sync_Enabled_Wait_ToDisk(t *testing.T) {
 		assert.NoError(t, w.WriteRow(tc.Clock.Now(), []any{"foo", "bar", 123}))
 		tc.Logger.Infof("TEST: write unblocked")
 	}()
-	w.ExpectWritesCount(t, 2)
-	w.TriggerSync(t)
+	tc.ExpectWritesCount(t, 2)
+	tc.TriggerSync(t)
 	wg.Wait()
 
 	// Write one row and trigger sync
@@ -143,8 +144,8 @@ func TestVolume_Writer_Sync_Enabled_Wait_ToDisk(t *testing.T) {
 		assert.NoError(t, w.WriteRow(tc.Clock.Now(), []any{"abc", "def", 456}))
 		tc.Logger.Infof("TEST: write unblocked")
 	}()
-	w.ExpectWritesCount(t, 1)
-	w.TriggerSync(t)
+	tc.ExpectWritesCount(t, 1)
+	tc.TriggerSync(t)
 	wg.Wait()
 
 	// Last write
@@ -153,7 +154,7 @@ func TestVolume_Writer_Sync_Enabled_Wait_ToDisk(t *testing.T) {
 		defer wg.Done()
 		assert.NoError(t, w.WriteRow(tc.Clock.Now(), []any{"ghi", "jkl", 789}))
 	}()
-	w.ExpectWritesCount(t, 1)
+	tc.ExpectWritesCount(t, 1)
 
 	// Close writer and volume - it triggers the last sync
 	assert.NoError(t, tc.Volume.Close())
@@ -236,8 +237,8 @@ func TestVolume_Writer_Sync_Enabled_Wait_ToDiskCache(t *testing.T) {
 		assert.NoError(t, w.WriteRow(tc.Clock.Now(), []any{"foo", "bar", 123}))
 		tc.Logger.Infof("TEST: write unblocked")
 	}()
-	w.ExpectWritesCount(t, 2)
-	w.TriggerSync(t)
+	tc.ExpectWritesCount(t, 2)
+	tc.TriggerSync(t)
 	wg.Wait()
 
 	// Write one row and trigger sync
@@ -247,8 +248,8 @@ func TestVolume_Writer_Sync_Enabled_Wait_ToDiskCache(t *testing.T) {
 		assert.NoError(t, w.WriteRow(tc.Clock.Now(), []any{"abc", "def", 456}))
 		tc.Logger.Infof("TEST: write unblocked")
 	}()
-	w.ExpectWritesCount(t, 1)
-	w.TriggerSync(t)
+	tc.ExpectWritesCount(t, 1)
+	tc.TriggerSync(t)
 	wg.Wait()
 
 	// Last write
@@ -257,7 +258,7 @@ func TestVolume_Writer_Sync_Enabled_Wait_ToDiskCache(t *testing.T) {
 		defer wg.Done()
 		assert.NoError(t, w.WriteRow(tc.Clock.Now(), []any{"ghi", "jkl", 789}))
 	}()
-	w.ExpectWritesCount(t, 1)
+	tc.ExpectWritesCount(t, 1)
 
 	// Close writer and volume - it triggers the last sync
 	assert.NoError(t, tc.Volume.Close())
@@ -319,17 +320,17 @@ func TestVolume_Writer_Sync_Enabled_NoWait_ToDisk(t *testing.T) {
 	// Write two rows and trigger sync
 	assert.NoError(t, w.WriteRow(tc.Clock.Now(), []any{"foo", "bar", 123}))
 	assert.NoError(t, w.WriteRow(tc.Clock.Now(), []any{"foo", "bar", 123}))
-	w.ExpectWritesCount(t, 2)
-	w.TriggerSync(t)
+	tc.ExpectWritesCount(t, 2)
+	tc.TriggerSync(t)
 
 	// Write one row and trigger sync
 	assert.NoError(t, w.WriteRow(tc.Clock.Now(), []any{"abc", "def", 456}))
-	w.ExpectWritesCount(t, 1)
-	w.TriggerSync(t)
+	tc.ExpectWritesCount(t, 1)
+	tc.TriggerSync(t)
 
 	// Last write
 	assert.NoError(t, w.WriteRow(tc.Clock.Now(), []any{"ghi", "jkl", 789}))
-	w.ExpectWritesCount(t, 1)
+	tc.ExpectWritesCount(t, 1)
 
 	// Close writer and volume - it triggers the last sync
 	assert.NoError(t, tc.Volume.Close())
@@ -396,17 +397,17 @@ func TestVolume_Writer_Sync_Enabled_NoWait_ToDiskCache(t *testing.T) {
 	// Write two rows and trigger sync
 	assert.NoError(t, w.WriteRow(tc.Clock.Now(), []any{"foo", "bar", 123}))
 	assert.NoError(t, w.WriteRow(tc.Clock.Now(), []any{"foo", "bar", 123}))
-	w.ExpectWritesCount(t, 2)
-	w.TriggerSync(t)
+	tc.ExpectWritesCount(t, 2)
+	tc.TriggerSync(t)
 
 	// Write one row and trigger sync
 	assert.NoError(t, w.WriteRow(tc.Clock.Now(), []any{"abc", "def", 456}))
-	w.ExpectWritesCount(t, 1)
-	w.TriggerSync(t)
+	tc.ExpectWritesCount(t, 1)
+	tc.TriggerSync(t)
 
 	// Last write
 	assert.NoError(t, w.WriteRow(tc.Clock.Now(), []any{"ghi", "jkl", 789}))
-	w.ExpectWritesCount(t, 1)
+	tc.ExpectWritesCount(t, 1)
 
 	// Close writer and volume - it triggers the last sync
 	assert.NoError(t, tc.Volume.Close())
@@ -463,15 +464,15 @@ func TestVolume_Writer_Sync_Disabled(t *testing.T) {
 	// Write two rows and trigger sync
 	assert.NoError(t, w.WriteRow(tc.Clock.Now(), []any{"foo", "bar", 123}))
 	assert.NoError(t, w.WriteRow(tc.Clock.Now(), []any{"foo", "bar", 123}))
-	w.ExpectWritesCount(t, 2)
+	tc.ExpectWritesCount(t, 2)
 
 	// Write one row and trigger sync
 	assert.NoError(t, w.WriteRow(tc.Clock.Now(), []any{"abc", "def", 456}))
-	w.ExpectWritesCount(t, 1)
+	tc.ExpectWritesCount(t, 1)
 
 	// Last write
 	assert.NoError(t, w.WriteRow(tc.Clock.Now(), []any{"ghi", "jkl", 789}))
-	w.ExpectWritesCount(t, 1)
+	tc.ExpectWritesCount(t, 1)
 
 	// Close writer and volume
 	assert.NoError(t, tc.Volume.Close())
@@ -601,7 +602,7 @@ func (tc *writerTestCase) OpenVolume(opts ...Option) (*Volume, error) {
 	return vol, err
 }
 
-func (tc *writerTestCase) NewWriter(opts ...Option) (*test.Writer, error) {
+func (tc *writerTestCase) NewWriter(opts ...Option) (writer.Writer, error) {
 	if tc.Volume == nil {
 		// Write file with the VolumeID
 		require.NoError(tc.TB, os.WriteFile(filepath.Join(tc.VolumePath, volume.IDFile), []byte("my-volume"), 0o640))
@@ -620,7 +621,7 @@ func (tc *writerTestCase) NewWriter(opts ...Option) (*test.Writer, error) {
 		return nil, err
 	}
 
-	return w.(*test.Writer), nil
+	return w, nil
 }
 
 type testAllocator struct {

--- a/internal/pkg/service/buffer/storage/level/local/writer/writer.go
+++ b/internal/pkg/service/buffer/storage/level/local/writer/writer.go
@@ -32,6 +32,8 @@ type Writer interface {
 	// Close the writer and sync data to the disk.
 	Close() error
 
+	// Events provides listening to the writer lifecycle.
+	Events() *Events
 	// DirPath is absolute path to the slice directory. It contains slice file and optionally an auxiliary files.
 	DirPath() string
 	// FilePath is absolute path to the slice file.


### PR DESCRIPTION
Jira: https://keboola.atlassian.net/browse/PSGO-286

Changes:
- Added `local/writer.Writer` lifecycle events: `OnWriterOpen`, `OnWriterClose`.
  - It is used by the `statistics.Collector` in the next PR.
  
-----------------------

![image](https://github.com/keboola/keboola-as-code/assets/19371734/15f49e29-fe70-444a-ae3f-9723cef235e9)


---------------------------