### PR TITLE
feat: Storage repository for File and Slice entities

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -45,6 +45,7 @@ require (
 	github.com/prometheus/client_golang v1.15.1
 	github.com/prometheus/client_model v0.4.0
 	github.com/prometheus/common v0.42.0
+	github.com/relvacode/iso8601 v1.3.0
 	github.com/santhosh-tekuri/jsonschema/v5 v5.3.0
 	github.com/schollz/progressbar/v3 v3.13.1
 	github.com/sirupsen/logrus v1.9.2
@@ -221,7 +222,6 @@ require (
 	github.com/pkg/errors v0.9.1 // indirect
 	github.com/pmezard/go-difflib v1.0.0 // indirect
 	github.com/prometheus/procfs v0.9.0 // indirect
-	github.com/relvacode/iso8601 v1.3.0 // indirect
 	github.com/rivo/uniseg v0.4.3 // indirect
 	github.com/secure-systems-lab/go-securesystemslib v0.7.0 // indirect
 	github.com/soheilhy/cmux v0.1.5 // indirect

--- a/internal/pkg/service/buffer/definition/repository/branch_repo_test.go
+++ b/internal/pkg/service/buffer/definition/repository/branch_repo_test.go
@@ -16,7 +16,6 @@ import (
 	serviceErrors "github.com/keboola/keboola-as-code/internal/pkg/service/common/errors"
 	"github.com/keboola/keboola-as-code/internal/pkg/service/common/etcdop/op"
 	"github.com/keboola/keboola-as-code/internal/pkg/service/common/utctime"
-	"github.com/keboola/keboola-as-code/internal/pkg/utils/errors"
 	"github.com/keboola/keboola-as-code/internal/pkg/utils/etcdhelper"
 )
 
@@ -64,20 +63,14 @@ func TestRepository_Branch(t *testing.T) {
 		// Get - not found
 		if err := r.Get(branch1.BranchKey).Do(ctx).Err(); assert.Error(t, err) {
 			assert.Equal(t, `branch "123/567" not found in the project`, err.Error())
-			var errWithStatus serviceErrors.WithStatusCode
-			if assert.True(t, errors.As(err, &errWithStatus)) {
-				assert.Equal(t, http.StatusNotFound, errWithStatus.StatusCode())
-			}
+			serviceErrors.AssertErrorStatusCode(t, http.StatusNotFound, err)
 		}
 	}
 	{
 		// GetDeleted - not found
 		if err := r.GetDeleted(branch1.BranchKey).Do(ctx).Err(); assert.Error(t, err) {
 			assert.Equal(t, `deleted branch "123/567" not found in the project`, err.Error())
-			var errWithStatus serviceErrors.WithStatusCode
-			if assert.True(t, errors.As(err, &errWithStatus)) {
-				assert.Equal(t, http.StatusNotFound, errWithStatus.StatusCode())
-			}
+			serviceErrors.AssertErrorStatusCode(t, http.StatusNotFound, err)
 		}
 	}
 
@@ -113,10 +106,7 @@ func TestRepository_Branch(t *testing.T) {
 		// GetDeleted - not found
 		if err := r.GetDeleted(branch1.BranchKey).Do(ctx).Err(); assert.Error(t, err) {
 			assert.Equal(t, `deleted branch "123/567" not found in the project`, err.Error())
-			var errWithStatus serviceErrors.WithStatusCode
-			if assert.True(t, errors.As(err, &errWithStatus)) {
-				assert.Equal(t, http.StatusNotFound, errWithStatus.StatusCode())
-			}
+			serviceErrors.AssertErrorStatusCode(t, http.StatusNotFound, err)
 		}
 	}
 
@@ -125,10 +115,7 @@ func TestRepository_Branch(t *testing.T) {
 	{
 		if err := r.Create(&branch1).Do(ctx).Err(); assert.Error(t, err) {
 			assert.Equal(t, `branch "123/567" already exists in the project`, err.Error())
-			var errWithStatus serviceErrors.WithStatusCode
-			if assert.True(t, errors.As(err, &errWithStatus)) {
-				assert.Equal(t, http.StatusConflict, errWithStatus.StatusCode())
-			}
+			serviceErrors.AssertErrorStatusCode(t, http.StatusConflict, err)
 		}
 	}
 
@@ -171,10 +158,7 @@ func TestRepository_Branch(t *testing.T) {
 		// Get - not found
 		if err := r.Get(branch1.BranchKey).Do(ctx).Err(); assert.Error(t, err) {
 			assert.Equal(t, `branch "123/567" not found in the project`, err.Error())
-			var errWithStatus serviceErrors.WithStatusCode
-			if assert.True(t, errors.As(err, &errWithStatus)) {
-				assert.Equal(t, http.StatusNotFound, errWithStatus.StatusCode())
-			}
+			serviceErrors.AssertErrorStatusCode(t, http.StatusNotFound, err)
 		}
 	}
 	{
@@ -200,10 +184,7 @@ func TestRepository_Branch(t *testing.T) {
 	// -----------------------------------------------------------------------------------------------------------------
 	if err := r.SoftDelete(branch1.BranchKey).Do(ctx).Err(); assert.Error(t, err) {
 		assert.Equal(t, `branch "123/567" not found in the project`, err.Error())
-		var errWithStatus serviceErrors.WithStatusCode
-		if assert.True(t, errors.As(err, &errWithStatus)) {
-			assert.Equal(t, http.StatusNotFound, errWithStatus.StatusCode())
-		}
+		serviceErrors.AssertErrorStatusCode(t, http.StatusNotFound, err)
 	}
 
 	// Undelete
@@ -230,10 +211,7 @@ func TestRepository_Branch(t *testing.T) {
 		// GetDeleted - not found
 		if err := r.GetDeleted(branch1.BranchKey).Do(ctx).Err(); assert.Error(t, err) {
 			assert.Equal(t, `deleted branch "123/567" not found in the project`, err.Error())
-			var errWithStatus serviceErrors.WithStatusCode
-			if assert.True(t, errors.As(err, &errWithStatus)) {
-				assert.Equal(t, http.StatusNotFound, errWithStatus.StatusCode())
-			}
+			serviceErrors.AssertErrorStatusCode(t, http.StatusNotFound, err)
 		}
 	}
 	{
@@ -254,10 +232,7 @@ func TestRepository_Branch(t *testing.T) {
 	// -----------------------------------------------------------------------------------------------------------------
 	if err := r.Undelete(branch1.BranchKey).Do(ctx).Err(); assert.Error(t, err) {
 		assert.Equal(t, `deleted branch "123/567" not found in the project`, err.Error())
-		var errWithStatus serviceErrors.WithStatusCode
-		if assert.True(t, errors.As(err, &errWithStatus)) {
-			assert.Equal(t, http.StatusNotFound, errWithStatus.StatusCode())
-		}
+		serviceErrors.AssertErrorStatusCode(t, http.StatusNotFound, err)
 	}
 
 	// Re-create causes Undelete
@@ -417,10 +392,7 @@ definition/sink/version/123/567/source-1/sink-3/0000000001
 		branch := branchTemplate(key.BranchKey{ProjectID: 123, BranchID: 111111})
 		if err := r.Create(&branch).Do(ctx).Err(); assert.Error(t, err) {
 			assert.Equal(t, "branch count limit reached in the project, the maximum is 100", err.Error())
-			var errWithStatus serviceErrors.WithStatusCode
-			if assert.True(t, errors.As(err, &errWithStatus)) {
-				assert.Equal(t, http.StatusConflict, errWithStatus.StatusCode())
-			}
+			serviceErrors.AssertErrorStatusCode(t, http.StatusConflict, err)
 		}
 	}
 }

--- a/internal/pkg/service/buffer/definition/repository/sink_repo_test.go
+++ b/internal/pkg/service/buffer/definition/repository/sink_repo_test.go
@@ -18,7 +18,6 @@ import (
 	serviceErrors "github.com/keboola/keboola-as-code/internal/pkg/service/common/errors"
 	"github.com/keboola/keboola-as-code/internal/pkg/service/common/etcdop/op"
 	"github.com/keboola/keboola-as-code/internal/pkg/service/common/utctime"
-	"github.com/keboola/keboola-as-code/internal/pkg/utils/errors"
 	"github.com/keboola/keboola-as-code/internal/pkg/utils/etcdhelper"
 )
 
@@ -84,30 +83,21 @@ func TestRepository_Sink(t *testing.T) {
 		// ExistsOrErr - not found
 		if err := r.ExistsOrErr(sink1.SinkKey).Do(ctx).Err(); assert.Error(t, err) {
 			assert.Equal(t, `sink "123/456/my-source-1/my-sink-1" not found in the source`, err.Error())
-			var errWithStatus serviceErrors.WithStatusCode
-			if assert.True(t, errors.As(err, &errWithStatus)) {
-				assert.Equal(t, http.StatusNotFound, errWithStatus.StatusCode())
-			}
+			serviceErrors.AssertErrorStatusCode(t, http.StatusNotFound, err)
 		}
 	}
 	{
 		// Get - not found
 		if err := r.Get(sink1.SinkKey).Do(ctx).Err(); assert.Error(t, err) {
 			assert.Equal(t, `sink "123/456/my-source-1/my-sink-1" not found in the source`, err.Error())
-			var errWithStatus serviceErrors.WithStatusCode
-			if assert.True(t, errors.As(err, &errWithStatus)) {
-				assert.Equal(t, http.StatusNotFound, errWithStatus.StatusCode())
-			}
+			serviceErrors.AssertErrorStatusCode(t, http.StatusNotFound, err)
 		}
 	}
 	{
 		// GetDeleted - not found
 		if err := r.GetDeleted(sink1.SinkKey).Do(ctx).Err(); assert.Error(t, err) {
 			assert.Equal(t, `deleted sink "123/456/my-source-1/my-sink-1" not found in the source`, err.Error())
-			var errWithStatus serviceErrors.WithStatusCode
-			if assert.True(t, errors.As(err, &errWithStatus)) {
-				assert.Equal(t, http.StatusNotFound, errWithStatus.StatusCode())
-			}
+			serviceErrors.AssertErrorStatusCode(t, http.StatusNotFound, err)
 		}
 	}
 
@@ -116,10 +106,7 @@ func TestRepository_Sink(t *testing.T) {
 	{
 		if err := r.Create("Create description", &sink1).Do(ctx).Err(); assert.Error(t, err) {
 			assert.Equal(t, `source "123/456/my-source-1" not found in the branch`, err.Error())
-			var errWithStatus serviceErrors.WithStatusCode
-			if assert.True(t, errors.As(err, &errWithStatus)) {
-				assert.Equal(t, http.StatusNotFound, errWithStatus.StatusCode())
-			}
+			serviceErrors.AssertErrorStatusCode(t, http.StatusNotFound, err)
 		}
 	}
 
@@ -182,10 +169,7 @@ func TestRepository_Sink(t *testing.T) {
 		// GetDeleted - not found
 		if err := r.GetDeleted(sink1.SinkKey).Do(ctx).Err(); assert.Error(t, err) {
 			assert.Equal(t, `deleted sink "123/456/my-source-1/my-sink-1" not found in the source`, err.Error())
-			var errWithStatus serviceErrors.WithStatusCode
-			if assert.True(t, errors.As(err, &errWithStatus)) {
-				assert.Equal(t, http.StatusNotFound, errWithStatus.StatusCode())
-			}
+			serviceErrors.AssertErrorStatusCode(t, http.StatusNotFound, err)
 		}
 	}
 	{
@@ -200,10 +184,7 @@ func TestRepository_Sink(t *testing.T) {
 	{
 		if err := r.Create("Create description", &sink1).Do(ctx).Err(); assert.Error(t, err) {
 			assert.Equal(t, `sink "123/456/my-source-1/my-sink-1" already exists in the source`, err.Error())
-			var errWithStatus serviceErrors.WithStatusCode
-			if assert.True(t, errors.As(err, &errWithStatus)) {
-				assert.Equal(t, http.StatusConflict, errWithStatus.StatusCode())
-			}
+			serviceErrors.AssertErrorStatusCode(t, http.StatusConflict, err)
 		}
 	}
 
@@ -244,10 +225,7 @@ func TestRepository_Sink(t *testing.T) {
 		}).Do(ctx).Err()
 		if assert.Error(t, err) {
 			assert.Equal(t, `sink "123/456/my-source/non-existent" not found in the source`, err.Error())
-			var errWithStatus serviceErrors.WithStatusCode
-			if assert.True(t, errors.As(err, &errWithStatus)) {
-				assert.Equal(t, http.StatusNotFound, errWithStatus.StatusCode())
-			}
+			serviceErrors.AssertErrorStatusCode(t, http.StatusNotFound, err)
 		}
 	}
 
@@ -267,10 +245,7 @@ func TestRepository_Sink(t *testing.T) {
 	{
 		if err := r.Version(sink1.SinkKey, 10).Do(ctx).Err(); assert.Error(t, err) {
 			assert.Equal(t, `sink version "123/456/my-source-1/my-sink-1/0000000010" not found in the source`, err.Error())
-			var errWithStatus serviceErrors.WithStatusCode
-			if assert.True(t, errors.As(err, &errWithStatus)) {
-				assert.Equal(t, http.StatusNotFound, errWithStatus.StatusCode())
-			}
+			serviceErrors.AssertErrorStatusCode(t, http.StatusNotFound, err)
 		}
 	}
 
@@ -283,20 +258,14 @@ func TestRepository_Sink(t *testing.T) {
 		// ExistsOrErr - not found
 		if err := r.ExistsOrErr(sink1.SinkKey).Do(ctx).Err(); assert.Error(t, err) {
 			assert.Equal(t, `sink "123/456/my-source-1/my-sink-1" not found in the source`, err.Error())
-			var errWithStatus serviceErrors.WithStatusCode
-			if assert.True(t, errors.As(err, &errWithStatus)) {
-				assert.Equal(t, http.StatusNotFound, errWithStatus.StatusCode())
-			}
+			serviceErrors.AssertErrorStatusCode(t, http.StatusNotFound, err)
 		}
 	}
 	{
 		// Get - not found
 		if err := r.Get(sink1.SinkKey).Do(ctx).Err(); assert.Error(t, err) {
 			assert.Equal(t, `sink "123/456/my-source-1/my-sink-1" not found in the source`, err.Error())
-			var errWithStatus serviceErrors.WithStatusCode
-			if assert.True(t, errors.As(err, &errWithStatus)) {
-				assert.Equal(t, http.StatusNotFound, errWithStatus.StatusCode())
-			}
+			serviceErrors.AssertErrorStatusCode(t, http.StatusNotFound, err)
 		}
 	}
 	{
@@ -330,10 +299,7 @@ func TestRepository_Sink(t *testing.T) {
 	// -----------------------------------------------------------------------------------------------------------------
 	if err := r.SoftDelete(sink1.SinkKey).Do(ctx).Err(); assert.Error(t, err) {
 		assert.Equal(t, `sink "123/456/my-source-1/my-sink-1" not found in the source`, err.Error())
-		var errWithStatus serviceErrors.WithStatusCode
-		if assert.True(t, errors.As(err, &errWithStatus)) {
-			assert.Equal(t, http.StatusNotFound, errWithStatus.StatusCode())
-		}
+		serviceErrors.AssertErrorStatusCode(t, http.StatusNotFound, err)
 	}
 
 	// Undelete
@@ -362,10 +328,7 @@ func TestRepository_Sink(t *testing.T) {
 		// GetDeleted - not found
 		if err := r.GetDeleted(sink1.SinkKey).Do(ctx).Err(); assert.Error(t, err) {
 			assert.Equal(t, `deleted sink "123/456/my-source-1/my-sink-1" not found in the source`, err.Error())
-			var errWithStatus serviceErrors.WithStatusCode
-			if assert.True(t, errors.As(err, &errWithStatus)) {
-				assert.Equal(t, http.StatusNotFound, errWithStatus.StatusCode())
-			}
+			serviceErrors.AssertErrorStatusCode(t, http.StatusNotFound, err)
 		}
 	}
 	{
@@ -386,10 +349,7 @@ func TestRepository_Sink(t *testing.T) {
 	// -----------------------------------------------------------------------------------------------------------------
 	if err := r.Undelete(sink1.SinkKey).Do(ctx).Err(); assert.Error(t, err) {
 		assert.Equal(t, `deleted sink "123/456/my-source-1/my-sink-1" not found in the source`, err.Error())
-		var errWithStatus serviceErrors.WithStatusCode
-		if assert.True(t, errors.As(err, &errWithStatus)) {
-			assert.Equal(t, http.StatusNotFound, errWithStatus.StatusCode())
-		}
+		serviceErrors.AssertErrorStatusCode(t, http.StatusNotFound, err)
 	}
 
 	// Re-create causes Undelete + new version record
@@ -599,10 +559,7 @@ definition/sink/version/123/456/my-source-2/my-sink-2/0000000001
 		sink := sinkTemplate(key.SinkKey{SourceKey: sink1.SourceKey, SinkID: "over-maximum-count"})
 		if err := r.Create("Create description", &sink).Do(ctx).Err(); assert.Error(t, err) {
 			assert.Equal(t, "sink count limit reached in the source, the maximum is 100", err.Error())
-			var errWithStatus serviceErrors.WithStatusCode
-			if assert.True(t, errors.As(err, &errWithStatus)) {
-				assert.Equal(t, http.StatusConflict, errWithStatus.StatusCode())
-			}
+			serviceErrors.AssertErrorStatusCode(t, http.StatusConflict, err)
 		}
 	}
 
@@ -641,10 +598,7 @@ definition/sink/version/123/456/my-source-2/my-sink-2/0000000001
 		}).Do(ctx).Err()
 		if assert.Error(t, err) {
 			assert.Equal(t, "version count limit reached in the sink, the maximum is 1000", err.Error())
-			var errWithStatus serviceErrors.WithStatusCode
-			if assert.True(t, errors.As(err, &errWithStatus)) {
-				assert.Equal(t, http.StatusConflict, errWithStatus.StatusCode())
-			}
+			serviceErrors.AssertErrorStatusCode(t, http.StatusConflict, err)
 		}
 	}
 }

--- a/internal/pkg/service/buffer/definition/repository/source_repo_test.go
+++ b/internal/pkg/service/buffer/definition/repository/source_repo_test.go
@@ -17,7 +17,6 @@ import (
 	serviceErrors "github.com/keboola/keboola-as-code/internal/pkg/service/common/errors"
 	"github.com/keboola/keboola-as-code/internal/pkg/service/common/etcdop/op"
 	"github.com/keboola/keboola-as-code/internal/pkg/service/common/utctime"
-	"github.com/keboola/keboola-as-code/internal/pkg/utils/errors"
 	"github.com/keboola/keboola-as-code/internal/pkg/utils/etcdhelper"
 )
 
@@ -77,20 +76,14 @@ func TestRepository_Source(t *testing.T) {
 		// Get - not found
 		if err := r.Get(source1.SourceKey).Do(ctx).Err(); assert.Error(t, err) {
 			assert.Equal(t, `source "123/456/my-source-1" not found in the branch`, err.Error())
-			var errWithStatus serviceErrors.WithStatusCode
-			if assert.True(t, errors.As(err, &errWithStatus)) {
-				assert.Equal(t, http.StatusNotFound, errWithStatus.StatusCode())
-			}
+			serviceErrors.AssertErrorStatusCode(t, http.StatusNotFound, err)
 		}
 	}
 	{
 		// GetDeleted - not found
 		if err := r.GetDeleted(source1.SourceKey).Do(ctx).Err(); assert.Error(t, err) {
 			assert.Equal(t, `deleted source "123/456/my-source-1" not found in the branch`, err.Error())
-			var errWithStatus serviceErrors.WithStatusCode
-			if assert.True(t, errors.As(err, &errWithStatus)) {
-				assert.Equal(t, http.StatusNotFound, errWithStatus.StatusCode())
-			}
+			serviceErrors.AssertErrorStatusCode(t, http.StatusNotFound, err)
 		}
 	}
 
@@ -99,10 +92,7 @@ func TestRepository_Source(t *testing.T) {
 	{
 		if err := r.Create("Create description", &source1).Do(ctx).Err(); assert.Error(t, err) {
 			assert.Equal(t, `branch "123/456" not found in the project`, err.Error())
-			var errWithStatus serviceErrors.WithStatusCode
-			if assert.True(t, errors.As(err, &errWithStatus)) {
-				assert.Equal(t, http.StatusNotFound, errWithStatus.StatusCode())
-			}
+			serviceErrors.AssertErrorStatusCode(t, http.StatusNotFound, err)
 		}
 	}
 
@@ -157,10 +147,7 @@ func TestRepository_Source(t *testing.T) {
 		// GetDeleted - not found
 		if err := r.GetDeleted(source1.SourceKey).Do(ctx).Err(); assert.Error(t, err) {
 			assert.Equal(t, `deleted source "123/456/my-source-1" not found in the branch`, err.Error())
-			var errWithStatus serviceErrors.WithStatusCode
-			if assert.True(t, errors.As(err, &errWithStatus)) {
-				assert.Equal(t, http.StatusNotFound, errWithStatus.StatusCode())
-			}
+			serviceErrors.AssertErrorStatusCode(t, http.StatusNotFound, err)
 		}
 	}
 	{
@@ -175,10 +162,7 @@ func TestRepository_Source(t *testing.T) {
 	{
 		if err := r.Create("Create description", &source1).Do(ctx).Err(); assert.Error(t, err) {
 			assert.Equal(t, `source "123/456/my-source-1" already exists in the branch`, err.Error())
-			var errWithStatus serviceErrors.WithStatusCode
-			if assert.True(t, errors.As(err, &errWithStatus)) {
-				assert.Equal(t, http.StatusConflict, errWithStatus.StatusCode())
-			}
+			serviceErrors.AssertErrorStatusCode(t, http.StatusConflict, err)
 		}
 	}
 
@@ -221,10 +205,7 @@ func TestRepository_Source(t *testing.T) {
 		}).Do(ctx).Err()
 		if assert.Error(t, err) {
 			assert.Equal(t, `source "123/456/non-existent" not found in the branch`, err.Error())
-			var errWithStatus serviceErrors.WithStatusCode
-			if assert.True(t, errors.As(err, &errWithStatus)) {
-				assert.Equal(t, http.StatusNotFound, errWithStatus.StatusCode())
-			}
+			serviceErrors.AssertErrorStatusCode(t, http.StatusNotFound, err)
 		}
 	}
 
@@ -244,10 +225,7 @@ func TestRepository_Source(t *testing.T) {
 	{
 		if err := r.Version(source1.SourceKey, 10).Do(ctx).Err(); assert.Error(t, err) {
 			assert.Equal(t, `source version "123/456/my-source-1/0000000010" not found in the branch`, err.Error())
-			var errWithStatus serviceErrors.WithStatusCode
-			if assert.True(t, errors.As(err, &errWithStatus)) {
-				assert.Equal(t, http.StatusNotFound, errWithStatus.StatusCode())
-			}
+			serviceErrors.AssertErrorStatusCode(t, http.StatusNotFound, err)
 		}
 	}
 
@@ -277,10 +255,7 @@ func TestRepository_Source(t *testing.T) {
 		// Get - not found
 		if err := r.Get(source1.SourceKey).Do(ctx).Err(); assert.Error(t, err) {
 			assert.Equal(t, `source "123/456/my-source-1" not found in the branch`, err.Error())
-			var errWithStatus serviceErrors.WithStatusCode
-			if assert.True(t, errors.As(err, &errWithStatus)) {
-				assert.Equal(t, http.StatusNotFound, errWithStatus.StatusCode())
-			}
+			serviceErrors.AssertErrorStatusCode(t, http.StatusNotFound, err)
 		}
 	}
 	{
@@ -314,10 +289,7 @@ func TestRepository_Source(t *testing.T) {
 	// -----------------------------------------------------------------------------------------------------------------
 	if err := r.SoftDelete(source1.SourceKey).Do(ctx).Err(); assert.Error(t, err) {
 		assert.Equal(t, `source "123/456/my-source-1" not found in the branch`, err.Error())
-		var errWithStatus serviceErrors.WithStatusCode
-		if assert.True(t, errors.As(err, &errWithStatus)) {
-			assert.Equal(t, http.StatusNotFound, errWithStatus.StatusCode())
-		}
+		serviceErrors.AssertErrorStatusCode(t, http.StatusNotFound, err)
 	}
 
 	// Undelete
@@ -346,10 +318,7 @@ func TestRepository_Source(t *testing.T) {
 		// GetDeleted - not found
 		if err := r.GetDeleted(source1.SourceKey).Do(ctx).Err(); assert.Error(t, err) {
 			assert.Equal(t, `deleted source "123/456/my-source-1" not found in the branch`, err.Error())
-			var errWithStatus serviceErrors.WithStatusCode
-			if assert.True(t, errors.As(err, &errWithStatus)) {
-				assert.Equal(t, http.StatusNotFound, errWithStatus.StatusCode())
-			}
+			serviceErrors.AssertErrorStatusCode(t, http.StatusNotFound, err)
 		}
 	}
 	{
@@ -370,10 +339,7 @@ func TestRepository_Source(t *testing.T) {
 	// -----------------------------------------------------------------------------------------------------------------
 	if err := r.Undelete(source1.SourceKey).Do(ctx).Err(); assert.Error(t, err) {
 		assert.Equal(t, `deleted source "123/456/my-source-1" not found in the branch`, err.Error())
-		var errWithStatus serviceErrors.WithStatusCode
-		if assert.True(t, errors.As(err, &errWithStatus)) {
-			assert.Equal(t, http.StatusNotFound, errWithStatus.StatusCode())
-		}
+		serviceErrors.AssertErrorStatusCode(t, http.StatusNotFound, err)
 	}
 
 	// Re-create causes Undelete + new version record
@@ -588,10 +554,7 @@ definition/sink/version/123/456/my-source-1/sink-3/0000000001
 		source := sourceTemplate(key.SourceKey{BranchKey: key.BranchKey{ProjectID: projectID, BranchID: 456}, SourceID: "over-maximum-count"})
 		if err := r.Create("Create description", &source).Do(ctx).Err(); assert.Error(t, err) {
 			assert.Equal(t, "source count limit reached in the branch, the maximum is 100", err.Error())
-			var errWithStatus serviceErrors.WithStatusCode
-			if assert.True(t, errors.As(err, &errWithStatus)) {
-				assert.Equal(t, http.StatusConflict, errWithStatus.StatusCode())
-			}
+			serviceErrors.AssertErrorStatusCode(t, http.StatusConflict, err)
 		}
 	}
 
@@ -630,10 +593,7 @@ definition/sink/version/123/456/my-source-1/sink-3/0000000001
 		}).Do(ctx).Err()
 		if assert.Error(t, err) {
 			assert.Equal(t, "version count limit reached in the source, the maximum is 1000", err.Error())
-			var errWithStatus serviceErrors.WithStatusCode
-			if assert.True(t, errors.As(err, &errWithStatus)) {
-				assert.Equal(t, http.StatusConflict, errWithStatus.StatusCode())
-			}
+			serviceErrors.AssertErrorStatusCode(t, http.StatusConflict, err)
 		}
 	}
 }

--- a/internal/pkg/service/buffer/sink/tablesink/storage/file.go
+++ b/internal/pkg/service/buffer/sink/tablesink/storage/file.go
@@ -34,11 +34,11 @@ type FileType string
 
 type FileKey struct {
 	key.SinkKey
-	FileID FileID `json:"fileId" validate:"required"`
+	FileID
 }
 
 type FileID struct {
-	OpenedAt utctime.UTCTime `json:"openedAt" validate:"required"`
+	OpenedAt utctime.UTCTime `json:"fileOpenedAt" validate:"required"`
 }
 
 func (v FileID) String() string {

--- a/internal/pkg/service/buffer/sink/tablesink/storage/file_test.go
+++ b/internal/pkg/service/buffer/sink/tablesink/storage/file_test.go
@@ -31,7 +31,7 @@ func TestFileID_Validation(t *testing.T) {
 	// Empty
 	err := val.Validate(ctx, FileID{})
 	if assert.Error(t, err) {
-		assert.Equal(t, `"openedAt" is a required field`, err.Error())
+		assert.Equal(t, `"fileOpenedAt" is a required field`, err.Error())
 	}
 }
 
@@ -64,7 +64,7 @@ func TestFileKey_Validation(t *testing.T) {
 - "branchId" is a required field
 - "sourceId" is a required field
 - "sinkId" is a required field
-- "fileId" is a required field
+- "fileOpenedAt" is a required field
 `), strings.TrimSpace(err.Error()))
 	}
 }
@@ -118,7 +118,7 @@ func TestFile_Validation(t *testing.T) {
 - "branchId" is a required field
 - "sourceId" is a required field
 - "sinkId" is a required field
-- "fileId" is a required field
+- "fileOpenedAt" is a required field
 - "type" is a required field
 - "state" is a required field
 - "columns" is a required field

--- a/internal/pkg/service/buffer/sink/tablesink/storage/filestate.go
+++ b/internal/pkg/service/buffer/sink/tablesink/storage/filestate.go
@@ -15,7 +15,25 @@ const FileClosing FileState = "closing"
 const FileImporting FileState = "importing"
 
 // FileImported
-// The File has been successfully imported.
+// The File has been successfully imported to the target table.
 const FileImported FileState = "imported"
 
+// FileState is an enum type for file states.
+//
+// Example File and Slice transitions.
+//
+//      FILE            SLICE1           SLICE2           SLICE3
+//  -----------------------------------------------------------------
+//  FileWriting      SliceWriting     -------------    --------------
+//  FileWriting      SliceClosing     SliceWriting     --------------
+//  FileWriting      SliceUploading   SliceWriting     --------------
+//  FileWriting      SliceUploaded    SliceWriting     --------------
+//  FileWriting      SliceUploaded    SliceClosing     --------------
+//  ...
+//  FileWriting      SliceUploaded    SliceUploaded    SliceWriting
+//  FileClosing      SliceUploaded    SliceUploaded    SliceClosing
+//  FileClosing      SliceUploaded    SliceUploaded    SliceUploading
+//  FileClosing      SliceUploaded    SliceUploaded    SliceUploaded
+//  FileImporting    SliceUploaded    SliceUploaded    SliceUploaded
+//  FileImported     SliceImported    SliceImported    SliceImported
 type FileState string

--- a/internal/pkg/service/buffer/sink/tablesink/storage/filestate_test.go
+++ b/internal/pkg/service/buffer/sink/tablesink/storage/filestate_test.go
@@ -1,0 +1,60 @@
+package storage
+
+import (
+	"github.com/benbjohnson/clock"
+	"github.com/keboola/go-utils/pkg/wildcards"
+	"github.com/keboola/keboola-as-code/internal/pkg/service/common/utctime"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	"testing"
+	"time"
+)
+
+func TestFile_StateTransition(t *testing.T) {
+	t.Parallel()
+
+	clk := clock.Mock{}
+	clk.Set(utctime.MustParse("2000-01-01T00:00:00.000Z").Time())
+
+	// Create file entity
+	fileKey := testFileKey()
+	f := File{
+		FileKey: fileKey,
+		State:   FileWriting,
+	}
+
+	// FileClosing
+	clk.Add(time.Hour)
+	require.NoError(t, f.StateTransition(clk.Now(), FileClosing))
+	assert.Equal(t, File{
+		FileKey:   fileKey,
+		State:     FileClosing,
+		ClosingAt: ptr(utctime.MustParse("2000-01-01T01:00:00.000Z")),
+	}, f)
+
+	// FileImporting
+	clk.Add(time.Hour)
+	require.NoError(t, f.StateTransition(clk.Now(), FileImporting))
+	assert.Equal(t, File{
+		FileKey:     fileKey,
+		State:       FileImporting,
+		ClosingAt:   ptr(utctime.MustParse("2000-01-01T01:00:00.000Z")),
+		ImportingAt: ptr(utctime.MustParse("2000-01-01T02:00:00.000Z")),
+	}, f)
+
+	// FileImported
+	clk.Add(time.Hour)
+	require.NoError(t, f.StateTransition(clk.Now(), FileImported))
+	assert.Equal(t, File{
+		FileKey:     fileKey,
+		State:       FileImported,
+		ClosingAt:   ptr(utctime.MustParse("2000-01-01T01:00:00.000Z")),
+		ImportingAt: ptr(utctime.MustParse("2000-01-01T02:00:00.000Z")),
+		ImportedAt:  ptr(utctime.MustParse("2000-01-01T03:00:00.000Z")),
+	}, f)
+
+	// Invalid
+	if err := f.StateTransition(clk.Now(), FileImporting); assert.Error(t, err) {
+		wildcards.Assert(t, `unexpected file "%s" state transition from "imported" to "importing"`, err.Error())
+	}
+}

--- a/internal/pkg/service/buffer/sink/tablesink/storage/level.go
+++ b/internal/pkg/service/buffer/sink/tablesink/storage/level.go
@@ -24,8 +24,8 @@ func (l Level) String() string {
 	return string(l)
 }
 
-// ToLevel gets the lowest storage.Level at which at least one file slice is present.
-func (s FileState) ToLevel() Level {
+// Level gets the lowest storage.Level at which at least one file slice is present.
+func (s FileState) Level() Level {
 	switch s {
 	case FileWriting, FileClosing:
 		return LevelLocal
@@ -38,8 +38,8 @@ func (s FileState) ToLevel() Level {
 	}
 }
 
-// ToLevel gets the storage.Level at which the slice is present.
-func (s SliceState) ToLevel() Level {
+// Level gets the storage.Level at which the slice is present.
+func (s SliceState) Level() Level {
 	switch s {
 	case SliceWriting, SliceClosing, SliceUploading:
 		return LevelLocal

--- a/internal/pkg/service/buffer/sink/tablesink/storage/level.go
+++ b/internal/pkg/service/buffer/sink/tablesink/storage/level.go
@@ -24,6 +24,21 @@ func (l Level) String() string {
 	return string(l)
 }
 
+// ToLevel gets the lowest storage.Level at which at least one file slice is present.
+func (s FileState) ToLevel() Level {
+	switch s {
+	case FileWriting, FileClosing:
+		return LevelLocal
+	case FileImporting:
+		return LevelStaging
+	case FileImported:
+		return LevelTarget
+	default:
+		panic(errors.Errorf(`unexpected file state "%v"`, s))
+	}
+}
+
+// ToLevel gets the storage.Level at which the slice is present.
 func (s SliceState) ToLevel() Level {
 	switch s {
 	case SliceWriting, SliceClosing, SliceUploading:

--- a/internal/pkg/service/buffer/sink/tablesink/storage/level/local/file.go
+++ b/internal/pkg/service/buffer/sink/tablesink/storage/level/local/file.go
@@ -17,3 +17,13 @@ type File struct {
 	// DiskAllocation configures pre-allocation of the disk space for file slices.
 	DiskAllocation DiskAllocation `json:"diskAllocation"`
 }
+
+func NewFile(cfg Config, fileDir string) File {
+	return File{
+		Dir:               fileDir,
+		Compression:       cfg.Compression.Simplify(),
+		DiskSync:          cfg.DiskSync,
+		VolumesAssignment: cfg.VolumesAssignment,
+		DiskAllocation:    cfg.DiskAllocation,
+	}
+}

--- a/internal/pkg/service/buffer/sink/tablesink/storage/level/local/slice.go
+++ b/internal/pkg/service/buffer/sink/tablesink/storage/level/local/slice.go
@@ -2,6 +2,7 @@ package local
 
 import (
 	"github.com/c2h5oh/datasize"
+	"path/filepath"
 
 	"github.com/keboola/keboola-as-code/internal/pkg/service/buffer/sink/tablesink/storage/compression"
 	"github.com/keboola/keboola-as-code/internal/pkg/service/buffer/sink/tablesink/storage/level/local/writer/disksync"
@@ -21,4 +22,30 @@ type Slice struct {
 	DiskSync disksync.Config `json:"diskSync"`
 	// AllocatedDiskSpace defines the disk size that is pre-allocated when creating the slice.
 	AllocatedDiskSpace datasize.ByteSize `json:"allocatedDiskSpace"`
+}
+
+func (f File) NewSlice(sliceDir string, previousSliceSize datasize.ByteSize) (Slice, error) {
+	// Create filename according to the compression type
+	filename, err := compression.Filename("slice.csv", f.Compression.Type)
+	if err != nil {
+		return Slice{}, err
+	}
+
+	// Calculated pre-allocated disk space
+	var allocatedDiskSpace datasize.ByteSize
+	if f.DiskAllocation.Enabled {
+		if f.DiskAllocation.SizePercent > 0 && previousSliceSize > 0 {
+			allocatedDiskSpace = previousSliceSize
+		} else {
+			allocatedDiskSpace = (f.DiskAllocation.Size * datasize.ByteSize(f.DiskAllocation.SizePercent)) / 100
+		}
+	}
+
+	return Slice{
+		Dir:                filepath.Join(f.Dir, sliceDir),
+		Filename:           filename,
+		Compression:        f.Compression,
+		DiskSync:           f.DiskSync,
+		AllocatedDiskSpace: allocatedDiskSpace,
+	}, nil
 }

--- a/internal/pkg/service/buffer/sink/tablesink/storage/level/local/writer/volume/volumes.go
+++ b/internal/pkg/service/buffer/sink/tablesink/storage/level/local/writer/volume/volumes.go
@@ -39,7 +39,7 @@ func (v *Volumes) Events() *writer.Events {
 
 // VolumesFor returns volumes list according to the file settings.
 // One slice of the file should be written simultaneously to each volume.
-func (v *Volumes) VolumesFor(file *storage.File) []*Volume {
+func (v *Volumes) VolumesFor(file storage.File) []*Volume {
 	return v.assignVolumes(
 		file.LocalStorage.VolumesAssignment.PerPod,
 		file.LocalStorage.VolumesAssignment.PreferredTypes,

--- a/internal/pkg/service/buffer/sink/tablesink/storage/level/local/writer/volume/volumes_test.go
+++ b/internal/pkg/service/buffer/sink/tablesink/storage/level/local/writer/volume/volumes_test.go
@@ -358,7 +358,7 @@ func createVolumes(t *testing.T, volumesPath string, volumes []string) {
 	}
 }
 
-func newStorageFile(t *testing.T, openedAt utctime.UTCTime) *storage.File {
+func newStorageFile(t *testing.T, openedAt utctime.UTCTime) storage.File {
 	t.Helper()
 	f := test.NewFileOpenedAt(openedAt.String())
 

--- a/internal/pkg/service/buffer/sink/tablesink/storage/level/staging/file.go
+++ b/internal/pkg/service/buffer/sink/tablesink/storage/level/staging/file.go
@@ -2,6 +2,7 @@ package staging
 
 import (
 	"github.com/keboola/go-client/pkg/keboola"
+	"github.com/keboola/keboola-as-code/internal/pkg/service/buffer/sink/tablesink/storage/level/local"
 
 	"github.com/keboola/keboola-as-code/internal/pkg/service/buffer/sink/tablesink/storage/compression"
 	"github.com/keboola/keboola-as-code/internal/pkg/service/common/utctime"
@@ -15,4 +16,13 @@ type File struct {
 	// UploadCredentials to the staging storage.
 	UploadCredentials           *keboola.FileUploadCredentials `json:"credentials" validate:"required"`
 	UploadCredentialsExpiration utctime.UTCTime                `json:"credentialsExpiration" validate:"required"`
+}
+
+func NewFile(cfg Config, localFile local.File, credentials *keboola.FileUploadCredentials) File {
+	// Note: Compression in the staging storage is same as in the local storage, but it can be modified in the future.
+	return File{
+		Compression:                 localFile.Compression,
+		UploadCredentials:           credentials,
+		UploadCredentialsExpiration: utctime.From(credentials.CredentialsExpiration()),
+	}
 }

--- a/internal/pkg/service/buffer/sink/tablesink/storage/level/staging/slice.go
+++ b/internal/pkg/service/buffer/sink/tablesink/storage/level/staging/slice.go
@@ -2,6 +2,8 @@ package staging
 
 import (
 	"github.com/keboola/keboola-as-code/internal/pkg/service/buffer/sink/tablesink/storage/compression"
+	"github.com/keboola/keboola-as-code/internal/pkg/service/buffer/sink/tablesink/storage/level/local"
+	"github.com/keboola/keboola-as-code/internal/pkg/utils/errors"
 )
 
 type Slice struct {
@@ -9,4 +11,21 @@ type Slice struct {
 	Path string `json:"path" validate:"required"`
 	// Compression configuration.
 	Compression compression.Config `json:"compression"  validate:"dive"`
+}
+
+func (f File) NewSlice(path string, localSlice local.Slice) (Slice, error) {
+	// Add compression extension to the path
+	switch f.Compression.Type {
+	case compression.TypeNone:
+		// nop
+	case compression.TypeGZIP:
+		path += ".gz"
+	default:
+		return Slice{}, errors.Errorf(`compression type "%s" is not supported by the staging storage`, f.Compression.Type)
+	}
+
+	return Slice{
+		Path:        path,
+		Compression: localSlice.Compression,
+	}, nil
 }

--- a/internal/pkg/service/buffer/sink/tablesink/storage/level/target/file.go
+++ b/internal/pkg/service/buffer/sink/tablesink/storage/level/target/file.go
@@ -1,9 +1,18 @@
 package target
 
-import "github.com/keboola/go-client/pkg/keboola"
+import (
+	"github.com/keboola/go-client/pkg/keboola"
+	"github.com/keboola/keboola-as-code/internal/pkg/service/buffer/sink/tablesink/storage/level/staging"
+)
 
 type File struct {
 	TableID keboola.TableID `json:"tableId" validate:"required"`
 	// StorageJob is the last table import job.
 	StorageJob *keboola.StorageJob `json:"storageJob,omitempty"`
+}
+
+func NewFile(cfg Config, tableID keboola.TableID, stagingFile staging.File) File {
+	return File{
+		TableID: tableID,
+	}
 }

--- a/internal/pkg/service/buffer/sink/tablesink/storage/level_test.go
+++ b/internal/pkg/service/buffer/sink/tablesink/storage/level_test.go
@@ -8,12 +8,12 @@ import (
 
 func TestSliceState_ToLevel(t *testing.T) {
 	t.Parallel()
-	assert.Equal(t, LevelLocal, SliceWriting.ToLevel())
-	assert.Equal(t, LevelLocal, SliceClosing.ToLevel())
-	assert.Equal(t, LevelLocal, SliceUploading.ToLevel())
-	assert.Equal(t, LevelStaging, SliceUploaded.ToLevel())
-	assert.Equal(t, LevelTarget, SliceImported.ToLevel())
+	assert.Equal(t, LevelLocal, SliceWriting.Level())
+	assert.Equal(t, LevelLocal, SliceClosing.Level())
+	assert.Equal(t, LevelLocal, SliceUploading.Level())
+	assert.Equal(t, LevelStaging, SliceUploaded.Level())
+	assert.Equal(t, LevelTarget, SliceImported.Level())
 	assert.PanicsWithError(t, `unexpected slice state "foo"`, func() {
-		SliceState("foo").ToLevel()
+		SliceState("foo").Level()
 	})
 }

--- a/internal/pkg/service/buffer/sink/tablesink/storage/repository/file_repo.go
+++ b/internal/pkg/service/buffer/sink/tablesink/storage/repository/file_repo.go
@@ -133,7 +133,7 @@ func (r *FileRepository) get(k storage.FileKey) op.ForType[*op.KeyValueT[storage
 // - "All" prefix is used for classic CRUD operations.
 // - "InLevel" prefix is used for effective watching of the storage level.
 func (r *FileRepository) put(v storage.File, create bool) *op.TxnOp {
-	level := v.State.ToLevel()
+	level := v.State.Level()
 	etcdKey := r.schema.AllLevels().ByKey(v.FileKey)
 
 	txn := op.NewTxnOp(r.client)

--- a/internal/pkg/service/buffer/sink/tablesink/storage/repository/file_repo.go
+++ b/internal/pkg/service/buffer/sink/tablesink/storage/repository/file_repo.go
@@ -1,3 +1,184 @@
+package repository
+
+import (
+	"context"
+	"fmt"
+	"github.com/benbjohnson/clock"
+	"github.com/keboola/go-client/pkg/keboola"
+	"github.com/keboola/keboola-as-code/internal/pkg/service/buffer/definition"
+	"github.com/keboola/keboola-as-code/internal/pkg/service/buffer/definition/key"
+	"github.com/keboola/keboola-as-code/internal/pkg/service/buffer/sink/tablesink/storage"
+	"github.com/keboola/keboola-as-code/internal/pkg/service/buffer/sink/tablesink/storage/compression"
+	"github.com/keboola/keboola-as-code/internal/pkg/service/buffer/sink/tablesink/storage/level/local"
+	"github.com/keboola/keboola-as-code/internal/pkg/service/buffer/sink/tablesink/storage/level/staging"
+	"github.com/keboola/keboola-as-code/internal/pkg/service/buffer/sink/tablesink/storage/level/target"
+	serviceError "github.com/keboola/keboola-as-code/internal/pkg/service/common/errors"
+	"github.com/keboola/keboola-as-code/internal/pkg/service/common/etcdop/iterator"
+	"github.com/keboola/keboola-as-code/internal/pkg/service/common/etcdop/op"
+	"github.com/keboola/keboola-as-code/internal/pkg/service/common/utctime"
+	"github.com/keboola/keboola-as-code/internal/pkg/utils/errors"
+	etcd "go.etcd.io/etcd/client/v3"
+	"path/filepath"
+	"time"
+)
+
+type FileRepository struct {
+	clock   clock.Clock
+	client  etcd.KV
+	schema  fileSchema
+	config  storage.Config
+	backoff storage.RetryBackoff
+	all     *Repository
+}
+
+func newFileRepository(d dependencies, config storage.Config, backoff storage.RetryBackoff, all *Repository) *FileRepository {
+	return &FileRepository{
+		clock:   d.Clock(),
+		client:  d.EtcdClient(),
+		schema:  newFileSchema(d.EtcdSerde()),
+		config:  config,
+		backoff: backoff,
+		all:     all,
+	}
+}
+
+func (r *FileRepository) List(parentKey fmt.Stringer) iterator.DefinitionT[storage.File] {
+	return r.schema.AllLevels().InObject(parentKey).GetAll(r.client)
+}
+
+func (r *FileRepository) Get(k storage.FileKey) op.ForType[*op.KeyValueT[storage.File]] {
+	return r.get(k).WithEmptyResultAsError(func() error {
+		return serviceError.NewResourceNotFoundError("file", k.String(), "sink")
+	})
+}
+
+func (r *FileRepository) Create(sinkKey key.SinkKey, credentials *keboola.FileUploadCredentials) *op.AtomicOp[storage.File] {
+	var sinkKV *op.KeyValueT[definition.Sink]
+	var result storage.File
+	return op.Atomic(r.client, &result).
+		// Sink must exist
+		ReadOp(r.all.sink.Get(sinkKey).WithResultTo(&sinkKV)).
+		// Save
+		WriteOrErr(func() (op op.Op, err error) {
+			sink := sinkKV.Value
+
+			// File should be created only for the table sinks
+			if sink.Type != definition.SinkTypeTable {
+				return nil, errors.Errorf(`unexpected sink type "%s", expected table sink`, sink.Type)
+			}
+
+			// Apply configuration patch from the sink to the global config
+			cfg := r.config.With(sink.Table.Storage)
+
+			// Create entity
+			result, err = newFile(r.clock.Now(), cfg, sink.SinkKey, sink.Table.Mapping, credentials)
+			if err != nil {
+				return nil, err
+			}
+
+			// Save operation
+			return r.put(result, true), nil
+		})
+}
+
+func (r *FileRepository) IncrementRetry(k storage.FileKey, reason string) *op.AtomicOp[storage.File] {
+	return r.update(k, func(slice storage.File) (storage.File, error) {
+		slice.IncrementRetry(r.backoff, r.clock.Now(), reason)
+		return slice, nil
+	})
+}
+
+func (r *FileRepository) StateTransition(k storage.FileKey, to storage.FileState) *op.AtomicOp[storage.File] {
+	now := r.clock.Now()
+	return r.
+		update(k, func(file storage.File) (storage.File, error) {
+			if err := file.StateTransition(now, to); err == nil {
+				return file, nil
+			} else {
+				return storage.File{}, err
+			}
+		}).
+		AddFrom(r.all.slice.onFileStateTransition(k, now, to))
+}
+
+func (r *FileRepository) Delete(k storage.FileKey) *op.TxnOp {
+	txn := op.NewTxnOp(r.client)
+
+	// Delete entity from All prefix
+	txn.And(
+		r.schema.
+			AllLevels().ByKey(k).DeleteIfExists(r.client).
+			WithEmptyResultAsError(func() error {
+				return serviceError.NewResourceNotFoundError("file", k.String(), "sink")
+			}),
+	)
+
+	// Delete entity from InLevel prefixes
+	for _, l := range storage.AllLevels() {
+		txn.Then(r.schema.InLevel(l).ByKey(k).Delete(r.client))
+	}
+
+	// Delete all slices
+	txn.And(r.all.slice.deleteAll(k))
+
+	return txn
+}
+
+func (r *FileRepository) get(k storage.FileKey) op.ForType[*op.KeyValueT[storage.File]] {
+	return r.schema.AllLevels().ByKey(k).Get(r.client)
+}
+
+// put saves the file.
+// The entity is stored in 2 copies, under "All" prefix and "InLevel" prefix.
+// - "All" prefix is used for classic CRUD operations.
+// - "InLevel" prefix is used for effective watching of the storage level.
+func (r *FileRepository) put(v storage.File, create bool) *op.TxnOp {
+	level := v.State.ToLevel()
+	etcdKey := r.schema.AllLevels().ByKey(v.FileKey)
+
+	txn := op.NewTxnOp(r.client)
+	if create {
+		// Entity must not exist on create
+		txn.
+			If(etcd.Compare(etcd.ModRevision(etcdKey.Key()), "=", 0)).
+			AddProcessor(func(ctx context.Context, r *op.TxnResult) {
+				if r.Err() == nil && !r.Succeeded() {
+					r.AddErr(serviceError.NewResourceAlreadyExistsError("file", v.FileKey.String(), "sink"))
+				}
+			})
+	}
+
+	// Put entity to All and InLevel prefixes
+	txn.Then(etcdKey.Put(r.client, v))
+	txn.Then(r.schema.InLevel(level).ByKey(v.FileKey).Put(r.client, v))
+
+	// Delete entity from other levels, if any
+	// This simply handles the entity transition between different levels.
+	for _, l := range storage.AllLevels() {
+		if l != level {
+			txn.Then(r.schema.InLevel(l).ByKey(v.FileKey).Delete(r.client))
+		}
+	}
+
+	return txn
+}
+
+func (r *FileRepository) update(k storage.FileKey, updateFn func(storage.File) (storage.File, error)) *op.AtomicOp[storage.File] {
+	var result storage.File
+	var kv *op.KeyValueT[storage.File]
+	return op.Atomic(r.client, &result).
+		// Read entity for modification
+		ReadOp(r.Get(k).WithResultTo(&kv)).
+		// Prepare the new value
+		BeforeWriteOrErr(func() (err error) {
+			result, err = updateFn(kv.Value)
+			return err
+		}).
+		// Save the updated object
+		Write(func() op.Op {
+			return r.put(result, false)
+		})
+}
 
 // newFile creates file definition.
 func newFile(now time.Time, cfg storage.Config, sinkKey key.SinkKey, mapping definition.TableMapping, credentials *keboola.FileUploadCredentials) (f storage.File, err error) {

--- a/internal/pkg/service/buffer/sink/tablesink/storage/repository/file_repo.go
+++ b/internal/pkg/service/buffer/sink/tablesink/storage/repository/file_repo.go
@@ -1,0 +1,25 @@
+
+// newFile creates file definition.
+func newFile(now time.Time, cfg storage.Config, sinkKey key.SinkKey, mapping definition.TableMapping, credentials *keboola.FileUploadCredentials) (f storage.File, err error) {
+	// Validate compression type.
+	// Other parts of the system are also prepared for other types of compression,
+	// but now only GZIP is supported in the Keboola platform.
+	switch cfg.Local.Compression.Type {
+	case compression.TypeNone, compression.TypeGZIP: // ok
+	default:
+		return storage.File{}, errors.Errorf(`file compression type "%s" is not supported`, cfg.Local.Compression.Type)
+	}
+
+	// Convert path separator, on Windows
+	fileKey := storage.FileKey{SinkKey: sinkKey, FileID: storage.FileID{OpenedAt: utctime.From(now)}}
+	fileDir := filepath.FromSlash(fileKey.String()) //nolint:forbidigo
+
+	f.FileKey = fileKey
+	f.Type = storage.FileTypeCSV // different file types are not supported now
+	f.State = storage.FileWriting
+	f.Columns = mapping.Columns
+	f.LocalStorage = local.NewFile(cfg.Local, fileDir)
+	f.StagingStorage = staging.NewFile(cfg.Staging, f.LocalStorage, credentials)
+	f.TargetStorage = target.NewFile(cfg.Target, mapping.TableID, f.StagingStorage)
+	return f, nil
+}

--- a/internal/pkg/service/buffer/sink/tablesink/storage/repository/file_repo.go
+++ b/internal/pkg/service/buffer/sink/tablesink/storage/repository/file_repo.go
@@ -92,11 +92,10 @@ func (r *FileRepository) StateTransition(k storage.FileKey, to storage.FileState
 	now := r.clock.Now()
 	return r.
 		update(k, func(file storage.File) (storage.File, error) {
-			if err := file.StateTransition(now, to); err == nil {
-				return file, nil
-			} else {
+			if err := file.StateTransition(now, to); err != nil {
 				return storage.File{}, err
 			}
+			return file, nil
 		}).
 		AddFrom(r.all.slice.onFileStateTransition(k, now, to))
 }

--- a/internal/pkg/service/buffer/sink/tablesink/storage/repository/file_repo_test.go
+++ b/internal/pkg/service/buffer/sink/tablesink/storage/repository/file_repo_test.go
@@ -1,0 +1,434 @@
+package repository
+
+import (
+	"context"
+	"github.com/benbjohnson/clock"
+	"github.com/c2h5oh/datasize"
+	"github.com/keboola/go-client/pkg/keboola"
+	"github.com/keboola/go-client/pkg/keboola/storage_file_upload/s3"
+	"github.com/keboola/keboola-as-code/internal/pkg/service/buffer/definition"
+	"github.com/keboola/keboola-as-code/internal/pkg/service/buffer/definition/column"
+	"github.com/keboola/keboola-as-code/internal/pkg/service/buffer/definition/key"
+	defRepository "github.com/keboola/keboola-as-code/internal/pkg/service/buffer/definition/repository"
+	"github.com/keboola/keboola-as-code/internal/pkg/service/buffer/sink/tablesink/storage"
+	"github.com/keboola/keboola-as-code/internal/pkg/service/buffer/sink/tablesink/storage/compression"
+	"github.com/keboola/keboola-as-code/internal/pkg/service/buffer/sink/tablesink/storage/level/local"
+	"github.com/keboola/keboola-as-code/internal/pkg/service/buffer/sink/tablesink/storage/level/local/writer/disksync"
+	deps "github.com/keboola/keboola-as-code/internal/pkg/service/common/dependencies"
+	serviceError "github.com/keboola/keboola-as-code/internal/pkg/service/common/errors"
+	"github.com/keboola/keboola-as-code/internal/pkg/service/common/utctime"
+	"github.com/keboola/keboola-as-code/internal/pkg/utils/etcdhelper"
+	"github.com/relvacode/iso8601"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	"net/http"
+	"testing"
+	"time"
+)
+
+func branchTemplate(k key.BranchKey) definition.Branch {
+	return definition.Branch{BranchKey: k}
+}
+
+func sourceTemplate(k key.SourceKey) definition.Source {
+	return definition.Source{
+		SourceKey:   k,
+		Type:        definition.SourceTypeHTTP,
+		Name:        "My Source",
+		Description: "My Description",
+		HTTP:        &definition.HTTPSource{Secret: "012345678901234567890123456789012345678912345678"},
+	}
+}
+
+func sinkTemplate(k key.SinkKey) definition.Sink {
+	return definition.Sink{
+		SinkKey:     k,
+		Type:        definition.SinkTypeTable,
+		Name:        "My Sink",
+		Description: "My Description",
+		Table: &definition.TableSink{
+			Storage: &storage.ConfigPatch{
+				Local: &local.ConfigPatch{
+					DiskSync: &disksync.Config{
+						Mode:            disksync.ModeDisk,
+						Wait:            true,
+						CheckInterval:   1 * time.Millisecond,
+						CountTrigger:    100,
+						BytesTrigger:    100 * datasize.KB,
+						IntervalTrigger: 100 * time.Millisecond,
+					},
+				},
+			},
+			Mapping: definition.TableMapping{
+				TableID: keboola.MustParseTableID("in.bucket.table"),
+				Columns: column.Columns{
+					column.Datetime{Name: "datetime"},
+					column.Body{Name: "body"},
+				},
+			},
+		},
+	}
+}
+
+func TestRepository_File(t *testing.T) {
+	t.Parallel()
+	ctx := context.Background()
+
+	now := utctime.MustParse("2000-01-01T19:00:00.000Z").Time()
+	clk := clock.NewMock()
+	clk.Set(now)
+
+	// Fixtures
+	projectID := keboola.ProjectID(123)
+	branchKey := key.BranchKey{ProjectID: projectID, BranchID: 456}
+	sourceKey := key.SourceKey{BranchKey: branchKey, SourceID: "my-source"}
+	sinkKey1 := key.SinkKey{SourceKey: sourceKey, SinkID: "my-sink-1"}
+	sinkKey2 := key.SinkKey{SourceKey: sourceKey, SinkID: "my-sink-2"}
+	cfg := storage.NewConfig()
+	credentials := &keboola.FileUploadCredentials{
+		S3UploadParams: &s3.UploadParams{
+			Credentials: s3.Credentials{
+				Expiration: iso8601.Time{Time: now.Add(time.Hour)},
+			},
+		},
+	}
+	nonExistentFileKey := storage.FileKey{
+		SinkKey: sinkKey1,
+		FileID:  storage.FileID{OpenedAt: utctime.MustParse("2000-01-01T18:00:00.000Z")},
+	}
+
+	d := deps.NewMocked(t, deps.WithEnabledEtcdClient(), deps.WithClock(clk))
+	client := d.TestEtcdClient()
+	defRepo := defRepository.New(d)
+	backoff := storage.NoRandomizationBackoff()
+	r := newWithBackoff(d, defRepo, cfg, backoff).File()
+
+	// Empty
+	// -----------------------------------------------------------------------------------------------------------------
+	{
+		// List - empty
+		files, err := r.List(projectID).Do(ctx).All()
+		assert.NoError(t, err)
+		assert.Empty(t, files)
+		files, err = r.List(sinkKey1).Do(ctx).All()
+		assert.NoError(t, err)
+		assert.Empty(t, files)
+	}
+	{
+		// Get - not found
+		if err := r.Get(nonExistentFileKey).Do(ctx).Err(); assert.Error(t, err) {
+			assert.Equal(t, `file "123/456/my-source/my-sink-1/2000-01-01T18:00:00.000Z" not found in the sink`, err.Error())
+			serviceError.AssertErrorStatusCode(t, http.StatusNotFound, err)
+		}
+	}
+
+	// Create - parent sink doesn't exists
+	// -----------------------------------------------------------------------------------------------------------------
+	// Entity exists only in memory
+	{
+		if err := r.Create(sinkKey1, credentials).Do(ctx).Err(); assert.Error(t, err) {
+			assert.Equal(t, `sink "123/456/my-source/my-sink-1" not found in the source`, err.Error())
+			serviceError.AssertErrorStatusCode(t, http.StatusNotFound, err)
+		}
+	}
+
+	// Create parent branch, source and sinks
+	// -----------------------------------------------------------------------------------------------------------------
+	{
+		branch := branchTemplate(branchKey)
+		require.NoError(t, defRepo.Branch().Create(&branch).Do(ctx).Err())
+		source := sourceTemplate(sourceKey)
+		require.NoError(t, defRepo.Source().Create("Create source", &source).Do(ctx).Err())
+		sink1 := sinkTemplate(sinkKey1)
+		require.NoError(t, defRepo.Sink().Create("Create sink", &sink1).Do(ctx).Err())
+		sink2 := sinkTemplate(sinkKey2)
+		require.NoError(t, defRepo.Sink().Create("Create sink", &sink2).Do(ctx).Err())
+	}
+
+	// Create
+	// -----------------------------------------------------------------------------------------------------------------
+	var fileKey1, fileKey2 storage.FileKey
+	{
+		// Create 2 files in different sinks
+		file1, err := r.Create(sinkKey1, credentials).Do(ctx).ResultOrErr()
+		require.NoError(t, err)
+		fileKey1 = file1.FileKey
+
+		file2, err := r.Create(sinkKey2, credentials).Do(ctx).ResultOrErr()
+		require.NoError(t, err)
+		fileKey2 = file2.FileKey
+	}
+	{
+		// List
+		files, err := r.List(projectID).Do(ctx).All()
+		assert.NoError(t, err)
+		assert.Len(t, files, 2)
+		files, err = r.List(branchKey).Do(ctx).All()
+		assert.NoError(t, err)
+		assert.Len(t, files, 2)
+		files, err = r.List(sourceKey).Do(ctx).All()
+		assert.NoError(t, err)
+		assert.Len(t, files, 2)
+		files, err = r.List(sinkKey1).Do(ctx).All()
+		assert.NoError(t, err)
+		assert.Len(t, files, 1)
+		files, err = r.List(sinkKey2).Do(ctx).All()
+		assert.NoError(t, err)
+		assert.Len(t, files, 1)
+	}
+	{
+		// Get
+		result1, err := r.Get(fileKey1).Do(ctx).ResultOrErr()
+		require.NoError(t, err)
+		assert.Equal(t, now, result1.Value.OpenedAt().Time())
+		result2, err := r.Get(fileKey2).Do(ctx).ResultOrErr()
+		require.NoError(t, err)
+		assert.Equal(t, now, result2.Value.OpenedAt().Time())
+	}
+
+	// Create - already exists
+	// -----------------------------------------------------------------------------------------------------------------
+	{
+		if err := r.Create(sinkKey1, credentials).Do(ctx).Err(); assert.Error(t, err) {
+			assert.Equal(t, `file "123/456/my-source/my-sink-1/2000-01-01T19:00:00.000Z" already exists in the sink`, err.Error())
+			serviceError.AssertErrorStatusCode(t, http.StatusConflict, err)
+		}
+	}
+
+	// Update (update is private method, public methods IncrementRetry and StateTransition are tested bellow)
+	// -----------------------------------------------------------------------------------------------------------------
+	clk.Add(time.Hour)
+	{
+		// Modify configuration
+		result, err := r.update(fileKey1, func(v storage.File) (storage.File, error) {
+			v.LocalStorage.DiskSync.Wait = false
+			return v, nil
+		}).Do(ctx).ResultOrErr()
+		require.NoError(t, err)
+		assert.False(t, result.LocalStorage.DiskSync.Wait)
+		kv, err := r.Get(fileKey1).Do(ctx).ResultOrErr()
+		require.NoError(t, err)
+		assert.Equal(t, result, kv.Value)
+	}
+
+	// Update - not found
+	// -----------------------------------------------------------------------------------------------------------------
+	{
+		err := r.update(nonExistentFileKey, func(v storage.File) (storage.File, error) {
+			return v, nil
+		}).Do(ctx).Err()
+		if assert.Error(t, err) {
+			assert.Equal(t, `file "123/456/my-source/my-sink-1/2000-01-01T18:00:00.000Z" not found in the sink`, err.Error())
+			serviceError.AssertErrorStatusCode(t, http.StatusNotFound, err)
+		}
+	}
+
+	// Increment retry attempt
+	// -----------------------------------------------------------------------------------------------------------------
+	{
+		result, err := r.IncrementRetry(fileKey1, "some error").Do(ctx).ResultOrErr()
+		require.NoError(t, err)
+		assert.Equal(t, 1, result.RetryAttempt)
+		assert.Equal(t, "some error", result.RetryReason)
+		assert.Equal(t, "2000-01-01T20:00:00.000Z", result.LastFailedAt.String())
+		assert.Equal(t, "2000-01-01T20:02:00.000Z", result.RetryAfter.String())
+		kv, err := r.Get(fileKey1).Do(ctx).ResultOrErr()
+		require.NoError(t, err)
+		assert.Equal(t, result, kv.Value)
+	}
+
+	// Switch file state
+	// -----------------------------------------------------------------------------------------------------------------
+	for _, to := range []storage.FileState{storage.FileClosing, storage.FileImporting, storage.FileImported} {
+		clk.Add(time.Hour)
+
+		result, err := r.StateTransition(fileKey1, to).Do(ctx).ResultOrErr()
+		require.NoError(t, err)
+
+		// File state has been switched
+		assert.Equal(t, to, result.State)
+
+		// Retry should be reset
+		assert.Equal(t, 0, result.RetryAttempt)
+		assert.Nil(t, result.LastFailedAt)
+
+		// Check timestamp
+		switch to {
+		case storage.FileClosing:
+			assert.Equal(t, utctime.From(clk.Now()).String(), result.ClosingAt.String())
+		case storage.FileImporting:
+			assert.Equal(t, utctime.From(clk.Now()).String(), result.ImportingAt.String())
+		case storage.FileImported:
+			assert.Equal(t, utctime.From(clk.Now()).String(), result.ImportedAt.String())
+		}
+	}
+
+	// Switch file state - already in the state
+	// -----------------------------------------------------------------------------------------------------------------
+	if err := r.StateTransition(fileKey1, storage.FileImported).Do(ctx).Err(); assert.Error(t, err) {
+		assert.Equal(t, `unexpected file "123/456/my-source/my-sink-1/2000-01-01T19:00:00.000Z" state transition from "imported" to "imported"`, err.Error())
+		serviceError.AssertErrorStatusCode(t, http.StatusBadRequest, err)
+	}
+
+	// Switch file state - unexpected transition
+	// -----------------------------------------------------------------------------------------------------------------
+	if err := r.StateTransition(fileKey1, storage.FileImporting).Do(ctx).Err(); assert.Error(t, err) {
+		assert.Equal(t, `unexpected file "123/456/my-source/my-sink-1/2000-01-01T19:00:00.000Z" state transition from "imported" to "importing"`, err.Error())
+		serviceError.AssertErrorStatusCode(t, http.StatusBadRequest, err)
+	}
+
+	// Delete
+	// -----------------------------------------------------------------------------------------------------------------
+	{
+		assert.NoError(t, r.Delete(fileKey2).Do(ctx).Err())
+	}
+	{
+		// Get - not found
+		if err := r.Get(fileKey2).Do(ctx).Err(); assert.Error(t, err) {
+			assert.Equal(t, `file "123/456/my-source/my-sink-2/2000-01-01T19:00:00.000Z" not found in the sink`, err.Error())
+			serviceError.AssertErrorStatusCode(t, http.StatusNotFound, err)
+		}
+	}
+	{
+		// List - empty
+		files, err := r.List(sinkKey2).Do(ctx).All()
+		assert.NoError(t, err)
+		assert.Empty(t, files)
+	}
+
+	// Delete - not found
+	// -----------------------------------------------------------------------------------------------------------------
+	if err := r.Delete(nonExistentFileKey).Do(ctx).Err(); assert.Error(t, err) {
+		assert.Equal(t, `file "123/456/my-source/my-sink-1/2000-01-01T18:00:00.000Z" not found in the sink`, err.Error())
+		serviceError.AssertErrorStatusCode(t, http.StatusNotFound, err)
+	}
+
+	// Check etcd state - file2 has been deleted, but file 1 exists
+	// -----------------------------------------------------------------------------------------------------------------
+	etcdhelper.AssertKVsString(t, client, expectedFileEtcdState(), etcdhelper.WithIgnoredKeyPattern("^definition/"))
+}
+
+func expectedFileEtcdState() string {
+	return `
+<<<<<
+storage/file/all/123/456/my-source/my-sink-1/2000-01-01T19:00:00.000Z
+-----
+{
+  "projectId": 123,
+  "branchId": 456,
+  "sourceId": "my-source",
+  "sinkId": "my-sink-1",
+  "fileOpenedAt": "2000-01-01T19:00:00.000Z",
+  "type": "csv",
+  "state": "imported",
+  "closingAt": "2000-01-01T21:00:00.000Z",
+  "importingAt": "2000-01-01T22:00:00.000Z",
+  "importedAt": "2000-01-01T23:00:00.000Z",
+  "columns": [
+    {
+      "type": "datetime",
+      "name": "datetime"
+    },
+    {
+      "type": "body",
+      "name": "body"
+    }
+  ],
+  "local": {
+    "dir": "123/456/my-source/my-sink-1/2000-01-01T19:00:00.000Z",
+    "compression": {
+      "type": "gzip",
+      "gzip": {
+        "level": 1,
+        "implementation": "parallel",
+        "blockSize": "256KB",
+        "concurrency": 0
+      }
+    },
+    "volumesAssignment": {
+      "perPod": 1,
+      "preferredTypes": [
+        "default"
+      ]
+    },
+    "diskSync": {
+      "mode": "disk",
+      "wait": false,
+      "checkInterval": 1000000,
+      "countTrigger": 100,
+      "bytesTrigger": "100KB",
+      "intervalTrigger": 100000000
+    },
+    "diskAllocation": {
+      "enabled": true,
+      "size": "100MB",
+      "sizePercent": 110
+    }
+  },
+  "staging": {
+    "compression": {
+      "type": "gzip",
+      "gzip": {
+        "level": 1,
+        "implementation": "parallel",
+        "blockSize": "256KB",
+        "concurrency": 0
+      }
+    },
+    "credentials": {%A},
+    "credentialsExpiration": "2000-01-01T20:00:00.000Z"
+  },
+  "target": {
+    "tableId": "in.bucket.table"
+  }
+}
+>>>>>
+
+<<<<<
+storage/file/level/target/123/456/my-source/my-sink-1/2000-01-01T19:00:00.000Z
+-----
+{
+  "projectId": 123,
+  "branchId": 456,
+  "sourceId": "my-source",
+  "sinkId": "my-sink-1",
+  "fileOpenedAt": "2000-01-01T19:00:00.000Z",
+%A
+}
+>>>>>
+`
+}
+
+func TestNewFile_InvalidCompressionType(t *testing.T) {
+	t.Parallel()
+
+	// Fixtures
+	projectID := keboola.ProjectID(123)
+	branchKey := key.BranchKey{ProjectID: projectID, BranchID: 456}
+	sourceKey := key.SourceKey{BranchKey: branchKey, SourceID: "my-source"}
+	sinkKey := key.SinkKey{SourceKey: sourceKey, SinkID: "my-sink"}
+	now := utctime.MustParse("2000-01-01T19:00:00.000Z").Time()
+	cfg := storage.NewConfig()
+	mapping := definition.TableMapping{
+		TableID: keboola.MustParseTableID("in.bucket.table"),
+		Columns: column.Columns{
+			column.Datetime{Name: "datetime"},
+			column.Body{Name: "body"},
+		},
+	}
+	credentials := &keboola.FileUploadCredentials{
+		S3UploadParams: &s3.UploadParams{
+			Credentials: s3.Credentials{
+				Expiration: iso8601.Time{Time: now.Add(time.Hour)},
+			},
+		},
+	}
+
+	// Set unsupported compression type
+	cfg.Local.Compression.Type = compression.TypeZSTD
+
+	// Assert
+	_, err := newFile(now, cfg, sinkKey, mapping, credentials)
+	require.Error(t, err)
+	assert.Equal(t, `file compression type "zstd" is not supported`, err.Error())
+}

--- a/internal/pkg/service/buffer/sink/tablesink/storage/repository/file_schema.go
+++ b/internal/pkg/service/buffer/sink/tablesink/storage/repository/file_schema.go
@@ -1,0 +1,72 @@
+package repository
+
+import (
+	"fmt"
+	"github.com/keboola/go-client/pkg/keboola"
+	. "github.com/keboola/keboola-as-code/internal/pkg/service/buffer/definition/key"
+	. "github.com/keboola/keboola-as-code/internal/pkg/service/buffer/sink/tablesink/storage"
+	. "github.com/keboola/keboola-as-code/internal/pkg/service/common/etcdop"
+	"github.com/keboola/keboola-as-code/internal/pkg/service/common/etcdop/serde"
+	"github.com/keboola/keboola-as-code/internal/pkg/utils/errors"
+)
+
+type (
+	// fileSchema is an etcd prefix that stores all file entities.
+	fileSchema struct{ PrefixT[File] }
+	// fileSchemaInLevel - see fileSchema.AllLevels and fileSchema.InLevel methods.
+	// The entity is stored in 2 copies, under "All" prefix and "InLevel" prefix.
+	// - "All" prefix is used for classic CRUD operations.
+	// - "InLevel" prefix is used for effective watching of the storage level.
+	fileSchemaInLevel  fileSchema
+	fileSchemaInObject fileSchema
+)
+
+func newFileSchema(s *serde.Serde) fileSchema {
+	return fileSchema{PrefixT: NewTypedPrefix[File]("storage/file", s)}
+}
+
+func (s fileSchema) AllLevels() fileSchemaInLevel {
+	return fileSchemaInLevel{PrefixT: s.PrefixT.Add("all")}
+}
+
+func (s fileSchema) InLevel(level Level) fileSchemaInLevel {
+	switch level {
+	case LevelLocal, LevelStaging, LevelTarget:
+		return fileSchemaInLevel{PrefixT: s.PrefixT.Add("level").Add(level.String())}
+	default:
+		panic(errors.Errorf(`unexpected storage level "%v"`, level))
+	}
+}
+
+func (v fileSchemaInLevel) ByKey(k FileKey) KeyT[File] {
+	return v.PrefixT.Key(k.String())
+}
+
+func (v fileSchemaInLevel) InObject(k fmt.Stringer) fileSchemaInObject {
+	switch k.(type) {
+	case keboola.ProjectID, BranchKey, SourceKey, SinkKey:
+		return v.inObject(k)
+	default:
+		panic(errors.Errorf(`unexpected object key "%T"`, k))
+	}
+}
+
+func (v fileSchemaInLevel) InProject(projectID keboola.ProjectID) fileSchemaInObject {
+	return v.inObject(projectID)
+}
+
+func (v fileSchemaInLevel) InBranch(k BranchKey) fileSchemaInObject {
+	return v.inObject(k)
+}
+
+func (v fileSchemaInLevel) InSource(k SourceKey) fileSchemaInObject {
+	return v.inObject(k)
+}
+
+func (v fileSchemaInLevel) InSink(k SinkKey) fileSchemaInObject {
+	return v.inObject(k)
+}
+
+func (v fileSchemaInLevel) inObject(objectKey fmt.Stringer) fileSchemaInObject {
+	return fileSchemaInObject{PrefixT: v.PrefixT.Add(objectKey.String())}
+}

--- a/internal/pkg/service/buffer/sink/tablesink/storage/repository/file_schema_test.go
+++ b/internal/pkg/service/buffer/sink/tablesink/storage/repository/file_schema_test.go
@@ -1,0 +1,80 @@
+package repository
+
+import (
+	"fmt"
+	"github.com/keboola/keboola-as-code/internal/pkg/service/buffer/sink/tablesink/storage"
+	"github.com/keboola/keboola-as-code/internal/pkg/service/buffer/sink/tablesink/storage/test"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+
+	"github.com/keboola/keboola-as-code/internal/pkg/service/common/etcdop/serde"
+)
+
+func TestFileSchema(t *testing.T) {
+	t.Parallel()
+	s := newFileSchema(serde.NewJSON(serde.NoValidation))
+
+	fileKey := test.NewFileKey()
+
+	cases := []struct{ actual, expected string }{
+		{
+			s.Prefix(),
+			"storage/file/",
+		},
+		{
+			s.AllLevels().Prefix(),
+			"storage/file/all/",
+		},
+		{
+			s.InLevel(storage.LevelLocal).Prefix(),
+			"storage/file/level/local/",
+		},
+		{
+			s.InLevel(storage.LevelStaging).Prefix(),
+			"storage/file/level/staging/",
+		},
+		{
+			s.InLevel(storage.LevelTarget).Prefix(),
+			"storage/file/level/target/",
+		},
+		{
+			s.InLevel(storage.LevelLocal).InObject(fileKey.ProjectID).Prefix(),
+			"storage/file/level/local/123/",
+		},
+		{
+			s.InLevel(storage.LevelLocal).InProject(fileKey.ProjectID).Prefix(),
+			"storage/file/level/local/123/",
+		},
+		{
+			s.InLevel(storage.LevelLocal).InBranch(fileKey.BranchKey).Prefix(),
+			"storage/file/level/local/123/456/",
+		},
+		{
+			s.InLevel(storage.LevelLocal).InSource(fileKey.SourceKey).Prefix(),
+			"storage/file/level/local/123/456/my-source/",
+		},
+		{
+			s.InLevel(storage.LevelLocal).InSink(fileKey.SinkKey).Prefix(),
+			"storage/file/level/local/123/456/my-source/my-sink/",
+		},
+		{
+			s.InLevel(storage.LevelLocal).ByKey(fileKey).Key(),
+			"storage/file/level/local/123/456/my-source/my-sink/2000-01-01T19:00:00.000Z",
+		},
+	}
+
+	for i, c := range cases {
+		assert.Equal(t, c.expected, c.actual, fmt.Sprintf(`case "%d"`, i+1))
+	}
+
+	// Test panics
+	assert.Panics(t, func() {
+		// Unexpected storage level
+		s.InLevel("foo")
+	})
+	assert.Panics(t, func() {
+		// There is no file in slice level, slice is in file, not file in slice
+		s.InLevel(storage.LevelLocal).InObject(storage.SliceKey{})
+	})
+}

--- a/internal/pkg/service/buffer/sink/tablesink/storage/repository/repository.go
+++ b/internal/pkg/service/buffer/sink/tablesink/storage/repository/repository.go
@@ -1,0 +1,41 @@
+package repository
+
+import (
+	"github.com/benbjohnson/clock"
+	defRepository "github.com/keboola/keboola-as-code/internal/pkg/service/buffer/definition/repository"
+	"github.com/keboola/keboola-as-code/internal/pkg/service/buffer/sink/tablesink/storage"
+	"github.com/keboola/keboola-as-code/internal/pkg/service/common/etcdop/serde"
+	etcd "go.etcd.io/etcd/client/v3"
+)
+
+type dependencies interface {
+	Clock() clock.Clock
+	EtcdClient() *etcd.Client
+	EtcdSerde() *serde.Serde
+}
+
+type Repository struct {
+	sink  *defRepository.SinkRepository
+	file  *FileRepository
+	slice *SliceRepository
+}
+
+func New(d dependencies, definitionRepo *defRepository.Repository, cfg storage.Config) *Repository {
+	return newWithBackoff(d, definitionRepo, cfg, storage.DefaultBackoff())
+}
+
+func newWithBackoff(d dependencies, definitionRepo *defRepository.Repository, cfg storage.Config, backoff storage.RetryBackoff) *Repository {
+	r := &Repository{}
+	r.sink = definitionRepo.Sink()
+	r.file = newFileRepository(d, cfg, backoff, r)
+	r.slice = newSliceRepository(d, backoff, r)
+	return r
+}
+
+func (r *Repository) File() *FileRepository {
+	return r.file
+}
+
+func (r *Repository) Slice() *SliceRepository {
+	return r.slice
+}

--- a/internal/pkg/service/buffer/sink/tablesink/storage/repository/slice_repo.go
+++ b/internal/pkg/service/buffer/sink/tablesink/storage/repository/slice_repo.go
@@ -100,11 +100,11 @@ func (r *SliceRepository) StateTransition(k storage.SliceKey, to storage.SliceSt
 			}
 
 			// Switch slice state
-			if err := slice.StateTransition(r.clock.Now(), to); err == nil {
-				return slice, nil
-			} else {
+			if err := slice.StateTransition(r.clock.Now(), to); err != nil {
 				return storage.Slice{}, err
 			}
+
+			return slice, nil
 		}).
 		ReadOp(r.all.file.Get(k.FileKey).WithResultTo(&file))
 }

--- a/internal/pkg/service/buffer/sink/tablesink/storage/repository/slice_repo.go
+++ b/internal/pkg/service/buffer/sink/tablesink/storage/repository/slice_repo.go
@@ -1,3 +1,253 @@
+package repository
+
+import (
+	"context"
+	"fmt"
+	"github.com/benbjohnson/clock"
+	"github.com/c2h5oh/datasize"
+	"github.com/keboola/keboola-as-code/internal/pkg/service/buffer/sink/tablesink/storage"
+	"github.com/keboola/keboola-as-code/internal/pkg/service/buffer/sink/tablesink/storage/compression"
+	serviceError "github.com/keboola/keboola-as-code/internal/pkg/service/common/errors"
+	"github.com/keboola/keboola-as-code/internal/pkg/service/common/etcdop/iterator"
+	"github.com/keboola/keboola-as-code/internal/pkg/service/common/etcdop/op"
+	"github.com/keboola/keboola-as-code/internal/pkg/service/common/utctime"
+	"github.com/keboola/keboola-as-code/internal/pkg/utils/errors"
+	etcd "go.etcd.io/etcd/client/v3"
+	"path/filepath"
+	"reflect"
+	"time"
+)
+
+type SliceRepository struct {
+	clock   clock.Clock
+	client  etcd.KV
+	schema  sliceSchema
+	backoff storage.RetryBackoff
+	all     *Repository
+}
+
+func newSliceRepository(d dependencies, backoff storage.RetryBackoff, all *Repository) *SliceRepository {
+	return &SliceRepository{
+		clock:   d.Clock(),
+		client:  d.EtcdClient(),
+		schema:  newSliceSchema(d.EtcdSerde()),
+		backoff: backoff,
+		all:     all,
+	}
+}
+
+func (r *SliceRepository) List(parentKey fmt.Stringer) iterator.DefinitionT[storage.Slice] {
+	return r.schema.AllLevels().InObject(parentKey).GetAll(r.client)
+}
+
+func (r *SliceRepository) Get(k storage.SliceKey) op.ForType[*op.KeyValueT[storage.Slice]] {
+	return r.schema.
+		AllLevels().ByKey(k).Get(r.client).
+		WithEmptyResultAsError(func() error {
+			return serviceError.NewResourceNotFoundError("slice", k.String(), "file")
+		})
+}
+
+func (r *SliceRepository) Create(fileKey storage.FileKey, volumeID storage.VolumeID) *op.AtomicOp[storage.Slice] {
+	var fileKV *op.KeyValueT[storage.File]
+	var result storage.Slice
+
+	// Save the slice
+	return op.Atomic(r.client, &result).
+		// Sink must exist
+		ReadOp(r.all.sink.ExistsOrErr(fileKey.SinkKey)).
+		// File must exist and be in the FileWriting state
+		ReadOp(r.all.file.get(fileKey).WithResultTo(&fileKV)).
+		BeforeWriteOrErr(func() error {
+			if fileKV == nil {
+				return serviceError.NewResourceNotFoundError("file", fileKey.String(), "sink")
+			} else if fileState := fileKV.Value.State; fileState != storage.FileWriting {
+				return serviceError.NewBadRequestError(errors.Errorf(
+					`slice cannot be created: unexpected file "%s" state "%s", expected "%s"`,
+					fileKey.String(), fileState, storage.FileWriting,
+				))
+			} else {
+				return nil
+			}
+		}).
+		// Save
+		WriteOrErr(func() (op op.Op, err error) {
+			// Create entity
+			result, err = newSlice(r.clock.Now(), fileKV.Value, volumeID, 0)
+			if err != nil {
+				return nil, err
+			}
+
+			// Save operation
+			return r.put(result, result, true), nil
+		})
+}
+
+func (r *SliceRepository) IncrementRetry(k storage.SliceKey, reason string) *op.AtomicOp[storage.Slice] {
+	return r.update(k, func(slice storage.Slice) (storage.Slice, error) {
+		slice.IncrementRetry(r.backoff, r.clock.Now(), reason)
+		return slice, nil
+	})
+}
+
+func (r *SliceRepository) StateTransition(k storage.SliceKey, to storage.SliceState) *op.AtomicOp[storage.Slice] {
+	var file *op.KeyValueT[storage.File]
+	return r.
+		update(k, func(slice storage.Slice) (storage.Slice, error) {
+			// Validate file and slice state combination
+			if err := validateFileAndSliceStates(file.Value.State, to); err != nil {
+				return slice, errors.PrefixErrorf(err, `unexpected slice "%s" state:`, slice.SliceKey)
+			}
+
+			// Switch slice state
+			if err := slice.StateTransition(r.clock.Now(), to); err == nil {
+				return slice, nil
+			} else {
+				return storage.Slice{}, err
+			}
+		}).
+		ReadOp(r.all.file.Get(k.FileKey).WithResultTo(&file))
+}
+
+func (r *SliceRepository) Delete(k storage.SliceKey) *op.TxnOp {
+	txn := op.NewTxnOp(r.client)
+
+	// Delete entity from All prefix
+	txn.And(
+		r.schema.
+			AllLevels().ByKey(k).DeleteIfExists(r.client).
+			WithEmptyResultAsError(func() error {
+				return serviceError.NewResourceNotFoundError("slice", k.String(), "file")
+			}),
+	)
+
+	// Delete entity from InLevel prefixes
+	for _, l := range storage.AllLevels() {
+		txn.Then(r.schema.InLevel(l).ByKey(k).Delete(r.client))
+	}
+
+	return txn
+}
+
+func (r *SliceRepository) deleteAll(parentKey fmt.Stringer) *op.TxnOp {
+	txn := op.NewTxnOp(r.client)
+
+	// Delete entity from All prefix
+	txn.Then(r.schema.AllLevels().InObject(parentKey).DeleteAll(r.client))
+
+	// Delete entity from InLevel prefixes
+	for _, l := range storage.AllLevels() {
+		txn.Then(r.schema.InLevel(l).InObject(parentKey).DeleteAll(r.client))
+	}
+
+	return txn
+}
+
+// put saves the slice.
+// The entity is stored in 2 copies, under "All" prefix and "InLevel" prefix.
+// - "All" prefix is used for classic CRUD operations.
+// - "InLevel" prefix is used for effective watching of the storage level.
+func (r *SliceRepository) put(oldValue, newValue storage.Slice, create bool) *op.TxnOp {
+	level := newValue.State.ToLevel()
+	etcdKey := r.schema.AllLevels().ByKey(newValue.SliceKey)
+
+	txn := op.NewTxnOp(r.client)
+	if create {
+		// Entity must not exist on create
+		txn.
+			If(etcd.Compare(etcd.ModRevision(etcdKey.Key()), "=", 0)).
+			AddProcessor(func(ctx context.Context, r *op.TxnResult) {
+				if r.Err() == nil && !r.Succeeded() {
+					r.AddErr(serviceError.NewResourceAlreadyExistsError("slice", newValue.SliceKey.String(), "file"))
+				}
+			})
+	}
+
+	// Save entity to All prefix
+	txn.Then(etcdKey.Put(r.client, newValue))
+
+	// Save entity to new level.
+	txn.Then(r.schema.InLevel(level).ByKey(newValue.SliceKey).Put(r.client, newValue))
+
+	// Delete entity from old level, if needed.
+	if !create && newValue.State.ToLevel() != oldValue.State.ToLevel() {
+		txn.Then(r.schema.InLevel(oldValue.State.ToLevel()).ByKey(oldValue.SliceKey).Delete(r.client))
+	}
+
+	return txn
+}
+
+func (r *SliceRepository) onFileStateTransition(k storage.FileKey, now time.Time, newFileState storage.FileState) *op.AtomicOp[op.NoResult] {
+	// Validate and modify slice state
+	return r.updateAllInFile(k, func(slice storage.Slice) (storage.Slice, error) {
+		if newFileState == storage.FileClosing && slice.State == storage.SliceWriting {
+			// Switch slice state on FileClosing
+			if err := slice.StateTransition(now, storage.SliceClosing); err != nil {
+				return slice, err
+			}
+		} else if newFileState == storage.FileImported && slice.State == storage.SliceUploaded {
+			// Switch slice state on FileImported
+			if err := slice.StateTransition(now, storage.SliceImported); err != nil {
+				return slice, err
+			}
+		}
+
+		// Validate file and slice state combination
+		if err := validateFileAndSliceStates(newFileState, slice.State); err != nil {
+			return slice, errors.PrefixErrorf(err, `unexpected slice "%s" state:`, slice.SliceKey)
+		}
+
+		return slice, nil
+	})
+}
+
+func (r *SliceRepository) update(k storage.SliceKey, updateFn func(slice storage.Slice) (storage.Slice, error)) *op.AtomicOp[storage.Slice] {
+	var oldValue, newValue storage.Slice
+	var kv *op.KeyValueT[storage.Slice]
+	return op.Atomic(r.client, &newValue).
+		// Read entity for modification
+		ReadOp(r.Get(k).WithResultTo(&kv)).
+		// Prepare the new value
+		BeforeWriteOrErr(func() (err error) {
+			oldValue = kv.Value
+			newValue, err = updateFn(oldValue)
+			return err
+		}).
+		// Save the updated object
+		Write(func() op.Op {
+			return r.put(oldValue, newValue, false)
+		})
+}
+
+// updateAllInFile updates all slices in a file.
+func (r *SliceRepository) updateAllInFile(parentKey storage.FileKey, updateFn func(slice storage.Slice) (storage.Slice, error)) *op.AtomicOp[op.NoResult] {
+	var original []storage.Slice
+	return op.Atomic(r.client, &op.NoResult{}).
+		// Read entities for modification
+		ReadOp(r.List(parentKey).WithResultTo(&original)).
+		// Modify and save entities
+		WriteOrErr(func() (op.Op, error) {
+			txn := op.NewTxnOp(r.client)
+			errs := errors.NewMultiError()
+			for _, oldValue := range original {
+				if newValue, err := updateFn(oldValue); err == nil {
+					// Save modified value, if here is a difference
+					if !reflect.DeepEqual(newValue, oldValue) {
+						txn.Then(r.put(oldValue, newValue, false))
+					}
+				} else {
+					errs.Append(err)
+				}
+			}
+			if err := errs.ErrorOrNil(); err != nil {
+				return nil, err
+			}
+			if !txn.Empty() {
+				return txn, nil
+			}
+			return nil, nil
+		})
+}
 
 // newSlice creates slice definition.
 func newSlice(now time.Time, file storage.File, volumeID storage.VolumeID, prevSliceSize datasize.ByteSize) (s storage.Slice, err error) {

--- a/internal/pkg/service/buffer/sink/tablesink/storage/repository/slice_repo.go
+++ b/internal/pkg/service/buffer/sink/tablesink/storage/repository/slice_repo.go
@@ -1,0 +1,31 @@
+
+// newSlice creates slice definition.
+func newSlice(now time.Time, file storage.File, volumeID storage.VolumeID, prevSliceSize datasize.ByteSize) (s storage.Slice, err error) {
+	// Validate compression type.
+	// Other parts of the system are also prepared for other types of compression,
+	// but now only GZIP is supported in the Keboola platform.
+	switch file.LocalStorage.Compression.Type {
+	case compression.TypeNone, compression.TypeGZIP: // ok
+	default:
+		return storage.Slice{}, errors.Errorf(`file compression type "%s" is not supported`, file.LocalStorage.Compression.Type)
+	}
+
+	// Convert path separator, on Windows
+	sliceKey := storage.SliceKey{FileKey: file.FileKey, SliceID: storage.SliceID{VolumeID: volumeID, OpenedAt: utctime.From(now)}}
+	sliceDir := filepath.FromSlash(sliceKey.SliceID.OpenedAt.String()) //nolint: forbidigo
+
+	// Generate unique staging storage path
+	stagingPath := fmt.Sprintf(`%s_%s`, sliceKey.OpenedAt().String(), sliceKey.VolumeID)
+
+	s.SliceKey = sliceKey
+	s.Type = file.Type
+	s.State = storage.SliceWriting
+	s.Columns = file.Columns
+	if s.LocalStorage, err = file.LocalStorage.NewSlice(sliceDir, prevSliceSize); err != nil {
+		return storage.Slice{}, err
+	}
+	if s.StagingStorage, err = file.StagingStorage.NewSlice(stagingPath, s.LocalStorage); err != nil {
+		return storage.Slice{}, err
+	}
+	return s, nil
+}

--- a/internal/pkg/service/buffer/sink/tablesink/storage/repository/slice_repo.go
+++ b/internal/pkg/service/buffer/sink/tablesink/storage/repository/slice_repo.go
@@ -148,7 +148,7 @@ func (r *SliceRepository) deleteAll(parentKey fmt.Stringer) *op.TxnOp {
 // - "All" prefix is used for classic CRUD operations.
 // - "InLevel" prefix is used for effective watching of the storage level.
 func (r *SliceRepository) put(oldValue, newValue storage.Slice, create bool) *op.TxnOp {
-	level := newValue.State.ToLevel()
+	level := newValue.State.Level()
 	etcdKey := r.schema.AllLevels().ByKey(newValue.SliceKey)
 
 	txn := op.NewTxnOp(r.client)
@@ -170,8 +170,8 @@ func (r *SliceRepository) put(oldValue, newValue storage.Slice, create bool) *op
 	txn.Then(r.schema.InLevel(level).ByKey(newValue.SliceKey).Put(r.client, newValue))
 
 	// Delete entity from old level, if needed.
-	if !create && newValue.State.ToLevel() != oldValue.State.ToLevel() {
-		txn.Then(r.schema.InLevel(oldValue.State.ToLevel()).ByKey(oldValue.SliceKey).Delete(r.client))
+	if !create && newValue.State.Level() != oldValue.State.Level() {
+		txn.Then(r.schema.InLevel(oldValue.State.Level()).ByKey(oldValue.SliceKey).Delete(r.client))
 	}
 
 	return txn

--- a/internal/pkg/service/buffer/sink/tablesink/storage/repository/slice_repo_test.go
+++ b/internal/pkg/service/buffer/sink/tablesink/storage/repository/slice_repo_test.go
@@ -1,0 +1,466 @@
+package repository
+
+import (
+	"context"
+	"github.com/benbjohnson/clock"
+	"github.com/keboola/go-client/pkg/keboola"
+	"github.com/keboola/go-client/pkg/keboola/storage_file_upload/s3"
+	"github.com/keboola/keboola-as-code/internal/pkg/service/buffer/definition"
+	"github.com/keboola/keboola-as-code/internal/pkg/service/buffer/definition/column"
+	"github.com/keboola/keboola-as-code/internal/pkg/service/buffer/definition/key"
+	defRepository "github.com/keboola/keboola-as-code/internal/pkg/service/buffer/definition/repository"
+	"github.com/keboola/keboola-as-code/internal/pkg/service/buffer/sink/tablesink/storage"
+	"github.com/keboola/keboola-as-code/internal/pkg/service/buffer/sink/tablesink/storage/compression"
+	"github.com/keboola/keboola-as-code/internal/pkg/service/buffer/sink/tablesink/storage/test"
+	deps "github.com/keboola/keboola-as-code/internal/pkg/service/common/dependencies"
+	serviceError "github.com/keboola/keboola-as-code/internal/pkg/service/common/errors"
+	"github.com/keboola/keboola-as-code/internal/pkg/service/common/utctime"
+	"github.com/keboola/keboola-as-code/internal/pkg/utils/etcdhelper"
+	"github.com/relvacode/iso8601"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	"net/http"
+	"strings"
+	"testing"
+	"time"
+)
+
+func TestRepository_Slice(t *testing.T) {
+	t.Parallel()
+	ctx := context.Background()
+
+	now := utctime.MustParse("2000-01-03T01:00:00.000Z").Time()
+	clk := clock.NewMock()
+	clk.Set(now)
+
+	// Fixtures
+	projectID := keboola.ProjectID(123)
+	branchKey := key.BranchKey{ProjectID: projectID, BranchID: 456}
+	sourceKey := key.SourceKey{BranchKey: branchKey, SourceID: "my-source"}
+	sinkKey := key.SinkKey{SourceKey: sourceKey, SinkID: "my-sink"}
+	volumeID := storage.VolumeID("my-volume")
+	cfg := storage.NewConfig()
+	credentials := &keboola.FileUploadCredentials{
+		S3UploadParams: &s3.UploadParams{
+			Credentials: s3.Credentials{
+				Expiration: iso8601.Time{Time: now.Add(time.Hour)},
+			},
+		},
+	}
+	nonExistentSliceKey := storage.SliceKey{
+		FileKey: storage.FileKey{SinkKey: sinkKey, FileID: storage.FileID{OpenedAt: utctime.MustParse("2000-01-02T01:00:00.000Z")}},
+		SliceID: storage.SliceID{VolumeID: volumeID, OpenedAt: utctime.MustParse("2000-01-02T02:00:00.000Z")},
+	}
+
+	d := deps.NewMocked(t, deps.WithEnabledEtcdClient(), deps.WithClock(clk))
+	client := d.TestEtcdClient()
+	defRepo := defRepository.New(d)
+	backoff := storage.NoRandomizationBackoff()
+	r := newWithBackoff(d, defRepo, cfg, backoff).Slice()
+
+	// Empty
+	// -----------------------------------------------------------------------------------------------------------------
+	{
+		// List - empty
+		slices, err := r.List(projectID).Do(ctx).All()
+		assert.NoError(t, err)
+		assert.Empty(t, slices)
+		slices, err = r.List(sinkKey).Do(ctx).All()
+		assert.NoError(t, err)
+		assert.Empty(t, slices)
+	}
+	{
+		// Get - not found
+		if err := r.Get(nonExistentSliceKey).Do(ctx).Err(); assert.Error(t, err) {
+			assert.Equal(t, `slice "123/456/my-source/my-sink/2000-01-02T01:00:00.000Z/my-volume/2000-01-02T02:00:00.000Z" not found in the file`, err.Error())
+			serviceError.AssertErrorStatusCode(t, http.StatusNotFound, err)
+		}
+	}
+
+	// Create - parent sink doesn't exists
+	// -----------------------------------------------------------------------------------------------------------------
+	{
+		fileKey := test.NewFileKey()
+		if err := r.Create(fileKey, volumeID).Do(ctx).Err(); assert.Error(t, err) {
+			assert.Equal(t, `sink "123/456/my-source/my-sink" not found in the source`, err.Error())
+			serviceError.AssertErrorStatusCode(t, http.StatusNotFound, err)
+		}
+	}
+
+	// Create parent branch, source, sink and files
+	// -----------------------------------------------------------------------------------------------------------------
+	var fileKey1, fileKey2, fileKey3 storage.FileKey
+	{
+		branch := branchTemplate(branchKey)
+		require.NoError(t, defRepo.Branch().Create(&branch).Do(ctx).Err())
+		source := sourceTemplate(sourceKey)
+		require.NoError(t, defRepo.Source().Create("Create source", &source).Do(ctx).Err())
+		sink := sinkTemplate(sinkKey)
+		require.NoError(t, defRepo.Sink().Create("Create sink", &sink).Do(ctx).Err())
+
+		clk.Add(time.Hour)
+		file1, err := r.all.file.Create(sink.SinkKey, credentials).Do(ctx).ResultOrErr()
+		require.NoError(t, err)
+		fileKey1 = file1.FileKey
+
+		clk.Add(time.Hour)
+		file2, err := r.all.file.Create(sink.SinkKey, credentials).Do(ctx).ResultOrErr()
+		require.NoError(t, err)
+		fileKey2 = file2.FileKey
+
+		clk.Add(time.Hour)
+		file3, err := r.all.file.Create(sink.SinkKey, credentials).Do(ctx).ResultOrErr()
+		require.NoError(t, err)
+		fileKey3 = file3.FileKey
+	}
+
+	// Create - parent file doesn't exists
+	// -----------------------------------------------------------------------------------------------------------------
+	{
+		fileKey := test.NewFileKey()
+		fileKey.SinkKey = sinkKey
+		if err := r.Create(fileKey, volumeID).Do(ctx).Err(); assert.Error(t, err) {
+			assert.Equal(t, `file "123/456/my-source/my-sink/2000-01-01T19:00:00.000Z" not found in the sink`, err.Error())
+			serviceError.AssertErrorStatusCode(t, http.StatusNotFound, err)
+		}
+	}
+
+	// Create - parent file is not in storage.FileWriting state
+	// -----------------------------------------------------------------------------------------------------------------
+	{
+		require.NoError(t, r.all.File().StateTransition(fileKey3, storage.FileClosing).Do(ctx).Err())
+
+		if err := r.Create(fileKey3, volumeID).Do(ctx).Err(); assert.Error(t, err) {
+			assert.Equal(t, `slice cannot be created: unexpected file "123/456/my-source/my-sink/2000-01-03T04:00:00.000Z" state "closing", expected "writing"`, err.Error())
+			serviceError.AssertErrorStatusCode(t, http.StatusBadRequest, err)
+		}
+	}
+
+	// Create
+	// -----------------------------------------------------------------------------------------------------------------
+	var sliceKey1, sliceKey2 storage.SliceKey
+	{
+		// Create 2 slices in different files
+		slice1, err := r.Create(fileKey1, volumeID).Do(ctx).ResultOrErr()
+		require.NoError(t, err)
+		sliceKey1 = slice1.SliceKey
+
+		slice2, err := r.Create(fileKey2, volumeID).Do(ctx).ResultOrErr()
+		require.NoError(t, err)
+		sliceKey2 = slice2.SliceKey
+	}
+	{
+		// List
+		slices, err := r.List(projectID).Do(ctx).All()
+		assert.NoError(t, err)
+		assert.Len(t, slices, 2)
+		slices, err = r.List(branchKey).Do(ctx).All()
+		assert.NoError(t, err)
+		assert.Len(t, slices, 2)
+		slices, err = r.List(sourceKey).Do(ctx).All()
+		assert.NoError(t, err)
+		assert.Len(t, slices, 2)
+		slices, err = r.List(sinkKey).Do(ctx).All()
+		assert.NoError(t, err)
+		assert.Len(t, slices, 2)
+		slices, err = r.List(fileKey1).Do(ctx).All()
+		assert.NoError(t, err)
+		assert.Len(t, slices, 1)
+		slices, err = r.List(fileKey2).Do(ctx).All()
+		assert.NoError(t, err)
+		assert.Len(t, slices, 1)
+	}
+	{
+		// Get
+		result1, err := r.Get(sliceKey1).Do(ctx).ResultOrErr()
+		require.NoError(t, err)
+		assert.Equal(t, clk.Now(), result1.Value.OpenedAt().Time())
+		result2, err := r.Get(sliceKey2).Do(ctx).ResultOrErr()
+		require.NoError(t, err)
+		assert.Equal(t, clk.Now(), result2.Value.OpenedAt().Time())
+	}
+
+	// Create - already exists
+	// -----------------------------------------------------------------------------------------------------------------
+	{
+		if err := r.Create(fileKey2, volumeID).Do(ctx).Err(); assert.Error(t, err) {
+			assert.Equal(t, `slice "123/456/my-source/my-sink/2000-01-03T03:00:00.000Z/my-volume/2000-01-03T04:00:00.000Z" already exists in the file`, err.Error())
+			serviceError.AssertErrorStatusCode(t, http.StatusConflict, err)
+		}
+	}
+
+	// Update (update is private method, public methods IncrementRetry and StateTransition are tested bellow)
+	// -----------------------------------------------------------------------------------------------------------------
+	clk.Add(time.Hour)
+	{
+		// Increment retry
+		result, err := r.update(sliceKey1, func(v storage.Slice) (storage.Slice, error) {
+			v.LocalStorage.DiskSync.Wait = false
+			return v, nil
+		}).Do(ctx).ResultOrErr()
+		require.NoError(t, err)
+		assert.False(t, result.LocalStorage.DiskSync.Wait)
+		kv, err := r.Get(sliceKey1).Do(ctx).ResultOrErr()
+		require.NoError(t, err)
+		assert.Equal(t, result, kv.Value)
+	}
+
+	// Update - not found
+	// -----------------------------------------------------------------------------------------------------------------
+	{
+		err := r.update(nonExistentSliceKey, func(v storage.Slice) (storage.Slice, error) {
+			return v, nil
+		}).Do(ctx).Err()
+		if assert.Error(t, err) {
+			assert.Equal(t, `slice "123/456/my-source/my-sink/2000-01-02T01:00:00.000Z/my-volume/2000-01-02T02:00:00.000Z" not found in the file`, err.Error())
+			serviceError.AssertErrorStatusCode(t, http.StatusNotFound, err)
+		}
+	}
+
+	// Increment retry attempt
+	// -----------------------------------------------------------------------------------------------------------------
+	{
+		result, err := r.IncrementRetry(sliceKey1, "some error").Do(ctx).ResultOrErr()
+		require.NoError(t, err)
+		assert.Equal(t, 1, result.RetryAttempt)
+		assert.Equal(t, "some error", result.RetryReason)
+		assert.Equal(t, "2000-01-03T05:00:00.000Z", result.LastFailedAt.String())
+		assert.Equal(t, "2000-01-03T05:02:00.000Z", result.RetryAfter.String())
+		kv, err := r.Get(sliceKey1).Do(ctx).ResultOrErr()
+		require.NoError(t, err)
+		assert.Equal(t, result, kv.Value)
+	}
+
+	// Switch slice state
+	// -----------------------------------------------------------------------------------------------------------------
+	for _, to := range []storage.SliceState{storage.SliceClosing, storage.SliceUploading, storage.SliceUploaded} {
+		clk.Add(time.Hour)
+
+		result, err := r.StateTransition(sliceKey1, to).Do(ctx).ResultOrErr()
+		require.NoError(t, err)
+
+		// Slice state has been switched
+		assert.Equal(t, to, result.State)
+
+		// Retry should be reset
+		assert.Equal(t, 0, result.RetryAttempt)
+		assert.Nil(t, result.LastFailedAt)
+
+		// Check timestamp
+		switch to {
+		case storage.SliceClosing:
+			assert.Equal(t, utctime.From(clk.Now()).String(), result.ClosingAt.String())
+		case storage.SliceUploading:
+			assert.Equal(t, utctime.From(clk.Now()).String(), result.UploadingAt.String())
+		case storage.SliceUploaded:
+			assert.Equal(t, utctime.From(clk.Now()).String(), result.UploadedAt.String())
+		case storage.SliceImported:
+			assert.Equal(t, utctime.From(clk.Now()).String(), result.ImportedAt.String())
+		}
+	}
+
+	// Switch slice state - already in the state
+	// -----------------------------------------------------------------------------------------------------------------
+	if err := r.StateTransition(sliceKey1, storage.SliceUploaded).Do(ctx).Err(); assert.Error(t, err) {
+		assert.Equal(t, `unexpected slice "123/456/my-source/my-sink/2000-01-03T02:00:00.000Z/my-volume/2000-01-03T04:00:00.000Z" state transition from "uploaded" to "uploaded"`, err.Error())
+		serviceError.AssertErrorStatusCode(t, http.StatusBadRequest, err)
+	}
+
+	// Switch slice state - unexpected transition (1)
+	// -----------------------------------------------------------------------------------------------------------------
+	if err := r.StateTransition(sliceKey1, storage.SliceUploading).Do(ctx).Err(); assert.Error(t, err) {
+		assert.Equal(t, `unexpected slice "123/456/my-source/my-sink/2000-01-03T02:00:00.000Z/my-volume/2000-01-03T04:00:00.000Z" state transition from "uploaded" to "uploading"`, err.Error())
+		serviceError.AssertErrorStatusCode(t, http.StatusBadRequest, err)
+	}
+
+	// Switch slice state - unexpected transition (2)
+	// -----------------------------------------------------------------------------------------------------------------
+	if err := r.StateTransition(sliceKey1, storage.SliceImported).Do(ctx).Err(); assert.Error(t, err) {
+		assert.Equal(t, strings.TrimSpace(`
+unexpected slice "123/456/my-source/my-sink/2000-01-03T02:00:00.000Z/my-volume/2000-01-03T04:00:00.000Z" state:
+- unexpected combination: file state "writing" and slice state "imported"
+`), err.Error())
+		serviceError.AssertErrorStatusCode(t, http.StatusBadRequest, err)
+	}
+
+	// Switch file state
+	// -----------------------------------------------------------------------------------------------------------------
+	{
+		for _, to := range []storage.FileState{storage.FileClosing, storage.FileImporting, storage.FileImported} {
+			clk.Add(time.Hour)
+
+			result, err := r.all.File().StateTransition(fileKey1, to).Do(ctx).ResultOrErr()
+			require.NoError(t, err)
+
+			// File state has been switched
+			assert.Equal(t, to, result.State)
+
+			// Retry fields should be reset
+			assert.Equal(t, 0, result.RetryAttempt)
+			assert.Nil(t, result.LastFailedAt)
+
+			// Check timestamp
+			switch to {
+			case storage.FileClosing:
+				assert.Equal(t, utctime.From(clk.Now()).String(), result.ClosingAt.String())
+			case storage.FileImporting:
+				assert.Equal(t, utctime.From(clk.Now()).String(), result.ImportingAt.String())
+			case storage.FileImported:
+				assert.Equal(t, utctime.From(clk.Now()).String(), result.ImportedAt.String())
+			}
+		}
+	}
+
+	// Delete
+	// -----------------------------------------------------------------------------------------------------------------
+	{
+		assert.NoError(t, r.Delete(sliceKey2).Do(ctx).Err())
+	}
+	{
+		// Get - not found
+		if err := r.Get(sliceKey2).Do(ctx).Err(); assert.Error(t, err) {
+			assert.Equal(t, `slice "123/456/my-source/my-sink/2000-01-03T03:00:00.000Z/my-volume/2000-01-03T04:00:00.000Z" not found in the file`, err.Error())
+			serviceError.AssertErrorStatusCode(t, http.StatusNotFound, err)
+		}
+	}
+	{
+		// List - empty
+		slices, err := r.List(fileKey2).Do(ctx).All()
+		assert.NoError(t, err)
+		assert.Empty(t, slices)
+	}
+
+	// Delete - not found
+	// -----------------------------------------------------------------------------------------------------------------
+	if err := r.Delete(nonExistentSliceKey).Do(ctx).Err(); assert.Error(t, err) {
+		assert.Equal(t, `slice "123/456/my-source/my-sink/2000-01-02T01:00:00.000Z/my-volume/2000-01-02T02:00:00.000Z" not found in the file`, err.Error())
+		serviceError.AssertErrorStatusCode(t, http.StatusNotFound, err)
+	}
+
+	// Check etcd state - slice2 has been deleted, but slice 1 exists
+	// -----------------------------------------------------------------------------------------------------------------
+	etcdhelper.AssertKVsString(t, client, expectedSliceEtcdState(), etcdhelper.WithIgnoredKeyPattern("^(definition|storage/file)/"))
+}
+
+func expectedSliceEtcdState() string {
+	return `
+<<<<<
+storage/slice/all/123/456/my-source/my-sink/2000-01-03T02:00:00.000Z/my-volume/2000-01-03T04:00:00.000Z
+-----
+{
+  "projectId": 123,
+  "branchId": 456,
+  "sourceId": "my-source",
+  "sinkId": "my-sink",
+  "fileOpenedAt": "2000-01-03T02:00:00.000Z",
+  "sliceOpenedAt": "2000-01-03T04:00:00.000Z",
+  "volumeId": "my-volume",
+  "type": "csv",
+  "state": "imported",
+  "closingAt": "2000-01-03T06:00:00.000Z",
+  "uploadingAt": "2000-01-03T07:00:00.000Z",
+  "uploadedAt": "2000-01-03T08:00:00.000Z",
+  "importedAt": "2000-01-03T11:00:00.000Z",
+  "columns": [
+    {
+      "type": "datetime",
+      "name": "datetime"
+    },
+    {
+      "type": "body",
+      "name": "body"
+    }
+  ],
+  "local": {
+    "dir": "123/456/my-source/my-sink/2000-01-03T02:00:00.000Z/2000-01-03T04:00:00.000Z",
+    "filename": "slice.csv.gz",
+    "compression": {
+      "type": "gzip",
+      "gzip": {
+        "level": 1,
+        "implementation": "parallel",
+        "blockSize": "256KB",
+        "concurrency": 0
+      }
+    },
+    "diskSync": {
+      "mode": "disk",
+      "wait": false,
+      "checkInterval": 1000000,
+      "countTrigger": 100,
+      "bytesTrigger": "100KB",
+      "intervalTrigger": 100000000
+    },
+    "allocatedDiskSpace": "110MB"
+  },
+  "staging": {
+    "path": "2000-01-03T04:00:00.000Z_my-volume.gz",
+    "compression": {
+      "type": "gzip",
+      "gzip": {
+        "level": 1,
+        "implementation": "parallel",
+        "blockSize": "256KB",
+        "concurrency": 0
+      }
+    }
+  }
+}
+>>>>>
+
+<<<<<
+storage/slice/level/target/123/456/my-source/my-sink/2000-01-03T02:00:00.000Z/my-volume/2000-01-03T04:00:00.000Z
+-----
+{
+  "projectId": 123,
+  "branchId": 456,
+  "sourceId": "my-source",
+  "sinkId": "my-sink",
+  "fileOpenedAt": "2000-01-03T02:00:00.000Z",
+  "sliceOpenedAt": "2000-01-03T04:00:00.000Z",
+  "volumeId": "my-volume",
+  "type": "csv",
+  "state": "imported",
+%A
+}
+>>>>>
+`
+}
+
+func TestNewSlice_InvalidCompressionType(t *testing.T) {
+	t.Parallel()
+
+	// Fixtures
+	projectID := keboola.ProjectID(123)
+	branchKey := key.BranchKey{ProjectID: projectID, BranchID: 456}
+	sourceKey := key.SourceKey{BranchKey: branchKey, SourceID: "my-source"}
+	sinkKey := key.SinkKey{SourceKey: sourceKey, SinkID: "my-sink"}
+	now := utctime.MustParse("2000-01-01T19:00:00.000Z").Time()
+	cfg := storage.NewConfig()
+	mapping := definition.TableMapping{
+		TableID: keboola.MustParseTableID("in.bucket.table"),
+		Columns: column.Columns{
+			column.Datetime{Name: "datetime"},
+			column.Body{Name: "body"},
+		},
+	}
+	credentials := &keboola.FileUploadCredentials{
+		S3UploadParams: &s3.UploadParams{
+			Credentials: s3.Credentials{
+				Expiration: iso8601.Time{Time: now.Add(time.Hour)},
+			},
+		},
+	}
+
+	// Create file
+	file, err := newFile(now, cfg, sinkKey, mapping, credentials)
+	require.NoError(t, err)
+
+	// Set unsupported compression type
+	file.LocalStorage.Compression.Type = compression.TypeZSTD
+
+	// Assert
+	_, err = newSlice(now, file, "my-volume", 0)
+	require.Error(t, err)
+	assert.Equal(t, `file compression type "zstd" is not supported`, err.Error())
+}

--- a/internal/pkg/service/buffer/sink/tablesink/storage/repository/slice_schema.go
+++ b/internal/pkg/service/buffer/sink/tablesink/storage/repository/slice_schema.go
@@ -1,0 +1,76 @@
+package repository
+
+import (
+	"fmt"
+	"github.com/keboola/go-client/pkg/keboola"
+	. "github.com/keboola/keboola-as-code/internal/pkg/service/buffer/definition/key"
+	. "github.com/keboola/keboola-as-code/internal/pkg/service/buffer/sink/tablesink/storage"
+	. "github.com/keboola/keboola-as-code/internal/pkg/service/common/etcdop"
+	"github.com/keboola/keboola-as-code/internal/pkg/service/common/etcdop/serde"
+	"github.com/keboola/keboola-as-code/internal/pkg/utils/errors"
+)
+
+type (
+	// sliceSchema is an etcd prefix that stores all slice entities.
+	sliceSchema struct{ PrefixT[Slice] }
+	// sliceSchemaInLevel - see sliceSchema.AllLevels and sliceSchema.InLevel methods.
+	// The entity is stored in 2 copies, under "All" prefix and "InLevel" prefix.
+	// - "All" prefix is used for classic CRUD operations.
+	// - "InLevel" prefix is used for effective watching of the storage level.
+	sliceSchemaInLevel  sliceSchema
+	sliceSchemaInObject sliceSchema
+)
+
+func newSliceSchema(s *serde.Serde) sliceSchema {
+	return sliceSchema{PrefixT: NewTypedPrefix[Slice]("storage/slice", s)}
+}
+
+func (s sliceSchema) AllLevels() sliceSchemaInLevel {
+	return sliceSchemaInLevel{PrefixT: s.PrefixT.Add("all")}
+}
+
+func (s sliceSchema) InLevel(level Level) sliceSchemaInLevel {
+	switch level {
+	case LevelLocal, LevelStaging, LevelTarget:
+		return sliceSchemaInLevel{PrefixT: s.PrefixT.Add("level").Add(level.String())}
+	default:
+		panic(errors.Errorf(`unexpected storage level "%v"`, level))
+	}
+}
+
+func (v sliceSchemaInLevel) ByKey(k SliceKey) KeyT[Slice] {
+	return v.PrefixT.Key(k.String())
+}
+
+func (v sliceSchemaInLevel) InObject(k fmt.Stringer) sliceSchemaInObject {
+	switch k.(type) {
+	case keboola.ProjectID, BranchKey, SourceKey, SinkKey, FileKey:
+		return v.inObject(k)
+	default:
+		panic(errors.Errorf(`unexpected object key "%T"`, k))
+	}
+}
+
+func (v sliceSchemaInLevel) InProject(projectID keboola.ProjectID) sliceSchemaInObject {
+	return v.inObject(projectID)
+}
+
+func (v sliceSchemaInLevel) InBranch(k BranchKey) sliceSchemaInObject {
+	return v.inObject(k)
+}
+
+func (v sliceSchemaInLevel) InSource(k SourceKey) sliceSchemaInObject {
+	return v.inObject(k)
+}
+
+func (v sliceSchemaInLevel) InSink(k SinkKey) sliceSchemaInObject {
+	return v.inObject(k)
+}
+
+func (v sliceSchemaInLevel) InFile(k FileKey) sliceSchemaInObject {
+	return v.inObject(k)
+}
+
+func (v sliceSchemaInLevel) inObject(objectKey fmt.Stringer) sliceSchemaInObject {
+	return sliceSchemaInObject{PrefixT: v.PrefixT.Add(objectKey.String())}
+}

--- a/internal/pkg/service/buffer/sink/tablesink/storage/repository/slice_schema_test.go
+++ b/internal/pkg/service/buffer/sink/tablesink/storage/repository/slice_schema_test.go
@@ -1,0 +1,84 @@
+package repository
+
+import (
+	"fmt"
+	"github.com/keboola/keboola-as-code/internal/pkg/service/buffer/sink/tablesink/storage"
+	"github.com/keboola/keboola-as-code/internal/pkg/service/buffer/sink/tablesink/storage/test"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+
+	"github.com/keboola/keboola-as-code/internal/pkg/service/common/etcdop/serde"
+)
+
+func TestSliceSchema(t *testing.T) {
+	t.Parallel()
+	s := newSliceSchema(serde.NewJSON(serde.NoValidation))
+
+	sliceKey := test.NewSliceKey()
+
+	cases := []struct{ actual, expected string }{
+		{
+			s.Prefix(),
+			"storage/slice/",
+		},
+		{
+			s.AllLevels().Prefix(),
+			"storage/slice/all/",
+		},
+		{
+			s.InLevel(storage.LevelLocal).Prefix(),
+			"storage/slice/level/local/",
+		},
+		{
+			s.InLevel(storage.LevelStaging).Prefix(),
+			"storage/slice/level/staging/",
+		},
+		{
+			s.InLevel(storage.LevelTarget).Prefix(),
+			"storage/slice/level/target/",
+		},
+		{
+			s.InLevel(storage.LevelLocal).InObject(sliceKey.ProjectID).Prefix(),
+			"storage/slice/level/local/123/",
+		},
+		{
+			s.InLevel(storage.LevelLocal).InProject(sliceKey.ProjectID).Prefix(),
+			"storage/slice/level/local/123/",
+		},
+		{
+			s.InLevel(storage.LevelLocal).InBranch(sliceKey.BranchKey).Prefix(),
+			"storage/slice/level/local/123/456/",
+		},
+		{
+			s.InLevel(storage.LevelLocal).InSource(sliceKey.SourceKey).Prefix(),
+			"storage/slice/level/local/123/456/my-source/",
+		},
+		{
+			s.InLevel(storage.LevelLocal).InSink(sliceKey.SinkKey).Prefix(),
+			"storage/slice/level/local/123/456/my-source/my-sink/",
+		},
+		{
+			s.InLevel(storage.LevelLocal).InFile(sliceKey.FileKey).Prefix(),
+			"storage/slice/level/local/123/456/my-source/my-sink/2000-01-01T19:00:00.000Z/",
+		},
+		{
+			s.InLevel(storage.LevelLocal).ByKey(sliceKey).Key(),
+			"storage/slice/level/local/123/456/my-source/my-sink/2000-01-01T19:00:00.000Z/my-volume/2000-01-01T20:00:00.000Z",
+		},
+	}
+
+	for i, c := range cases {
+		assert.Equal(t, c.expected, c.actual, fmt.Sprintf(`case "%d"`, i+1))
+	}
+
+	// Test panics
+	assert.Panics(t, func() {
+		// Unexpected storage level
+		s.InLevel("foo")
+	})
+	assert.Panics(t, func() {
+		// There is no file in slice level, slice is in file, not file in slice
+		s.InLevel(storage.LevelLocal).InObject(storage.SliceKey{})
+	})
+}

--- a/internal/pkg/service/buffer/sink/tablesink/storage/repository/state.go
+++ b/internal/pkg/service/buffer/sink/tablesink/storage/repository/state.go
@@ -1,0 +1,41 @@
+package repository
+
+import (
+	"github.com/keboola/keboola-as-code/internal/pkg/service/buffer/sink/tablesink/storage"
+	serviceError "github.com/keboola/keboola-as-code/internal/pkg/service/common/errors"
+	"github.com/keboola/keboola-as-code/internal/pkg/utils/errors"
+)
+
+// validateFileAndSliceStates validates combination of file and slice state.
+func validateFileAndSliceStates(fileState storage.FileState, sliceState storage.SliceState) error {
+	valid := false
+
+	switch fileState {
+	case storage.FileWriting, storage.FileClosing:
+		// Check allowed states
+		switch sliceState {
+		case storage.SliceWriting, storage.SliceClosing, storage.SliceUploading, storage.SliceUploaded:
+			valid = true
+		}
+	case storage.FileImporting:
+		// Slice must be uploaded
+		if sliceState == storage.SliceUploaded {
+			valid = true
+		}
+	case storage.FileImported:
+		// Slice must be marked as imported
+		if sliceState == storage.SliceImported {
+			valid = true
+		}
+	default:
+		panic(errors.Errorf(`unexpected file state "%s`, fileState))
+	}
+
+	if !valid {
+		return serviceError.NewBadRequestError(
+			errors.Errorf(`unexpected combination: file state "%s" and slice state "%s"`, fileState, sliceState),
+		)
+	}
+
+	return nil
+}

--- a/internal/pkg/service/buffer/sink/tablesink/storage/repository/state.go
+++ b/internal/pkg/service/buffer/sink/tablesink/storage/repository/state.go
@@ -8,34 +8,28 @@ import (
 
 // validateFileAndSliceStates validates combination of file and slice state.
 func validateFileAndSliceStates(fileState storage.FileState, sliceState storage.SliceState) error {
-	valid := false
-
 	switch fileState {
 	case storage.FileWriting, storage.FileClosing:
 		// Check allowed states
 		switch sliceState {
 		case storage.SliceWriting, storage.SliceClosing, storage.SliceUploading, storage.SliceUploaded:
-			valid = true
+			return nil
 		}
 	case storage.FileImporting:
 		// Slice must be uploaded
 		if sliceState == storage.SliceUploaded {
-			valid = true
+			return nil
 		}
 	case storage.FileImported:
 		// Slice must be marked as imported
 		if sliceState == storage.SliceImported {
-			valid = true
+			return nil
 		}
 	default:
 		panic(errors.Errorf(`unexpected file state "%s`, fileState))
 	}
 
-	if !valid {
-		return serviceError.NewBadRequestError(
-			errors.Errorf(`unexpected combination: file state "%s" and slice state "%s"`, fileState, sliceState),
-		)
-	}
-
-	return nil
+	return serviceError.NewBadRequestError(
+		errors.Errorf(`unexpected combination: file state "%s" and slice state "%s"`, fileState, sliceState),
+	)
 }

--- a/internal/pkg/service/buffer/sink/tablesink/storage/repository/state_test.go
+++ b/internal/pkg/service/buffer/sink/tablesink/storage/repository/state_test.go
@@ -1,0 +1,210 @@
+package repository
+
+import (
+	"context"
+	"github.com/benbjohnson/clock"
+	"github.com/keboola/go-client/pkg/keboola"
+	"github.com/keboola/go-client/pkg/keboola/storage_file_upload/s3"
+	"github.com/keboola/keboola-as-code/internal/pkg/service/buffer/definition/key"
+	defRepository "github.com/keboola/keboola-as-code/internal/pkg/service/buffer/definition/repository"
+	"github.com/keboola/keboola-as-code/internal/pkg/service/buffer/sink/tablesink/storage"
+	deps "github.com/keboola/keboola-as-code/internal/pkg/service/common/dependencies"
+	"github.com/keboola/keboola-as-code/internal/pkg/service/common/utctime"
+	"github.com/relvacode/iso8601"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	"strings"
+	"testing"
+	"time"
+)
+
+func TestRepository_FileAndSliceStateTransitions(t *testing.T) {
+	t.Parallel()
+	ctx := context.Background()
+
+	now := utctime.MustParse("2000-01-01T19:00:00.000Z").Time()
+	clk := clock.NewMock()
+	clk.Set(now)
+
+	// Fixtures
+	projectID := keboola.ProjectID(123)
+	branchKey := key.BranchKey{ProjectID: projectID, BranchID: 456}
+	sourceKey := key.SourceKey{BranchKey: branchKey, SourceID: "my-source"}
+	sinkKey := key.SinkKey{SourceKey: sourceKey, SinkID: "my-sink"}
+	volumeID := storage.VolumeID("my-volume")
+	cfg := storage.NewConfig()
+	credentials := &keboola.FileUploadCredentials{
+		S3UploadParams: &s3.UploadParams{
+			Credentials: s3.Credentials{
+				Expiration: iso8601.Time{Time: now.Add(time.Hour)},
+			},
+		},
+	}
+
+	d := deps.NewMocked(t, deps.WithEnabledEtcdClient(), deps.WithClock(clk))
+	//client := d.TestEtcdClient()
+	defRepo := defRepository.New(d)
+	backoff := storage.NoRandomizationBackoff()
+	r := newWithBackoff(d, defRepo, cfg, backoff)
+
+	// Create parent branch, source and sinks
+	// -----------------------------------------------------------------------------------------------------------------
+	{
+		branch := branchTemplate(branchKey)
+		require.NoError(t, defRepo.Branch().Create(&branch).Do(ctx).Err())
+		source := sourceTemplate(sourceKey)
+		require.NoError(t, defRepo.Source().Create("Create source", &source).Do(ctx).Err())
+		sink := sinkTemplate(sinkKey)
+		require.NoError(t, defRepo.Sink().Create("Create sink", &sink).Do(ctx).Err())
+	}
+
+	// Create file with 3 slices
+	// -----------------------------------------------------------------------------------------------------------------
+	var file storage.File
+	var slice1, slice2, slice3 storage.Slice
+	{
+		var err error
+		file, err = r.File().Create(sinkKey, credentials).Do(ctx).ResultOrErr()
+		require.NoError(t, err)
+		clk.Add(time.Hour)
+		slice1, err = r.Slice().Create(file.FileKey, volumeID).Do(ctx).ResultOrErr()
+		require.NoError(t, err)
+		clk.Add(time.Hour)
+		slice2, err = r.Slice().Create(file.FileKey, volumeID).Do(ctx).ResultOrErr()
+		require.NoError(t, err)
+		clk.Add(time.Hour)
+		slice3, err = r.Slice().Create(file.FileKey, volumeID).Do(ctx).ResultOrErr()
+		require.NoError(t, err)
+	}
+
+	// INVALID: SliceUploading - invalid transition
+	// -----------------------------------------------------------------------------------------------------------------
+	{
+		err := r.Slice().StateTransition(slice1.SliceKey, storage.SliceUploading).Do(ctx).Err()
+		require.Error(t, err)
+		assert.Equal(t, `unexpected slice "123/456/my-source/my-sink/2000-01-01T19:00:00.000Z/my-volume/2000-01-01T20:00:00.000Z" state transition from "writing" to "uploading"`, err.Error())
+	}
+
+	// INVALID: FileImporting - invalid transition
+	// -----------------------------------------------------------------------------------------------------------------
+	{
+		err := r.File().StateTransition(file.FileKey, storage.FileImporting).Do(ctx).Err()
+		require.Error(t, err)
+		assert.Equal(t, `unexpected file "123/456/my-source/my-sink/2000-01-01T19:00:00.000Z" state transition from "writing" to "importing"`, err.Error())
+	}
+
+	// VALID: SliceClosing
+	// -----------------------------------------------------------------------------------------------------------------
+	{
+		require.NoError(t, r.Slice().StateTransition(slice1.SliceKey, storage.SliceClosing).Do(ctx).Err())
+		require.NoError(t, r.Slice().StateTransition(slice2.SliceKey, storage.SliceClosing).Do(ctx).Err())
+		slice1KV, err := r.Slice().Get(slice1.SliceKey).Do(ctx).ResultOrErr()
+		require.NoError(t, err)
+		assert.Equal(t, storage.SliceClosing, slice1KV.Value.State)
+		slice2KV, err := r.Slice().Get(slice2.SliceKey).Do(ctx).ResultOrErr()
+		require.NoError(t, err)
+		assert.Equal(t, storage.SliceClosing, slice2KV.Value.State)
+	}
+
+	// VALID: FileClosing, slices in SliceWriting state are switched to SliceClosing state
+	// -----------------------------------------------------------------------------------------------------------------
+	{
+		require.NoError(t, r.File().StateTransition(file.FileKey, storage.FileClosing).Do(ctx).Err())
+		fileKV, err := r.File().Get(file.FileKey).Do(ctx).ResultOrErr()
+		require.NoError(t, err)
+		assert.Equal(t, storage.FileClosing, fileKV.Value.State)
+		slice3KV, err := r.Slice().Get(slice3.SliceKey).Do(ctx).ResultOrErr()
+		require.NoError(t, err)
+		assert.Equal(t, storage.SliceClosing, slice3KV.Value.State)
+	}
+
+	// VALID: SliceUploading
+	// -----------------------------------------------------------------------------------------------------------------
+	{
+		require.NoError(t, r.Slice().StateTransition(slice1.SliceKey, storage.SliceUploading).Do(ctx).Err())
+		require.NoError(t, r.Slice().StateTransition(slice2.SliceKey, storage.SliceUploading).Do(ctx).Err())
+		slice1KV, err := r.Slice().Get(slice1.SliceKey).Do(ctx).ResultOrErr()
+		require.NoError(t, err)
+		assert.Equal(t, storage.SliceUploading, slice1KV.Value.State)
+		slice2KV, err := r.Slice().Get(slice2.SliceKey).Do(ctx).ResultOrErr()
+		require.NoError(t, err)
+		assert.Equal(t, storage.SliceUploading, slice2KV.Value.State)
+	}
+
+	// VALID: SliceUploaded
+	// -----------------------------------------------------------------------------------------------------------------
+	{
+		require.NoError(t, r.Slice().StateTransition(slice1.SliceKey, storage.SliceUploaded).Do(ctx).Err())
+		require.NoError(t, r.Slice().StateTransition(slice2.SliceKey, storage.SliceUploaded).Do(ctx).Err())
+		slice1KV, err := r.Slice().Get(slice1.SliceKey).Do(ctx).ResultOrErr()
+		require.NoError(t, err)
+		assert.Equal(t, storage.SliceUploaded, slice1KV.Value.State)
+		slice2KV, err := r.Slice().Get(slice2.SliceKey).Do(ctx).ResultOrErr()
+		require.NoError(t, err)
+		assert.Equal(t, storage.SliceUploaded, slice2KV.Value.State)
+	}
+
+	// INVALID: FileImporting (1) - a slice is not uploaded
+	// -----------------------------------------------------------------------------------------------------------------
+	{
+		err := r.File().StateTransition(file.FileKey, storage.FileImporting).Do(ctx).Err()
+		require.Error(t, err)
+		assert.Equal(t, strings.TrimSpace(`
+unexpected slice "123/456/my-source/my-sink/2000-01-01T19:00:00.000Z/my-volume/2000-01-01T22:00:00.000Z" state:
+- unexpected combination: file state "importing" and slice state "closing"
+`), err.Error())
+	}
+
+	// VALID: SliceUploading
+	// -----------------------------------------------------------------------------------------------------------------
+	{
+		require.NoError(t, r.Slice().StateTransition(slice3.SliceKey, storage.SliceUploading).Do(ctx).Err())
+		slice1KV, err := r.Slice().Get(slice3.SliceKey).Do(ctx).ResultOrErr()
+		require.NoError(t, err)
+		assert.Equal(t, storage.SliceUploading, slice1KV.Value.State)
+	}
+
+	// INVALID: FileImporting (2) - a slice is not uploaded
+	// -----------------------------------------------------------------------------------------------------------------
+	{
+		err := r.File().StateTransition(file.FileKey, storage.FileImporting).Do(ctx).Err()
+		require.Error(t, err)
+		assert.Equal(t, strings.TrimSpace(`
+unexpected slice "123/456/my-source/my-sink/2000-01-01T19:00:00.000Z/my-volume/2000-01-01T22:00:00.000Z" state:
+- unexpected combination: file state "importing" and slice state "uploading"
+`), err.Error())
+	}
+
+	// VALID: SliceUploaded
+	// -----------------------------------------------------------------------------------------------------------------
+	{
+		require.NoError(t, r.Slice().StateTransition(slice3.SliceKey, storage.SliceUploaded).Do(ctx).Err())
+		slice1KV, err := r.Slice().Get(slice3.SliceKey).Do(ctx).ResultOrErr()
+		require.NoError(t, err)
+		assert.Equal(t, storage.SliceUploaded, slice1KV.Value.State)
+	}
+
+	// VALID: FileImporting - all slices are in SliceUploaded state
+	// -----------------------------------------------------------------------------------------------------------------
+	{
+		require.NoError(t, r.File().StateTransition(file.FileKey, storage.FileImporting).Do(ctx).Err())
+		fileKV, err := r.File().Get(file.FileKey).Do(ctx).ResultOrErr()
+		require.NoError(t, err)
+		assert.Equal(t, storage.FileImporting, fileKV.Value.State)
+		slice3KV, err := r.Slice().Get(slice3.SliceKey).Do(ctx).ResultOrErr()
+		require.NoError(t, err)
+		assert.Equal(t, storage.SliceUploaded, slice3KV.Value.State)
+	}
+
+	// VALID: FileImported - slices in SliceUploaded state are switched to SliceImported state
+	// -----------------------------------------------------------------------------------------------------------------
+	{
+		require.NoError(t, r.File().StateTransition(file.FileKey, storage.FileImported).Do(ctx).Err())
+		fileKV, err := r.File().Get(file.FileKey).Do(ctx).ResultOrErr()
+		require.NoError(t, err)
+		assert.Equal(t, storage.FileImported, fileKV.Value.State)
+		slice3KV, err := r.Slice().Get(slice3.SliceKey).Do(ctx).ResultOrErr()
+		require.NoError(t, err)
+		assert.Equal(t, storage.SliceImported, slice3KV.Value.State)
+	}
+}

--- a/internal/pkg/service/buffer/sink/tablesink/storage/retry.go
+++ b/internal/pkg/service/buffer/sink/tablesink/storage/retry.go
@@ -35,7 +35,7 @@ func NewBackoff(wrapped *backoff.ExponentialBackOff) RetryBackoff {
 func DefaultBackoff() RetryBackoff {
 	b := newBackoff()
 	b.Reset()
-	return NewBackoff(newBackoff())
+	return NewBackoff(b)
 }
 
 func NoRandomizationBackoff() RetryBackoff {

--- a/internal/pkg/service/buffer/sink/tablesink/storage/slice.go
+++ b/internal/pkg/service/buffer/sink/tablesink/storage/slice.go
@@ -32,8 +32,8 @@ type SliceKey struct {
 }
 
 type SliceID struct {
+	OpenedAt utctime.UTCTime `json:"sliceOpenedAt" validate:"required"`
 	VolumeID VolumeID        `json:"volumeId" validate:"required"`
-	OpenedAt utctime.UTCTime `json:"openedAt" validate:"required"`
 }
 
 func (v SliceID) String() string {

--- a/internal/pkg/service/buffer/sink/tablesink/storage/slice_test.go
+++ b/internal/pkg/service/buffer/sink/tablesink/storage/slice_test.go
@@ -33,8 +33,8 @@ func TestSliceID_Validation(t *testing.T) {
 	err := val.Validate(ctx, SliceID{})
 	if assert.Error(t, err) {
 		assert.Equal(t, strings.TrimSpace(`
+- "sliceOpenedAt" is a required field
 - "volumeId" is a required field
-- "openedAt" is a required field
 `), strings.TrimSpace(err.Error()))
 	}
 }
@@ -76,9 +76,9 @@ func TestSliceKey_Validation(t *testing.T) {
 - "branchId" is a required field
 - "sourceId" is a required field
 - "sinkId" is a required field
-- "fileId" is a required field
+- "fileOpenedAt" is a required field
+- "sliceOpenedAt" is a required field
 - "volumeId" is a required field
-- "openedAt" is a required field
 `), strings.TrimSpace(err.Error()))
 	}
 }
@@ -137,9 +137,9 @@ func TestSlice_Validation(t *testing.T) {
 - "branchId" is a required field
 - "sourceId" is a required field
 - "sinkId" is a required field
-- "fileId" is a required field
+- "fileOpenedAt" is a required field
+- "sliceOpenedAt" is a required field
 - "volumeId" is a required field
-- "openedAt" is a required field
 - "type" is a required field
 - "state" is a required field
 - "columns" is a required field

--- a/internal/pkg/service/buffer/sink/tablesink/storage/slicestate.go
+++ b/internal/pkg/service/buffer/sink/tablesink/storage/slicestate.go
@@ -16,7 +16,7 @@ const SliceClosing SliceState = "closing"
 const SliceUploading SliceState = "uploading"
 
 // SliceUploaded
-// The Slice has been successfully uploaded.
+// The Slice has been successfully uploaded to the staging storage.
 // The Slice can be removed from the local storage.
 const SliceUploaded SliceState = "uploaded"
 
@@ -25,4 +25,5 @@ const SliceUploaded SliceState = "uploaded"
 // The Slice can be removed from the staging storage, if needed.
 const SliceImported SliceState = "imported"
 
+// SliceState is an enum type for slice states, see also FileState.
 type SliceState string

--- a/internal/pkg/service/buffer/sink/tablesink/storage/slicestate_test.go
+++ b/internal/pkg/service/buffer/sink/tablesink/storage/slicestate_test.go
@@ -1,0 +1,72 @@
+package storage
+
+import (
+	"github.com/benbjohnson/clock"
+	"github.com/keboola/go-utils/pkg/wildcards"
+	"github.com/keboola/keboola-as-code/internal/pkg/service/common/utctime"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	"testing"
+	"time"
+)
+
+func TestSlice_StateTransition(t *testing.T) {
+	t.Parallel()
+
+	clk := clock.Mock{}
+	clk.Set(utctime.MustParse("2000-01-01T00:00:00.000Z").Time())
+
+	// Create file entity
+	sliceKey := testSliceKey()
+	f := Slice{
+		SliceKey: sliceKey,
+		State:    SliceWriting,
+	}
+
+	// SliceClosing
+	clk.Add(time.Hour)
+	require.NoError(t, f.StateTransition(clk.Now(), SliceClosing))
+	assert.Equal(t, Slice{
+		SliceKey:  sliceKey,
+		State:     SliceClosing,
+		ClosingAt: ptr(utctime.MustParse("2000-01-01T01:00:00.000Z")),
+	}, f)
+
+	// SliceUploading
+	clk.Add(time.Hour)
+	require.NoError(t, f.StateTransition(clk.Now(), SliceUploading))
+	assert.Equal(t, Slice{
+		SliceKey:    sliceKey,
+		State:       SliceUploading,
+		ClosingAt:   ptr(utctime.MustParse("2000-01-01T01:00:00.000Z")),
+		UploadingAt: ptr(utctime.MustParse("2000-01-01T02:00:00.000Z")),
+	}, f)
+
+	// SliceUploaded
+	clk.Add(time.Hour)
+	require.NoError(t, f.StateTransition(clk.Now(), SliceUploaded))
+	assert.Equal(t, Slice{
+		SliceKey:    sliceKey,
+		State:       SliceUploaded,
+		ClosingAt:   ptr(utctime.MustParse("2000-01-01T01:00:00.000Z")),
+		UploadingAt: ptr(utctime.MustParse("2000-01-01T02:00:00.000Z")),
+		UploadedAt:  ptr(utctime.MustParse("2000-01-01T03:00:00.000Z")),
+	}, f)
+
+	// SliceImported
+	clk.Add(time.Hour)
+	require.NoError(t, f.StateTransition(clk.Now(), SliceImported))
+	assert.Equal(t, Slice{
+		SliceKey:    sliceKey,
+		State:       SliceImported,
+		ClosingAt:   ptr(utctime.MustParse("2000-01-01T01:00:00.000Z")),
+		UploadingAt: ptr(utctime.MustParse("2000-01-01T02:00:00.000Z")),
+		UploadedAt:  ptr(utctime.MustParse("2000-01-01T03:00:00.000Z")),
+		ImportedAt:  ptr(utctime.MustParse("2000-01-01T04:00:00.000Z")),
+	}, f)
+
+	// Invalid
+	if err := f.StateTransition(clk.Now(), SliceUploaded); assert.Error(t, err) {
+		wildcards.Assert(t, `unexpected slice "%s" state transition from "imported" to "uploaded"`, err.Error())
+	}
+}

--- a/internal/pkg/service/buffer/sink/tablesink/storage/test/file.go
+++ b/internal/pkg/service/buffer/sink/tablesink/storage/test/file.go
@@ -39,13 +39,13 @@ func NewFileKeyOpenedAt(openedAtStr string) storage.FileKey {
 	}
 }
 
-func NewFile() *storage.File {
+func NewFile() storage.File {
 	return NewFileOpenedAt("2000-01-01T19:00:00.000Z")
 }
 
-func NewFileOpenedAt(openedAtStr string) *storage.File {
+func NewFileOpenedAt(openedAtStr string) storage.File {
 	openedAt := utctime.MustParse(openedAtStr)
-	return &storage.File{
+	return storage.File{
 		FileKey: NewFileKeyOpenedAt(openedAtStr),
 		Type:    storage.FileTypeCSV,
 		State:   storage.FileWriting,

--- a/internal/pkg/service/common/errors/test.go
+++ b/internal/pkg/service/common/errors/test.go
@@ -1,0 +1,15 @@
+package errors
+
+import (
+	"github.com/keboola/keboola-as-code/internal/pkg/utils/errors"
+	"github.com/stretchr/testify/assert"
+	"testing"
+)
+
+func AssertErrorStatusCode(t *testing.T, expectedStatusCode int, err error) {
+	t.Helper()
+	var errWithStatus WithStatusCode
+	if assert.True(t, errors.As(err, &errWithStatus)) {
+		assert.Equal(t, expectedStatusCode, errWithStatus.StatusCode())
+	}
+}


### PR DESCRIPTION
Part of: https://keboola.atlassian.net/browse/PSGO-286
Old code is delete in: https://github.com/keboola/keboola-as-code/pull/1471

Changes:
- Created storage repository for File and Slice entities.

----------------

There are two models in the Stream API:
- **Definition model**
  - Pernament entities for service configuration.
  - `Versioned`
  - `SoftDeletable`
  - Please see [package](https://github.com/keboola/keboola-as-code/tree/michaljurecko-PSGO-286-storage-repository-v2/internal/pkg/service/buffer/definition) and [PR](https://github.com/keboola/keboola-as-code/pull/1442).
- **Storage model**
  - This PR.
  - Temporary entities for file/slice metadata.
  - `Retryable`
  - `StateTransition`
  
-------------------

Coverage is almost `100%`, except for a couple of `panic` calls. 

![image](https://github.com/keboola/keboola-as-code/assets/19371734/9e233df2-4b80-4de0-aadc-a40d3dd7a34e)
