### PR TITLE
Improve file download: fix closing, render single progress bar for all slices

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -34,6 +34,7 @@ require (
 	github.com/jpillora/longestcommon v0.0.0-20161227235612-adb9d91ee629
 	github.com/keboola/go-client v1.16.6
 	github.com/keboola/go-utils v0.8.1
+	github.com/klauspost/pgzip v1.2.6
 	github.com/kylelemons/godebug v1.1.0
 	github.com/lafikl/consistent v0.0.0-20220512074542-bdd3606bfc3e
 	github.com/lestrrat-go/strftime v1.0.6
@@ -204,6 +205,7 @@ require (
 	github.com/jmespath/go-jmespath v0.4.0 // indirect
 	github.com/jonboulle/clockwork v0.2.2 // indirect
 	github.com/json-iterator/go v1.1.12 // indirect
+	github.com/klauspost/compress v1.16.3 // indirect
 	github.com/kyokomi/emoji/v2 v2.2.10 // indirect
 	github.com/lucasb-eyer/go-colorful v1.2.0 // indirect
 	github.com/mattn/go-runewidth v0.0.14 // indirect

--- a/go.sum
+++ b/go.sum
@@ -1523,6 +1523,10 @@ github.com/klauspost/compress v1.11.13/go.mod h1:aoV0uJVorq1K+umq18yTdKaF57EivdY
 github.com/klauspost/compress v1.13.4/go.mod h1:8dP1Hq4DHOhN9w426knH3Rhby4rFm6D8eO+e+Dq5Gzg=
 github.com/klauspost/compress v1.13.6/go.mod h1:/3/Vjq9QcHkK5uEr5lBEmyoZ1iFhe47etQ6QUkpK6sk=
 github.com/klauspost/compress v1.15.1/go.mod h1:/3/Vjq9QcHkK5uEr5lBEmyoZ1iFhe47etQ6QUkpK6sk=
+github.com/klauspost/compress v1.16.3 h1:XuJt9zzcnaz6a16/OU53ZjWp/v7/42WcR5t2a0PcNQY=
+github.com/klauspost/compress v1.16.3/go.mod h1:ntbaceVETuRiXiv4DpjP66DpAtAGkEQskQzEyD//IeE=
+github.com/klauspost/pgzip v1.2.6 h1:8RXeL5crjEUFnR2/Sn6GJNWtSQ3Dk8pq4CL3jvdDyjU=
+github.com/klauspost/pgzip v1.2.6/go.mod h1:Ch1tH69qFZu15pkjo5kYi6mth2Zzwzt50oCQKQE9RUs=
 github.com/kolo/xmlrpc v0.0.0-20201022064351-38db28db192b/go.mod h1:pcaDhQK0/NJZEvtCO0qQPPropqV0sJOJ6YW7X+9kRwM=
 github.com/kolo/xmlrpc v0.0.0-20220921171641-a4b6fa1dd06b/go.mod h1:pcaDhQK0/NJZEvtCO0qQPPropqV0sJOJ6YW7X+9kRwM=
 github.com/konsorten/go-windows-terminal-sequences v1.0.1/go.mod h1:T0+1ngSBFLxvqU3pZ+m/2kptfBszLMUkC4ZK/EgS/cQ=

--- a/pkg/lib/operation/project/remote/file/download/options.go
+++ b/pkg/lib/operation/project/remote/file/download/options.go
@@ -1,0 +1,29 @@
+package download
+
+import (
+	"path/filepath"
+
+	"github.com/keboola/go-client/pkg/keboola"
+)
+
+type Options struct {
+	File        *keboola.FileDownloadCredentials
+	Output      string
+	AllowSliced bool
+}
+
+func (o *Options) ToStdout() bool {
+	return o.Output == StdoutOutput
+}
+
+// FormattedOutput returns formatted file output for logging purposes.
+func (o *Options) FormattedOutput() string {
+	switch {
+	case o.ToStdout():
+		return "stdout"
+	case o.AllowSliced && o.File.IsSliced:
+		return filepath.Join(o.Output, "<slice>") // nolint:forbidigo
+	default:
+		return o.Output
+	}
+}

--- a/test/cli/remote-file/download-file-disk/expected-stderr
+++ b/test/cli/remote-file/download-file-disk/expected-stderr
@@ -1,1 +1,1 @@
-%A downloading 100% %A
+%ADownloading%A

--- a/test/cli/remote-file/download-file-stdout/expected-stderr
+++ b/test/cli/remote-file/download-file-stdout/expected-stderr
@@ -1,1 +1,1 @@
-%A downloading 100% %A
+%ADownloading%A

--- a/test/cli/remote-file/download-slices-disk/expected-stderr
+++ b/test/cli/remote-file/download-slices-disk/expected-stderr
@@ -1,1 +1,1 @@
-%A downloading slice "slice1" 1/2 100% %A downloading slice "slice2" 2/2 100% %A
+%ADownloading%A

--- a/test/cli/remote-file/download-slices-disk/expected-stdout
+++ b/test/cli/remote-file/download-slices-disk/expected-stdout
@@ -1,1 +1,1 @@
-File "%%TEST_FILE_TEST1_ID%%" downloaded to "file.csv".
+File "%%TEST_FILE_TEST1_ID%%" downloaded to "file.csv%e<slice>".

--- a/test/cli/remote-file/download-slices-stdout/expected-stderr
+++ b/test/cli/remote-file/download-slices-stdout/expected-stderr
@@ -1,1 +1,1 @@
-%A downloading slice "slice1" 1/2 100% %A downloading slice "slice2" 2/2 100% %A
+%ADownloading%A

--- a/test/cli/remote-table-download/run-ok/expected-stderr
+++ b/test/cli/remote-table-download/run-ok/expected-stderr
@@ -1,1 +1,1 @@
-%A downloading slice "_0_0_0.csv" 1/1 100% %A
+%ADownloading%A

--- a/test/cli/remote-table-download/run-ok/expected-stdout
+++ b/test/cli/remote-table-download/run-ok/expected-stdout
@@ -1,5 +1,3 @@
 Unloading table, please wait.
 Table "in.c-test.accounts" unloaded to file "%d".
-Creating file "data.csv"
-Downloading slices
-File "%d" downloaded to "data.csv".
+File "%s" downloaded to "data.csv".


### PR DESCRIPTION
Jira: https://keboola.atlassian.net/jira/servicedesk/projects/SUPPORT/queues/custom/149/SUPPORT-3260

Changes:
- Added missing call of the `Close` method on slice reader.
- Added missing call of the `Close` method on progress bar.
- One progress bar is used for all slices.

![image](https://github.com/keboola/keboola-as-code/assets/19371734/c066c3bd-2ceb-4dcc-89ce-1cfdc0789209)
