### PR TITLE
refactor: Update etcd docker image for supporting Apple M1 (linux/arm64)

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -65,7 +65,7 @@ services:
   # Same etcd is used for all services, but with different namespace
   etcd:
     hostname: etcd
-    image: docker.io/bitnami/etcd:3.5.5-debian-11-r16
+    image: docker.io/bitnami/etcd:3.5.11-debian-11-r3
     environment:
       ALLOW_NONE_AUTHENTICATION: "no"
       ETCD_NAME: "etcd"

--- a/provisioning/common/etcd/values.yaml
+++ b/provisioning/common/etcd/values.yaml
@@ -16,7 +16,7 @@ tolerations:
 
 # Locked/updated etcd image
 image:
-  tag: 3.5.5-debian-11-r16
+  tag: 3.5.11-debian-11-r3
 
 # Additional pod annotations
 podAnnotations:

--- a/scripts/tests.sh
+++ b/scripts/tests.sh
@@ -29,7 +29,7 @@ fi
 # Run tests, sequentially because the API is shared resource
 echo "Running tests ..."
 export KBC_VERSION_CHECK=false # do not check the latest version in the tests
-cmd="gotestsum --no-color=false --format \"$TEST_LOG_FORMAT\" -- -timeout 600s -p $TEST_PARALLELISM_PKG -parallel $TEST_PARALLELISM -v $TEST_ARGS  "$TEST_PACKAGE" $@"
+cmd="gotestsum --no-color=false --format \"$TEST_LOG_FORMAT\" -- -timeout 1200s -p $TEST_PARALLELISM_PKG -parallel $TEST_PARALLELISM -v $TEST_ARGS  "$TEST_PACKAGE" $@"
 echo $cmd
 eval $cmd
 echo "Ok. All tests passed."


### PR DESCRIPTION
Jira: https://keboola.atlassian.net/browse/PSGO-344

**Changes:**

- updated etcd docker image for supporting Apple M1 linux/arm64. (we will have to change it on production)
- updated timeout for tests 600s -> 1200s
-----------
