### PR TITLE
fix: Replace misused Txn.Then with Txn.Merge(And)

### DIFF
--- a/internal/pkg/service/buffer/sink/tablesink/storage/repository/file_repo_test.go
+++ b/internal/pkg/service/buffer/sink/tablesink/storage/repository/file_repo_test.go
@@ -1936,7 +1936,7 @@ func registerWriterVolumes(t *testing.T, ctx context.Context, volumeRepo *reposi
 
 	txn := op.Txn(session.Client())
 	for _, vol := range volumes[:count] {
-		txn.And(volumeRepo.RegisterWriterVolume(vol, session.Lease()))
+		txn.Merge(volumeRepo.RegisterWriterVolume(vol, session.Lease()))
 	}
 	require.NoError(t, txn.Do(ctx).Err())
 }

--- a/internal/pkg/service/buffer/sink/tablesink/storage/repository/hook.go
+++ b/internal/pkg/service/buffer/sink/tablesink/storage/repository/hook.go
@@ -142,7 +142,7 @@ func (h *hook) NewUsedDiskSpaceProvider() UsedDiskSpaceProvider {
 		for _, sinkKey := range sinkKeys {
 			// Load statistics only once, the provider can be reused within op.AtomicOp retries.
 			if _, ok := result[sinkKey]; !ok {
-				txn.Then(h.stats.MaxUsedDiskSizeBySliceIn(sinkKey, recordsForSliceDiskSizeCalc).OnResult(func(r *op.TxnResult[datasize.ByteSize]) {
+				txn.Merge(h.stats.MaxUsedDiskSizeBySliceIn(sinkKey, recordsForSliceDiskSizeCalc).OnResult(func(r *op.TxnResult[datasize.ByteSize]) {
 					result[sinkKey] = r.Result()
 				}))
 			}

--- a/internal/pkg/service/buffer/sink/tablesink/storage/volume/registration/registration.go
+++ b/internal/pkg/service/buffer/sink/tablesink/storage/volume/registration/registration.go
@@ -43,7 +43,7 @@ func RegisterVolumes[V volume.Volume](d dependencies, cfg Config, volumes *volum
 	errCh := etcdop.ResistantSession(ctx, wg, logger, client, cfg.TTLSeconds, func(session *concurrency.Session) error {
 		txn := op.Txn(client)
 		for _, vol := range volumes.All() {
-			txn.Then(putOpFactory(vol.Metadata(), session.Lease()))
+			txn.Merge(putOpFactory(vol.Metadata(), session.Lease()))
 		}
 		return txn.Do(ctx).Err()
 	})

--- a/internal/pkg/service/common/etcdop/op/txn.go
+++ b/internal/pkg/service/common/etcdop/op/txn.go
@@ -170,7 +170,7 @@ func (v *TxnOp[R]) lowLevelTxn(ctx context.Context) (*lowLevelTxn[R], error) {
 		if lowLevel, err := op.Op(ctx); err != nil {
 			errs.Append(errors.PrefixErrorf(err, "cannot create operation [then][%d]", i))
 		} else if lowLevel.Op.IsTxn() {
-			errs.Append(errors.Errorf(`cannot create operation [then][%d]: operation "%T" is a transaction, use ThenTxn, not Then`, i, lowLevel.Op))
+			errs.Append(errors.Errorf(`cannot create operation [then][%d]: operation is a transaction, use ThenTxn, not Then`, i))
 		} else {
 			out.addThen(lowLevel.Op, lowLevel.MapResponse)
 		}
@@ -180,7 +180,7 @@ func (v *TxnOp[R]) lowLevelTxn(ctx context.Context) (*lowLevelTxn[R], error) {
 		if lowLevel, err := op.Op(ctx); err != nil {
 			errs.Append(errors.PrefixErrorf(err, "cannot create operation [thenTxn][%d]", i))
 		} else if !lowLevel.Op.IsTxn() {
-			errs.Append(errors.Errorf(`cannot create operation [thenTxn][%d]: operation "%T" is not a transaction, use Then, not ThenTxn`, i, lowLevel.Op))
+			errs.Append(errors.Errorf(`cannot create operation [thenTxn][%d]: operation is not a transaction, use Then, not ThenTxn`, i))
 		} else {
 			out.addThen(lowLevel.Op, lowLevel.MapResponse)
 		}

--- a/internal/pkg/service/common/etcdop/op/txn_test.go
+++ b/internal/pkg/service/common/etcdop/op/txn_test.go
@@ -343,6 +343,26 @@ txn OnResult: succeeded
 	}
 }
 
+func TestTxnOp_Then_CalledWithTxn(t *testing.T) {
+	t.Parallel()
+
+	client := etcd.KV(nil)
+	_, err := Txn(client).Then(Txn(client)).Op(context.Background())
+	if assert.Error(t, err) {
+		assert.Equal(t, "cannot create operation [then][0]: operation is a transaction, use ThenTxn, not Then", err.Error())
+	}
+}
+
+func TestTxnOp_ThenTxn_CalledWithoutTxn(t *testing.T) {
+	t.Parallel()
+
+	client := etcd.KV(nil)
+	_, err := Txn(client).ThenTxn(etcdop.Key("foo").Put(client, "bar")).Op(context.Background())
+	if assert.Error(t, err) {
+		assert.Equal(t, "cannot create operation [thenTxn][0]: operation is not a transaction, use Then, not ThenTxn", err.Error())
+	}
+}
+
 func TestTxnOp_Merge_Simple(t *testing.T) {
 	t.Parallel()
 	ctx := context.Background()


### PR DESCRIPTION
Jira: https://keboola.atlassian.net/browse/PSGO-352

--------------

**Issue:**
- In multiple places in the code was used `txn.Then(subTxn)` instead of `txn.Merge/And(subTxn)`.
- - `Then` and `Merge` operations are valid and tested, but was misused.
- If all IF conditions in transactions are fulfilled, then both operations behave same :exclamation: 
- The problem is that if SOME IF conditions are not met, the sub transaction is applied, if `Then` is used.
- With `Merge/And` ALL IF conditions, from all sub-transactions must be meet, then all sub-txns are applied.
- The misused `Then/Merge` calls were also in the `AtomicOp` impl.

---------------------------

**Changes:**
- `Txn.And` merhod has been renamed to `Txn.Merge` to be more clear.
- `Then` method cannot be called with a transaction.
  - I created a new method `ThenTxn` - it can be called only with a transaction.
  - **In this way, the method interface helps us to avoid mistakes.**
  - If you want to add a transaction, you have to make a decision, and select `ThenTxn` or `Merge` method.
- AtomicOp uses the `Merge` instead of the `Then`, :arrow_left: there was also a mistake here.
- Added more unit tests.

---------------------------

**Details:**
[etcd transaction](https://etcd.io/docs/v3.5/learning/api/#transaction):
  - Has `0..n` IF conditions.
  - Has `0..n` THEN operations.
  - Has `0..n` ELSE operations.
  - THEN and ELSE branches may contain nested transaction.

Our high-level interface `op.TxnOp` match low-level interface, has `If`, `Then` and `Else` methods.
- So these methods must be preserved.

Our use-case is to always `Merge` transactions, and do either everything or nothing. 

But nested transactions via `ThenTxn` can also be a valid use-case, but we don't have it yet.

---------------

**Tests**

See tests: `TestTxnOp_Then_Simple`, `TestTxnOp_Merge_Simple`, `TestTxnOp_Then_Simple_Ifs` and `TestTxnOp_Merge_Simple_Ifs` to see differences between `Then` and `Merge` ops.

Main difference is here:
`Then` - `TestTxnOp_Then_Simple_Ifs`
https://github.com/keboola/keboola-as-code/blob/00e5cbdb503513707adca3984f75c484e99dd4f7/internal/pkg/service/common/etcdop/op/txn_test.go#L597-L607

`Merge` - `TestTxnOp_Merge_Simple_Ifs`
https://github.com/keboola/keboola-as-code/blob/00e5cbdb503513707adca3984f75c484e99dd4f7/internal/pkg/service/common/etcdop/op/txn_test.go#L703-L715

-----------

**Future improvements:**
- In a next PR, I will lock File/Slice rotation transaction by a snapshot in a test.
  - To prevent future bugs in this important Stream API part.