### PR TITLE
Simplify servicectx package

### DIFF
--- a/cmd/buffer-api/main.go
+++ b/cmd/buffer-api/main.go
@@ -75,7 +75,7 @@ func run() error {
 	}
 
 	// Create process abstraction.
-	proc, err := servicectx.New(ctx, cancel, servicectx.WithLogger(logger), servicectx.WithUniqueID(cfg.UniqueID))
+	proc, err := servicectx.New(servicectx.WithLogger(logger), servicectx.WithUniqueID(cfg.UniqueID))
 	if err != nil {
 		return err
 	}

--- a/cmd/buffer-worker/main.go
+++ b/cmd/buffer-worker/main.go
@@ -64,7 +64,7 @@ func run() error {
 	}
 
 	// Create process abstraction.
-	proc, err := servicectx.New(ctx, cancel, servicectx.WithLogger(logger), servicectx.WithUniqueID(cfg.UniqueID))
+	proc, err := servicectx.New(servicectx.WithLogger(logger), servicectx.WithUniqueID(cfg.UniqueID))
 	if err != nil {
 		return err
 	}

--- a/cmd/templates-api/main.go
+++ b/cmd/templates-api/main.go
@@ -75,7 +75,7 @@ func run() error {
 	}
 
 	// Create process abstraction.
-	proc, err := servicectx.New(ctx, cancel, servicectx.WithLogger(logger), servicectx.WithUniqueID(cfg.UniqueID))
+	proc, err := servicectx.New(servicectx.WithLogger(logger), servicectx.WithUniqueID(cfg.UniqueID))
 	if err != nil {
 		return err
 	}

--- a/internal/pkg/service/cli/cmd/cmd.go
+++ b/internal/pkg/service/cli/cmd/cmd.go
@@ -1,7 +1,6 @@
 package cmd
 
 import (
-	"context"
 	"fmt"
 	"io"
 	"os"
@@ -158,17 +157,16 @@ func NewRootCommand(stdin io.Reader, stdout io.Writer, stderr io.Writer, envs *e
 		prompt := cli.NewPrompt(os.Stdin, os.Stdout, os.Stderr, root.options.GetBool(options.NonInteractiveOpt))
 
 		// Create process abstraction
-		ctx, cancel := context.WithCancel(cmd.Context())
-		proc, err := servicectx.New(ctx, cancel)
+		proc, err := servicectx.New()
 		if err != nil {
 			return err
 		}
 
 		// Create dependencies provider
-		p.Set(dependencies.NewProvider(ctx, root.logger, proc, root.fs, dialog.New(prompt, root.options), root.options))
+		p.Set(dependencies.NewProvider(cmd.Context(), root.logger, proc, root.fs, dialog.New(prompt, root.options), root.options))
 
 		// Check version
-		if err := versionCheck.Run(ctx, root.options.GetBool("version-check"), p.BaseScope()); err != nil {
+		if err := versionCheck.Run(cmd.Context(), root.options.GetBool("version-check"), p.BaseScope()); err != nil {
 			// Ignore error, send to logs
 			root.logger.DebugfCtx(cmd.Context(), `Version check: %s.`, err.Error())
 		} else {

--- a/internal/pkg/service/cli/dependencies/dependencies_test.go
+++ b/internal/pkg/service/cli/dependencies/dependencies_test.go
@@ -69,9 +69,8 @@ func TestDifferentProjectIdInManifestAndToken(t *testing.T) {
 	)
 
 	// Assert
-	ctx := context.Background()
-	proc := servicectx.NewForTest(t, ctx)
-	baseScp := newBaseScope(ctx, logger, proc, httpClient, fs, dialog.New(nopPrompt.New(), opts), opts)
+	proc := servicectx.NewForTest(t)
+	baseScp := newBaseScope(context.Background(), logger, proc, httpClient, fs, dialog.New(nopPrompt.New(), opts), opts)
 	localScp, err := newLocalCommandScope(baseScp)
 	assert.NoError(t, err)
 	_, err = newRemoteCommandScope(context.Background(), localScp)

--- a/internal/pkg/service/common/dependencies/mocked.go
+++ b/internal/pkg/service/common/dependencies/mocked.go
@@ -274,7 +274,7 @@ func NewMocked(t *testing.T, opts ...MockedOption) Mocked {
 
 	// Create service process
 	cfg.procOpts = append([]servicectx.Option{servicectx.WithLogger(logger)}, cfg.procOpts...)
-	proc := servicectx.NewForTest(t, cfg.ctx, cfg.procOpts...)
+	proc := servicectx.NewForTest(t, cfg.procOpts...)
 
 	// Create dependencies container
 	var err error

--- a/internal/pkg/service/common/dependencies/public_test.go
+++ b/internal/pkg/service/common/dependencies/public_test.go
@@ -17,7 +17,7 @@ func TestNewPublicDeps_LazyLoadComponents(t *testing.T) {
 	t.Parallel()
 	ctx := context.Background()
 	httpClient := httpclient.New()
-	baseDeps := newBaseScope(ctx, log.NewNopLogger(), telemetry.NewNop(), clock.New(), servicectx.NewForTest(t, ctx), httpClient)
+	baseDeps := newBaseScope(ctx, log.NewNopLogger(), telemetry.NewNop(), clock.New(), servicectx.NewForTest(t), httpClient)
 
 	// Create public deps without loading components.
 	deps, err := newPublicScope(context.Background(), baseDeps, "https://connection.keboola.com")

--- a/internal/pkg/service/common/servicectx/servicectx.go
+++ b/internal/pkg/service/common/servicectx/servicectx.go
@@ -41,6 +41,7 @@ type Process struct {
 	shutdown chan context.Context
 	done     chan struct{}
 
+	// lock synchronizes Add, OnShutdown and Shutdown methods, so these methods are atomic.
 	lock        *sync.Mutex
 	terminating chan struct{}
 	onShutdown  []OnShutdownFn
@@ -134,7 +135,7 @@ func New(opts ...Option) (*Process, error) {
 			// Trigger shutdown on signal
 			v.Shutdown(context.Background(), errors.Errorf("%s", sig))
 		case <-v.terminating:
-			// The process was shut down by another trigger, stop goroutine
+			// The Process was shut down by another trigger, stop goroutine
 			return
 		}
 	}()

--- a/internal/pkg/service/common/servicectx/servicectx.go
+++ b/internal/pkg/service/common/servicectx/servicectx.go
@@ -14,24 +14,45 @@ import (
 	"github.com/keboola/keboola-as-code/internal/pkg/utils/errors"
 )
 
+const (
+	// ctxShutdownReasonKey stores the error that triggered shutdown.
+	ctxShutdownReasonKey = ctxKey("shutdownReason")
+)
+
+// Process is a stack of shutdown callbacks.
+// Callbacks are invoked sequentially, in LIFO order.
+// This makes it possible to register resource graceful shutdown callback when creating the resource.
+// It is simple approach for complex applications.
+//
+// Callbacks are registered via the OnShutdown method.
+//
+// Root goroutines are registered via the Add method.
+// Graceful shutdown waits for all root goroutines and shutdown callbacks.
+//
+// Graceful shutdown can be triggered by:
+//   - Signals SIGINT, SIGTERM
+//   - Call of the Shutdown method.
+//   - Call of the ShutdownFn function provided by the Add method.
 type Process struct {
 	uniqueID string
 
 	logger   log.Logger
 	wg       *sync.WaitGroup
-	errCh    chan error
+	shutdown chan context.Context
+	done     chan struct{}
 
-	lock          *sync.Mutex
-	terminating   bool
-	onShutdown    []OnShutdownFn
-	shutdownCtxCh chan context.Context
+	lock        *sync.Mutex
+	terminating chan struct{}
+	onShutdown  []OnShutdownFn
 }
 
-type Option func(c *config)
+type ctxKey string
 
-type OnShutdownFn func(context.Context)
+type OnShutdownFn func(ctx context.Context)
 
 type ShutdownFn func(context.Context, error)
+
+type Option func(c *config)
 
 type config struct {
 	uniqueID string
@@ -79,50 +100,59 @@ func New(opts ...Option) (*Process, error) {
 		c.uniqueID = fmt.Sprintf(`%s-%05d`, hostname, pid)
 	}
 
-	// Create channel used by both the signal handler and service goroutines
-	// to notify the main goroutine when to stop the server.
-	errCh := make(chan error, 1)
-
-	// Create channel used to pass the shutdown context to OnShutdownFn callbacks.
-	shutdownCtxCh := make(chan context.Context, 1)
-
-	proc := &Process{
-		logger:        c.logger,
-		wg:            &sync.WaitGroup{},
-		errCh:         errCh,
-		uniqueID:      c.uniqueID,
-		lock:          &sync.Mutex{},
-		shutdownCtxCh: shutdownCtxCh,
+	v := &Process{
+		uniqueID:    c.uniqueID,
+		logger:      c.logger,
+		wg:          &sync.WaitGroup{},
+		done:        make(chan struct{}),
+		lock:        &sync.Mutex{},
+		terminating: make(chan struct{}),
+		shutdown:    make(chan context.Context, 1),
 	}
 
-	// Register onShutdown operation
-	proc.Add(func(ctx context.Context, _ ShutdownFn) {
-		<-ctx.Done()
-		shutdownCtx := <-proc.shutdownCtxCh
+	// Execute OnShutdown callbacks and wait for them
+	v.wg.Add(1)
+	go func() {
+		defer v.wg.Done()
+
+		// Wait for shutdown, see Shutdown function
+		shutdownCtx := <-v.shutdown
 
 		// Iterate callbacks in reverse order, LIFO, see the OnShutdown method
-		for i := len(proc.onShutdown) - 1; i >= 0; i-- {
-			proc.onShutdown[i](shutdownCtx)
+		for i := len(v.onShutdown) - 1; i >= 0; i-- {
+			v.onShutdown[i](shutdownCtx)
 		}
-	})
+	}()
 
-	// Setup interrupt handler,
-	// so SIGINT and SIGTERM signals cause the services to stop gracefully.
+	// Setup interrupt handler, so SIGINT and SIGTERM signals trigger shutdown.
 	go func() {
 		sigCh := make(chan os.Signal, 1)
 		signal.Notify(sigCh, syscall.SIGINT, syscall.SIGTERM)
 
 		select {
-		case <-ctx.Done():
-			// Shutdown was triggered by another way
 		case sig := <-sigCh:
-			// Shutdown signal
-			proc.Shutdown(ctx, errors.Errorf("%s", sig))
+			// Trigger shutdown on signal
+			v.Shutdown(context.Background(), errors.Errorf("%s", sig))
+		case <-v.terminating:
+			// The process was shut down by another trigger, stop goroutine
+			return
 		}
 	}()
 
-	proc.logger.Infof(`process unique id "%s"`, proc.UniqueID())
-	return proc, nil
+	// Finalizer
+	go func() {
+		// Wait for all work
+		v.wg.Wait()
+
+		// Log message after successful termination
+		v.logger.Info("exited")
+
+		// Unblock WaitForShutdown method calls
+		close(v.done)
+	}()
+
+	v.logger.Infof(`process unique id "%s"`, v.UniqueID())
+	return v, nil
 }
 
 func NewForTest(t *testing.T, opts ...Option) *Process {
@@ -144,37 +174,20 @@ func NewForTest(t *testing.T, opts ...Option) *Process {
 
 // Shutdown triggers termination of the Process.
 func (v *Process) Shutdown(ctx context.Context, err error) {
+	ctx = context.WithValue(ctx, ctxShutdownReasonKey, err) // see ShutdownReason function
+
 	v.lock.Lock()
-	if v.terminating {
-		v.lock.Unlock()
+	defer v.lock.Unlock()
+
+	select {
+	case <-v.terminating:
 		return
+	default:
+		close(v.terminating)
+		v.logger.Infof("exiting (%v)", err)
+		v.shutdown <- ctx
+		close(v.shutdown)
 	}
-	v.terminating = true
-	v.lock.Unlock()
-
-	v.logger.Infof("exiting (%v)", err)
-	v.errCh <- err
-	close(v.errCh)
-	v.shutdownCtxCh <- ctx
-	close(v.shutdownCtxCh)
-}
-
-func (v *Process) WaitForShutdown() {
-	// Wait for signal
-	_, ok := <-v.errCh
-	if !ok {
-		// Channel is closed, the process is already terminating, wait for completion
-		v.wg.Wait()
-		return
-	}
-
-	// Send cancellation signal to the goroutines.
-	v.cancel()
-
-	// Wait for all operations
-	v.wg.Wait()
-
-	v.logger.Info("exited")
 }
 
 // UniqueID returns unique process ID, it consists of hostname and PID.
@@ -182,26 +195,45 @@ func (v *Process) UniqueID() string {
 	return v.uniqueID
 }
 
-// Add an operation.
-// The Process is graceful terminated when all operations are completed.
-// The ctx parameter can be used to wait for the service termination.
-// The errCh parameter can be used to stop the service with an error.
-func (v *Process) Add(operation func(context.Context, ShutdownFn)) {
-	v.wg.Add(1)
-	go func() {
-		defer v.wg.Done()
-		operation(v.ctx, v.Shutdown)
-	}()
+// Add a root operation.
+// The operation can terminate the entire process by calling the shutdown callback with an error.
+func (v *Process) Add(operation func(ShutdownFn)) {
+	v.lock.Lock()
+	defer v.lock.Unlock()
+
+	select {
+	case <-v.terminating:
+		v.logger.Errorf(`cannot Add operation: the Process is terminating`)
+	default:
+		v.wg.Add(1)
+		go func() {
+			defer v.wg.Done()
+			operation(v.Shutdown)
+		}()
+	}
 }
 
 // OnShutdown registers a callback that is invoked when the process is terminating.
 // Graceful shutdown waits until the callback has finished.
-// Callbacks are invoked sequentially, in LIFO order, see the New function.
+// Callbacks are invoked sequentially, in LIFO order.
 func (v *Process) OnShutdown(fn OnShutdownFn) {
 	v.lock.Lock()
-	if v.terminating {
-		v.logger.Errorf(`cannot register OnShutdown callback: the process is terminating`)
+	defer v.lock.Unlock()
+
+	select {
+	case <-v.terminating:
+		v.logger.Errorf(`cannot register OnShutdown callback: the Process is terminating`)
+	default:
+		v.onShutdown = append(v.onShutdown, fn)
 	}
-	v.onShutdown = append(v.onShutdown, fn)
-	v.lock.Unlock()
+}
+
+func (v *Process) WaitForShutdown() {
+	<-v.done
+}
+
+// ShutdownReason gets the shutdown reason error.
+func ShutdownReason(ctx context.Context) error {
+	v, _ := ctx.Value(ctxShutdownReasonKey).(error)
+	return v
 }

--- a/internal/pkg/telemetry/metric/prometheus/prometheus.go
+++ b/internal/pkg/telemetry/metric/prometheus/prometheus.go
@@ -66,16 +66,17 @@ func ServeMetrics(ctx context.Context, serviceName, listenAddr string, logger lo
 	handler := http.NewServeMux()
 	handler.Handle("/"+Endpoint, promhttp.HandlerFor(registry, opts))
 	srv := &http.Server{Addr: listenAddr, Handler: handler, ReadHeaderTimeout: 10 * time.Second}
-	proc.Add(func(ctx context.Context, shutdown servicectx.ShutdownFn) {
+	proc.Add(func(shutdown servicectx.ShutdownFn) {
 		logger.InfofCtx(ctx, `HTTP server listening on "%s/%s"`, listenAddr, Endpoint)
-		shutdown(ctx, srv.ListenAndServe())
+		serverErr := srv.ListenAndServe() // ListenAndServe blocks while the server is running
+		shutdown(context.Background(), serverErr)
 	})
 	proc.OnShutdown(func(ctx context.Context) {
-		logger.InfofCtx(ctx, `shutting down HTTP server at "%s"`, listenAddr)
-
 		// Shutdown gracefully with a 30s timeout.
-		ctx, cancel := context.WithTimeout(context.Background(), shutdownTimeout)
+		ctx, cancel := context.WithTimeout(ctx, shutdownTimeout)
 		defer cancel()
+
+		logger.InfofCtx(ctx, `shutting down HTTP server at "%s"`, listenAddr)
 
 		if err := srv.Shutdown(ctx); err != nil {
 			logger.ErrorfCtx(ctx, `HTTP server shutdown error: %s`, err)

--- a/internal/pkg/template/repository/manager/manager.go
+++ b/internal/pkg/template/repository/manager/manager.go
@@ -74,7 +74,7 @@ func New(ctx context.Context, d dependencies, defaultRepositories []model.Templa
 	}
 
 	// Free all repositories on server shutdown
-	d.Process().OnShutdown(func(ctx context.Context) {
+	d.Process().OnShutdown(func(_ context.Context) {
 		m.Free()
 	})
 


### PR DESCRIPTION
Jira: https://keboola.atlassian.net/browse/PSGO-313
Related to: https://github.com/keboola/keboola-as-code/pull/1460

Changes:
- Removed `servicectx.Process.ctx` field and `Process.Ctx()` method.
  - It is [anti-pattern](https://go.dev/blog/context-and-structs).
- Simplified code and fixed edge-cases.