### PR TITLE
 fix: Fix iterator in TxnOp, don't load empty page

### DIFF
--- a/internal/pkg/service/common/etcdop/iterator/iterator.go
+++ b/internal/pkg/service/common/etcdop/iterator/iterator.go
@@ -271,13 +271,11 @@ func (v *Iterator) moveToPage(resp *etcd.GetResponse) bool {
 		}
 	}
 
-	// Handle empty result
 	v.values = kvs
 	v.header = header
 	v.lastIndexOnPage = len(v.values) - 1
-	if v.lastIndexOnPage == -1 {
-		return false
-	}
+	v.indexOnPage = -1
+	v.page++
 
 	// Prepare next page
 	if more {
@@ -292,9 +290,8 @@ func (v *Iterator) moveToPage(resp *etcd.GetResponse) bool {
 		v.start = end
 	}
 
-	v.indexOnPage = -1
-	v.page++
-	return true
+	// Stop on empty result
+	return v.lastIndexOnPage != -1
 }
 
 func (v Result) Header() *Header {


### PR DESCRIPTION
Jira: https://keboola.atlassian.net/browse/PSGO-370

**Changes:**
- Iterator in a tranction is no more loading an additional/unnecessary empty page.

-----------

See new - failing test:
![image](https://github.com/keboola/keboola-as-code/assets/19371734/019ab7d3-bc64-44a9-a245-31236990b6bf)

