### PR TITLE
feat: Add iterator WithResultTo, AndOnFirstPage and AndOnPage methods

### DIFF
--- a/internal/pkg/service/buffer/sink/tablesink/storage/retry_test.go
+++ b/internal/pkg/service/buffer/sink/tablesink/storage/retry_test.go
@@ -1,24 +1,18 @@
 package storage
 
 import (
-	"context"
-	"strings"
+	"github.com/keboola/keboola-as-code/internal/pkg/service/buffer/sink/tablesink/storage/test/testvalidation"
 	"testing"
 
 	"github.com/stretchr/testify/assert"
 
 	"github.com/keboola/keboola-as-code/internal/pkg/service/common/utctime"
-	"github.com/keboola/keboola-as-code/internal/pkg/validator"
 )
 
 func TestRetryable_Validation(t *testing.T) {
 	t.Parallel()
 
-	cases := []struct {
-		Name          string
-		ExpectedError string
-		Value         Retryable
-	}{
+	cases := testvalidation.TestCases[Retryable]{
 		{
 			Name:  "empty",
 			Value: Retryable{},
@@ -62,16 +56,5 @@ func TestRetryable_Validation(t *testing.T) {
 	}
 
 	// Run test cases
-	ctx := context.Background()
-	val := validator.New()
-	for _, tc := range cases {
-		err := val.Validate(ctx, tc.Value)
-		if tc.ExpectedError == "" {
-			assert.NoError(t, err, tc.Name)
-		} else {
-			if assert.Error(t, err, tc.Name) {
-				assert.Equal(t, strings.TrimSpace(tc.ExpectedError), strings.TrimSpace(err.Error()), tc.Name)
-			}
-		}
-	}
+	cases.Run(t)
 }


### PR DESCRIPTION
Part of: https://keboola.atlassian.net/browse/PSGO-286

Changes:
- Added `WithResultTo`, `AndOnFirstPage` and `AndOnPage` methods to the typed iterator.

Note:
- `With` means `Set`
- `And` means `Add`
- if the value is immutable


---------------------



![image](https://github.com/keboola/keboola-as-code/assets/19371734/6d9923bd-6f20-4887-a9a4-d8779476d052)


---------------------

## Intro

`Iterator` provides pagination over etcd get operations results.
- Each page is provided by one get request.
- It is primarily designed for the gradual processing of records, so that we do not have to load them all into memory.
- In some cases, we know that there will not be a lot of records and we need to load them all, the `All` method is used for that.
- To simplify code, I added `WithResultTo`, it is similar to `Add`, but records are stored to the slice provided as an argument.
- Other operations already have `WithResultTo` method, but it was missing for the iterator.
