### PR TITLE
feat: Add generic result to Put and Atomic operation

### DIFF
--- a/internal/pkg/service/buffer/definition/repository/repository.go
+++ b/internal/pkg/service/buffer/definition/repository/repository.go
@@ -19,7 +19,7 @@ type Repository struct {
 	sink   *SinkRepository
 }
 
-func NewRepository(d dependencies) *Repository {
+func New(d dependencies) *Repository {
 	r := &Repository{}
 	r.branch = newBranchRepository(d, r)
 	r.source = newSourceRepository(d, r)

--- a/internal/pkg/service/buffer/definition/repository/source_repo.go
+++ b/internal/pkg/service/buffer/definition/repository/source_repo.go
@@ -70,20 +70,21 @@ func (r *SourceRepository) GetDeleted(k key.SourceKey) op.ForType[*op.KeyValueT[
 		})
 }
 
-func (r *SourceRepository) Create(versionDescription string, input *definition.Source) *op.AtomicOp {
+func (r *SourceRepository) Create(versionDescription string, input *definition.Source) *op.AtomicOp[definition.Source] {
 	k := input.SourceKey
-	v := *input
+	result := *input
+
 	var actual, deleted *op.KeyValueT[definition.Source]
 
-	return op.Atomic(r.client).
-		ReadOp(r.all.branch.ExistsOrErr(v.BranchKey)).
-		ReadOp(r.checkMaxSourcesPerBranch(v.BranchKey, 1)).
+	return op.Atomic(r.client, &result).
+		ReadOp(r.all.branch.ExistsOrErr(result.BranchKey)).
+		ReadOp(r.checkMaxSourcesPerBranch(result.BranchKey, 1)).
 		// Get gets actual version to check if the object already exists
 		ReadOp(r.schema.Active().ByKey(k).Get(r.client).WithResultTo(&actual)).
 		// GetDelete gets deleted version to check if we have to do undelete
 		ReadOp(r.schema.Deleted().ByKey(k).Get(r.client).WithResultTo(&deleted)).
 		// Object must not exists
-		BeforeWrite(func() error {
+		BeforeWriteOrErr(func() error {
 			if actual != nil {
 				return serviceError.NewResourceAlreadyExistsError("source", k.String(), "branch")
 			}
@@ -96,24 +97,24 @@ func (r *SourceRepository) Create(versionDescription string, input *definition.S
 			// Was the object previously deleted?
 			if deleted != nil {
 				// Set version from the deleted value
-				v.Version = deleted.Value.Version
+				result.Version = deleted.Value.Version
 				// Delete key from the "deleted" prefix, if any
 				txn.Then(r.schema.Deleted().ByKey(k).Delete(r.client))
 			}
 
 			// Increment version and save
-			v.IncrementVersion(v, r.clock.Now(), versionDescription)
+			result.IncrementVersion(result, r.clock.Now(), versionDescription)
 
 			// Create the object
-			txn.Then(r.schema.Active().ByKey(k).Put(r.client, v))
+			txn.Then(r.schema.Active().ByKey(k).Put(r.client, result))
 
 			// Save record to the versions history
-			txn.Then(r.schema.Versions().Of(k).Version(v.VersionNumber()).Put(r.client, v))
+			txn.Then(r.schema.Versions().Of(k).Version(result.VersionNumber()).Put(r.client, result))
 
 			// Update the input entity after a successful operation
 			txn.OnResult(func(r *op.TxnResult) {
 				if r.Succeeded() {
-					*input = v
+					*input = result
 				}
 			})
 
@@ -122,38 +123,37 @@ func (r *SourceRepository) Create(versionDescription string, input *definition.S
 		AddFrom(r.all.sink.undeleteAllFrom(k))
 }
 
-func (r *SourceRepository) Update(k key.SourceKey, versionDescription string, updateFn func(definition.Source) definition.Source) *op.AtomicOp {
-	var v definition.Source
+func (r *SourceRepository) Update(k key.SourceKey, versionDescription string, updateFn func(definition.Source) definition.Source) *op.AtomicOp[definition.Source] {
+	var result definition.Source
 	var kv *op.KeyValueT[definition.Source]
-	return op.Atomic(r.client).
+	return op.Atomic(r.client, &result).
 		ReadOp(r.checkMaxSourcesVersionsPerSource(k, 1)).
 		// Read and modify the object
 		ReadOp(r.Get(k).WithResultTo(&kv)).
 		// Prepare the new value
-		BeforeWrite(func() error {
-			v = kv.Value
-			v = updateFn(v)
-			v.IncrementVersion(v, r.clock.Now(), versionDescription)
-			return nil
+		BeforeWrite(func() {
+			result = kv.Value
+			result = updateFn(result)
+			result.IncrementVersion(result, r.clock.Now(), versionDescription)
 		}).
 		// Save the update object
 		Write(func() op.Op {
-			return r.schema.Active().ByKey(k).Put(r.client, v)
+			return r.schema.Active().ByKey(k).Put(r.client, result)
 		}).
 		// Save record to the versions history
 		Write(func() op.Op {
-			return r.schema.Versions().Of(k).Version(v.VersionNumber()).Put(r.client, v)
+			return r.schema.Versions().Of(k).Version(result.VersionNumber()).Put(r.client, result)
 		})
 }
 
-func (r *SourceRepository) SoftDelete(k key.SourceKey) *op.AtomicOp {
+func (r *SourceRepository) SoftDelete(k key.SourceKey) *op.AtomicOp[op.NoResult] {
 	return r.softDelete(k, false)
 }
 
-func (r *SourceRepository) softDelete(k key.SourceKey, deletedWithParent bool) *op.AtomicOp {
+func (r *SourceRepository) softDelete(k key.SourceKey, deletedWithParent bool) *op.AtomicOp[op.NoResult] {
 	// Move object from the active to the deleted prefix
 	var kv *op.KeyValueT[definition.Source]
-	return op.Atomic(r.client).
+	return op.Atomic(r.client, &op.NoResult{}).
 		// Move object from the active prefix to the deleted prefix
 		ReadOp(r.Get(k).WithResultTo(&kv)).
 		Write(func() op.Op { return r.softDeleteValue(kv.Value, deletedWithParent) }).
@@ -163,9 +163,9 @@ func (r *SourceRepository) softDelete(k key.SourceKey, deletedWithParent bool) *
 
 // softDeleteAllFrom the parent key.
 // All objects are marked with DeletedWithParent=true.
-func (r *SourceRepository) softDeleteAllFrom(parentKey any) *op.AtomicOp {
+func (r *SourceRepository) softDeleteAllFrom(parentKey any) *op.AtomicOp[op.NoResult] {
 	var writeOps []op.Op
-	return op.Atomic(r.client).
+	return op.Atomic(r.client, &op.NoResult{}).
 		Read(func() op.Op {
 			writeOps = nil // reset after retry
 			return r.List(parentKey).ForEachOp(func(v definition.Source, _ *iterator.Header) error {
@@ -189,14 +189,18 @@ func (r *SourceRepository) softDeleteValue(v definition.Source, deletedWithParen
 	)
 }
 
-func (r *SourceRepository) Undelete(k key.SourceKey) *op.AtomicOp {
+func (r *SourceRepository) Undelete(k key.SourceKey) *op.AtomicOp[definition.Source] {
 	// Move object from the deleted to the active prefix
+	var result definition.Source
 	var kv *op.KeyValueT[definition.Source]
-	return op.Atomic(r.client).
+	return op.Atomic(r.client, &result).
 		ReadOp(r.all.branch.ExistsOrErr(k.BranchKey)).
 		ReadOp(r.checkMaxSourcesPerBranch(k.BranchKey, 1)).
 		// Move object from the deleted prefix to the active prefix
 		ReadOp(r.GetDeleted(k).WithResultTo(&kv)).
+		// Unwrap KV
+		BeforeWrite(func() { result = kv.Value }).
+		// Undelete
 		Write(func() op.Op { return r.undeleteValue(kv.Value) }).
 		// Undelete children
 		AddFrom(r.all.sink.undeleteAllFrom(k))
@@ -204,9 +208,9 @@ func (r *SourceRepository) Undelete(k key.SourceKey) *op.AtomicOp {
 
 // undeleteAllFrom the parent key.
 // Only object with DeletedWithParent=true are undeleted.
-func (r *SourceRepository) undeleteAllFrom(parentKey any) *op.AtomicOp {
+func (r *SourceRepository) undeleteAllFrom(parentKey any) *op.AtomicOp[op.NoResult] {
 	var writeOps []op.Op
-	return op.Atomic(r.client).
+	return op.Atomic(r.client, &op.NoResult{}).
 		Read(func() op.Op {
 			writeOps = nil // reset after retry
 			return r.ListDeleted(parentKey).ForEachOp(func(v definition.Source, _ *iterator.Header) error {
@@ -248,17 +252,17 @@ func (r *SourceRepository) Version(k key.SourceKey, version definition.VersionNu
 		})
 }
 
-func (r *SourceRepository) Rollback(k key.SourceKey, to definition.VersionNumber) *op.AtomicOp {
-	var v definition.Source
+func (r *SourceRepository) Rollback(k key.SourceKey, to definition.VersionNumber) *op.AtomicOp[definition.Source] {
+	var result definition.Source
 	var latest, target *op.KeyValueT[definition.Source]
 
-	return op.Atomic(r.client).
+	return op.Atomic(r.client, &result).
 		// Get latest version to calculate next version number
 		ReadOp(r.schema.Versions().Of(k).GetOne(r.client, etcd.WithSort(etcd.SortByKey, etcd.SortDescend)).WithResultTo(&latest)).
 		// Get target version
 		ReadOp(r.schema.Versions().Of(k).Version(to).Get(r.client).WithResultTo(&target)).
 		// Return the most significant error
-		BeforeWrite(func() error {
+		BeforeWriteOrErr(func() error {
 			if latest == nil {
 				return serviceError.NewResourceNotFoundError("source", k.String(), "branch")
 			} else if target == nil {
@@ -267,19 +271,18 @@ func (r *SourceRepository) Rollback(k key.SourceKey, to definition.VersionNumber
 			return nil
 		}).
 		// Prepare the new value
-		BeforeWrite(func() error {
-			v = target.Value
-			v.Version = latest.Value.Version
-			v.IncrementVersion(v, r.clock.Now(), fmt.Sprintf("Rollback to version %d", target.Value.Version.Number))
-			return nil
+		BeforeWrite(func() {
+			result = target.Value
+			result.Version = latest.Value.Version
+			result.IncrementVersion(result, r.clock.Now(), fmt.Sprintf("Rollback to version %d", target.Value.Version.Number))
 		}).
 		// Save the object
 		Write(func() op.Op {
-			return r.schema.Active().ByKey(k).Put(r.client, v)
+			return r.schema.Active().ByKey(k).Put(r.client, result)
 		}).
 		// Save record to the versions history
 		Write(func() op.Op {
-			return r.schema.Versions().Of(k).Version(v.VersionNumber()).Put(r.client, v)
+			return r.schema.Versions().Of(k).Version(result.VersionNumber()).Put(r.client, result)
 		})
 }
 

--- a/internal/pkg/service/buffer/sink/tablesink/statistics/repository/delete.go
+++ b/internal/pkg/service/buffer/sink/tablesink/statistics/repository/delete.go
@@ -11,8 +11,8 @@ import (
 // Delete returns an etcd operation to delete all statistics associated with the object key.
 // Statistics for the storage.LevelTarget are not deleted but are rolled up to the parent object.
 // This operation should not be used separately but atomically together with the deletion of the object.
-func (r *Repository) Delete(objectKey fmt.Stringer) *op.AtomicOp {
-	ops := op.Atomic(r.client)
+func (r *Repository) Delete(objectKey fmt.Stringer) *op.AtomicOp[op.NoResult] {
+	ops := op.Atomic(r.client, &op.NoResult{})
 	for _, level := range storage.AllLevels() {
 		// Object prefix contains all statistics related to the object
 		objectPfx := r.schema.InLevel(level).InObject(objectKey)

--- a/internal/pkg/service/buffer/sink/tablesink/statistics/repository/move.go
+++ b/internal/pkg/service/buffer/sink/tablesink/statistics/repository/move.go
@@ -12,7 +12,7 @@ type transformFn func(value *statistics.Value)
 
 // Move returns an etcd operation to move slice statistics to a different storage level.
 // This operation should not be used separately but atomically together with changing the slice state.
-func (r *Repository) Move(sliceKey storage.SliceKey, from, to storage.Level, transform ...transformFn) *op.AtomicOp {
+func (r *Repository) Move(sliceKey storage.SliceKey, from, to storage.Level, transform ...transformFn) *op.AtomicOp[statistics.Value] {
 	if from == to {
 		panic(errors.Errorf(`from and to categories are same and equal to "%s"`, to))
 	}
@@ -20,8 +20,8 @@ func (r *Repository) Move(sliceKey storage.SliceKey, from, to storage.Level, tra
 	fromKey := r.schema.InLevel(from).InSlice(sliceKey)
 	toKey := r.schema.InLevel(to).InSlice(sliceKey)
 
-	ops := op.Atomic(r.client)
 	var value statistics.Value
+	ops := op.Atomic(r.client, &value)
 
 	// Load statistics value from the old key
 	ops.Read(func() op.Op {

--- a/internal/pkg/service/buffer/sink/tablesink/statistics/repository/move_test.go
+++ b/internal/pkg/service/buffer/sink/tablesink/statistics/repository/move_test.go
@@ -16,7 +16,7 @@ import (
 	"github.com/keboola/keboola-as-code/internal/pkg/utils/etcdhelper"
 )
 
-func TestMove_SameLevels_Panic(t *testing.T) {
+func TestRepository_Move_SameLevels_Panic(t *testing.T) {
 	t.Parallel()
 
 	d := dependencies.NewMocked(t, dependencies.WithEnabledEtcdClient())
@@ -26,7 +26,7 @@ func TestMove_SameLevels_Panic(t *testing.T) {
 	})
 }
 
-func TestMoveOp(t *testing.T) {
+func TestRepository_Move(t *testing.T) {
 	t.Parallel()
 
 	ctx, cancel := context.WithTimeout(context.Background(), 10*time.Second)

--- a/internal/pkg/service/common/etcdop/etcdop.go
+++ b/internal/pkg/service/common/etcdop/etcdop.go
@@ -11,7 +11,7 @@
 // A new operation can be defined as a:
 // New<Operation>(<operation factory>, <response processor>) function.
 //
-// On Operation.Do(ctx, etcdClient) call :
+// On Operation.Do(ctx) call :
 //   - The <operation factory> is executed, result is an etcd operation.
 //   - The etcd operation is executed, result is an etcd response.
 //   - The <response processor> is executed, to process the etcd response.

--- a/internal/pkg/service/common/etcdop/key_test.go
+++ b/internal/pkg/service/common/etcdop/key_test.go
@@ -2,6 +2,7 @@ package etcdop
 
 import (
 	"context"
+	"github.com/stretchr/testify/require"
 	"testing"
 
 	"github.com/stretchr/testify/assert"
@@ -22,81 +23,81 @@ func TestKeyOperations(t *testing.T) {
 
 	// Get - not found
 	kv, err := k.Get(client).Do(ctx).ResultOrErr()
-	assert.NoError(t, err)
+	require.NoError(t, err)
 	assert.Nil(t, kv)
 
 	// Exists - not found
 	found, err := k.Exists(client).Do(ctx).ResultOrErr()
-	assert.NoError(t, err)
+	require.NoError(t, err)
 	assert.False(t, found)
 
 	// ------
 	// Put
-	assert.NoError(t, k.Put(client, "bar").Do(ctx).Err())
+	require.NoError(t, k.Put(client, "bar").Do(ctx).Err())
 
 	// Get - found
 	kv, err = k.Get(client).Do(ctx).ResultOrErr()
-	assert.NoError(t, err)
+	require.NoError(t, err)
 	assert.NotNil(t, kv)
 	assert.Equal(t, []byte("bar"), kv.Value)
 
 	// Exists - found
 	found, err = k.Exists(client).Do(ctx).ResultOrErr()
-	assert.NoError(t, err)
+	require.NoError(t, err)
 	assert.True(t, found)
 
 	// ------
 	// Delete - found
 	found, err = k.Delete(client).Do(ctx).ResultOrErr()
-	assert.NoError(t, err)
+	require.NoError(t, err)
 	assert.True(t, found)
 
 	// Delete - not found
 	found, err = k.Delete(client).Do(ctx).ResultOrErr()
-	assert.NoError(t, err)
+	require.NoError(t, err)
 	assert.False(t, found)
 
 	// Get - not found
 	kv, err = k.Get(client).Do(ctx).ResultOrErr()
-	assert.NoError(t, err)
+	require.NoError(t, err)
 	assert.Nil(t, kv)
 
 	// Exists - not found
 	found, err = k.Exists(client).Do(ctx).ResultOrErr()
-	assert.NoError(t, err)
+	require.NoError(t, err)
 	assert.False(t, found)
 
 	// ------
 	// PutIfNotExists - key not found -> ok
 	ok, err := k.PutIfNotExists(client, "value1").Do(ctx).ResultOrErr()
-	assert.NoError(t, err)
+	require.NoError(t, err)
 	assert.True(t, ok)
 
 	// Get - found - value 1
 	kv, err = k.Get(client).Do(ctx).ResultOrErr()
-	assert.NoError(t, err)
+	require.NoError(t, err)
 	assert.NotNil(t, kv)
 	assert.Equal(t, []byte("value1"), kv.Value)
 
 	// PutIfNotExists - key found -> not ok
 	ok, err = k.PutIfNotExists(client, "value1").Do(ctx).ResultOrErr()
-	assert.NoError(t, err)
+	require.NoError(t, err)
 	assert.False(t, ok)
 
 	// Get - found - value 1
 	kv, err = k.Get(client).Do(ctx).ResultOrErr()
-	assert.NoError(t, err)
+	require.NoError(t, err)
 	assert.NotNil(t, kv)
 	assert.Equal(t, []byte("value1"), kv.Value)
 
 	// DeleteIfExists - found
 	ok, err = k.DeleteIfExists(client).Do(ctx).ResultOrErr()
-	assert.NoError(t, err)
+	require.NoError(t, err)
 	assert.True(t, ok)
 
 	// DeleteIfNotExists - not found
 	ok, err = k.DeleteIfExists(client).Do(ctx).ResultOrErr()
-	assert.NoError(t, err)
+	require.NoError(t, err)
 	assert.False(t, ok)
 }
 
@@ -110,82 +111,84 @@ func TestTypedKeyOperations(t *testing.T) {
 
 	// Get - not found
 	kv, err := k.Get(client).Do(ctx).ResultOrErr()
-	assert.NoError(t, err)
+	require.NoError(t, err)
 	assert.Nil(t, kv)
 
 	// Exists - not found
 	found, err := k.Exists(client).Do(ctx).ResultOrErr()
-	assert.NoError(t, err)
+	require.NoError(t, err)
 	assert.False(t, found)
 
 	// ------
 	// Put
-	assert.NoError(t, k.Put(client, "bar").Do(ctx).Err())
+	result, err := k.Put(client, "bar").Do(ctx).ResultOrErr()
+	require.NoError(t, err)
+	assert.Equal(t, fooType("bar"), result)
 
 	// Get - found
 	kv, err = k.Get(client).Do(ctx).ResultOrErr()
-	assert.NoError(t, err)
+	require.NoError(t, err)
 	assert.NotNil(t, kv)
 	assert.Equal(t, fooType("bar"), kv.Value)
 
 	// Exists - found
 	found, err = k.Exists(client).Do(ctx).ResultOrErr()
-	assert.NoError(t, err)
+	require.NoError(t, err)
 	assert.True(t, found)
 
 	// ------
 	// Delete - found
 	found, err = k.Delete(client).Do(ctx).ResultOrErr()
-	assert.NoError(t, err)
+	require.NoError(t, err)
 	assert.True(t, found)
 
 	// Delete - not found
 	found, err = k.Delete(client).Do(ctx).ResultOrErr()
-	assert.NoError(t, err)
+	require.NoError(t, err)
 	assert.False(t, found)
 
 	// Get - not found
 	kv, err = k.Get(client).Do(ctx).ResultOrErr()
-	assert.NoError(t, err)
+	require.NoError(t, err)
 	assert.Nil(t, kv)
 
 	// Exists - not found
 	found, err = k.Exists(client).Do(ctx).ResultOrErr()
-	assert.NoError(t, err)
+	require.NoError(t, err)
 	assert.False(t, found)
 
 	// ------
 	// PutIfNotExists - key not found -> ok
 	ok, err := k.PutIfNotExists(client, "value1").Do(ctx).ResultOrErr()
-	assert.NoError(t, err)
+	require.NoError(t, err)
 	assert.True(t, ok)
 
 	// Get - found - value 1
 	kv, err = k.Get(client).Do(ctx).ResultOrErr()
-	assert.NoError(t, err)
+	require.NoError(t, err)
 	assert.NotNil(t, kv)
 	assert.Equal(t, fooType("value1"), kv.Value)
 
 	// PutIfNotExists - key found -> not ok
 	ok, err = k.PutIfNotExists(client, "value1").Do(ctx).ResultOrErr()
-	assert.NoError(t, err)
+	require.NoError(t, err)
 	assert.False(t, ok)
 
 	// Get - found - value 1
 	kv, err = k.Get(client).Do(ctx).ResultOrErr()
-	assert.NoError(t, err)
+	require.NoError(t, err)
 	assert.NotNil(t, kv)
 	assert.Equal(t, fooType("value1"), kv.Value)
 
 	// ------
 	// DeleteIfExists - found
 	ok, err = k.DeleteIfExists(client).Do(ctx).ResultOrErr()
-	assert.NoError(t, err)
+	require.NoError(t, err)
 	assert.True(t, ok)
 
 	// DeleteIfNotExists - not found
 	ok, err = k.DeleteIfExists(client).Do(ctx).ResultOrErr()
-	assert.NoError(t, err)
+	require.NoError(t, err)
 	assert.False(t, ok)
 }
 

--- a/internal/pkg/service/common/etcdop/op/bool.go
+++ b/internal/pkg/service/common/etcdop/op/bool.go
@@ -13,6 +13,6 @@ type BoolMapper func(ctx context.Context, r RawResponse) (bool, error)
 
 // NewBoolOp wraps an operation, the result of which us true/false value.
 // True means success of the operation.
-func NewBoolOp(client etcd.KV, factory Factory, mapper BoolMapper) BoolOp {
+func NewBoolOp(client etcd.KV, factory LowLevelFactory, mapper BoolMapper) BoolOp {
 	return NewForType[bool](client, factory, mapper)
 }

--- a/internal/pkg/service/common/etcdop/op/count.go
+++ b/internal/pkg/service/common/etcdop/op/count.go
@@ -12,6 +12,6 @@ type CountOp = ForType[int64]
 type CountMapper func(ctx context.Context, raw RawResponse) (int64, error)
 
 // NewCountOp wraps an operation, the result of which is a count.
-func NewCountOp(client etcd.KV, factory Factory, mapper CountMapper) CountOp {
+func NewCountOp(client etcd.KV, factory LowLevelFactory, mapper CountMapper) CountOp {
 	return NewForType[int64](client, factory, mapper)
 }

--- a/internal/pkg/service/common/etcdop/op/many.go
+++ b/internal/pkg/service/common/etcdop/op/many.go
@@ -15,11 +15,11 @@ type GetManyMapper func(ctx context.Context, raw RawResponse) ([]*KeyValue, erro
 type GetManyTMapper[T any] func(ctx context.Context, raw RawResponse) (KeyValuesT[T], error)
 
 // NewGetManyOp wraps an operation, the result of which is zero or multiple KV pairs.
-func NewGetManyOp(client etcd.KV, factory Factory, mapper GetManyMapper) GetManyOp {
+func NewGetManyOp(client etcd.KV, factory LowLevelFactory, mapper GetManyMapper) GetManyOp {
 	return NewForType[[]*KeyValue](client, factory, mapper)
 }
 
 // NewGetManyTOp wraps an operation, the result of which is zero or multiple KV pairs, values are encoded as the type T.
-func NewGetManyTOp[T any](client etcd.KV, factory Factory, mapper GetManyTMapper[T]) ForType[KeyValuesT[T]] {
+func NewGetManyTOp[T any](client etcd.KV, factory LowLevelFactory, mapper GetManyTMapper[T]) ForType[KeyValuesT[T]] {
 	return NewForType[KeyValuesT[T]](client, factory, mapper)
 }

--- a/internal/pkg/service/common/etcdop/op/noresult.go
+++ b/internal/pkg/service/common/etcdop/op/noresult.go
@@ -19,10 +19,10 @@ type NoResultOp struct {
 type NoResultMapper func(ctx context.Context, raw RawResponse) error
 
 // NewNoResultOp wraps an operation, the result of which is an error or nil.
-func NewNoResultOp(client etcd.KV, factory Factory, mapper NoResultMapper) NoResultOp {
+func NewNoResultOp(client etcd.KV, factory LowLevelFactory, mapper NoResultMapper) NoResultOp {
 	out := NoResultOp{}
 	out.client = client
-	out.factory = factory
+	out.lowLevelFactory = factory
 	out.mapper = func(ctx context.Context, raw RawResponse) (NoResult, error) {
 		err := mapper(ctx, raw)
 		return NoResult{}, err

--- a/internal/pkg/service/common/etcdop/op/one.go
+++ b/internal/pkg/service/common/etcdop/op/one.go
@@ -15,11 +15,11 @@ type GetOneMapper func(ctx context.Context, raw RawResponse) (*KeyValue, error)
 type GetOneTProcessor[T any] func(ctx context.Context, raw RawResponse) (*KeyValueT[T], error)
 
 // NewGetOneOp wraps an operation, the result of which is one KV pair.
-func NewGetOneOp(client etcd.KV, factory Factory, mapper GetOneMapper) GetOneOp {
+func NewGetOneOp(client etcd.KV, factory LowLevelFactory, mapper GetOneMapper) GetOneOp {
 	return NewForType[*KeyValue](client, factory, mapper)
 }
 
 // NewGetOneTOp wraps an operation, the result of which is one KV pair, value is encoded as the type T.
-func NewGetOneTOp[T any](client etcd.KV, factory Factory, mapper GetOneTProcessor[T]) ForType[*KeyValueT[T]] {
+func NewGetOneTOp[T any](client etcd.KV, factory LowLevelFactory, mapper GetOneTProcessor[T]) ForType[*KeyValueT[T]] {
 	return NewForType[*KeyValueT[T]](client, factory, mapper)
 }


### PR DESCRIPTION
Part of: https://keboola.atlassian.net/browse/PSGO-286

**Changes:**
- Atomic etcd operation didn't have result, now it can carry a result value - result of the operation.

**Intro**
- We are using [etcd](https://etcd.io/) dabase in our Stream and Templates API.
- It is a KV store used also by the Kubernetes.
- [Etcd Watch API](https://etcd.io/docs/v3.5/learning/api/#watch-api) is important for us in Stream API to achieve fast operation without locks and pooling (without regularly checking changes from the client side).
- Etcd supports [transactions](https://etcd.io/docs/v3.5/learning/api/#transaction), but they are different from RDBS.
  - Transaction in etcd is a `if/then/else` tree.
- [etcdop](https://github.com/keboola/keboola-as-code/tree/michaljurecko-PSGO-286-atomic-op-result/internal/pkg/service/common/etcdop) and other packages in the directory provide high-level API for etcd:
  - It is something like ORM for RDBS.
  - It provides: serialization/deserialization to/from JSON, callbacks, joining operations into transactions:
    - Please read [documentation](https://github.com/keboola/keboola-as-code/blob/cad3e78bcfe887ab91ee9228ba61aaad2df9ddb0/internal/pkg/service/common/etcdop/etcdop.go#L1-L34).
    - And go through packages files to get an overview of them.
    - Read documentation about [AtomicOp](https://github.com/keboola/keboola-as-code/blob/cad3e78bcfe887ab91ee9228ba61aaad2df9ddb0/internal/pkg/service/common/etcdop/op/atomic.go#L14-L34).
 - In mentioned packages, [the generic programing](https://go.dev/doc/tutorial/generics) is heavily used. 
​

Test in the RFC branch are disabled now.
- As we finish the individual parts, we also fix the tests.
- That's why I'm attaching a screenshot of the tests regarding the changed packages.

![image](https://github.com/keboola/keboola-as-code/assets/19371734/24897f59-2cfb-4b0c-ae7a-b1ac6c13a408)
