### PR TITLE
feat: Update FileRepository.Create - switch previous FileWriting to FileClosing

### DIFF
--- a/internal/pkg/service/buffer/sink/tablesink/storage/repository/file_repo_test.go
+++ b/internal/pkg/service/buffer/sink/tablesink/storage/repository/file_repo_test.go
@@ -196,12 +196,12 @@ func TestRepository_File(t *testing.T) {
 		}
 	}
 
-	// Update (update is private method, public methods IncrementRetry and StateTransition are tested bellow)
+	// Update (readAndUpdate is private method, public methods IncrementRetry and StateTransition are tested bellow)
 	// -----------------------------------------------------------------------------------------------------------------
 	clk.Add(time.Hour)
 	{
 		// Modify configuration
-		result, err := r.update(fileKey1, func(v storage.File) (storage.File, error) {
+		result, err := r.readAndUpdate(fileKey1, func(v storage.File) (storage.File, error) {
 			v.LocalStorage.DiskSync.Wait = false
 			return v, nil
 		}).Do(ctx).ResultOrErr()
@@ -215,7 +215,7 @@ func TestRepository_File(t *testing.T) {
 	// Update - not found
 	// -----------------------------------------------------------------------------------------------------------------
 	{
-		err := r.update(nonExistentFileKey, func(v storage.File) (storage.File, error) {
+		err := r.readAndUpdate(nonExistentFileKey, func(v storage.File) (storage.File, error) {
 			return v, nil
 		}).Do(ctx).Err()
 		if assert.Error(t, err) {

--- a/internal/pkg/service/buffer/sink/tablesink/storage/repository/slice_repo_test.go
+++ b/internal/pkg/service/buffer/sink/tablesink/storage/repository/slice_repo_test.go
@@ -198,12 +198,12 @@ func TestRepository_Slice(t *testing.T) {
 		}
 	}
 
-	// Update (update is private method, public methods IncrementRetry and StateTransition are tested bellow)
+	// Update (readAndUpdate is private method, public methods IncrementRetry and StateTransition are tested bellow)
 	// -----------------------------------------------------------------------------------------------------------------
 	clk.Add(time.Hour)
 	{
 		// Increment retry
-		result, err := r.update(sliceKey1, func(v storage.Slice) (storage.Slice, error) {
+		result, err := r.readAndUpdate(sliceKey1, func(v storage.Slice) (storage.Slice, error) {
 			v.LocalStorage.DiskSync.Wait = false
 			return v, nil
 		}).Do(ctx).ResultOrErr()
@@ -217,7 +217,7 @@ func TestRepository_Slice(t *testing.T) {
 	// Update - not found
 	// -----------------------------------------------------------------------------------------------------------------
 	{
-		err := r.update(nonExistentSliceKey, func(v storage.Slice) (storage.Slice, error) {
+		err := r.readAndUpdate(nonExistentSliceKey, func(v storage.Slice) (storage.Slice, error) {
 			return v, nil
 		}).Do(ctx).Err()
 		if assert.Error(t, err) {

--- a/internal/pkg/service/buffer/sink/tablesink/storage/repository/state_test.go
+++ b/internal/pkg/service/buffer/sink/tablesink/storage/repository/state_test.go
@@ -31,6 +31,7 @@ func TestRepository_FileAndSliceStateTransitions(t *testing.T) {
 	branchKey := key.BranchKey{ProjectID: projectID, BranchID: 456}
 	sourceKey := key.SourceKey{BranchKey: branchKey, SourceID: "my-source"}
 	sinkKey := key.SinkKey{SourceKey: sourceKey, SinkID: "my-sink"}
+	fileKey := storage.FileKey{SinkKey: sinkKey, FileID: storage.FileID{OpenedAt: utctime.From(now)}}
 	volumeID := storage.VolumeID("my-volume")
 	cfg := storage.NewConfig()
 	credentials := &keboola.FileUploadCredentials{
@@ -64,7 +65,7 @@ func TestRepository_FileAndSliceStateTransitions(t *testing.T) {
 	var slice1, slice2, slice3 storage.Slice
 	{
 		var err error
-		file, err = r.File().Create(sinkKey, credentials).Do(ctx).ResultOrErr()
+		file, err = r.File().Create(fileKey, credentials).Do(ctx).ResultOrErr()
 		require.NoError(t, err)
 		clk.Add(time.Hour)
 		slice1, err = r.Slice().Create(file.FileKey, volumeID, 0).Do(ctx).ResultOrErr()


### PR DESCRIPTION
Jira: https://keboola.atlassian.net/browse/PSGO-328

Change:
- If there is an old file in the `FileWriting` state in the sink, then it is switched to the `FileClosing` state, when a new file is created.

I recommend reading gradually each commit.

![image](https://github.com/keboola/keboola-as-code/assets/19371734/968689ef-8248-4919-a29b-d484302f80aa)
