### PR TITLE
Improve confimap pkg

### DIFF
--- a/internal/pkg/service/common/configmap/bind.go
+++ b/internal/pkg/service/common/configmap/bind.go
@@ -47,17 +47,21 @@ type BindSpec struct {
 	GenerateDumpConfigFlag bool
 }
 
-// FlagToFieldFn translates flag definition to the field name in the configuration.
-type FlagToFieldFn func(flag *pflag.Flag) (orderedmap.Path, bool)
-
-// ConfigStruct of a service.
-type ConfigStruct interface {
+// ValueWithNormalization is a nested value with the Normalize method that is called on Bind and BindToViper.
+type ValueWithNormalization interface {
 	Normalize()
+}
+
+// ValueWithValidation is a nested value with the Validate method that is called on Bind and BindToViper.
+type ValueWithValidation interface {
 	Validate() error
 }
 
+// FlagToFieldFn translates flag definition to the field name in the configuration.
+type FlagToFieldFn func(flag *pflag.Flag) (orderedmap.Path, bool)
+
 // Bind flags, ENVs and config files to target configuration structures.
-func Bind(cfg BindSpec, targets ...ConfigStruct) error {
+func Bind(cfg BindSpec, targets ...any) error {
 	if len(targets) == 0 {
 		return errors.Errorf(`at least one ConfigStruct must be provided`)
 	}

--- a/internal/pkg/service/common/configmap/configmap.go
+++ b/internal/pkg/service/common/configmap/configmap.go
@@ -122,6 +122,13 @@
 //	    - tag2
 //	interactive: false
 //
+// # Normalization and Validation
+//
+// Configuration structure and each nested value inside it and marked with the "configKey" tag may:
+//  - Implement the Normalize method, see ValueWithNormalization interface.
+//  - Implement the Validate method, see ValueWithValidation interface.
+//  - Has "validate" tag to define validation rules.
+//
 // # SetBy
 //
 // If you need to find out the source of the value, wrap the field type in the generic type Value[T].

--- a/internal/pkg/service/common/configmap/configmap_test.go
+++ b/internal/pkg/service/common/configmap/configmap_test.go
@@ -3,6 +3,7 @@ package configmap
 import (
 	"net/netip"
 	"net/url"
+	"strings"
 	"time"
 )
 
@@ -10,16 +11,36 @@ type CustomStringType string
 
 type CustomIntType int
 
-type TestConfigWithValidationError struct {
-	Foo             string `configKey:"foo"`
+// TestValueNV is a value with Normalize and Validate methods.
+type TestValueNV struct {
 	ValidationError error
+	Foo             string `configKey:"foo"`
 }
 
-func (c TestConfigWithValidationError) Normalize() {
-	// nop
+func (c *TestValueNV) Normalize() {
+	c.Foo = strings.TrimSpace(c.Foo)
 }
 
-func (c TestConfigWithValidationError) Validate() error {
+func (c *TestValueNV) Validate() error {
+	return c.ValidationError
+}
+
+// TestConfigNV is a configuration structure with Normalize and Validate methods.
+type TestConfigNV struct {
+	ValidationError error
+	Key1            TestValueNV `configKey:"key1"`
+	Key2            struct {
+		KeyA TestValueNV `configKey:"keyA" validate:"required"`
+		KeyB TestValueNV `configKey:"keyB" validate:"required"`
+	} `configKey:"key2"`
+	Normalized string
+}
+
+func (c *TestConfigNV) Normalize() {
+	c.Normalized = "normalized"
+}
+
+func (c *TestConfigNV) Validate() error {
 	return c.ValidationError
 }
 

--- a/internal/pkg/service/common/configmap/dump.go
+++ b/internal/pkg/service/common/configmap/dump.go
@@ -43,10 +43,13 @@ func (v dumpedValue) MarshalJSON() ([]byte, error) {
 }
 
 // Dump the configuration structure to an internal buffer.
-func (d *Dumper) Dump(v ConfigStruct) *Dumper {
+func (d *Dumper) Dump(v any) *Dumper {
 	err := Visit(reflect.ValueOf(v), VisitConfig{
 		OnField: mapAndFilterField(),
 		OnValue: func(vc *VisitContext) error {
+			if !vc.Leaf {
+				return nil
+			}
 			return d.values.SetNestedPath(vc.MappedPath, dumpValue(vc))
 		},
 	})

--- a/internal/pkg/service/common/configmap/flags.go
+++ b/internal/pkg/service/common/configmap/flags.go
@@ -74,7 +74,7 @@ func StructToFlags(fs *pflag.FlagSet, v any, outFlagToField map[string]orderedma
 			case bool:
 				fs.Bool(flagName, v, usage)
 			case string:
-				if value.IsZero() {
+				if vc.Value.IsZero() {
 					// Don't set the default Value, if the original Value is empty.
 					// For example empty time.Duration(0) is represented as not empty string "0s",
 					// but we don't want to show the empty string, as we do not do in other empty cases either.

--- a/internal/pkg/service/common/configmap/flags.go
+++ b/internal/pkg/service/common/configmap/flags.go
@@ -14,7 +14,7 @@ import (
 // Each field tagged by "configKey" tag is mapped to a flag.
 // Field can optionally have the "configUsage" tag.
 // Inspired by: https://stackoverflow.com/a/72893101
-func StructToFlags(fs *pflag.FlagSet, v ConfigStruct, outFlagToField map[string]orderedmap.Path) error {
+func StructToFlags(fs *pflag.FlagSet, v any, outFlagToField map[string]orderedmap.Path) error {
 	// Dereference pointer, if any
 	value := reflect.ValueOf(v)
 	if value.Kind() == reflect.Pointer {
@@ -30,6 +30,10 @@ func StructToFlags(fs *pflag.FlagSet, v ConfigStruct, outFlagToField map[string]
 	return Visit(value, VisitConfig{
 		OnField: mapAndFilterField(),
 		OnValue: func(vc *VisitContext) error {
+			if !vc.Leaf {
+				return nil
+			}
+
 			fieldName := vc.MappedPath.String()
 			flagName := fieldToFlagName(fieldName)
 			if flagName == "" {

--- a/internal/pkg/service/common/configmap/flags_test.go
+++ b/internal/pkg/service/common/configmap/flags_test.go
@@ -12,10 +12,10 @@ import (
 	"github.com/stretchr/testify/assert"
 )
 
-func TestStructToFlags_Empty(t *testing.T) {
+func TestStructToFlags_AlmostEmpty(t *testing.T) {
 	t.Parallel()
 
-	in := TestConfig{}
+	in := TestConfig{Float: 123.45}
 
 	expected := `
       --address string             
@@ -25,7 +25,7 @@ func TestStructToFlags_Empty(t *testing.T) {
       --duration string            
       --duration-nullable string   
       --embedded string            
-      --float float                
+      --float float                 (default 123.45)
       --int int                    
       --int-slice ints             
       --nested-bar int             

--- a/internal/pkg/validator/validator.go
+++ b/internal/pkg/validator/validator.go
@@ -76,8 +76,13 @@ func New(rules ...Rule) Validator {
 			return anonymousField
 		}
 
-		// Prefer JSON field name in error messages
-		name := strings.SplitN(fld.Tag.Get("json"), ",", 2)[0]
+		// Prefer name defined by the configKey tag
+		name := strings.SplitN(fld.Tag.Get("configKey"), ",", 2)[0]
+
+		// Alternatively use JSON field name in error messages
+		if name == "" {
+			name = strings.SplitN(fld.Tag.Get("json"), ",", 2)[0]
+		}
 
 		// Alternatively use YAML field name
 		if name == "" {


### PR DESCRIPTION
Part of: https://keboola.atlassian.net/browse/PSGO-286

Changes:
- Improved/simplified validation of a configuration stucruer.
- Not only the configuration structure, but also all the values inside it MAY implement the `Normalize` and `Validate` methods.
- Configuration structure is validated by the `validator` pkg on `Bind` and `BindToViper`.
- See updated docs.

----

Tests:

![image](https://github.com/keboola/keboola-as-code/assets/19371734/823e8c7c-2933-41d6-905f-b8bcd219c27c)

