### PR TITLE
feat: Add method compression.Config.Simplify()

### DIFF
--- a/internal/pkg/service/buffer/sink/tablesink/storage/compression/config.go
+++ b/internal/pkg/service/buffer/sink/tablesink/storage/compression/config.go
@@ -24,13 +24,13 @@ type Config struct {
 type GZIPConfig struct {
 	Level          int                `json:"level" configKey:"level" validate:"min=1,max=9"  configUsage:"GZIP compression level: 1-9."`
 	Implementation GZIPImplementation `json:"implementation" configKey:"implementation" validate:"required,oneof=standard fast parallel" configUsage:"GZIP implementation: standard, fast, parallel."`
-	BlockSize      datasize.ByteSize  `json:"blockSize" configKey:"blockSize" validate:"required,min=16384,max=104857600" configUsage:"GZIP parallel block size."` // 16kB-100MB
+	BlockSize      datasize.ByteSize  `json:"blockSize" configKey:"blockSize" validate:"required,minBytes=16kB,maxBytes=100MB" configUsage:"GZIP parallel block size."`
 	Concurrency    int                `json:"concurrency" configKey:"concurrency" configUsage:"GZIP parallel concurrency, 0 = auto."`
 }
 
 type ZSTDConfig struct {
 	Level       zstd.EncoderLevel `json:"level" configKey:"level" validate:"min=1,max=4" configUsage:"ZSTD compression level: fastest, default, better, best."`
-	WindowSize  datasize.ByteSize `json:"windowSize" configKey:"windowSize" validate:"required,min=1024,max=536870912" configUsage:"ZSTD window size."` // 1kB-512MB
+	WindowSize  datasize.ByteSize `json:"windowSize" configKey:"windowSize" validate:"required,minBytes=1kB,maxBytes=512MB" configUsage:"ZSTD window size."`
 	Concurrency int               `json:"concurrency" configKey:"concurrency" configUsage:"ZSTD concurrency, 0 = auto"`
 }
 
@@ -69,4 +69,15 @@ func DefaultZSTDConfig() Config {
 			Concurrency: 0,
 		},
 	}
+}
+
+// Simplify removes unnecessary parts of the configuration.
+func (c Config) Simplify() Config {
+	if c.Type != TypeGZIP {
+		c.GZIP = nil
+	}
+	if c.Type != TypeZSTD {
+		c.ZSTD = nil
+	}
+	return c
 }

--- a/internal/pkg/service/buffer/sink/tablesink/storage/compression/config_test.go
+++ b/internal/pkg/service/buffer/sink/tablesink/storage/compression/config_test.go
@@ -106,7 +106,7 @@ func TestConfig_Validation(t *testing.T) {
 		},
 		{
 			Name:          "gzip: block size under min",
-			ExpectedError: `"gzip.blockSize" must be 16,384 or greater`,
+			ExpectedError: `"gzip.blockSize" must be 16KB or greater`,
 			Config: Config{
 				Type: TypeGZIP,
 				GZIP: &GZIPConfig{
@@ -118,7 +118,7 @@ func TestConfig_Validation(t *testing.T) {
 		},
 		{
 			Name:          "gzip: block size over max",
-			ExpectedError: `"gzip.blockSize" must be 104,857,600 or less`,
+			ExpectedError: `"gzip.blockSize" must be 100MB or less`,
 			Config: Config{
 				Type: TypeGZIP,
 				GZIP: &GZIPConfig{
@@ -169,7 +169,7 @@ func TestConfig_Validation(t *testing.T) {
 		},
 		{
 			Name:          "zstd: window size under min",
-			ExpectedError: `"zstd.windowSize" must be 1,024 or greater`,
+			ExpectedError: `"zstd.windowSize" must be 1KB or greater`,
 			Config: Config{
 				Type: TypeZSTD,
 				ZSTD: &ZSTDConfig{
@@ -181,7 +181,7 @@ func TestConfig_Validation(t *testing.T) {
 		},
 		{
 			Name:          "zstd: window size over max",
-			ExpectedError: `"zstd.windowSize" must be 536,870,912 or less`,
+			ExpectedError: `"zstd.windowSize" must be 512MB or less`,
 			Config: Config{
 				Type: TypeZSTD,
 				ZSTD: &ZSTDConfig{
@@ -206,4 +206,23 @@ func TestConfig_Validation(t *testing.T) {
 			}
 		}
 	}
+}
+
+func TestConfig_Simplify(t *testing.T) {
+	t.Parallel()
+
+	gzipCfg := DefaultGZIPConfig().GZIP
+	zstdCfg := DefaultZSTDConfig().ZSTD
+
+	// None
+	cfg := Config{Type: TypeNone, GZIP: gzipCfg, ZSTD: zstdCfg}
+	assert.Equal(t, Config{Type: TypeNone}, cfg.Simplify())
+
+	// GZIP
+	cfg = Config{Type: TypeGZIP, GZIP: gzipCfg, ZSTD: zstdCfg}
+	assert.Equal(t, Config{Type: TypeGZIP, GZIP: gzipCfg}, cfg.Simplify())
+
+	// ZSTD
+	cfg = Config{Type: TypeZSTD, GZIP: gzipCfg, ZSTD: zstdCfg}
+	assert.Equal(t, Config{Type: TypeZSTD, ZSTD: zstdCfg}, cfg.Simplify())
 }


### PR DESCRIPTION
Part of: https://keboola.atlassian.net/browse/PSGO-286

Changes:
- Added method to simplify compression configuration, unused parts are removed, object in database and test dumps in smaller.

![image](https://github.com/keboola/keboola-as-code/assets/19371734/90fa461f-ea76-4024-915b-969cd9b1eb40)

