### PR TITLE
refactor: Update go-client - Split API struct to PublicAPI and AuthorizedAPI

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -12,11 +12,11 @@ jobs:
     secrets: inherit
     uses: ./.github/workflows/check-licenses.yml
 
-#  test-lint:
-#    name: "Lint"
-#    secrets: inherit
-#    uses: ./.github/workflows/test-lint.yml
-#
+  test-lint:
+    name: "Lint"
+    secrets: inherit
+    uses: ./.github/workflows/test-lint.yml
+
 #  test-unit:
 #    name: "Unit Tests"
 #    secrets: inherit

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -31,8 +31,8 @@ jobs:
 #    name: "E2E: Buffer"
 #    secrets: inherit
 #    uses: ./.github/workflows/test-e2e-service-buffer.yml
-#
-#  test-e2e-service-templates:
-#    name: "E2E: Templates"
-#    secrets: inherit
-#    uses: ./.github/workflows/test-e2e-service-templates.yml
+
+  test-e2e-service-templates:
+    name: "E2E: Templates"
+    secrets: inherit
+    uses: ./.github/workflows/test-e2e-service-templates.yml

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -21,11 +21,11 @@ jobs:
 #    name: "Unit Tests"
 #    secrets: inherit
 #    uses: ./.github/workflows/test-unit.yml
-#
-#  test-e2e-cli:
-#    name: "E2E: CLI"
-#    secrets: inherit
-#    uses: ./.github/workflows/test-e2e-cli.yml
+
+  test-e2e-cli:
+    name: "E2E: CLI"
+    secrets: inherit
+    uses: ./.github/workflows/test-e2e-cli.yml
 #
 #  test-e2e-service-buffer:
 #    name: "E2E: Buffer"

--- a/docs/buffer/overview.md
+++ b/docs/buffer/overview.md
@@ -31,21 +31,8 @@ See [internal/pkg/service/common/dependencies/dependencies.go](../../internal/pk
 for a detailed explanation of dependency injection and the command design pattern implementation.
 
 ## Worker Implementation
-Entrypoint: [cmd/buffer-worker/main.go](../../cmd/buffer-worker/main.go).
 
-Worker behavior is implemented in [internal/pkg/service/buffer/worker/service/service.go](../../internal/pkg/service/buffer/worker/service/service.go).
-
-The [`internal/pkg/service/buffer/watcher`](../../internal/pkg/service/buffer/watcher) package provides cache for API nodes
-and synchronization between API/Worker nodes. See [internal/pkg/service/buffer/watcher/watcher.go](../../internal/pkg/service/buffer/watcher/watcher.go) for details.
-
-The [`internal/pkg/service/common/distribution`](../../internal/pkg/service/common/distribution) package
-provides distribution of various keys/tasks between worker nodes. See [internal/pkg/service/common/distribution/doc.go](../../internal/pkg/service/common/distribution/doc.go) for details.
-
-The [`internal/pkg/service/common/task`](../../internal/pkg/service/common/task) package
-provides task abstraction for long-running operations in the Worker node.
-
-The [`internal/pkg/service/buffer/worker/task/orchestrator`](../../internal/pkg/service/common/task/orchestrator) package
-combines `distribution.Node` and `task.Node` to run a task on one node in the cluster only, as a reaction to a watch event. See [internal/pkg/service/buffer/worker/task/orchestrator/orchestrator.go](../../internal/pkg/service/common/task/orchestrator/orchestrator.go) for details.
+TODO
 
 ## Resources
 

--- a/docs/telemetry.md
+++ b/docs/telemetry.md
@@ -25,8 +25,8 @@ Other services send OpenTelemetry spans and metrics to DataDog.
 The official DataDog adapter [ddtrace/opentelemetry](https://gopkg.in/DataDog/dd-trace-go.v1/ddtrace/opentelemetry) is used to
 send spans.
 
-Customizations and improvements can be found in [ddprovider.go](../internal/pkg/telemetry/ddprovider.go)
-and [ddtracer.go](../internal/pkg/telemetry/ddtracer.go).
+Customizations and improvements can be found in [datadogprovider.go](../internal/pkg/telemetry/datadog/provider.go)
+and [datadog/tracer.go](../internal/pkg/telemetry/datadog/tracer.go).
 
 #### Metrics
 

--- a/docs/telemetry.md
+++ b/docs/telemetry.md
@@ -25,7 +25,7 @@ Other services send OpenTelemetry spans and metrics to DataDog.
 The official DataDog adapter [ddtrace/opentelemetry](https://gopkg.in/DataDog/dd-trace-go.v1/ddtrace/opentelemetry) is used to
 send spans.
 
-Customizations and improvements can be found in [datadogprovider.go](../internal/pkg/telemetry/datadog/provider.go)
+Customizations and improvements can be found in [datadog/provider.go](../internal/pkg/telemetry/datadog/provider.go)
 and [datadog/tracer.go](../internal/pkg/telemetry/datadog/tracer.go).
 
 #### Metrics

--- a/go.mod
+++ b/go.mod
@@ -33,7 +33,7 @@ require (
 	github.com/jarcoal/httpmock v1.3.0
 	github.com/joho/godotenv v1.5.1
 	github.com/jpillora/longestcommon v0.0.0-20161227235612-adb9d91ee629
-	github.com/keboola/go-client v1.16.7
+	github.com/keboola/go-client v1.18.1-0.20240102154200-941bcb94c6fb
 	github.com/keboola/go-utils v0.8.3
 	github.com/klauspost/compress v1.16.3
 	github.com/klauspost/pgzip v1.2.6

--- a/go.mod
+++ b/go.mod
@@ -33,7 +33,7 @@ require (
 	github.com/jarcoal/httpmock v1.3.0
 	github.com/joho/godotenv v1.5.1
 	github.com/jpillora/longestcommon v0.0.0-20161227235612-adb9d91ee629
-	github.com/keboola/go-client v1.18.1-0.20240102154200-941bcb94c6fb
+	github.com/keboola/go-client v1.19.0
 	github.com/keboola/go-utils v0.8.3
 	github.com/klauspost/compress v1.16.3
 	github.com/klauspost/pgzip v1.2.6

--- a/go.sum
+++ b/go.sum
@@ -1519,8 +1519,8 @@ github.com/karrick/godirwalk v1.8.0/go.mod h1:H5KPZjojv4lE+QYImBI8xVtrBRgYrIVsaR
 github.com/karrick/godirwalk v1.10.3/go.mod h1:RoGL9dQei4vP9ilrpETWE8CLOZ1kiN0LhBygSwrAsHA=
 github.com/kballard/go-shellquote v0.0.0-20180428030007-95032a82bc51 h1:Z9n2FFNUXsshfwJMBgNA0RU6/i7WVaAegv3PtuIHPMs=
 github.com/kballard/go-shellquote v0.0.0-20180428030007-95032a82bc51/go.mod h1:CzGEWj7cYgsdH8dAjBGEr58BoE7ScuLd+fwFZ44+/x8=
-github.com/keboola/go-client v1.18.1-0.20240102154200-941bcb94c6fb h1:qRNnrbomW3df7zMAfXPBYjp6tjv7V/zzaletjs/Bnwk=
-github.com/keboola/go-client v1.18.1-0.20240102154200-941bcb94c6fb/go.mod h1:IKV+vw8MC/C2EUcMuUD++8tOqjylsvxVdSCsCsn+jdc=
+github.com/keboola/go-client v1.19.0 h1:oUkUCA9zAE2HkkMCALMsAzHFY68MEQUqVfdDFcKtaUQ=
+github.com/keboola/go-client v1.19.0/go.mod h1:IKV+vw8MC/C2EUcMuUD++8tOqjylsvxVdSCsCsn+jdc=
 github.com/keboola/go-jsonnet v0.19.1 h1:vdWv6lKNX2WdZl4R8PCOnOWINIjdcwmLqNssU7OUv+Y=
 github.com/keboola/go-jsonnet v0.19.1/go.mod h1:pSOb2+VoKZjVbIB4z58am8q15yWO/VTEp6n1GxW3x0I=
 github.com/keboola/go-utils v0.8.3 h1:FCAircm1wlI0S6MgJxfmoo5HvjX2p0/LnClNfPMnI7k=

--- a/go.sum
+++ b/go.sum
@@ -1519,8 +1519,8 @@ github.com/karrick/godirwalk v1.8.0/go.mod h1:H5KPZjojv4lE+QYImBI8xVtrBRgYrIVsaR
 github.com/karrick/godirwalk v1.10.3/go.mod h1:RoGL9dQei4vP9ilrpETWE8CLOZ1kiN0LhBygSwrAsHA=
 github.com/kballard/go-shellquote v0.0.0-20180428030007-95032a82bc51 h1:Z9n2FFNUXsshfwJMBgNA0RU6/i7WVaAegv3PtuIHPMs=
 github.com/kballard/go-shellquote v0.0.0-20180428030007-95032a82bc51/go.mod h1:CzGEWj7cYgsdH8dAjBGEr58BoE7ScuLd+fwFZ44+/x8=
-github.com/keboola/go-client v1.16.7 h1:ztEYMp8zhyrlDBATWh9FQM/NO7gT+j+ntWEsAmt8ei8=
-github.com/keboola/go-client v1.16.7/go.mod h1:IKV+vw8MC/C2EUcMuUD++8tOqjylsvxVdSCsCsn+jdc=
+github.com/keboola/go-client v1.18.1-0.20240102154200-941bcb94c6fb h1:qRNnrbomW3df7zMAfXPBYjp6tjv7V/zzaletjs/Bnwk=
+github.com/keboola/go-client v1.18.1-0.20240102154200-941bcb94c6fb/go.mod h1:IKV+vw8MC/C2EUcMuUD++8tOqjylsvxVdSCsCsn+jdc=
 github.com/keboola/go-jsonnet v0.19.1 h1:vdWv6lKNX2WdZl4R8PCOnOWINIjdcwmLqNssU7OUv+Y=
 github.com/keboola/go-jsonnet v0.19.1/go.mod h1:pSOb2+VoKZjVbIB4z58am8q15yWO/VTEp6n1GxW3x0I=
 github.com/keboola/go-utils v0.8.3 h1:FCAircm1wlI0S6MgJxfmoo5HvjX2p0/LnClNfPMnI7k=

--- a/internal/pkg/mapper/branchmetadata/branchmetadata.go
+++ b/internal/pkg/mapper/branchmetadata/branchmetadata.go
@@ -15,7 +15,7 @@ type branchMetadataMapper struct {
 }
 
 type dependencies interface {
-	KeboolaProjectAPI() *keboola.API
+	KeboolaProjectAPI() *keboola.AuthorizedAPI
 }
 
 func NewMapper(s *state.State, d dependencies) *branchMetadataMapper {

--- a/internal/pkg/mapper/configmetadata/configmetadata.go
+++ b/internal/pkg/mapper/configmetadata/configmetadata.go
@@ -15,7 +15,7 @@ type configMetadataMapper struct {
 }
 
 type dependencies interface {
-	KeboolaProjectAPI() *keboola.API
+	KeboolaProjectAPI() *keboola.AuthorizedAPI
 }
 
 func NewMapper(s *state.State, d dependencies) *configMetadataMapper {

--- a/internal/pkg/mapper/scheduler/scheduler.go
+++ b/internal/pkg/mapper/scheduler/scheduler.go
@@ -7,7 +7,7 @@ import (
 )
 
 type dependencies interface {
-	KeboolaProjectAPI() *keboola.API
+	KeboolaProjectAPI() *keboola.AuthorizedAPI
 }
 
 type schedulerMapper struct {

--- a/internal/pkg/model/component.go
+++ b/internal/pkg/model/component.go
@@ -19,11 +19,11 @@ const ComponentsUpdateTimeout = 20 * time.Second
 type ComponentsProvider struct {
 	updateLock       *sync.RWMutex
 	logger           log.Logger
-	keboolaPublicAPI *keboola.API
+	keboolaPublicAPI *keboola.PublicAPI
 	value            *ComponentsMap
 }
 
-func NewComponentsProvider(index *keboola.IndexComponents, logger log.Logger, keboolaPublicAPI *keboola.API) *ComponentsProvider {
+func NewComponentsProvider(index *keboola.IndexComponents, logger log.Logger, keboolaPublicAPI *keboola.PublicAPI) *ComponentsProvider {
 	return &ComponentsProvider{
 		updateLock:       &sync.RWMutex{},
 		logger:           logger,

--- a/internal/pkg/plan/encrypt/executor.go
+++ b/internal/pkg/plan/encrypt/executor.go
@@ -19,12 +19,12 @@ type executor struct {
 	ctx               context.Context
 	projectID         keboola.ProjectID
 	logger            log.Logger
-	keboolaProjectAPI *keboola.API
+	keboolaProjectAPI *keboola.AuthorizedAPI
 	uow               *local.UnitOfWork
 	errors            errors.MultiError
 }
 
-func newExecutor(ctx context.Context, projectID keboola.ProjectID, logger log.Logger, keboolaProjectAPI *keboola.API, state *state.State, plan *Plan) *executor {
+func newExecutor(ctx context.Context, projectID keboola.ProjectID, logger log.Logger, keboolaProjectAPI *keboola.AuthorizedAPI, state *state.State, plan *Plan) *executor {
 	return &executor{
 		Plan:              plan,
 		ctx:               ctx,

--- a/internal/pkg/plan/encrypt/plan.go
+++ b/internal/pkg/plan/encrypt/plan.go
@@ -26,7 +26,7 @@ func (p *Plan) Name() string {
 	return "encrypt"
 }
 
-func (p *Plan) Invoke(ctx context.Context, projectID keboola.ProjectID, logger log.Logger, keboolaProjectAPI *keboola.API, state *state.State) error {
+func (p *Plan) Invoke(ctx context.Context, projectID keboola.ProjectID, logger log.Logger, keboolaProjectAPI *keboola.AuthorizedAPI, state *state.State) error {
 	return newExecutor(ctx, projectID, logger, keboolaProjectAPI, state, p).invoke()
 }
 

--- a/internal/pkg/plan/persist/executor.go
+++ b/internal/pkg/plan/persist/executor.go
@@ -21,7 +21,7 @@ type executor struct {
 	errors  errors.MultiError
 }
 
-func newExecutor(ctx context.Context, logger log.Logger, keboolaProjectAPI *keboola.API, projectState *state.State, plan *Plan) *executor {
+func newExecutor(ctx context.Context, logger log.Logger, keboolaProjectAPI *keboola.AuthorizedAPI, projectState *state.State, plan *Plan) *executor {
 	return &executor{
 		Plan:    plan,
 		State:   projectState,

--- a/internal/pkg/plan/persist/plan.go
+++ b/internal/pkg/plan/persist/plan.go
@@ -34,6 +34,6 @@ func (p *Plan) Log(logger log.Logger) {
 	}
 }
 
-func (p *Plan) Invoke(ctx context.Context, logger log.Logger, keboolaProjectAPI *keboola.API, projectState *state.State) error {
+func (p *Plan) Invoke(ctx context.Context, logger log.Logger, keboolaProjectAPI *keboola.AuthorizedAPI, projectState *state.State) error {
 	return newExecutor(ctx, logger, keboolaProjectAPI, projectState, p).invoke()
 }

--- a/internal/pkg/project/project.go
+++ b/internal/pkg/project/project.go
@@ -30,7 +30,7 @@ func LoadManifest(ctx context.Context, fs filesystem.Fs, ignoreErrors bool) (*Ma
 
 type dependencies interface {
 	Components() *model.ComponentsMap
-	KeboolaProjectAPI() *keboola.API
+	KeboolaProjectAPI() *keboola.AuthorizedAPI
 	Logger() log.Logger
 	Telemetry() telemetry.Telemetry
 }

--- a/internal/pkg/service/buffer/event/sender.go
+++ b/internal/pkg/service/buffer/event/sender.go
@@ -34,7 +34,7 @@ type Params struct {
 	Stats      statistics.Value
 }
 
-func (s *Sender) SendSliceUploadEvent(ctx context.Context, api *keboola.API, start time.Time, errPtr *error, slice model.Slice, stats statistics.Value) {
+func (s *Sender) SendSliceUploadEvent(ctx context.Context, api *keboola.AuthorizedAPI, start time.Time, errPtr *error, slice model.Slice, stats statistics.Value) {
 	// Get error
 	var err error
 	if errPtr != nil {
@@ -68,7 +68,7 @@ func (s *Sender) SendSliceUploadEvent(ctx context.Context, api *keboola.API, sta
 	}
 }
 
-func (s *Sender) SendFileImportEvent(ctx context.Context, api *keboola.API, start time.Time, errPtr *error, file model.File, stats statistics.Value) {
+func (s *Sender) SendFileImportEvent(ctx context.Context, api *keboola.AuthorizedAPI, start time.Time, errPtr *error, file model.File, stats statistics.Value) {
 	// Get error
 	var err error
 	if errPtr != nil {
@@ -145,7 +145,7 @@ Error:
 }
 */
 
-func (s *Sender) sendEvent(ctx context.Context, api *keboola.API, start time.Time, err error, task string, msg func(error) string, params Params) {
+func (s *Sender) sendEvent(ctx context.Context, api *keboola.AuthorizedAPI, start time.Time, err error, task string, msg func(error) string, params Params) {
 	event := &keboola.Event{
 		ComponentID: componentID,
 		Message:     msg(err),

--- a/internal/pkg/service/buffer/sink/tablesink/storage/level/local/writer/base.go
+++ b/internal/pkg/service/buffer/sink/tablesink/storage/level/local/writer/base.go
@@ -2,6 +2,7 @@ package writer
 
 import (
 	"context"
+
 	"github.com/benbjohnson/clock"
 
 	"github.com/keboola/keboola-as-code/internal/pkg/log"

--- a/internal/pkg/service/buffer/sink/tablesink/storage/level/local/writer/event.go
+++ b/internal/pkg/service/buffer/sink/tablesink/storage/level/local/writer/event.go
@@ -2,6 +2,7 @@ package writer
 
 import (
 	"context"
+
 	"github.com/keboola/keboola-as-code/internal/pkg/utils/errors"
 )
 

--- a/internal/pkg/service/buffer/worker/service/service.go
+++ b/internal/pkg/service/buffer/worker/service/service.go
@@ -28,7 +28,7 @@ type Service struct {
 	wg            *sync.WaitGroup
 	clock         clock.Clock
 	logger        log.Logger
-	publicAPI     *keboola.API
+	publicAPI     *keboola.PublicAPI
 	store         *store.Store
 	fileManager   *file.Manager
 	etcdClient    *etcd.Client
@@ -48,7 +48,7 @@ type dependencies interface {
 	Telemetry() telemetry.Telemetry
 	Process() *servicectx.Process
 	WorkerConfig() config.WorkerConfig
-	KeboolaPublicAPI() *keboola.API
+	KeboolaPublicAPI() *keboola.PublicAPI
 	EtcdClient() *etcd.Client
 	EtcdSerde() *serde.Serde
 	Schema() *schema.Schema

--- a/internal/pkg/service/cli/cmd/dbt/generate/env.go
+++ b/internal/pkg/service/cli/cmd/dbt/generate/env.go
@@ -27,10 +27,10 @@ func EnvCommand(p dependencies.Provider) *cobra.Command {
 				return err
 			}
 
-			// Options
+			// Get default branch
 			branch, err := d.KeboolaProjectAPI().GetDefaultBranchRequest().Send(cmd.Context())
 			if err != nil {
-				return errors.Errorf("cannot find default branch: %w", err)
+				return errors.Errorf("cannot get default branch: %w", err)
 			}
 
 			// Get all Snowflake workspaces for the dialog
@@ -44,7 +44,7 @@ func EnvCommand(p dependencies.Provider) *cobra.Command {
 					snowflakeWorkspaces = append(snowflakeWorkspaces, w)
 				}
 			}
-			opts, err := d.Dialogs().AskGenerateEnv(snowflakeWorkspaces)
+			opts, err := d.Dialogs().AskGenerateEnv(branch.BranchKey, snowflakeWorkspaces)
 			if err != nil {
 				return err
 			}

--- a/internal/pkg/service/cli/cmd/dbt/init.go
+++ b/internal/pkg/service/cli/cmd/dbt/init.go
@@ -5,6 +5,7 @@ import (
 
 	"github.com/keboola/keboola-as-code/internal/pkg/service/cli/dependencies"
 	"github.com/keboola/keboola-as-code/internal/pkg/service/cli/helpmsg"
+	"github.com/keboola/keboola-as-code/internal/pkg/utils/errors"
 	initOp "github.com/keboola/keboola-as-code/pkg/lib/operation/dbt/init"
 )
 
@@ -19,14 +20,20 @@ func InitCommand(p dependencies.Provider) *cobra.Command {
 				return err
 			}
 
-			// Ask options
-			opts, err := p.BaseScope().Dialogs().AskDbtInit()
+			// Get dependencies
+			d, err := p.RemoteCommandScope(cmd.Context())
 			if err != nil {
 				return err
 			}
 
-			// Get dependencies
-			d, err := p.RemoteCommandScope(cmd.Context())
+			// Get default branch
+			branch, err := d.KeboolaProjectAPI().GetDefaultBranchRequest().Send(cmd.Context())
+			if err != nil {
+				return errors.Errorf("cannot get default branch: %w", err)
+			}
+
+			// Ask options
+			opts, err := p.BaseScope().Dialogs().AskDbtInit(branch.BranchKey)
 			if err != nil {
 				return err
 			}

--- a/internal/pkg/service/cli/cmd/remote/create/bucket.go
+++ b/internal/pkg/service/cli/cmd/remote/create/bucket.go
@@ -7,6 +7,7 @@ import (
 
 	"github.com/keboola/keboola-as-code/internal/pkg/service/cli/dependencies"
 	"github.com/keboola/keboola-as-code/internal/pkg/service/cli/helpmsg"
+	"github.com/keboola/keboola-as-code/internal/pkg/utils/errors"
 	"github.com/keboola/keboola-as-code/pkg/lib/operation/project/remote/create/bucket"
 )
 
@@ -22,8 +23,14 @@ func BucketCommand(p dependencies.Provider) *cobra.Command {
 				return err
 			}
 
+			// Get default branch
+			branch, err := d.KeboolaProjectAPI().GetDefaultBranchRequest().Send(cmd.Context())
+			if err != nil {
+				return errors.Errorf("cannot get default branch: %w", err)
+			}
+
 			// Options
-			opts, err := d.Dialogs().AskCreateBucket()
+			opts, err := d.Dialogs().AskCreateBucket(branch.BranchKey)
 			if err != nil {
 				return err
 			}

--- a/internal/pkg/service/cli/cmd/remote/file/upload.go
+++ b/internal/pkg/service/cli/cmd/remote/file/upload.go
@@ -7,6 +7,7 @@ import (
 
 	"github.com/keboola/keboola-as-code/internal/pkg/service/cli/dependencies"
 	"github.com/keboola/keboola-as-code/internal/pkg/service/cli/helpmsg"
+	"github.com/keboola/keboola-as-code/internal/pkg/utils/errors"
 	"github.com/keboola/keboola-as-code/pkg/lib/operation/project/remote/file/upload"
 )
 
@@ -22,8 +23,14 @@ func UploadCommand(p dependencies.Provider) *cobra.Command {
 				return err
 			}
 
+			// Get default branch
+			branch, err := d.KeboolaProjectAPI().GetDefaultBranchRequest().Send(cmd.Context())
+			if err != nil {
+				return errors.Errorf("cannot get default branch: %w", err)
+			}
+
 			// Ask options
-			opts, err := d.Dialogs().AskUploadFile("", "")
+			opts, err := d.Dialogs().AskUploadFile(branch.BranchKey, "", "")
 			if err != nil {
 				return err
 			}

--- a/internal/pkg/service/cli/cmd/remote/table/detail.go
+++ b/internal/pkg/service/cli/cmd/remote/table/detail.go
@@ -8,6 +8,7 @@ import (
 
 	"github.com/keboola/keboola-as-code/internal/pkg/service/cli/dependencies"
 	"github.com/keboola/keboola-as-code/internal/pkg/service/cli/helpmsg"
+	"github.com/keboola/keboola-as-code/internal/pkg/utils/errors"
 	"github.com/keboola/keboola-as-code/pkg/lib/operation/project/remote/table/detail"
 )
 
@@ -24,25 +25,29 @@ func DetailCommand(p dependencies.Provider) *cobra.Command {
 				return err
 			}
 
+			// Get default branch
+			branch, err := d.KeboolaProjectAPI().GetDefaultBranchRequest().Send(cmd.Context())
+			if err != nil {
+				return errors.Errorf("cannot get default branch: %w", err)
+			}
+
 			// Ask options
-			var tableID keboola.TableID
+			tableKey := keboola.TableKey{BranchID: branch.ID}
 			if len(args) == 0 {
-				tableID, _, err = askTable(cmd.Context(), d, false)
+				tableKey, _, err = askTable(cmd.Context(), d, branch.ID, false)
 				if err != nil {
 					return err
 				}
+			} else if id, err := keboola.ParseTableID(args[0]); err == nil {
+				tableKey.TableID = id
 			} else {
-				id, err := keboola.ParseTableID(args[0])
-				if err != nil {
-					return err
-				}
-				tableID = id
+				return err
 			}
 
 			// Send cmd successful/failed event
 			defer d.EventSender().SendCmdEvent(cmd.Context(), time.Now(), &cmdErr, "remote-table-detail")
 
-			return detail.Run(cmd.Context(), tableID, d)
+			return detail.Run(cmd.Context(), tableKey, d)
 		},
 	}
 

--- a/internal/pkg/service/cli/cmd/remote/table/utils.go
+++ b/internal/pkg/service/cli/cmd/remote/table/utils.go
@@ -15,10 +15,10 @@ import (
 // If the user selects this entry, they will be asked to enter an ID for the new table
 // (which will be checked to be a valid table ID), and if successful, the return value of
 // `createNew` will be `true`.
-func askTable(ctx context.Context, d dependencies.RemoteCommandScope, allowCreateNew bool) (tableID keboola.TableID, createNew bool, err error) {
-	allTables, err := d.KeboolaProjectAPI().ListTablesRequest(keboola.WithColumns()).Send(ctx)
+func askTable(ctx context.Context, d dependencies.RemoteCommandScope, branchID keboola.BranchID, allowCreateNew bool) (tableKey keboola.TableKey, createNew bool, err error) {
+	allTables, err := d.KeboolaProjectAPI().ListTablesRequest(branchID, keboola.WithColumns()).Send(ctx)
 	if err != nil {
-		return keboola.TableID{}, false, err
+		return keboola.TableKey{}, false, err
 	}
 
 	var opts []dialog.AskTableOption
@@ -28,19 +28,19 @@ func askTable(ctx context.Context, d dependencies.RemoteCommandScope, allowCreat
 
 	table, err := d.Dialogs().AskTable(*allTables, opts...)
 	if err != nil {
-		return keboola.TableID{}, false, err
+		return keboola.TableKey{}, false, err
 	}
 
 	if table != nil {
 		// user selected table
-		return table.ID, false, nil
+		return table.TableKey, false, nil
 	} else {
 		// user asked to create new table
 		tableID, err := keboola.ParseTableID(d.Dialogs().AskTableID())
 		if err != nil {
-			return keboola.TableID{}, false, err
+			return keboola.TableKey{}, false, err
 		}
 
-		return tableID, true, nil
+		return keboola.TableKey{BranchID: branchID, TableID: tableID}, true, nil
 	}
 }

--- a/internal/pkg/service/cli/cmd/remote/workspace/delete.go
+++ b/internal/pkg/service/cli/cmd/remote/workspace/delete.go
@@ -23,17 +23,17 @@ func DeleteCommand(p dependencies.Provider) *cobra.Command {
 				return err
 			}
 
-			// Options
+			// Get default branch
 			branch, err := d.KeboolaProjectAPI().GetDefaultBranchRequest().Send(cmd.Context())
 			if err != nil {
-				return errors.Errorf("cannot find default branch: %w", err)
+				return errors.Errorf("cannot get default branch: %w", err)
 			}
 
+			// Options
 			allWorkspaces, err := d.KeboolaProjectAPI().ListWorkspaces(cmd.Context(), branch.ID)
 			if err != nil {
 				return err
 			}
-
 			sandbox, err := d.Dialogs().AskWorkspace(allWorkspaces)
 			if err != nil {
 				return err

--- a/internal/pkg/service/cli/dialog/allowed_branches.go
+++ b/internal/pkg/service/cli/dialog/allowed_branches.go
@@ -27,7 +27,7 @@ type branchesDialog struct {
 }
 
 type branchesDialogDeps interface {
-	KeboolaProjectAPI() *keboola.API
+	KeboolaProjectAPI() *keboola.AuthorizedAPI
 }
 
 func (p *Dialogs) AskAllowedBranches(ctx context.Context, deps branchesDialogDeps) (model.AllowedBranches, error) {

--- a/internal/pkg/service/cli/dialog/buckets.go
+++ b/internal/pkg/service/cli/dialog/buckets.go
@@ -16,13 +16,13 @@ func (p *Dialogs) AskBucketID(all []*keboola.Bucket) (keboola.BucketID, error) {
 
 	selectOpts := make([]string, 0)
 	for _, b := range all {
-		selectOpts = append(selectOpts, fmt.Sprintf(`%s (%s)`, b.DisplayName, b.ID.String()))
+		selectOpts = append(selectOpts, fmt.Sprintf(`%s (%s)`, b.DisplayName, b.BucketID.String()))
 	}
 	if index, ok := p.SelectIndex(&prompt.SelectIndex{
 		Label:   "Select a bucket",
 		Options: selectOpts,
 	}); ok {
-		return all[index].ID, nil
+		return all[index].BucketID, nil
 	}
 
 	return keboola.BucketID{}, errors.New(`please specify bucket`)

--- a/internal/pkg/service/cli/dialog/create_bucket.go
+++ b/internal/pkg/service/cli/dialog/create_bucket.go
@@ -9,8 +9,8 @@ import (
 	"github.com/keboola/keboola-as-code/pkg/lib/operation/project/remote/create/bucket"
 )
 
-func (p *Dialogs) AskCreateBucket() (bucket.Options, error) {
-	opts := bucket.Options{}
+func (p *Dialogs) AskCreateBucket(branchKey keboola.BranchKey) (bucket.Options, error) {
+	opts := bucket.Options{BranchKey: branchKey}
 
 	if p.options.IsSet("stage") {
 		stage := p.options.GetString("stage")

--- a/internal/pkg/service/cli/dialog/create_table.go
+++ b/internal/pkg/service/cli/dialog/create_table.go
@@ -9,7 +9,7 @@ import (
 	"github.com/keboola/keboola-as-code/pkg/lib/operation/project/remote/create/table"
 )
 
-func (p *Dialogs) AskCreateTable(args []string, allBuckets []*keboola.Bucket) (table.Options, error) {
+func (p *Dialogs) AskCreateTable(args []string, branchKey keboola.BranchKey, allBuckets []*keboola.Bucket) (table.Options, error) {
 	opts := table.Options{}
 
 	if len(args) == 1 {
@@ -17,14 +17,15 @@ func (p *Dialogs) AskCreateTable(args []string, allBuckets []*keboola.Bucket) (t
 		if err != nil {
 			return opts, err
 		}
-		opts.BucketID = tableID.BucketID
+		opts.BucketKey = keboola.BucketKey{BranchID: branchKey.ID, BucketID: tableID.BucketID}
 		opts.Name = tableID.TableName
 	} else {
 		bucketID, err := p.AskBucketID(allBuckets)
 		if err != nil {
 			return opts, err
 		}
-		opts.BucketID = bucketID
+
+		opts.BucketKey = keboola.BucketKey{BranchID: branchKey.ID, BucketID: bucketID}
 
 		name := p.options.GetString(`name`)
 		if !p.options.IsSet(`name`) {

--- a/internal/pkg/service/cli/dialog/create_template.go
+++ b/internal/pkg/service/cli/dialog/create_template.go
@@ -19,7 +19,7 @@ import (
 
 type createTmplDialogDeps interface {
 	Components() *model.ComponentsMap
-	KeboolaProjectAPI() *keboola.API
+	KeboolaProjectAPI() *keboola.AuthorizedAPI
 	Logger() log.Logger
 }
 

--- a/internal/pkg/service/cli/dialog/dbt.go
+++ b/internal/pkg/service/cli/dialog/dbt.go
@@ -49,7 +49,7 @@ func validateTargetName(val any) error {
 	return nil
 }
 
-func (p *Dialogs) AskGenerateEnv(allWorkspaces []*keboola.WorkspaceWithConfig) (env.Options, error) {
+func (p *Dialogs) AskGenerateEnv(branchKey keboola.BranchKey, allWorkspaces []*keboola.WorkspaceWithConfig) (env.Options, error) {
 	targetName, err := p.AskTargetName()
 	if err != nil {
 		return env.Options{}, err
@@ -61,12 +61,13 @@ func (p *Dialogs) AskGenerateEnv(allWorkspaces []*keboola.WorkspaceWithConfig) (
 	}
 
 	return env.Options{
+		BranchKey:  branchKey,
 		TargetName: targetName,
 		Workspace:  workspace.Workspace,
 	}, nil
 }
 
-func (p *Dialogs) AskDbtInit() (initOp.DbtInitOptions, error) {
+func (p *Dialogs) AskDbtInit(branchKey keboola.BranchKey) (initOp.DbtInitOptions, error) {
 	targetName, err := p.AskTargetName()
 	if err != nil {
 		return initOp.DbtInitOptions{}, err
@@ -78,6 +79,7 @@ func (p *Dialogs) AskDbtInit() (initOp.DbtInitOptions, error) {
 	}
 
 	return initOp.DbtInitOptions{
+		BranchKey:     branchKey,
 		TargetName:    targetName,
 		WorkspaceName: workspaceName,
 	}, nil

--- a/internal/pkg/service/cli/dialog/files.go
+++ b/internal/pkg/service/cli/dialog/files.go
@@ -14,7 +14,7 @@ import (
 func (p *Dialogs) AskFile(allFiles []*keboola.File) (*keboola.File, error) {
 	selectOpts := make([]string, 0)
 	for _, w := range allFiles {
-		selectOpts = append(selectOpts, fmt.Sprintf(`%s (%d)`, w.Name, w.ID))
+		selectOpts = append(selectOpts, fmt.Sprintf(`%s (%d)`, w.Name, w.FileID))
 	}
 	if index, ok := p.SelectIndex(&prompt.SelectIndex{
 		Label:   "File",
@@ -43,8 +43,8 @@ func (p *Dialogs) AskFileOutput() (string, error) {
 	return output, nil
 }
 
-func (p *Dialogs) AskUploadFile(input string, defaultName string) (upload.Options, error) {
-	res := upload.Options{}
+func (p *Dialogs) AskUploadFile(branchKey keboola.BranchKey, input string, defaultName string) (upload.Options, error) {
+	res := upload.Options{BranchKey: branchKey}
 
 	name, err := p.askFileName(defaultName)
 	if err != nil {

--- a/internal/pkg/service/cli/dialog/init.go
+++ b/internal/pkg/service/cli/dialog/init.go
@@ -14,7 +14,7 @@ import (
 )
 
 type initDeps interface {
-	KeboolaProjectAPI() *keboola.API
+	KeboolaProjectAPI() *keboola.AuthorizedAPI
 }
 
 func (p *Dialogs) AskInitOptions(ctx context.Context, d initDeps) (initOp.Options, error) {

--- a/internal/pkg/service/cli/dialog/table.go
+++ b/internal/pkg/service/cli/dialog/table.go
@@ -64,7 +64,7 @@ func (p *Dialogs) AskTable(
 			return nil, err
 		}
 		for _, w := range allTables {
-			if w.ID == tableID {
+			if w.TableID == tableID {
 				return w, nil
 			}
 		}
@@ -77,7 +77,7 @@ func (p *Dialogs) AskTable(
 	}
 
 	for _, table := range allTables {
-		selectOpts = append(selectOpts, fmt.Sprintf(`%s (%s)`, table.DisplayName, table.ID))
+		selectOpts = append(selectOpts, fmt.Sprintf(`%s (%s)`, table.DisplayName, table.TableID))
 	}
 	index, ok := p.SelectIndex(&prompt.SelectIndex{
 		Label:      "Table",

--- a/internal/pkg/service/cli/event/sender.go
+++ b/internal/pkg/service/cli/event/sender.go
@@ -17,11 +17,11 @@ const componentID = keboola.ComponentID("keboola.keboola-as-code")
 
 type Sender struct {
 	logger    log.Logger
-	client    *keboola.API
+	client    *keboola.AuthorizedAPI
 	projectID keboola.ProjectID
 }
 
-func NewSender(logger log.Logger, client *keboola.API, projectID keboola.ProjectID) Sender {
+func NewSender(logger log.Logger, client *keboola.AuthorizedAPI, projectID keboola.ProjectID) Sender {
 	return Sender{logger: logger, client: client, projectID: projectID}
 }
 

--- a/internal/pkg/service/common/dependencies/dependencies.go
+++ b/internal/pkg/service/common/dependencies/dependencies.go
@@ -94,7 +94,7 @@ type BaseScope interface {
 type PublicScope interface {
 	Components() *model.ComponentsMap
 	ComponentsProvider() *model.ComponentsProvider
-	KeboolaPublicAPI() *keboola.API
+	KeboolaPublicAPI() *keboola.PublicAPI
 	StackFeatures() keboola.FeaturesMap
 	StackServices() keboola.ServicesMap
 	StorageAPIHost() string
@@ -102,7 +102,7 @@ type PublicScope interface {
 
 // ProjectScope dependencies require authentication - Storage API token.
 type ProjectScope interface {
-	KeboolaProjectAPI() *keboola.API
+	KeboolaProjectAPI() *keboola.AuthorizedAPI
 	ObjectIDGeneratorFactory() func(ctx context.Context) *keboola.TicketProvider
 	ProjectID() keboola.ProjectID
 	ProjectName() string

--- a/internal/pkg/service/common/dependencies/mocked.go
+++ b/internal/pkg/service/common/dependencies/mocked.go
@@ -76,7 +76,7 @@ type MockedConfig struct {
 	multipleTokenVerification bool
 
 	useRealAPIs       bool
-	keboolaProjectAPI *keboola.API
+	keboolaProjectAPI *keboola.AuthorizedAPI
 }
 
 type MockedOption func(c *MockedConfig)
@@ -293,7 +293,7 @@ func NewMocked(t *testing.T, opts ...MockedOption) Mocked {
 	// Use real APIs
 	if cfg.useRealAPIs {
 		d.baseScope.httpClient = client.NewTestClient()
-		d.publicScope.keboolaPublicAPI = cfg.keboolaProjectAPI
+		d.publicScope.keboolaPublicAPI = cfg.keboolaProjectAPI.PublicAPI
 		d.projectScope.keboolaProjectAPI = cfg.keboolaProjectAPI
 		d.mockedHTTPTransport = nil
 	}

--- a/internal/pkg/service/common/dependencies/project.go
+++ b/internal/pkg/service/common/dependencies/project.go
@@ -18,7 +18,7 @@ import (
 type projectScope struct {
 	token             keboola.Token
 	projectFeatures   keboola.FeaturesMap
-	keboolaProjectAPI *keboola.API
+	keboolaProjectAPI *keboola.AuthorizedAPI
 }
 
 type projectScopeDeps interface {
@@ -94,7 +94,7 @@ func newProjectScope(ctx context.Context, prjScp projectScopeDeps, token keboola
 	}
 
 	httpClient := prjScp.HTTPClient()
-	api, err := keboola.NewAPI(ctx, prjScp.StorageAPIHost(), keboola.WithClient(&httpClient), keboola.WithToken(token.Token))
+	api, err := keboola.NewAuthorizedAPI(ctx, prjScp.StorageAPIHost(), token.Token, keboola.WithClient(&httpClient))
 	if err != nil {
 		return nil, err
 	}
@@ -138,7 +138,7 @@ func (v *projectScope) StorageAPITokenID() string {
 	return v.token.ID
 }
 
-func (v *projectScope) KeboolaProjectAPI() *keboola.API {
+func (v *projectScope) KeboolaProjectAPI() *keboola.AuthorizedAPI {
 	v.check()
 	return v.keboolaProjectAPI
 }

--- a/internal/pkg/service/common/dependencies/public.go
+++ b/internal/pkg/service/common/dependencies/public.go
@@ -15,7 +15,7 @@ import (
 type publicScope struct {
 	base             BaseScope
 	components       Lazy[*model.ComponentsProvider]
-	keboolaPublicAPI *keboola.API
+	keboolaPublicAPI *keboola.PublicAPI
 	stackFeatures    keboola.FeaturesMap
 	stackServices    keboola.ServicesMap
 	storageAPIHost   string
@@ -92,7 +92,7 @@ func newPublicScope(ctx context.Context, baseScp BaseScope, storageAPIHost strin
 	}
 
 	// Create API
-	v.keboolaPublicAPI = keboola.NewAPIFromIndex(storageAPIHost, index, keboola.WithClient(&baseHTTPClient))
+	v.keboolaPublicAPI = keboola.NewPublicAPIFromIndex(storageAPIHost, index, keboola.WithClient(&baseHTTPClient))
 
 	// Cache components list if it has been loaded
 	if indexWithComponents != nil {
@@ -106,7 +106,7 @@ func newPublicScope(ctx context.Context, baseScp BaseScope, storageAPIHost strin
 	return v, nil
 }
 
-func storageAPIIndexWithComponents(ctx context.Context, d BaseScope, keboolaPublicAPI *keboola.API) (index *keboola.IndexComponents, err error) {
+func storageAPIIndexWithComponents(ctx context.Context, d BaseScope, keboolaPublicAPI *keboola.PublicAPI) (index *keboola.IndexComponents, err error) {
 	startTime := time.Now()
 	ctx, span := d.Telemetry().Tracer().Start(ctx, "keboola.go.common.dependencies.public.storageApiIndexWithComponents")
 	defer span.End(&err)
@@ -130,7 +130,7 @@ func (v *publicScope) StorageAPIHost() string {
 	return v.storageAPIHost
 }
 
-func (v *publicScope) KeboolaPublicAPI() *keboola.API {
+func (v *publicScope) KeboolaPublicAPI() *keboola.PublicAPI {
 	v.check()
 	return v.keboolaPublicAPI
 }

--- a/internal/pkg/state/remote/manager.go
+++ b/internal/pkg/state/remote/manager.go
@@ -22,7 +22,7 @@ import (
 type Manager struct {
 	state             model.ObjectStates
 	localManager      *local.Manager
-	keboolaProjectAPI *keboola.API
+	keboolaProjectAPI *keboola.AuthorizedAPI
 	mapper            *mapper.Mapper
 }
 
@@ -42,7 +42,7 @@ type UnitOfWork struct {
 	branchesSem *semaphore.Weighted
 }
 
-func NewManager(localManager *local.Manager, keboolaProjectAPI *keboola.API, objects model.ObjectStates, mapper *mapper.Mapper) *Manager {
+func NewManager(localManager *local.Manager, keboolaProjectAPI *keboola.AuthorizedAPI, objects model.ObjectStates, mapper *mapper.Mapper) *Manager {
 	return &Manager{
 		state:             objects,
 		localManager:      localManager,

--- a/internal/pkg/state/remote/manager_test.go
+++ b/internal/pkg/state/remote/manager_test.go
@@ -473,7 +473,7 @@ func newTestRemoteUOW(t *testing.T, mappers ...any) (*remote.UnitOfWork, *httpmo
 		}`),
 	)
 
-	api, err := keboola.NewAPI(context.Background(), "https://connection.keboola.com", keboola.WithClient(&c))
+	api, err := keboola.NewAuthorizedAPI(context.Background(), "https://connection.keboola.com", "my-token", keboola.WithClient(&c))
 	assert.NoError(t, err)
 	localManager, projectState := newTestLocalManager(t, mappers)
 	mapperInst := mapper.New().AddMapper(mappers...)

--- a/internal/pkg/state/state.go
+++ b/internal/pkg/state/state.go
@@ -60,7 +60,7 @@ type ObjectsContainer interface {
 
 type dependencies interface {
 	Components() *model.ComponentsMap
-	KeboolaProjectAPI() *keboola.API
+	KeboolaProjectAPI() *keboola.AuthorizedAPI
 	Logger() log.Logger
 	Telemetry() telemetry.Telemetry
 }

--- a/internal/pkg/template/context/upgrade/context_test.go
+++ b/internal/pkg/template/context/upgrade/context_test.go
@@ -35,7 +35,7 @@ func TestContext(t *testing.T) {
 			"features": []
 		}`),
 	)
-	api, err := keboola.NewAPI(context.Background(), "https://connection.keboola.com", keboola.WithClient(&c))
+	api, err := keboola.NewAuthorizedAPI(context.Background(), "https://connection.keboola.com", "my-token", keboola.WithClient(&c))
 	assert.NoError(t, err)
 	tickets := keboola.NewTicketProvider(context.Background(), api)
 

--- a/internal/pkg/template/context/use/context_test.go
+++ b/internal/pkg/template/context/use/context_test.go
@@ -40,7 +40,7 @@ func TestContext(t *testing.T) {
 		}`),
 	)
 	ctx := context.Background()
-	api, err := keboola.NewAPI(ctx, "https://connection.keboola.com", keboola.WithClient(&c))
+	api, err := keboola.NewAuthorizedAPI(ctx, "https://connection.keboola.com", "my-token", keboola.WithClient(&c))
 	assert.NoError(t, err)
 	tickets := keboola.NewTicketProvider(ctx, api)
 
@@ -195,7 +195,7 @@ func TestComponentsFunctions(t *testing.T) {
 		}`),
 	)
 	ctx := context.Background()
-	api, err := keboola.NewAPI(ctx, "https://connection.keboola.com", keboola.WithClient(&c))
+	api, err := keboola.NewAuthorizedAPI(ctx, "https://connection.keboola.com", "my-token", keboola.WithClient(&c))
 	assert.NoError(t, err)
 
 	d := dependenciesPkg.NewMocked(t)

--- a/internal/pkg/template/template.go
+++ b/internal/pkg/template/template.go
@@ -110,7 +110,7 @@ func ParseInputValue(ctx context.Context, value any, inputDef *templateInput.Inp
 
 type dependencies interface {
 	Components() *model.ComponentsMap
-	KeboolaProjectAPI() *keboola.API
+	KeboolaProjectAPI() *keboola.AuthorizedAPI
 	Logger() log.Logger
 	Telemetry() telemetry.Telemetry
 }

--- a/internal/pkg/utils/testhelper/storageenv/storageenv.go
+++ b/internal/pkg/utils/testhelper/storageenv/storageenv.go
@@ -13,12 +13,12 @@ import (
 
 type storageEnvTicketProvider struct {
 	ctx               context.Context
-	keboolaProjectAPI *keboola.API
+	keboolaProjectAPI *keboola.AuthorizedAPI
 	envs              *env.Map
 }
 
 // CreateStorageEnvTicketProvider allows you to generate new unique IDs via an ENV variable in the test.
-func CreateStorageEnvTicketProvider(ctx context.Context, keboolaProjectAPI *keboola.API, envs *env.Map) testhelper.EnvProvider {
+func CreateStorageEnvTicketProvider(ctx context.Context, keboolaProjectAPI *keboola.AuthorizedAPI, envs *env.Map) testhelper.EnvProvider {
 	return &storageEnvTicketProvider{ctx: ctx, keboolaProjectAPI: keboolaProjectAPI, envs: envs}
 }
 

--- a/internal/pkg/utils/testproject/project.go
+++ b/internal/pkg/utils/testproject/project.go
@@ -8,7 +8,6 @@ import (
 	"path/filepath"
 	"regexp"
 	"runtime"
-	"strconv"
 	"strings"
 	"sync"
 	"testing"
@@ -35,7 +34,7 @@ type Project struct {
 	initStartedAt     time.Time
 	ctx               context.Context
 	storageAPIToken   *keboola.Token
-	keboolaProjectAPI *keboola.API
+	keboolaProjectAPI *keboola.AuthorizedAPI
 	defaultBranch     *keboola.Branch
 	envs              *env.Map
 	mapsLock          *sync.Mutex
@@ -86,7 +85,7 @@ func GetTestProject(envs *env.Map) (*Project, UnlockFn, error) {
 
 	// Init storage API
 	httpClient := client.NewTestClient()
-	p.keboolaProjectAPI, err = keboola.NewAPI(ctx, p.StorageAPIHost(), keboola.WithClient(&httpClient), keboola.WithToken(p.Project.StorageAPIToken()))
+	p.keboolaProjectAPI, err = keboola.NewAuthorizedAPI(ctx, p.StorageAPIHost(), p.Project.StorageAPIToken(), keboola.WithClient(&httpClient))
 	if err != nil {
 		return nil, nil, err
 	}
@@ -146,7 +145,7 @@ func (p *Project) StorageAPIToken() *keboola.Token {
 	return p.storageAPIToken
 }
 
-func (p *Project) KeboolaProjectAPI() *keboola.API {
+func (p *Project) KeboolaProjectAPI() *keboola.AuthorizedAPI {
 	return p.keboolaProjectAPI
 }
 
@@ -277,7 +276,10 @@ func (p *Project) createBucketsTables(buckets []*fixtures.Bucket) error {
 	for _, b := range buckets {
 		req := p.keboolaProjectAPI.
 			CreateBucketRequest(&keboola.Bucket{
-				ID:          b.ID,
+				BucketKey: keboola.BucketKey{
+					BranchID: p.defaultBranch.ID,
+					BucketID: b.ID,
+				},
 				Description: b.Description,
 			}).
 			WithBefore(func(ctx context.Context) error {
@@ -286,15 +288,16 @@ func (p *Project) createBucketsTables(buckets []*fixtures.Bucket) error {
 			}).
 			WithOnComplete(func(ctx context.Context, apiBucket *keboola.Bucket, err error) error {
 				if err == nil {
-					p.logf("✔️ Bucket \"%s\".", apiBucket.ID)
+					p.logf("✔️ Bucket \"%s\".", apiBucket.BucketID)
 
 					for _, t := range b.Tables {
+						tableKey := keboola.TableKey{BranchID: p.defaultBranch.ID, TableID: t.ID}
 						if len(t.Rows) > 0 {
 							p.logf("▶ Table (with rows) \"%s\"...", t.Name)
 
 							fileName := fmt.Sprintf("%s.data", t.ID)
 							p.logf("▶ Table \"%s\" file resource \"%s\"...", t.Name, fileName)
-							file, err := p.keboolaProjectAPI.CreateFileResourceRequest(fileName).Send(ctx)
+							file, err := p.keboolaProjectAPI.CreateFileResourceRequest(p.defaultBranch.ID, fileName).Send(ctx)
 							if err != nil {
 								return err
 							}
@@ -318,14 +321,14 @@ func (p *Project) createBucketsTables(buckets []*fixtures.Bucket) error {
 							p.logf("✔️ Upload file \"%s\".", fileName)
 
 							p.logf("▶ Table \"%s\" from file resource \"%s\"...", t.Name, fileName)
-							_, err = p.keboolaProjectAPI.CreateTableFromFileRequest(t.ID, file.ID, keboola.WithPrimaryKey(t.PrimaryKey)).Send(ctx)
+							_, err = p.keboolaProjectAPI.CreateTableFromFileRequest(tableKey, file.FileKey, keboola.WithPrimaryKey(t.PrimaryKey)).Send(ctx)
 							if err != nil {
 								return err
 							}
 							p.logf("✔️ Table (with rows) \"%s\"(%s).", t.Name, t.ID)
 						} else {
 							p.logf("▶ Table \"%s\"...", t.Name)
-							_, err = p.keboolaProjectAPI.CreateTableRequest(t.ID, t.Columns, keboola.WithPrimaryKey(t.PrimaryKey)).Send(ctx)
+							_, err = p.keboolaProjectAPI.CreateTableRequest(tableKey, t.Columns, keboola.WithPrimaryKey(t.PrimaryKey)).Send(ctx)
 							if err != nil {
 								return err
 							}
@@ -367,7 +370,7 @@ func (p *Project) createFiles(files []*fixtures.File) error {
 			opts = append(opts, keboola.WithTags(fixture.Tags...))
 
 			p.logf("▶ File \"%s\"...", fixture.Name)
-			file, err := p.keboolaProjectAPI.CreateFileResourceRequest(fixture.Name, opts...).Send(ctx)
+			file, err := p.keboolaProjectAPI.CreateFileResourceRequest(p.defaultBranch.ID, fixture.Name, opts...).Send(ctx)
 			if err != nil {
 				errs.Append(errors.Errorf("could not create file \"%s\": %w", fixture.Name, err))
 				return
@@ -398,8 +401,8 @@ func (p *Project) createFiles(files []*fixtures.File) error {
 				}
 			}
 
-			p.logf("✔️ File \"%s\"(%s).", file.Name, file.ID)
-			p.setEnv(fmt.Sprintf("TEST_FILE_%s_ID", fixture.Name), strconv.Itoa(file.ID))
+			p.logf("✔️ File \"%s\"(%s).", file.Name, file.FileID)
+			p.setEnv(fmt.Sprintf("TEST_FILE_%s_ID", fixture.Name), file.FileID.String())
 		}()
 	}
 

--- a/internal/pkg/utils/testproject/snapshot.go
+++ b/internal/pkg/utils/testproject/snapshot.go
@@ -155,11 +155,11 @@ func (p *Project) NewSnapshot() (*fixtures.ProjectSnapshot, error) {
 	bucketsMap := map[keboola.BucketID]*fixtures.Bucket{}
 	grp.Go(func() error {
 		req := p.keboolaProjectAPI.
-			ListBucketsRequest().
+			ListBucketsRequest(p.defaultBranch.ID).
 			WithOnSuccess(func(_ context.Context, apiBuckets *[]*keboola.Bucket) error {
 				for _, b := range *apiBuckets {
-					bucketsMap[b.ID] = &fixtures.Bucket{
-						ID:          b.ID,
+					bucketsMap[b.BucketID] = &fixtures.Bucket{
+						ID:          b.BucketID,
 						URI:         b.URI,
 						DisplayName: b.DisplayName,
 						Description: b.Description,
@@ -175,7 +175,7 @@ func (p *Project) NewSnapshot() (*fixtures.ProjectSnapshot, error) {
 	var tables []*keboola.Table
 	grp.Go(func() error {
 		req := p.keboolaProjectAPI.
-			ListTablesRequest(keboola.WithBuckets(), keboola.WithColumns()).
+			ListTablesRequest(p.defaultBranch.ID, keboola.WithBuckets(), keboola.WithColumns()).
 			WithOnSuccess(func(_ context.Context, apiTables *[]*keboola.Table) error {
 				tables = append(tables, *apiTables...)
 				return nil
@@ -192,7 +192,7 @@ func (p *Project) NewSnapshot() (*fixtures.ProjectSnapshot, error) {
 		for attempt := 0; attempt < 10; attempt++ {
 			time.Sleep(100 * time.Millisecond)
 			err := p.keboolaProjectAPI.
-				ListFilesRequest().
+				ListFilesRequest(p.defaultBranch.ID).
 				WithOnSuccess(func(_ context.Context, apiFiles *[]*keboola.File) error {
 					// Reset the counter, if results differs.
 					// Ignore the URL field, it may contain a random/volatile time-based signature.
@@ -217,9 +217,9 @@ func (p *Project) NewSnapshot() (*fixtures.ProjectSnapshot, error) {
 
 	// Join buckets with tables
 	for _, t := range tables {
-		b := bucketsMap[t.ID.BucketID]
+		b := bucketsMap[t.TableID.BucketID]
 		b.Tables = append(b.Tables, &fixtures.Table{
-			ID:          t.ID,
+			ID:          t.TableID,
 			URI:         t.URI,
 			Name:        t.Name,
 			DisplayName: t.DisplayName,

--- a/pkg/lib/operation/dbt/generate/env/operation.go
+++ b/pkg/lib/operation/dbt/generate/env/operation.go
@@ -14,13 +14,14 @@ import (
 )
 
 type Options struct {
+	BranchKey  keboola.BranchKey
 	TargetName string
 	Workspace  *keboola.Workspace
 	Buckets    []listbuckets.Bucket // optional, set if the buckets have been loaded in a parent command
 }
 
 type dependencies interface {
-	KeboolaProjectAPI() *keboola.API
+	KeboolaProjectAPI() *keboola.AuthorizedAPI
 	LocalDbtProject(ctx context.Context) (*dbt.Project, bool, error)
 	Logger() log.Logger
 	Telemetry() telemetry.Telemetry
@@ -36,7 +37,7 @@ func Run(ctx context.Context, o Options, d dependencies) (err error) {
 	}
 
 	// List bucket, if not set
-	o.Buckets, err = listbuckets.Run(ctx, listbuckets.Options{TargetName: o.TargetName}, d)
+	o.Buckets, err = listbuckets.Run(ctx, listbuckets.Options{BranchKey: o.BranchKey, TargetName: o.TargetName}, d)
 	if err != nil {
 		return errors.Errorf("could not list buckets: %w", err)
 	}

--- a/pkg/lib/operation/dbt/generate/sources/generate_test.go
+++ b/pkg/lib/operation/dbt/generate/sources/generate_test.go
@@ -16,18 +16,24 @@ func TestGenerateSourcesDefinition(t *testing.T) {
 	t.Parallel()
 
 	bucket := &keboola.Bucket{
-		ID:          keboola.MustParseBucketID("out.c-main"),
+		BucketKey: keboola.BucketKey{
+			BranchID: 123,
+			BucketID: keboola.MustParseBucketID("out.c-main"),
+		},
 		URI:         "/uri",
 		DisplayName: "main",
 	}
 
 	dbtBucket := listbuckets.Bucket{
-		SourceName:  bucket.ID.String(),
-		Schema:      bucket.ID.String(),
+		SourceName:  bucket.BucketID.String(),
+		Schema:      bucket.BucketID.String(),
 		DatabaseEnv: "DBT_KBC_TARGET1_DATABASE",
 		Tables: []keboola.Table{
 			{
-				ID:          keboola.MustParseTableID("out.c-main.products"),
+				TableKey: keboola.TableKey{
+					BranchID: 123,
+					TableID:  keboola.MustParseTableID("out.c-main.products"),
+				},
 				URI:         "/uri",
 				Name:        "products",
 				DisplayName: "Products",
@@ -35,7 +41,10 @@ func TestGenerateSourcesDefinition(t *testing.T) {
 				Bucket:      bucket,
 			},
 			{
-				ID:          keboola.MustParseTableID("out.c-main.categories"),
+				TableKey: keboola.TableKey{
+					BranchID: 123,
+					TableID:  keboola.MustParseTableID("out.c-main.categories"),
+				},
 				URI:         "/uri",
 				Name:        "categories",
 				DisplayName: "Categories",
@@ -132,19 +141,25 @@ func TestGenerateSourcesDefinition_LinkedBucket(t *testing.T) {
 	t.Parallel()
 
 	bucket := &keboola.Bucket{
-		ID:          keboola.MustParseBucketID("out.c-main"),
+		BucketKey: keboola.BucketKey{
+			BranchID: 123,
+			BucketID: keboola.MustParseBucketID("out.c-main"),
+		},
 		URI:         "/uri",
 		DisplayName: "main",
 	}
 
 	dbtBucket := listbuckets.Bucket{
 		LinkedProjectID: 12345,
-		SourceName:      bucket.ID.String(),
-		Schema:          bucket.ID.String(),
+		SourceName:      bucket.BucketID.String(),
+		Schema:          bucket.BucketID.String(),
 		DatabaseEnv:     "DBT_KBC_TARGET1_12345_DATABASE",
 		Tables: []keboola.Table{
 			{
-				ID:          keboola.MustParseTableID("out.c-main.products"),
+				TableKey: keboola.TableKey{
+					BranchID: 123,
+					TableID:  keboola.MustParseTableID("out.c-main.products"),
+				},
 				URI:         "/uri",
 				Name:        "products",
 				DisplayName: "Products",
@@ -152,7 +167,10 @@ func TestGenerateSourcesDefinition_LinkedBucket(t *testing.T) {
 				Bucket:      bucket,
 			},
 			{
-				ID:          keboola.MustParseTableID("out.c-main.categories"),
+				TableKey: keboola.TableKey{
+					BranchID: 123,
+					TableID:  keboola.MustParseTableID("out.c-main.categories"),
+				},
 				URI:         "/uri",
 				Name:        "categories",
 				DisplayName: "Categories",

--- a/pkg/lib/operation/dbt/generate/sources/operation.go
+++ b/pkg/lib/operation/dbt/generate/sources/operation.go
@@ -16,12 +16,13 @@ import (
 )
 
 type Options struct {
+	BranchKey  keboola.BranchKey
 	TargetName string
 	Buckets    []listbuckets.Bucket // optional, set if the buckets have been loaded in a parent command
 }
 
 type dependencies interface {
-	KeboolaProjectAPI() *keboola.API
+	KeboolaProjectAPI() *keboola.AuthorizedAPI
 	LocalDbtProject(ctx context.Context) (*dbt.Project, bool, error)
 	Logger() log.Logger
 	Telemetry() telemetry.Telemetry
@@ -39,7 +40,7 @@ func Run(ctx context.Context, o Options, d dependencies) (err error) {
 	fs := project.Fs()
 
 	// List bucket, if not set
-	o.Buckets, err = listbuckets.Run(ctx, listbuckets.Options{TargetName: o.TargetName}, d)
+	o.Buckets, err = listbuckets.Run(ctx, listbuckets.Options{BranchKey: o.BranchKey, TargetName: o.TargetName}, d)
 	if err != nil {
 		return errors.Errorf("could not list buckets: %w", err)
 	}

--- a/pkg/lib/operation/dbt/init/operation.go
+++ b/pkg/lib/operation/dbt/init/operation.go
@@ -17,12 +17,13 @@ import (
 )
 
 type DbtInitOptions struct {
+	BranchKey     keboola.BranchKey
 	TargetName    string
 	WorkspaceName string
 }
 
 type dependencies interface {
-	KeboolaProjectAPI() *keboola.API
+	KeboolaProjectAPI() *keboola.AuthorizedAPI
 	LocalDbtProject(ctx context.Context) (*dbt.Project, bool, error)
 	Logger() log.Logger
 	Telemetry() telemetry.Telemetry
@@ -61,6 +62,7 @@ func Run(ctx context.Context, o DbtInitOptions, d dependencies) (err error) {
 
 	// List buckets
 	buckets, err := listbuckets.Run(ctx, listbuckets.Options{
+		BranchKey:  o.BranchKey,
 		TargetName: o.TargetName,
 	}, d)
 	if err != nil {
@@ -77,6 +79,7 @@ func Run(ctx context.Context, o DbtInitOptions, d dependencies) (err error) {
 
 	// Generate sources
 	err = sources.Run(ctx, sources.Options{
+		BranchKey:  o.BranchKey,
 		TargetName: o.TargetName,
 		Buckets:    buckets,
 	}, d)
@@ -86,6 +89,7 @@ func Run(ctx context.Context, o DbtInitOptions, d dependencies) (err error) {
 
 	// Generate env
 	err = env.Run(ctx, env.Options{
+		BranchKey:  o.BranchKey,
 		TargetName: o.TargetName,
 		Workspace:  workspace,
 		Buckets:    buckets,

--- a/pkg/lib/operation/dbt/listbuckets/group.go
+++ b/pkg/lib/operation/dbt/listbuckets/group.go
@@ -23,7 +23,7 @@ func groupTables(targetName string, in []*keboola.Table) (out []Bucket) {
 		var schema string
 		var databaseEnv string
 		if table.SourceTable == nil {
-			schema = table.ID.BucketID.String()
+			schema = table.TableID.BucketID.String()
 			databaseEnv = fmt.Sprintf("DBT_KBC_%s_DATABASE", strings.ToUpper(targetName))
 		} else {
 			projectID = table.SourceTable.Project.ID
@@ -31,12 +31,12 @@ func groupTables(targetName string, in []*keboola.Table) (out []Bucket) {
 			databaseEnv = fmt.Sprintf("DBT_KBC_%s_%d_DATABASE", strings.ToUpper(targetName), projectID)
 		}
 
-		key := table.Bucket.ID.String()
+		key := table.Bucket.BucketID.String()
 		bucket, ok := groupMap[key]
 		if !ok {
 			bucket.LinkedProjectID = projectID
 			bucket.Schema = schema
-			bucket.SourceName = table.Bucket.ID.String()
+			bucket.SourceName = table.Bucket.BucketID.String()
 			bucket.DatabaseEnv = databaseEnv
 		}
 		bucket.Tables = append(bucket.Tables, *table)

--- a/pkg/lib/operation/dbt/listbuckets/group_test.go
+++ b/pkg/lib/operation/dbt/listbuckets/group_test.go
@@ -11,43 +11,67 @@ func TestGroupTables(t *testing.T) {
 	t.Parallel()
 
 	mainBucket := &keboola.Bucket{
-		ID:          keboola.MustParseBucketID("out.c-main"),
+		BucketKey: keboola.BucketKey{
+			BranchID: 123,
+			BucketID: keboola.MustParseBucketID("out.c-main"),
+		},
 		DisplayName: "main",
 	}
 	secondBucket := &keboola.Bucket{
-		ID:          keboola.MustParseBucketID("out.c-second"),
+		BucketKey: keboola.BucketKey{
+			BranchID: 123,
+			BucketID: keboola.MustParseBucketID("out.c-second"),
+		},
 		DisplayName: "second",
 	}
 	linkedBucket := &keboola.Bucket{
-		ID:          keboola.MustParseBucketID("out.c-linked"),
+		BucketKey: keboola.BucketKey{
+			BranchID: 123,
+			BucketID: keboola.MustParseBucketID("out.c-linked"),
+		},
 		DisplayName: "linked",
 	}
 	mainTable1 := keboola.Table{
-		ID:          keboola.MustParseTableID("out.c-main.products"),
+		TableKey: keboola.TableKey{
+			BranchID: 123,
+			TableID:  keboola.MustParseTableID("out.c-main.products"),
+		},
 		Name:        "products",
 		DisplayName: "Products",
 		Bucket:      mainBucket,
 	}
 	mainTable2 := keboola.Table{
-		ID:          keboola.MustParseTableID("out.c-main.categories"),
+		TableKey: keboola.TableKey{
+			BranchID: 123,
+			TableID:  keboola.MustParseTableID("out.c-main.categories"),
+		},
 		Name:        "categories",
 		DisplayName: "Categories",
 		Bucket:      mainBucket,
 	}
 	secTable1 := keboola.Table{
-		ID:          keboola.MustParseTableID("out.c-second.products"),
+		TableKey: keboola.TableKey{
+			BranchID: 123,
+			TableID:  keboola.MustParseTableID("out.c-second.products"),
+		},
 		Name:        "products",
 		DisplayName: "Products",
 		Bucket:      secondBucket,
 	}
 	secTable2 := keboola.Table{
-		ID:          keboola.MustParseTableID("out.c-second.third"),
+		TableKey: keboola.TableKey{
+			BranchID: 123,
+			TableID:  keboola.MustParseTableID("out.c-second.third"),
+		},
 		Name:        "third",
 		DisplayName: "Third",
 		Bucket:      secondBucket,
 	}
 	linkedTable1 := keboola.Table{
-		ID: keboola.MustParseTableID("out.c-linked.foo"),
+		TableKey: keboola.TableKey{
+			BranchID: 123,
+			TableID:  keboola.MustParseTableID("out.c-linked.foo"),
+		},
 		SourceTable: &keboola.SourceTable{
 			Project: keboola.SourceProject{
 				ID:   12345,
@@ -61,7 +85,10 @@ func TestGroupTables(t *testing.T) {
 		Bucket:      linkedBucket,
 	}
 	linkedTable2 := keboola.Table{
-		ID: keboola.MustParseTableID("out.c-linked.bar"),
+		TableKey: keboola.TableKey{
+			BranchID: 123,
+			TableID:  keboola.MustParseTableID("out.c-linked.bar"),
+		},
 		SourceTable: &keboola.SourceTable{
 			Project: keboola.SourceProject{
 				ID:   12345,
@@ -80,21 +107,21 @@ func TestGroupTables(t *testing.T) {
 
 	assert.Equal(t, []Bucket{
 		{
-			SourceName:  mainBucket.ID.String(),
-			Schema:      mainBucket.ID.String(),
+			SourceName:  mainBucket.BucketID.String(),
+			Schema:      mainBucket.BucketID.String(),
 			DatabaseEnv: "DBT_KBC_TARGET1_DATABASE",
 			Tables:      []keboola.Table{mainTable1, mainTable2},
 		},
 		{
-			SourceName:  secondBucket.ID.String(),
-			Schema:      secondBucket.ID.String(),
+			SourceName:  secondBucket.BucketID.String(),
+			Schema:      secondBucket.BucketID.String(),
 			DatabaseEnv: "DBT_KBC_TARGET1_DATABASE",
 			Tables:      []keboola.Table{secTable1, secTable2},
 		},
 		{
 			LinkedProjectID: 12345,
-			SourceName:      linkedBucket.ID.String(), // defined by the linked bucket name
-			Schema:          "out.c-shared",           // defined by the source bucket name
+			SourceName:      linkedBucket.BucketID.String(), // defined by the linked bucket name
+			Schema:          "out.c-shared",                 // defined by the source bucket name
 			DatabaseEnv:     "DBT_KBC_TARGET1_12345_DATABASE",
 			Tables:          []keboola.Table{linkedTable1, linkedTable2},
 		},

--- a/pkg/lib/operation/dbt/listbuckets/listbuckets.go
+++ b/pkg/lib/operation/dbt/listbuckets/listbuckets.go
@@ -9,11 +9,12 @@ import (
 )
 
 type Options struct {
+	BranchKey  keboola.BranchKey
 	TargetName string
 }
 
 type dependencies interface {
-	KeboolaProjectAPI() *keboola.API
+	KeboolaProjectAPI() *keboola.AuthorizedAPI
 	Telemetry() telemetry.Telemetry
 }
 
@@ -21,7 +22,7 @@ func Run(ctx context.Context, o Options, d dependencies) (buckets []Bucket, err 
 	ctx, span := d.Telemetry().Tracer().Start(ctx, "keboola.go.operation.dbt.listBuckets")
 	defer span.End(&err)
 
-	tablesList, err := d.KeboolaProjectAPI().ListTablesRequest(keboola.WithBuckets()).Send(ctx)
+	tablesList, err := d.KeboolaProjectAPI().ListTablesRequest(o.BranchKey.ID, keboola.WithBuckets()).Send(ctx)
 	if err != nil {
 		return nil, err
 	}

--- a/pkg/lib/operation/project/local/create/config/operation.go
+++ b/pkg/lib/operation/project/local/create/config/operation.go
@@ -20,7 +20,7 @@ type Options struct {
 }
 
 type dependencies interface {
-	KeboolaProjectAPI() *keboola.API
+	KeboolaProjectAPI() *keboola.AuthorizedAPI
 	Logger() log.Logger
 	Telemetry() telemetry.Telemetry
 }

--- a/pkg/lib/operation/project/local/create/row/operation.go
+++ b/pkg/lib/operation/project/local/create/row/operation.go
@@ -21,7 +21,7 @@ type Options struct {
 }
 
 type dependencies interface {
-	KeboolaProjectAPI() *keboola.API
+	KeboolaProjectAPI() *keboola.AuthorizedAPI
 	Logger() log.Logger
 	Telemetry() telemetry.Telemetry
 }

--- a/pkg/lib/operation/project/local/encrypt/operation.go
+++ b/pkg/lib/operation/project/local/encrypt/operation.go
@@ -17,7 +17,7 @@ type Options struct {
 }
 
 type dependencies interface {
-	KeboolaProjectAPI() *keboola.API
+	KeboolaProjectAPI() *keboola.AuthorizedAPI
 	Logger() log.Logger
 	ProjectID() keboola.ProjectID
 	Telemetry() telemetry.Telemetry

--- a/pkg/lib/operation/project/local/persist/operation.go
+++ b/pkg/lib/operation/project/local/persist/operation.go
@@ -20,7 +20,7 @@ type Options struct {
 }
 
 type dependencies interface {
-	KeboolaProjectAPI() *keboola.API
+	KeboolaProjectAPI() *keboola.AuthorizedAPI
 	Logger() log.Logger
 	Telemetry() telemetry.Telemetry
 }

--- a/pkg/lib/operation/project/local/template/upgrade/operation.go
+++ b/pkg/lib/operation/project/local/template/upgrade/operation.go
@@ -25,7 +25,7 @@ type Options struct {
 type dependencies interface {
 	Logger() log.Logger
 	Components() *model.ComponentsMap
-	KeboolaProjectAPI() *keboola.API
+	KeboolaProjectAPI() *keboola.AuthorizedAPI
 	ObjectIDGeneratorFactory() func(ctx context.Context) *keboola.TicketProvider
 	ProjectID() keboola.ProjectID
 	StorageAPIHost() string

--- a/pkg/lib/operation/project/local/template/use/operation.go
+++ b/pkg/lib/operation/project/local/template/use/operation.go
@@ -38,7 +38,7 @@ type Options struct {
 
 type dependencies interface {
 	Components() *model.ComponentsMap
-	KeboolaProjectAPI() *keboola.API
+	KeboolaProjectAPI() *keboola.AuthorizedAPI
 	StorageAPIHost() string
 	StorageAPITokenID() string
 	Logger() log.Logger

--- a/pkg/lib/operation/project/remote/create/branch/operation.go
+++ b/pkg/lib/operation/project/remote/create/branch/operation.go
@@ -16,7 +16,7 @@ type Options struct {
 }
 
 type dependencies interface {
-	KeboolaProjectAPI() *keboola.API
+	KeboolaProjectAPI() *keboola.AuthorizedAPI
 	Logger() log.Logger
 	Telemetry() telemetry.Telemetry
 }

--- a/pkg/lib/operation/project/remote/create/bucket/operation.go
+++ b/pkg/lib/operation/project/remote/create/bucket/operation.go
@@ -11,6 +11,7 @@ import (
 )
 
 type Options struct {
+	BranchKey   keboola.BranchKey
 	Description string
 	DisplayName string
 	Name        string
@@ -18,7 +19,7 @@ type Options struct {
 }
 
 type dependencies interface {
-	KeboolaProjectAPI() *keboola.API
+	KeboolaProjectAPI() *keboola.AuthorizedAPI
 	Logger() log.Logger
 	Telemetry() telemetry.Telemetry
 }
@@ -33,9 +34,12 @@ func Run(ctx context.Context, o Options, d dependencies) (err error) {
 		o.Name = "c-" + o.Name
 	}
 	b := &keboola.Bucket{
-		ID: keboola.BucketID{
-			Stage:      o.Stage,
-			BucketName: o.Name,
+		BucketKey: keboola.BucketKey{
+			BranchID: o.BranchKey.ID,
+			BucketID: keboola.BucketID{
+				Stage:      o.Stage,
+				BucketName: o.Name,
+			},
 		},
 		Description: o.Description,
 		DisplayName: o.DisplayName,
@@ -44,6 +48,6 @@ func Run(ctx context.Context, o Options, d dependencies) (err error) {
 	if err != nil {
 		return err
 	}
-	logger.InfofCtx(ctx, `Created bucket "%s".`, b.ID.String())
+	logger.InfofCtx(ctx, `Created bucket "%s".`, b.BucketID.String())
 	return nil
 }

--- a/pkg/lib/operation/project/remote/file/download/operation.go
+++ b/pkg/lib/operation/project/remote/file/download/operation.go
@@ -26,7 +26,7 @@ const (
 )
 
 type dependencies interface {
-	KeboolaProjectAPI() *keboola.API
+	KeboolaProjectAPI() *keboola.AuthorizedAPI
 	Logger() log.Logger
 	Telemetry() telemetry.Telemetry
 }
@@ -50,7 +50,7 @@ func (d *downloader) Download(ctx context.Context) (returnErr error) {
 	if !d.options.ToStdout() {
 		defer func() {
 			if returnErr == nil {
-				d.Logger().InfofCtx(ctx, `File "%d" downloaded to "%s".`, d.options.File.ID, d.options.FormattedOutput())
+				d.Logger().InfofCtx(ctx, `File "%d" downloaded to "%s".`, d.options.File.FileID, d.options.FormattedOutput())
 			}
 		}()
 	}

--- a/pkg/lib/operation/project/remote/file/upload/operation.go
+++ b/pkg/lib/operation/project/remote/file/upload/operation.go
@@ -18,15 +18,16 @@ import (
 )
 
 type dependencies interface {
-	KeboolaProjectAPI() *keboola.API
+	KeboolaProjectAPI() *keboola.AuthorizedAPI
 	Logger() log.Logger
 	Telemetry() telemetry.Telemetry
 }
 
 type Options struct {
-	Input string
-	Name  string
-	Tags  []string
+	BranchKey keboola.BranchKey
+	Input     string
+	Name      string
+	Tags      []string
 }
 
 func Run(ctx context.Context, o Options, d dependencies) (f *keboola.FileUploadCredentials, err error) {
@@ -69,7 +70,7 @@ func Run(ctx context.Context, o Options, d dependencies) (f *keboola.FileUploadC
 		}
 	}
 
-	file, err := d.KeboolaProjectAPI().CreateFileResourceRequest(o.Name, opts...).Send(ctx)
+	file, err := d.KeboolaProjectAPI().CreateFileResourceRequest(o.BranchKey.ID, o.Name, opts...).Send(ctx)
 	if err != nil {
 		return nil, errors.Errorf(`error creating file resource: %w`, err)
 	}
@@ -80,7 +81,7 @@ func Run(ctx context.Context, o Options, d dependencies) (f *keboola.FileUploadC
 		if err != nil {
 			return nil, errors.Errorf(`error uploading file from stdin: %w`, err)
 		}
-		d.Logger().InfofCtx(ctx, `File "%s" uploaded with file id "%d".`, o.Name, file.ID)
+		d.Logger().InfofCtx(ctx, `File "%s" uploaded with file id "%d".`, o.Name, file.FileID)
 		return file, nil
 	}
 
@@ -92,7 +93,7 @@ func Run(ctx context.Context, o Options, d dependencies) (f *keboola.FileUploadC
 		if err != nil {
 			return nil, errors.Errorf(`error uploading file "%s": %w`, o.Input, err)
 		}
-		d.Logger().InfofCtx(ctx, `File "%s" uploaded with file id "%d".`, o.Name, file.ID)
+		d.Logger().InfofCtx(ctx, `File "%s" uploaded with file id "%d".`, o.Name, file.FileID)
 		return file, nil
 	}
 
@@ -117,7 +118,7 @@ func Run(ctx context.Context, o Options, d dependencies) (f *keboola.FileUploadC
 		}
 	}
 
-	d.Logger().InfofCtx(ctx, `File "%s" uploaded with file id "%d".`, o.Name, file.ID)
+	d.Logger().InfofCtx(ctx, `File "%s" uploaded with file id "%d".`, o.Name, file.FileID)
 	return file, nil
 }
 

--- a/pkg/lib/operation/project/remote/job/run/operation.go
+++ b/pkg/lib/operation/project/remote/job/run/operation.go
@@ -15,7 +15,7 @@ import (
 )
 
 type dependencies interface {
-	KeboolaProjectAPI() *keboola.API
+	KeboolaProjectAPI() *keboola.AuthorizedAPI
 	ProjectFeatures() keboola.FeaturesMap
 	Logger() log.Logger
 	Telemetry() telemetry.Telemetry
@@ -80,7 +80,7 @@ type JobQueue struct {
 	hasQueueV2 bool
 
 	ctx    context.Context
-	api    *keboola.API
+	api    *keboola.AuthorizedAPI
 	logger log.Logger
 
 	wg  *sync.WaitGroup
@@ -196,7 +196,7 @@ func (o *Job) Key() string {
 	return out
 }
 
-func (o *Job) Start(ctx context.Context, api *keboola.API, async bool, hasQueueV2 bool) error {
+func (o *Job) Start(ctx context.Context, api *keboola.AuthorizedAPI, async bool, hasQueueV2 bool) error {
 	if hasQueueV2 {
 		job, err := api.NewCreateJobRequest(o.ComponentID).
 			WithConfig(o.ConfigID).

--- a/pkg/lib/operation/project/remote/table/detail/operation.go
+++ b/pkg/lib/operation/project/remote/table/detail/operation.go
@@ -12,16 +12,16 @@ import (
 )
 
 type dependencies interface {
-	KeboolaProjectAPI() *keboola.API
+	KeboolaProjectAPI() *keboola.AuthorizedAPI
 	Logger() log.Logger
 	Telemetry() telemetry.Telemetry
 }
 
-func Run(ctx context.Context, tableID keboola.TableID, d dependencies) (err error) {
+func Run(ctx context.Context, tableKey keboola.TableKey, d dependencies) (err error) {
 	ctx, span := d.Telemetry().Tracer().Start(ctx, "keboola.go.operation.project.remote.table.detail")
 	defer span.End(&err)
 
-	table, err := d.KeboolaProjectAPI().GetTableRequest(tableID).Send(ctx)
+	table, err := d.KeboolaProjectAPI().GetTableRequest(tableKey).Send(ctx)
 	if err != nil {
 		return err
 	}
@@ -35,7 +35,7 @@ func Run(ctx context.Context, tableID keboola.TableID, d dependencies) (err erro
   Created at: %s
   Last import at: %s
   Last changed at: %s`,
-		table.ID,
+		table.TableID,
 		table.DisplayName,
 		strings.Join(table.PrimaryKey, ", "),
 		strings.Join(table.Columns, ", "),

--- a/pkg/lib/operation/project/remote/table/import/operation.go
+++ b/pkg/lib/operation/project/remote/table/import/operation.go
@@ -13,14 +13,14 @@ import (
 )
 
 type dependencies interface {
-	KeboolaProjectAPI() *keboola.API
+	KeboolaProjectAPI() *keboola.AuthorizedAPI
 	Logger() log.Logger
 	Telemetry() telemetry.Telemetry
 }
 
 type Options struct {
-	FileID          int
-	TableID         keboola.TableID
+	FileKey         keboola.FileKey
+	TableKey        keboola.TableKey
 	Columns         []string
 	Delimiter       string
 	Enclosure       string
@@ -34,24 +34,24 @@ func Run(ctx context.Context, o Options, d dependencies) (err error) {
 	ctx, span := d.Telemetry().Tracer().Start(ctx, "keboola.go.operation.project.remote.table.import")
 	defer span.End(&err)
 
-	if !checkTableExists(ctx, d, o.TableID) {
-		d.Logger().InfofCtx(ctx, `Table "%s" does not exist, creating it.`, o.TableID)
+	if !checkTableExists(ctx, d, o.TableKey) {
+		d.Logger().InfofCtx(ctx, `Table "%s" does not exist, creating it.`, o.TableKey.TableID)
 
 		rb := rollback.New(d.Logger())
-		err = EnsureBucketExists(ctx, d, rb, o.TableID.BucketID)
+		err = EnsureBucketExists(ctx, d, rb, o.TableKey.BucketKey())
 		if err != nil {
 			return err
 		}
 
-		_, err = d.KeboolaProjectAPI().CreateTableFromFileRequest(o.TableID, o.FileID, getCreateOptions(&o)...).Send(ctx)
+		_, err = d.KeboolaProjectAPI().CreateTableFromFileRequest(o.TableKey, o.FileKey, getCreateOptions(&o)...).Send(ctx)
 		if err != nil {
 			rb.Invoke(ctx)
 			return err
 		}
 
-		d.Logger().InfofCtx(ctx, `Created new table "%s" from file with id "%d".`, o.TableID, o.FileID)
+		d.Logger().InfofCtx(ctx, `Created new table "%s" from file with id "%d".`, o.TableKey.TableID, o.FileKey.FileID)
 	} else {
-		job, err := d.KeboolaProjectAPI().LoadDataFromFileRequest(o.TableID, o.FileID, getLoadOptions(&o)...).Send(ctx)
+		job, err := d.KeboolaProjectAPI().LoadDataFromFileRequest(o.TableKey, o.FileKey, getLoadOptions(&o)...).Send(ctx)
 		if err != nil {
 			return err
 		}
@@ -63,7 +63,7 @@ func Run(ctx context.Context, o Options, d dependencies) (err error) {
 		if err != nil {
 			return err
 		}
-		d.Logger().InfofCtx(ctx, `Loaded data from file "%d" into table "%s".`, o.FileID, o.TableID)
+		d.Logger().InfofCtx(ctx, `Loaded data from file "%d" into table "%s".`, o.FileKey.FileID, o.TableKey.TableID)
 	}
 
 	return nil
@@ -88,27 +88,27 @@ func getLoadOptions(o *Options) []keboola.LoadDataOption {
 	return opts
 }
 
-func EnsureBucketExists(ctx context.Context, d dependencies, rb rollback.Builder, id keboola.BucketID) error {
-	err := d.KeboolaProjectAPI().GetBucketRequest(id).SendOrErr(ctx)
+func EnsureBucketExists(ctx context.Context, d dependencies, rb rollback.Builder, bucketKey keboola.BucketKey) error {
+	err := d.KeboolaProjectAPI().GetBucketRequest(bucketKey).SendOrErr(ctx)
 	var apiErr *keboola.StorageError
 	if errors.As(err, &apiErr) && apiErr.ErrCode == "storage.buckets.notFound" {
-		d.Logger().InfofCtx(ctx, `Bucket "%s" does not exist, creating it.`, id)
+		d.Logger().InfofCtx(ctx, `Bucket "%s" does not exist, creating it.`, bucketKey.BucketID)
 		api := d.KeboolaProjectAPI()
 		// Bucket doesn't exist -> create it
-		bucket := &keboola.Bucket{ID: id}
+		bucket := &keboola.Bucket{BucketKey: bucketKey}
 		if _, err := api.CreateBucketRequest(bucket).Send(ctx); err != nil {
 			return err
 		}
 		rb.Add(func(ctx context.Context) error {
-			_, err := api.DeleteBucketRequest(id).Send(ctx)
+			_, err := api.DeleteBucketRequest(bucketKey).Send(ctx)
 			return err
 		})
 	}
 	return nil
 }
 
-func checkTableExists(ctx context.Context, d dependencies, id keboola.TableID) bool {
-	err := d.KeboolaProjectAPI().GetTableRequest(id).SendOrErr(ctx)
+func checkTableExists(ctx context.Context, d dependencies, tableKey keboola.TableKey) bool {
+	err := d.KeboolaProjectAPI().GetTableRequest(tableKey).SendOrErr(ctx)
 	var apiErr *keboola.StorageError
 	if errors.As(err, &apiErr) && apiErr.ErrCode == "storage.tables.notFound" {
 		return false

--- a/pkg/lib/operation/project/remote/table/unload/operation.go
+++ b/pkg/lib/operation/project/remote/table/unload/operation.go
@@ -14,13 +14,13 @@ import (
 )
 
 type dependencies interface {
-	KeboolaProjectAPI() *keboola.API
+	KeboolaProjectAPI() *keboola.AuthorizedAPI
 	Logger() log.Logger
 	Telemetry() telemetry.Telemetry
 }
 
 type Options struct {
-	TableID      keboola.TableID
+	TableKey     keboola.TableKey
 	Async        bool
 	Timeout      time.Duration
 	ChangedSince string
@@ -47,7 +47,7 @@ func Run(ctx context.Context, o Options, d dependencies) (file *keboola.Unloaded
 	ctx, span := d.Telemetry().Tracer().Start(ctx, "keboola.go.operation.project.remote.table.unload")
 	defer span.End(&err)
 
-	request := d.KeboolaProjectAPI().NewTableUnloadRequest(o.TableID).
+	request := d.KeboolaProjectAPI().NewTableUnloadRequest(o.TableKey).
 		WithChangedSince(o.ChangedSince).
 		WithChangedUntil(o.ChangedUntil).
 		WithColumns(o.Columns...).
@@ -72,9 +72,9 @@ func Run(ctx context.Context, o Options, d dependencies) (file *keboola.Unloaded
 		d.Logger().InfoCtx(ctx, "Unloading table, please wait.")
 		unloadedFile, err := request.SendAndWait(ctx, o.Timeout)
 		if err != nil {
-			return nil, errors.Errorf(`failed to unload table "%s": %w`, o.TableID, err)
+			return nil, errors.Errorf(`failed to unload table "%s": %w`, o.TableKey, err)
 		}
-		d.Logger().InfofCtx(ctx, `Table "%s" unloaded to file "%d".`, o.TableID, unloadedFile.File.ID)
+		d.Logger().InfofCtx(ctx, `Table "%s" unloaded to file "%d".`, o.TableKey.TableID, unloadedFile.File.FileID)
 		file = &unloadedFile.File
 	}
 

--- a/pkg/lib/operation/project/remote/workspace/create/operation.go
+++ b/pkg/lib/operation/project/remote/workspace/create/operation.go
@@ -18,7 +18,7 @@ type CreateOptions struct {
 }
 
 type dependencies interface {
-	KeboolaProjectAPI() *keboola.API
+	KeboolaProjectAPI() *keboola.AuthorizedAPI
 	Logger() log.Logger
 	Telemetry() telemetry.Telemetry
 }

--- a/pkg/lib/operation/project/remote/workspace/delete/operation.go
+++ b/pkg/lib/operation/project/remote/workspace/delete/operation.go
@@ -13,7 +13,7 @@ import (
 type dependencies interface {
 	Telemetry() telemetry.Telemetry
 	Logger() log.Logger
-	KeboolaProjectAPI() *keboola.API
+	KeboolaProjectAPI() *keboola.AuthorizedAPI
 }
 
 func Run(ctx context.Context, d dependencies, branchID keboola.BranchID, workspace *keboola.WorkspaceWithConfig) (err error) {

--- a/pkg/lib/operation/project/remote/workspace/detail/operation.go
+++ b/pkg/lib/operation/project/remote/workspace/detail/operation.go
@@ -11,7 +11,7 @@ import (
 )
 
 type dependencies interface {
-	KeboolaProjectAPI() *keboola.API
+	KeboolaProjectAPI() *keboola.AuthorizedAPI
 	Logger() log.Logger
 	Telemetry() telemetry.Telemetry
 }

--- a/pkg/lib/operation/project/remote/workspace/list/operation.go
+++ b/pkg/lib/operation/project/remote/workspace/list/operation.go
@@ -12,7 +12,7 @@ import (
 )
 
 type dependencies interface {
-	KeboolaProjectAPI() *keboola.API
+	KeboolaProjectAPI() *keboola.AuthorizedAPI
 	Logger() log.Logger
 	Telemetry() telemetry.Telemetry
 }

--- a/pkg/lib/operation/project/sync/init/operation.go
+++ b/pkg/lib/operation/project/sync/init/operation.go
@@ -29,7 +29,7 @@ type Options struct {
 type dependencies interface {
 	Components() *model.ComponentsMap
 	EmptyDir(ctx context.Context) (filesystem.Fs, error)
-	KeboolaProjectAPI() *keboola.API
+	KeboolaProjectAPI() *keboola.AuthorizedAPI
 	Logger() log.Logger
 	Options() *options.Options
 	ProjectID() keboola.ProjectID

--- a/pkg/lib/operation/project/sync/push/operation.go
+++ b/pkg/lib/operation/project/sync/push/operation.go
@@ -24,7 +24,7 @@ type Options struct {
 }
 
 type dependencies interface {
-	KeboolaProjectAPI() *keboola.API
+	KeboolaProjectAPI() *keboola.AuthorizedAPI
 	Logger() log.Logger
 	ProjectID() keboola.ProjectID
 	Telemetry() telemetry.Telemetry

--- a/pkg/lib/operation/state/load/operation.go
+++ b/pkg/lib/operation/state/load/operation.go
@@ -123,7 +123,7 @@ func LocalOperationOptions() Options {
 
 type dependencies interface {
 	Components() *model.ComponentsMap
-	KeboolaProjectAPI() *keboola.API
+	KeboolaProjectAPI() *keboola.AuthorizedAPI
 	Logger() log.Logger
 	Telemetry() telemetry.Telemetry
 }

--- a/pkg/lib/operation/template/local/create/operation.go
+++ b/pkg/lib/operation/template/local/create/operation.go
@@ -34,7 +34,7 @@ type Options struct {
 
 type dependencies interface {
 	Components() *model.ComponentsMap
-	KeboolaProjectAPI() *keboola.API
+	KeboolaProjectAPI() *keboola.AuthorizedAPI
 	LocalTemplateRepository(ctx context.Context) (*repository.Repository, bool, error)
 	Logger() log.Logger
 	Template(ctx context.Context, reference model.TemplateRef) (*template.Template, error)

--- a/pkg/lib/operation/template/sync/pull/operation.go
+++ b/pkg/lib/operation/template/sync/pull/operation.go
@@ -21,7 +21,7 @@ type Options struct {
 
 type dependencies interface {
 	Components() *model.ComponentsMap
-	KeboolaProjectAPI() *keboola.API
+	KeboolaProjectAPI() *keboola.AuthorizedAPI
 	Logger() log.Logger
 	Telemetry() telemetry.Telemetry
 }

--- a/test/cli/remote-create/table-interactive/expected-state.json
+++ b/test/cli/remote-create/table-interactive/expected-state.json
@@ -36,7 +36,7 @@
   ],
   "files": [
     {
-      "name": "table1",
+      "name": "create_table_in.c_bucket.table1",
       "tags": [],
       "isSliced": false,
       "isEncrypted": true,

--- a/test/cli/remote-create/table/expected-state.json
+++ b/test/cli/remote-create/table/expected-state.json
@@ -36,7 +36,7 @@
   ],
   "files": [
     {
-      "name": "table1",
+      "name": "create_table_in.c_bucket.table1",
       "tags": [],
       "isSliced": false,
       "isEncrypted": true,

--- a/test/cli/remote-dbt-init/ok-interactive/interaction.txt
+++ b/test/cli/remote-dbt-init/ok-interactive/interaction.txt
@@ -1,14 +1,14 @@
-< Please enter target name.
-> target1
-
-< Enter a name for a workspace to create:
-> dbt_source
-
 < Please enter Keboola Storage API host, eg. "connection.keboola.com".
 > %%TEST_KBC_STORAGE_API_HOST%%
 
 < Please enter Keboola Storage API token. The value will be hidden.
 > %%TEST_KBC_STORAGE_API_TOKEN%%
+
+< Please enter target name.
+> target1
+
+< Enter a name for a workspace to create:
+> dbt_source
 
 < Creating a new workspace, please wait.
 < [120s] Created the new workspace "dbt_source".


### PR DESCRIPTION
Jira: https://keboola.atlassian.net/browse/PSGO-335
Related to: https://github.com/keboola/go-client/pull/110

**Changes:**
- **go-client: Splited API struct to PublicAPI and AuthorizedAPI.**
  - https://github.com/keboola/go-client/pull/110
- **go-client: Changed {bucket,table,file} scope from project to branch**
  - https://github.com/keboola/go-client/pull/102 
  - For example `FileID` -> `FileKey{BranchID, FileID}`,
  - or `BucketID` -> `BucketKey{BranchID, BucketID}` and so on.
  - It was prepared earlier, it is a preparation for SOX, since even file/table storage can be now branched.
  - In this PR, only the default branch was added everywhere, no major changes were made.
- **Re-enabled linter + CLI and Templates API E2E tests.**

-----------
