### PR TITLE
Update go client to v1.16.6

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -32,7 +32,7 @@ require (
 	github.com/jarcoal/httpmock v1.3.0
 	github.com/joho/godotenv v1.5.1
 	github.com/jpillora/longestcommon v0.0.0-20161227235612-adb9d91ee629
-	github.com/keboola/go-client v1.16.5
+	github.com/keboola/go-client v1.16.6
 	github.com/keboola/go-utils v0.8.1
 	github.com/kylelemons/godebug v1.1.0
 	github.com/lafikl/consistent v0.0.0-20220512074542-bdd3606bfc3e

--- a/go.sum
+++ b/go.sum
@@ -1507,8 +1507,8 @@ github.com/karrick/godirwalk v1.8.0/go.mod h1:H5KPZjojv4lE+QYImBI8xVtrBRgYrIVsaR
 github.com/karrick/godirwalk v1.10.3/go.mod h1:RoGL9dQei4vP9ilrpETWE8CLOZ1kiN0LhBygSwrAsHA=
 github.com/kballard/go-shellquote v0.0.0-20180428030007-95032a82bc51 h1:Z9n2FFNUXsshfwJMBgNA0RU6/i7WVaAegv3PtuIHPMs=
 github.com/kballard/go-shellquote v0.0.0-20180428030007-95032a82bc51/go.mod h1:CzGEWj7cYgsdH8dAjBGEr58BoE7ScuLd+fwFZ44+/x8=
-github.com/keboola/go-client v1.16.5 h1:WVq6ZdE1wCYwE+bsjvpqlJwgMcQdJlC6Pcc2rie+ZJw=
-github.com/keboola/go-client v1.16.5/go.mod h1:quyluvmFybtDdtqHwddcTAWG1SAZXjxgx9tCl6fIKC8=
+github.com/keboola/go-client v1.16.6 h1:uzlIFjpoOMz3D6Qg92dufe3N0L8n3xFrhaQtejKNIvM=
+github.com/keboola/go-client v1.16.6/go.mod h1:IKV+vw8MC/C2EUcMuUD++8tOqjylsvxVdSCsCsn+jdc=
 github.com/keboola/go-jsonnet v0.19.1 h1:vdWv6lKNX2WdZl4R8PCOnOWINIjdcwmLqNssU7OUv+Y=
 github.com/keboola/go-jsonnet v0.19.1/go.mod h1:pSOb2+VoKZjVbIB4z58am8q15yWO/VTEp6n1GxW3x0I=
 github.com/keboola/go-utils v0.8.1 h1:nkTiAX9Me9NHvEkopm762BKV+iMNDqWyXmBsOTVDmyE=


### PR DESCRIPTION
Jira: https://keboola.atlassian.net/browse/PSGO-293
Related to: https://github.com/keboola/go-client/pull/106