### PR TITLE
refactor: Split rotateAllIn method, create rotateSink method

### DIFF
--- a/internal/pkg/service/buffer/sink/tablesink/storage/repository/file_repo.go
+++ b/internal/pkg/service/buffer/sink/tablesink/storage/repository/file_repo.go
@@ -352,6 +352,7 @@ func (r *FileRepository) rotateAllIn(rb rollback.Builder, now time.Time, parentK
 					txn.Merge(r.updateTxn(oldFile, modified))
 				} else {
 					errs.Append(err)
+					continue
 				}
 			}
 
@@ -362,6 +363,7 @@ func (r *FileRepository) rotateAllIn(rb rollback.Builder, now time.Time, parentK
 					txn.Merge(r.all.slice.updateTxn(oldSlice, modified))
 				} else {
 					errs.Append(err)
+					continue
 				}
 			}
 
@@ -374,6 +376,7 @@ func (r *FileRepository) rotateAllIn(rb rollback.Builder, now time.Time, parentK
 				file, err := newFile(cfg, resource, sink)
 				if err != nil {
 					errs.Append(err)
+					continue
 				}
 
 				// Assign volumes
@@ -382,6 +385,7 @@ func (r *FileRepository) rotateAllIn(rb rollback.Builder, now time.Time, parentK
 				// At least one volume must be assigned
 				if len(file.Assignment.Volumes) == 0 {
 					errs.Append(errors.New(`no volume is available for the file`))
+					continue
 				}
 
 				// Open slices in the assigned volumes

--- a/internal/pkg/service/buffer/sink/tablesink/storage/repository/hook.go
+++ b/internal/pkg/service/buffer/sink/tablesink/storage/repository/hook.go
@@ -129,7 +129,7 @@ func (h *hook) NewFileResourcesProvider(rb rollback.Builder) FileResourcesProvid
 
 		// Wait for goroutines
 		if err := grp.Wait(); err != nil {
-			return nil, err
+			return nil, errors.PrefixError(err, "cannot create file resource")
 		}
 
 		return result, nil


### PR DESCRIPTION
Jira: https://keboola.atlassian.net/browse/PSGO-356

**Changes:**
  - Splited rotateAllIn method, create rotateSink method 
  - Improved error handling, added missing `continue` callse (but replaced by methods split).
  - Added `TestFileRepository_Rotate_FileResourceError`.

-----------
