### PR TITLE
Use jsonEncoder for log file

### DIFF
--- a/internal/pkg/log/cli_test.go
+++ b/internal/pkg/log/cli_test.go
@@ -6,6 +6,7 @@ import (
 	"path/filepath"
 	"testing"
 
+	"github.com/keboola/go-utils/pkg/wildcards"
 	"github.com/stretchr/testify/assert"
 
 	"github.com/keboola/keboola-as-code/internal/pkg/utils/ioutil"
@@ -37,10 +38,16 @@ func TestCliLogger_File(t *testing.T) {
 	assert.NoError(t, file.File().Close())
 
 	// Assert, all levels logged with the level prefix
-	expected := "DEBUG\tDebug msg\nINFO\tInfo msg\nWARN\tWarn msg\nERROR\tError msg\n"
+	expected := `
+{"level":"debug","time":"%s","message":"Debug msg"}
+{"level":"info","time":"%s","message":"Info msg"}
+{"level":"warn","time":"%s","message":"Warn msg"}
+{"level":"error","time":"%s","message":"Error msg"}
+`
+
 	content, err := os.ReadFile(filePath)
 	assert.NoError(t, err)
-	assert.Equal(t, expected, string(content))
+	wildcards.Assert(t, expected, string(content))
 }
 
 func TestCliLogger_VerboseFalse(t *testing.T) {

--- a/internal/pkg/log/tofile.go
+++ b/internal/pkg/log/tofile.go
@@ -2,22 +2,22 @@
 package log
 
 import (
-	"go.uber.org/zap"
 	"go.uber.org/zap/zapcore"
 )
 
 // fileCore writes to a logFile.
 func fileCore(logFile *File) zapcore.Core {
 	// Log all
-	fileLevels := zap.LevelEnablerFunc(func(l zapcore.Level) bool { return true })
+	fileLevels := zapcore.DebugLevel
 
 	// Log time, level, msg
-	encoder := zapcore.NewConsoleEncoder(zapcore.EncoderConfig{
-		TimeKey:          "ts",
-		LevelKey:         "level",
-		MessageKey:       "msg",
-		EncodeLevel:      zapcore.CapitalLevelEncoder,
-		ConsoleSeparator: "\t",
+	encoder := zapcore.NewJSONEncoder(zapcore.EncoderConfig{
+		TimeKey:     "time",
+		LevelKey:    "level",
+		MessageKey:  "message",
+		EncodeLevel: zapcore.LowercaseLevelEncoder,
+		EncodeTime:  zapcore.ISO8601TimeEncoder,
 	})
+
 	return zapcore.NewCore(encoder, logFile.File(), fileLevels)
 }

--- a/test/cli/environment/env-file/out/myLog.txt
+++ b/test/cli/environment/env-file/out/myLog.txt
@@ -1,1 +1,2 @@
-DEBUG	Version:    %A
+{"level":"debug","time":"%s","message":"Version:    %s"}
+%A

--- a/test/cli/environment/log-file/out/log-file.txt
+++ b/test/cli/environment/log-file/out/log-file.txt
@@ -1,24 +1,22 @@
-DEBUG	Version:    %s
-DEBUG	Git commit: %s
-DEBUG	Build date: %s
-DEBUG	Go version: %s
-DEBUG	Os/Arch:    %s
-DEBUG	Running command [%s --log-file ./log-file.txt]
-DEBUG	Parsed options:
-DEBUG	  log-file = "./log-file.txt"
-DEBUG	  version-check = "false"
-DEBUG	Default options:
-DEBUG	  help = false
-DEBUG	  non-interactive = false
-DEBUG	  storage-api-token = ""
-DEBUG	  verbose = false
-DEBUG	  verbose-api = false
-DEBUG	  version = false
-DEBUG	  working-dir = ""
-DEBUG	Log file: %s
-DEBUG	Working dir: %s
-DEBUG	Version check: %s
-INFO%w
-INFO	Keboola CLI is %A
-INFO	%A
-INFO	Use "%s [command] --help" for more information about a command.
+{"level":"debug","time":"%s","message":"Version:    %s"}
+{"level":"debug","time":"%s","message":"Git commit: %s"}
+{"level":"debug","time":"%s","message":"Build date: %s"}
+{"level":"debug","time":"%s","message":"Go version: %s"}
+{"level":"debug","time":"%s","message":"Os/Arch:    %s"}
+{"level":"debug","time":"%s","message":"Running command [%s --log-file ./log-file.txt]"}
+{"level":"debug","time":"%s","message":"Parsed options:"}
+{"level":"debug","time":"%s","message":"  log-file = \"./log-file.txt\""}
+{"level":"debug","time":"%s","message":"  version-check = \"false\""}
+{"level":"debug","time":"%s","message":"Default options:"}
+{"level":"debug","time":"%s","message":"  help = false"}
+{"level":"debug","time":"%s","message":"  non-interactive = false"}
+{"level":"debug","time":"%s","message":"  storage-api-token = \"\""}
+{"level":"debug","time":"%s","message":"  verbose = false"}
+{"level":"debug","time":"%s","message":"  verbose-api = false"}
+{"level":"debug","time":"%s","message":"  version = false"}
+{"level":"debug","time":"%s","message":"  working-dir = \"\""}
+{"level":"debug","time":"%s","message":"Log file: %s"}
+{"level":"debug","time":"%s","message":"Working dir: %s"}
+{"level":"debug","time":"%s","message":"Version check: %s"}
+%A
+{"level":"info","time":"%s","message":"Use \"%s [command] --help\" for more information about a command."}


### PR DESCRIPTION
https://keboola.atlassian.net/browse/PSGO-298

Solution is slightly different than the original task but I do think it serves the intended purpose.

I decided to only change the format of the logfile for now. If someone wants to work with the logs, I think they should use this file and don't see a flag to modify stdout format as necessary. The logfile also has all logs in one place rather than having some in stdout and some in stderr which is more convenient for machine processing.
