### PR TITLE
feat: Serialize duration as string, not as nanosecs, in API responses and DB

### DIFF
--- a/internal/pkg/service/buffer/config/config_test.go
+++ b/internal/pkg/service/buffer/config/config_test.go
@@ -106,15 +106,15 @@ sink:
                 diskSync:
                     # Sync mode: "disabled", "cache" or "disk". Validation rules: required,oneof=disabled disk cache
                     mode: disk
-                    # Wait for sync to disk OS cache or to disk hardware, depending on the mode. Validation rules: excluded_if= Mode disabled
+                    # Wait for sync to disk OS cache or to disk hardware, depending on the mode.
                     wait: true
-                    # Minimal interval between syncs. Validation rules: min=0,maxDuration=2s,excluded_if=Mode disabled,required_if=Mode disk,required_if=Mode cache
+                    # Minimal interval between syncs. Validation rules: min=0,maxDuration=2s,required_if=Mode disk,required_if=Mode cache
                     checkInterval: 5ms
-                    # Written records count to trigger sync. Validation rules: max=1000000,excluded_if=Mode disabled,required_if=Mode disk,required_if=Mode cache
+                    # Written records count to trigger sync. Validation rules: max=1000000,required_if=Mode disk,required_if=Mode cache
                     countTrigger: 500
-                    # Written size to trigger sync. Validation rules: maxBytes=100MB,excluded_if=Mode disabled,required_if=Mode disk,required_if=Mode cache
+                    # Written size to trigger sync. Validation rules: maxBytes=100MB,required_if=Mode disk,required_if=Mode cache
                     bytesTrigger: 1MB
-                    # Interval from the last sync to trigger sync. Validation rules: min=0,maxDuration=2s,excluded_if=Mode disabled,required_if=Mode disk,required_if=Mode cache
+                    # Interval from the last sync to trigger sync. Validation rules: min=0,maxDuration=2s,required_if=Mode disk,required_if=Mode cache
                     intervalTrigger: 50ms
                 diskAllocation:
                     # Allocate disk space for each slice.

--- a/internal/pkg/service/buffer/definition/repository/sink_repo_test.go
+++ b/internal/pkg/service/buffer/definition/repository/sink_repo_test.go
@@ -470,10 +470,10 @@ definition/sink/active/123/456/my-source-1/my-sink-1
           "diskSync": {
             "mode": "disk",
             "wait": false,
-            "checkInterval": 1000000,
+            "checkInterval": "1ms",
             "countTrigger": 100,
             "bytesTrigger": "100KB",
-            "intervalTrigger": 100000000
+            "intervalTrigger": "100ms"
           }
         }
       }

--- a/internal/pkg/service/buffer/sink/tablesink/statistics/cache/cache_test.go
+++ b/internal/pkg/service/buffer/sink/tablesink/statistics/cache/cache_test.go
@@ -383,7 +383,7 @@ func TestCaches(t *testing.T) {
 		tc.Assert(l1Cache)
 
 		// Invalidate L2
-		clk.Add(l2Config.InvalidationInterval)
+		clk.Add(l2Config.InvalidationInterval.Duration())
 		if expectedRevision > 0 {
 			assert.Eventually(t, func() bool {
 				return l2Cache.Revision() >= expectedRevision

--- a/internal/pkg/service/buffer/sink/tablesink/statistics/cache/l2.go
+++ b/internal/pkg/service/buffer/sink/tablesink/statistics/cache/l2.go
@@ -52,7 +52,7 @@ func NewL2Cache(logger log.Logger, clk clock.Clock, l1Cache *L1, config statisti
 
 	// Periodically invalidates the cache.
 	c.wg.Add(1)
-	ticker := clk.Ticker(config.InvalidationInterval)
+	ticker := clk.Ticker(config.InvalidationInterval.Duration())
 	go func() {
 		defer c.wg.Done()
 		defer ticker.Stop()

--- a/internal/pkg/service/buffer/sink/tablesink/statistics/collector/collector.go
+++ b/internal/pkg/service/buffer/sink/tablesink/statistics/collector/collector.go
@@ -89,7 +89,7 @@ func New(logger log.Logger, clk clock.Clock, repository *repository.Repository, 
 
 	// Periodically collect statistics and sync them to the database
 	c.wg.Add(1)
-	ticker := clk.Ticker(c.config.SyncInterval)
+	ticker := clk.Ticker(c.config.SyncInterval.Duration())
 	go func() {
 		defer c.wg.Done()
 		defer ticker.Stop()
@@ -130,7 +130,7 @@ func (c *Collector) sync(filter *storage.SliceKey) error {
 	c.syncLock.Lock()
 	defer c.syncLock.Unlock()
 
-	ctx, cancel := context.WithTimeout(context.Background(), c.config.SyncTimeout)
+	ctx, cancel := context.WithTimeout(context.Background(), c.config.SyncTimeout.Duration())
 	defer cancel()
 
 	// Collect statistics

--- a/internal/pkg/service/buffer/sink/tablesink/statistics/collector/collector_test.go
+++ b/internal/pkg/service/buffer/sink/tablesink/statistics/collector/collector_test.go
@@ -37,7 +37,7 @@ func TestCollector(t *testing.T) {
 	syncCounter := 0
 	triggerSyncAndWait := func() {
 		syncCounter++
-		clk.Add(cfg.SyncInterval)
+		clk.Add(cfg.SyncInterval.Duration())
 		assert.Eventually(t, func() bool {
 			return strings.Count(d.DebugLogger().AllMessages(), "sync done") == syncCounter
 		}, time.Second, 10*time.Millisecond)

--- a/internal/pkg/service/buffer/sink/tablesink/statistics/config.go
+++ b/internal/pkg/service/buffer/sink/tablesink/statistics/config.go
@@ -2,6 +2,8 @@ package statistics
 
 import (
 	"time"
+
+	"github.com/keboola/keboola-as-code/internal/pkg/service/common/duration"
 )
 
 const (
@@ -16,22 +18,22 @@ type Config struct {
 }
 
 type SyncConfig struct {
-	SyncInterval time.Duration `configKey:"interval" configUsage:"Statistics synchronization interval, from memory to the etcd." validate:"required,minDuration=100ms,maxDuration=5s"`
-	SyncTimeout  time.Duration `configKey:"timeout" configUsage:"Statistics synchronization timeout."  validate:"required,minDuration=1s,maxDuration=1m"`
+	SyncInterval duration.Duration `configKey:"interval" configUsage:"Statistics synchronization interval, from memory to the etcd." validate:"required,minDuration=100ms,maxDuration=5s"`
+	SyncTimeout  duration.Duration `configKey:"timeout" configUsage:"Statistics synchronization timeout."  validate:"required,minDuration=1s,maxDuration=1m"`
 }
 
 type L2CacheConfig struct {
-	InvalidationInterval time.Duration `configKey:"invalidationInterval" configUsage:"Statistics L2 in-memory cache invalidation interval." validate:"required,minDuration=100ms,maxDuration=5s"`
+	InvalidationInterval duration.Duration `configKey:"invalidationInterval" configUsage:"Statistics L2 in-memory cache invalidation interval." validate:"required,minDuration=100ms,maxDuration=5s"`
 }
 
 func NewConfig() Config {
 	return Config{
 		Collector: SyncConfig{
-			SyncInterval: DefaultSyncInterval,
-			SyncTimeout:  DefaultSyncTimeout,
+			SyncInterval: duration.From(DefaultSyncInterval),
+			SyncTimeout:  duration.From(DefaultSyncTimeout),
 		},
 		L2Cache: L2CacheConfig{
-			InvalidationInterval: DefaultL2CacheInvalidationInterval,
+			InvalidationInterval: duration.From(DefaultL2CacheInvalidationInterval),
 		},
 	}
 }

--- a/internal/pkg/service/buffer/sink/tablesink/storage/config_test.go
+++ b/internal/pkg/service/buffer/sink/tablesink/storage/config_test.go
@@ -14,6 +14,7 @@ import (
 	"github.com/keboola/keboola-as-code/internal/pkg/service/buffer/sink/tablesink/storage/level/staging"
 	"github.com/keboola/keboola-as-code/internal/pkg/service/buffer/sink/tablesink/storage/level/target"
 	"github.com/keboola/keboola-as-code/internal/pkg/service/buffer/sink/tablesink/storage/volume/assignment"
+	"github.com/keboola/keboola-as-code/internal/pkg/service/common/duration"
 )
 
 func TestConfig_With(t *testing.T) {
@@ -60,7 +61,7 @@ func TestConfig_With(t *testing.T) {
 			Trigger: &staging.UploadTriggerPatch{
 				Count:    ptr(uint64(30000)),
 				Size:     ptr(4 * datasize.MB),
-				Interval: ptr(5 * time.Minute),
+				Interval: ptr(duration.From(5 * time.Minute)),
 			},
 		},
 	}
@@ -68,7 +69,7 @@ func TestConfig_With(t *testing.T) {
 	expectedCfg.Staging.Upload.Trigger = staging.UploadTrigger{
 		Count:    30000,
 		Size:     4 * datasize.MB,
-		Interval: 5 * time.Minute,
+		Interval: duration.From(5 * time.Minute),
 	}
 	// Compare
 	patchedConfig1 := defaultCfg.With(ConfigPatch{
@@ -83,10 +84,10 @@ func TestConfig_With(t *testing.T) {
 		DiskSync: &disksync.ConfigPatch{
 			Mode:            ptr(disksync.ModeCache),
 			Wait:            ptr(true),
-			CheckInterval:   ptr(10 * time.Millisecond),
+			CheckInterval:   ptr(duration.From(10 * time.Millisecond)),
 			CountTrigger:    ptr(uint(123)),
 			BytesTrigger:    ptr(1 * datasize.MB),
-			IntervalTrigger: ptr(100 * time.Millisecond),
+			IntervalTrigger: ptr(duration.From(100 * time.Millisecond)),
 		},
 		DiskAllocation: &diskalloc.ConfigPatch{
 			Enabled:     ptr(true),
@@ -97,10 +98,10 @@ func TestConfig_With(t *testing.T) {
 	expectedCfg.Local.DiskSync = disksync.Config{
 		Mode:            disksync.ModeCache,
 		Wait:            true,
-		CheckInterval:   10 * time.Millisecond,
+		CheckInterval:   duration.From(10 * time.Millisecond),
 		CountTrigger:    123,
 		BytesTrigger:    1 * datasize.MB,
-		IntervalTrigger: 100 * time.Millisecond,
+		IntervalTrigger: duration.From(100 * time.Millisecond),
 	}
 
 	expectedCfg.Local.DiskAllocation = diskalloc.Config{
@@ -113,14 +114,14 @@ func TestConfig_With(t *testing.T) {
 			Trigger: &target.ImportTriggerPatch{
 				Count:    ptr(uint64(60000)),
 				Size:     ptr(7 * datasize.MB),
-				Interval: ptr(8 * time.Minute),
+				Interval: ptr(duration.From(8 * time.Minute)),
 			},
 		},
 	}
 	expectedCfg.Target.Import.Trigger = target.ImportTrigger{
 		Count:    60000,
 		Size:     7 * datasize.MB,
-		Interval: 8 * time.Minute,
+		Interval: duration.From(8 * time.Minute),
 	}
 	// Compare
 	patchedConfig2 := patchedConfig1.With(ConfigPatch{

--- a/internal/pkg/service/buffer/sink/tablesink/storage/level/local/writer/csv/csv_benchmark_test.go
+++ b/internal/pkg/service/buffer/sink/tablesink/storage/level/local/writer/csv/csv_benchmark_test.go
@@ -14,6 +14,7 @@ import (
 	"github.com/keboola/keboola-as-code/internal/pkg/service/buffer/sink/tablesink/storage/compression"
 	"github.com/keboola/keboola-as-code/internal/pkg/service/buffer/sink/tablesink/storage/level/local/writer/disksync"
 	"github.com/keboola/keboola-as-code/internal/pkg/service/buffer/sink/tablesink/storage/level/local/writer/test/benchmark"
+	"github.com/keboola/keboola-as-code/internal/pkg/service/common/duration"
 )
 
 const (
@@ -217,10 +218,10 @@ func newBenchmark(configure func(wb *benchmark.WriterBenchmark)) *benchmark.Writ
 		Sync: disksync.Config{
 			Mode:            disksync.ModeDisk,
 			Wait:            true,
-			CheckInterval:   5 * time.Millisecond,
+			CheckInterval:   duration.From(5 * time.Millisecond),
 			CountTrigger:    500,
 			BytesTrigger:    1 * datasize.MB,
-			IntervalTrigger: 50 * time.Millisecond,
+			IntervalTrigger: duration.From(50 * time.Millisecond),
 		},
 		Compression: compression.NewNoneConfig(),
 		DataChFactory: func(ctx context.Context, n int, g *benchmark.RandomStringGenerator) <-chan []any {

--- a/internal/pkg/service/buffer/sink/tablesink/storage/level/local/writer/csv/csv_test.go
+++ b/internal/pkg/service/buffer/sink/tablesink/storage/level/local/writer/csv/csv_test.go
@@ -28,6 +28,7 @@ import (
 	"github.com/keboola/keboola-as-code/internal/pkg/service/buffer/sink/tablesink/storage/level/local/writer/test/testcase"
 	writerVolume "github.com/keboola/keboola-as-code/internal/pkg/service/buffer/sink/tablesink/storage/level/local/writer/volume"
 	"github.com/keboola/keboola-as-code/internal/pkg/service/buffer/sink/tablesink/storage/volume"
+	"github.com/keboola/keboola-as-code/internal/pkg/service/common/duration"
 	"github.com/keboola/keboola-as-code/internal/pkg/service/common/utctime"
 	"github.com/keboola/keboola-as-code/internal/pkg/utils/errors"
 	"github.com/keboola/keboola-as-code/internal/pkg/validator"
@@ -133,8 +134,8 @@ func TestCSVWriter_Close_WaitForWrites(t *testing.T) {
 	slice.LocalStorage.DiskSync.Mode = disksync.ModeDisk
 	slice.LocalStorage.DiskSync.Wait = true
 	// prevent sync during the test
-	slice.LocalStorage.DiskSync.CheckInterval = 2 * time.Second
-	slice.LocalStorage.DiskSync.IntervalTrigger = 2 * time.Second
+	slice.LocalStorage.DiskSync.CheckInterval = duration.From(2 * time.Second)
+	slice.LocalStorage.DiskSync.IntervalTrigger = duration.From(2 * time.Second)
 	val := validator.New()
 	assert.NoError(t, val.Validate(ctx, slice))
 
@@ -288,19 +289,19 @@ func newTestCase(comp fileCompression, syncMode disksync.Mode, syncWait bool, pa
 		syncConfig = disksync.Config{
 			Mode:            disksync.ModeDisk,
 			Wait:            syncWait,
-			CheckInterval:   5 * time.Millisecond,
+			CheckInterval:   duration.From(5 * time.Millisecond),
 			CountTrigger:    5000,
 			BytesTrigger:    1 * datasize.MB,
-			IntervalTrigger: intervalTrigger,
+			IntervalTrigger: duration.From(intervalTrigger),
 		}
 	case disksync.ModeCache:
 		syncConfig = disksync.Config{
 			Mode:            disksync.ModeCache,
 			Wait:            syncWait,
-			CheckInterval:   5 * time.Millisecond,
+			CheckInterval:   duration.From(5 * time.Millisecond),
 			CountTrigger:    5000,
 			BytesTrigger:    1 * datasize.MB,
-			IntervalTrigger: intervalTrigger,
+			IntervalTrigger: duration.From(intervalTrigger),
 		}
 	default:
 		panic(errors.Errorf(`unexpected mode "%v"`, syncMode))

--- a/internal/pkg/service/buffer/sink/tablesink/storage/level/local/writer/disksync/config.go
+++ b/internal/pkg/service/buffer/sink/tablesink/storage/level/local/writer/disksync/config.go
@@ -4,6 +4,8 @@ import (
 	"time"
 
 	"github.com/c2h5oh/datasize"
+
+	"github.com/keboola/keboola-as-code/internal/pkg/service/common/duration"
 )
 
 const (
@@ -42,7 +44,7 @@ type Config struct {
 	Wait bool `json:"wait" configKey:"wait" configUsage:"Wait for sync to disk OS cache or to disk hardware, depending on the mode."`
 	// CheckInterval defines how often BytesTrigger and IntervalTrigger will be checked.
 	// It is minimal interval between two syncs.
-	CheckInterval time.Duration `json:"checkInterval,omitempty" configKey:"checkInterval" validate:"min=0,maxDuration=2s,required_if=Mode disk,required_if=Mode cache" configUsage:"Minimal interval between syncs."`
+	CheckInterval duration.Duration `json:"checkInterval,omitempty" configKey:"checkInterval" validate:"min=0,maxDuration=2s,required_if=Mode disk,required_if=Mode cache" configUsage:"Minimal interval between syncs."`
 	// CountTrigger defines the writes count after the sync will be triggered.
 	// The number is count of the high-level writers, e.g., one table row = one write operation.
 	CountTrigger uint `json:"countTrigger,omitempty" configKey:"countTrigger" validate:"max=1000000,required_if=Mode disk,required_if=Mode cache" configUsage:"Written records count to trigger sync."`
@@ -50,7 +52,7 @@ type Config struct {
 	// Bytes are measured at the beginning of the writers chain.
 	BytesTrigger datasize.ByteSize `json:"bytesTrigger,omitempty" configKey:"bytesTrigger" validate:"maxBytes=100MB,required_if=Mode disk,required_if=Mode cache" configUsage:"Written size to trigger sync."`
 	// IntervalTrigger defines the interval from the last sync after the sync will be triggered.
-	IntervalTrigger time.Duration `json:"intervalTrigger,omitempty" configKey:"intervalTrigger" validate:"min=0,maxDuration=2s,required_if=Mode disk,required_if=Mode cache" configUsage:"Interval from the last sync to trigger sync."`
+	IntervalTrigger duration.Duration `json:"intervalTrigger,omitempty" configKey:"intervalTrigger" validate:"min=0,maxDuration=2s,required_if=Mode disk,required_if=Mode cache" configUsage:"Interval from the last sync to trigger sync."`
 }
 
 // ConfigPatch is same as the Config, but with optional/nullable fields.
@@ -58,10 +60,10 @@ type Config struct {
 type ConfigPatch struct {
 	Mode            *Mode              `json:"mode,omitempty"`
 	Wait            *bool              `json:"wait,omitempty"`
-	CheckInterval   *time.Duration     `json:"checkInterval,omitempty"`
+	CheckInterval   *duration.Duration `json:"checkInterval,omitempty"`
 	CountTrigger    *uint              `json:"countTrigger,omitempty"`
 	BytesTrigger    *datasize.ByteSize `json:"bytesTrigger,omitempty"`
-	IntervalTrigger *time.Duration     `json:"intervalTrigger,omitempty"`
+	IntervalTrigger *duration.Duration `json:"intervalTrigger,omitempty"`
 }
 
 // NewConfig provides default configuration.
@@ -69,10 +71,10 @@ func NewConfig() Config {
 	return Config{
 		Mode:            ModeDisk,
 		Wait:            true,
-		CheckInterval:   5 * time.Millisecond,
+		CheckInterval:   duration.From(5 * time.Millisecond),
 		CountTrigger:    500,
 		BytesTrigger:    1 * datasize.MB,
-		IntervalTrigger: 50 * time.Millisecond,
+		IntervalTrigger: duration.From(50 * time.Millisecond),
 	}
 }
 

--- a/internal/pkg/service/buffer/sink/tablesink/storage/level/local/writer/disksync/config_test.go
+++ b/internal/pkg/service/buffer/sink/tablesink/storage/level/local/writer/disksync/config_test.go
@@ -9,6 +9,7 @@ import (
 	"github.com/c2h5oh/datasize"
 	"github.com/stretchr/testify/assert"
 
+	"github.com/keboola/keboola-as-code/internal/pkg/service/common/duration"
 	"github.com/keboola/keboola-as-code/internal/pkg/validator"
 )
 
@@ -49,10 +50,10 @@ func TestConfig(t *testing.T) {
 			Config: Config{
 				Mode:            ModeDisk,
 				Wait:            true,
-				CheckInterval:   10 * time.Millisecond,
+				CheckInterval:   duration.From(10 * time.Millisecond),
 				CountTrigger:    100,
 				BytesTrigger:    100,
-				IntervalTrigger: 10 * time.Millisecond,
+				IntervalTrigger: duration.From(10 * time.Millisecond),
 			},
 		},
 		{
@@ -67,10 +68,10 @@ func TestConfig(t *testing.T) {
 			Config: Config{
 				Mode:            ModeCache,
 				Wait:            true,
-				CheckInterval:   10 * time.Millisecond,
+				CheckInterval:   duration.From(10 * time.Millisecond),
 				CountTrigger:    100,
 				BytesTrigger:    100,
-				IntervalTrigger: 10 * time.Millisecond,
+				IntervalTrigger: duration.From(10 * time.Millisecond),
 			},
 		},
 		{
@@ -79,10 +80,10 @@ func TestConfig(t *testing.T) {
 			Config: Config{
 				Mode:            ModeDisk,
 				Wait:            true,
-				CheckInterval:   10 * time.Second,
+				CheckInterval:   duration.From(10 * time.Second),
 				CountTrigger:    100,
 				BytesTrigger:    100,
-				IntervalTrigger: 10 * time.Millisecond,
+				IntervalTrigger: duration.From(10 * time.Millisecond),
 			},
 		},
 		{
@@ -91,10 +92,10 @@ func TestConfig(t *testing.T) {
 			Config: Config{
 				Mode:            ModeDisk,
 				Wait:            true,
-				CheckInterval:   10 * time.Millisecond,
+				CheckInterval:   duration.From(10 * time.Millisecond),
 				CountTrigger:    2000000,
 				BytesTrigger:    100,
-				IntervalTrigger: 10 * time.Millisecond,
+				IntervalTrigger: duration.From(10 * time.Millisecond),
 			},
 		},
 		{
@@ -103,10 +104,10 @@ func TestConfig(t *testing.T) {
 			Config: Config{
 				Mode:            ModeDisk,
 				Wait:            true,
-				CheckInterval:   10 * time.Millisecond,
+				CheckInterval:   duration.From(10 * time.Millisecond),
 				CountTrigger:    100,
 				BytesTrigger:    1 * datasize.GB,
-				IntervalTrigger: 10 * time.Millisecond,
+				IntervalTrigger: duration.From(10 * time.Millisecond),
 			},
 		},
 		{
@@ -115,10 +116,10 @@ func TestConfig(t *testing.T) {
 			Config: Config{
 				Mode:            ModeDisk,
 				Wait:            true,
-				CheckInterval:   10 * time.Millisecond,
+				CheckInterval:   duration.From(10 * time.Millisecond),
 				CountTrigger:    100,
 				BytesTrigger:    100,
-				IntervalTrigger: -10 * time.Millisecond,
+				IntervalTrigger: duration.From(-10 * time.Millisecond),
 			},
 		},
 		{
@@ -127,10 +128,10 @@ func TestConfig(t *testing.T) {
 			Config: Config{
 				Mode:            ModeDisk,
 				Wait:            true,
-				CheckInterval:   10 * time.Millisecond,
+				CheckInterval:   duration.From(10 * time.Millisecond),
 				CountTrigger:    100,
 				BytesTrigger:    100,
-				IntervalTrigger: 10 * time.Second,
+				IntervalTrigger: duration.From(10 * time.Second),
 			},
 		},
 	}

--- a/internal/pkg/service/buffer/sink/tablesink/storage/level/local/writer/disksync/disksync.go
+++ b/internal/pkg/service/buffer/sink/tablesink/storage/level/local/writer/disksync/disksync.go
@@ -74,10 +74,10 @@ func NewSyncer(logger log.Logger, clock clock.Clock, config Config, chain chain)
 
 	// Check conditions
 	if config.Mode != ModeDisabled {
-		if config.CheckInterval <= 0 {
+		if config.CheckInterval.Duration() <= 0 {
 			panic(errors.New("checkInterval is not set"))
 		}
-		if config.IntervalTrigger <= 0 {
+		if config.IntervalTrigger.Duration() <= 0 {
 			panic(errors.New("intervalTrigger is not set"))
 		}
 		if config.BytesTrigger <= 0 {
@@ -274,7 +274,7 @@ func (s *Syncer) TriggerSync(ctx context.Context, force bool) *notify.Notifier {
 }
 
 func (s *Syncer) syncLoop(ctx context.Context) {
-	ticker := s.clock.Ticker(s.config.CheckInterval)
+	ticker := s.clock.Ticker(s.config.CheckInterval.Duration())
 
 	s.wg.Add(1)
 	go func() {
@@ -291,7 +291,7 @@ func (s *Syncer) syncLoop(ctx context.Context) {
 				if count := s.writeOpsCount.Load(); count > 0 {
 					countTrigger := count >= uint64(s.config.CountTrigger)
 					bytesTrigger := datasize.ByteSize(s.bytesToSync.Load()) >= s.config.BytesTrigger
-					intervalTrigger := s.clock.Now().Sub(s.lastSyncAt.Load()) >= s.config.IntervalTrigger
+					intervalTrigger := s.clock.Now().Sub(s.lastSyncAt.Load()) >= s.config.IntervalTrigger.Duration()
 					if countTrigger || bytesTrigger || intervalTrigger {
 						s.TriggerSync(ctx, false)
 					}

--- a/internal/pkg/service/buffer/sink/tablesink/storage/level/local/writer/disksync/disksync_test.go
+++ b/internal/pkg/service/buffer/sink/tablesink/storage/level/local/writer/disksync/disksync_test.go
@@ -16,6 +16,7 @@ import (
 	"github.com/stretchr/testify/require"
 
 	"github.com/keboola/keboola-as-code/internal/pkg/log"
+	"github.com/keboola/keboola-as-code/internal/pkg/service/common/duration"
 	"github.com/keboola/keboola-as-code/internal/pkg/utils/errors"
 	"github.com/keboola/keboola-as-code/internal/pkg/utils/strhelper"
 	"github.com/keboola/keboola-as-code/internal/pkg/validator"
@@ -1000,7 +1001,7 @@ func TestSyncWriter_CountTrigger(t *testing.T) {
 
 	// Wait for sync
 	syncer.AddWriteOp(tc.Config.CountTrigger)
-	tc.Clock.Add(tc.Config.CheckInterval)
+	tc.Clock.Add(tc.Config.CheckInterval.Duration())
 	wg.Wait()
 
 	// Check output
@@ -1057,7 +1058,7 @@ func TestSyncWriter_IntervalTrigger(t *testing.T) {
 	}
 
 	// Wait for sync
-	tc.Clock.Add(tc.Config.IntervalTrigger)
+	tc.Clock.Add(tc.Config.IntervalTrigger.Duration())
 	wg.Wait()
 
 	// Check output
@@ -1128,7 +1129,7 @@ func TestSyncWriter_BytesTrigger(t *testing.T) {
 	}()
 
 	// Wait for sync
-	tc.Clock.Add(tc.Config.CheckInterval)
+	tc.Clock.Add(tc.Config.CheckInterval.Duration())
 	wg.Wait()
 
 	// Check output
@@ -1221,10 +1222,10 @@ func newWriterTestCase(tb testing.TB) *writerTestCase {
 	config := Config{
 		Mode:            ModeDisk,
 		Wait:            true,
-		CheckInterval:   1 * time.Millisecond,
+		CheckInterval:   duration.From(1 * time.Millisecond),
 		CountTrigger:    100,
 		BytesTrigger:    128 * datasize.KB,
-		IntervalTrigger: 10 * time.Millisecond,
+		IntervalTrigger: duration.From(10 * time.Millisecond),
 	}
 	val := validator.New()
 	require.NoError(tb, val.Validate(ctx, config))

--- a/internal/pkg/service/buffer/sink/tablesink/storage/level/staging/config.go
+++ b/internal/pkg/service/buffer/sink/tablesink/storage/level/staging/config.go
@@ -4,6 +4,8 @@ import (
 	"time"
 
 	"github.com/c2h5oh/datasize"
+
+	"github.com/keboola/keboola-as-code/internal/pkg/service/common/duration"
 )
 
 // Config configures for the staging storage.
@@ -25,11 +27,11 @@ func NewConfig() Config {
 		MaxSlicesPerFile:        100,
 		ParallelFileCreateLimit: 50,
 		Upload: UploadConfig{
-			MinInterval: 5 * time.Second,
+			MinInterval: duration.From(5 * time.Second),
 			Trigger: UploadTrigger{
 				Count:    10000,
 				Size:     1 * datasize.MB,
-				Interval: 1 * time.Minute,
+				Interval: duration.From(1 * time.Minute),
 			},
 		},
 	}
@@ -50,8 +52,8 @@ func (c Config) With(v ConfigPatch) Config {
 
 // UploadConfig configures the slice upload.
 type UploadConfig struct {
-	MinInterval time.Duration `configKey:"minInterval" configUsage:"Minimal interval between uploads." validate:"required,minDuration=1s,maxDuration=5m"`
-	Trigger     UploadTrigger `configKey:"trigger"`
+	MinInterval duration.Duration `configKey:"minInterval" configUsage:"Minimal interval between uploads." validate:"required,minDuration=1s,maxDuration=5m"`
+	Trigger     UploadTrigger     `configKey:"trigger"`
 }
 
 // UploadConfigPatch is same as the UploadConfig, but with optional/nullable fields.
@@ -74,7 +76,7 @@ func (c UploadConfig) With(v UploadConfigPatch) UploadConfig {
 type UploadTrigger struct {
 	Count    uint64            `json:"count" configKey:"count" configUsage:"Records count." validate:"required,min=1,max=10000000"`
 	Size     datasize.ByteSize `json:"size" configKey:"size" configUsage:"Records size." validate:"required,minBytes=100B,maxBytes=50MB"`
-	Interval time.Duration     `json:"interval" configKey:"interval" configUsage:"Duration from the last upload." validate:"required,minDuration=1s,maxDuration=30m"`
+	Interval duration.Duration `json:"interval" configKey:"interval" configUsage:"Duration from the last upload." validate:"required,minDuration=1s,maxDuration=30m"`
 }
 
 // UploadTriggerPatch is same as the UploadTrigger, but with optional/nullable fields.
@@ -82,7 +84,7 @@ type UploadTrigger struct {
 type UploadTriggerPatch struct {
 	Count    *uint64            `json:"count,omitempty" configKey:"count"`
 	Size     *datasize.ByteSize `json:"size,omitempty" configKey:"size"`
-	Interval *time.Duration     `json:"interval,omitempty" configKey:"interval"`
+	Interval *duration.Duration `json:"interval,omitempty" configKey:"interval"`
 }
 
 // With copies values from the UploadTriggerPatch, if any.

--- a/internal/pkg/service/buffer/sink/tablesink/storage/level/staging/config_test.go
+++ b/internal/pkg/service/buffer/sink/tablesink/storage/level/staging/config_test.go
@@ -10,6 +10,7 @@ import (
 	"github.com/keboola/keboola-as-code/internal/pkg/service/buffer/sink/tablesink/storage/level/staging"
 	"github.com/keboola/keboola-as-code/internal/pkg/service/buffer/sink/tablesink/storage/test"
 	"github.com/keboola/keboola-as-code/internal/pkg/service/buffer/sink/tablesink/storage/test/testvalidation"
+	"github.com/keboola/keboola-as-code/internal/pkg/service/common/duration"
 )
 
 func TestConfig_With(t *testing.T) {
@@ -25,13 +26,13 @@ func TestConfig_With(t *testing.T) {
 		MaxSlicesPerFile: test.Ptr(123),
 		Upload: &staging.UploadConfigPatch{
 			Trigger: &staging.UploadTriggerPatch{
-				Interval: test.Ptr(456 * time.Millisecond),
+				Interval: test.Ptr(duration.From(456 * time.Millisecond)),
 			},
 		},
 	})
 	expectedCfg := defaultCfg
 	expectedCfg.MaxSlicesPerFile = 123
-	expectedCfg.Upload.Trigger.Interval = 456 * time.Millisecond
+	expectedCfg.Upload.Trigger.Interval = duration.From(456 * time.Millisecond)
 	assert.Equal(t, expectedCfg, patchedCfg)
 }
 
@@ -42,7 +43,7 @@ func TestConfig_Validation(t *testing.T) {
 	overMaximumCfg.Upload.Trigger = staging.UploadTrigger{
 		Count:    10000000 + 1,
 		Size:     datasize.MustParseString("50MB") + 1,
-		Interval: 30*time.Minute + 1,
+		Interval: duration.From(30*time.Minute + 1),
 	}
 
 	// Test cases

--- a/internal/pkg/service/buffer/sink/tablesink/storage/level/target/config.go
+++ b/internal/pkg/service/buffer/sink/tablesink/storage/level/target/config.go
@@ -4,6 +4,8 @@ import (
 	"time"
 
 	"github.com/c2h5oh/datasize"
+
+	"github.com/keboola/keboola-as-code/internal/pkg/service/common/duration"
 )
 
 // Config configures the target storage.
@@ -20,11 +22,11 @@ type ConfigPatch struct {
 func NewConfig() Config {
 	return Config{
 		Import: ImportConfig{
-			MinInterval: 1 * time.Minute,
+			MinInterval: duration.From(1 * time.Minute),
 			Trigger: ImportTrigger{
 				Count:    50000,
 				Size:     5 * datasize.MB,
-				Interval: 5 * time.Minute,
+				Interval: duration.From(5 * time.Minute),
 			},
 		},
 	}
@@ -42,8 +44,8 @@ func (c Config) With(v ConfigPatch) Config {
 
 // ImportConfig configures the file import.
 type ImportConfig struct {
-	MinInterval time.Duration `configKey:"minInterval" configUsage:"Minimal interval between imports." validate:"required,minDuration=30s,maxDuration=30m"`
-	Trigger     ImportTrigger `configKey:"trigger"`
+	MinInterval duration.Duration `configKey:"minInterval" configUsage:"Minimal interval between imports." validate:"required,minDuration=30s,maxDuration=30m"`
+	Trigger     ImportTrigger     `configKey:"trigger"`
 }
 
 // ImportConfigPatch is same as the ImportConfig, but with optional/nullable fields.
@@ -66,7 +68,7 @@ func (c ImportConfig) With(v ImportConfigPatch) ImportConfig {
 type ImportTrigger struct {
 	Count    uint64            `json:"count" configKey:"count" configUsage:"Records count." validate:"required,min=1,max=10000000"`
 	Size     datasize.ByteSize `json:"size" configKey:"size" configUsage:"Records size." validate:"required,minBytes=100B,maxBytes=500MB"`
-	Interval time.Duration     `json:"interval" configKey:"interval" configUsage:"Duration from the last import." validate:"required,minDuration=60s,maxDuration=24h"`
+	Interval duration.Duration `json:"interval" configKey:"interval" configUsage:"Duration from the last import." validate:"required,minDuration=60s,maxDuration=24h"`
 }
 
 // ImportTriggerPatch is same as the ImportTrigger, but with optional/nullable fields.
@@ -74,7 +76,7 @@ type ImportTrigger struct {
 type ImportTriggerPatch struct {
 	Count    *uint64            `json:"count,omitempty" configKey:"count"`
 	Size     *datasize.ByteSize `json:"size,omitempty" configKey:"size"`
-	Interval *time.Duration     `json:"interval,omitempty" configKey:"interval"`
+	Interval *duration.Duration `json:"interval,omitempty" configKey:"interval"`
 }
 
 // With copies values from the ImportTriggerPatch, if any.

--- a/internal/pkg/service/buffer/sink/tablesink/storage/level/target/config_test.go
+++ b/internal/pkg/service/buffer/sink/tablesink/storage/level/target/config_test.go
@@ -10,6 +10,7 @@ import (
 	"github.com/keboola/keboola-as-code/internal/pkg/service/buffer/sink/tablesink/storage/level/target"
 	"github.com/keboola/keboola-as-code/internal/pkg/service/buffer/sink/tablesink/storage/test"
 	"github.com/keboola/keboola-as-code/internal/pkg/service/buffer/sink/tablesink/storage/test/testvalidation"
+	"github.com/keboola/keboola-as-code/internal/pkg/service/common/duration"
 )
 
 func TestConfig_With(t *testing.T) {
@@ -24,12 +25,12 @@ func TestConfig_With(t *testing.T) {
 	patchedCfg := defaultCfg.With(target.ConfigPatch{
 		Import: &target.ImportConfigPatch{
 			Trigger: &target.ImportTriggerPatch{
-				Interval: test.Ptr(456 * time.Millisecond),
+				Interval: test.Ptr(duration.From(456 * time.Millisecond)),
 			},
 		},
 	})
 	expectedCfg := defaultCfg
-	expectedCfg.Import.Trigger.Interval = 456 * time.Millisecond
+	expectedCfg.Import.Trigger.Interval = duration.From(456 * time.Millisecond)
 	assert.Equal(t, expectedCfg, patchedCfg)
 }
 
@@ -40,7 +41,7 @@ func TestConfig_Validation(t *testing.T) {
 	overMaximumCfg.Import.Trigger = target.ImportTrigger{
 		Count:    10000000 + 1,
 		Size:     datasize.MustParseString("500MB") + 1,
-		Interval: 24*time.Hour + 1,
+		Interval: duration.From(24*time.Hour + 1),
 	}
 
 	// Test cases

--- a/internal/pkg/service/buffer/sink/tablesink/storage/repository/file_repo__test.go
+++ b/internal/pkg/service/buffer/sink/tablesink/storage/repository/file_repo__test.go
@@ -362,10 +362,10 @@ storage/file/all/123/456/my-source/my-sink-1/2000-01-01T02:00:00.000Z
     "diskSync": {
       "mode": "disk",
       "wait": true,
-      "checkInterval": 5000000,
+      "checkInterval": "5ms",
       "countTrigger": 500,
       "bytesTrigger": "1MB",
-      "intervalTrigger": 50000000
+      "intervalTrigger": "50ms"
     },
     "diskAllocation": {
       "enabled": true,

--- a/internal/pkg/service/buffer/sink/tablesink/storage/repository/slice_repo__test.go
+++ b/internal/pkg/service/buffer/sink/tablesink/storage/repository/slice_repo__test.go
@@ -357,10 +357,10 @@ storage/slice/all/123/456/my-source/my-sink-1/2000-01-01T01:00:00.000Z/my-volume
     "diskSync": {
       "mode": "disk",
       "wait": false,
-      "checkInterval": 1000000,
+      "checkInterval": "1ms",
       "countTrigger": 100,
       "bytesTrigger": "100KB",
-      "intervalTrigger": 100000000
+      "intervalTrigger": "100ms"
     },
     "allocatedDiskSpace": "100MB"
   },

--- a/internal/pkg/service/buffer/sink/tablesink/storage/test/sink.go
+++ b/internal/pkg/service/buffer/sink/tablesink/storage/test/sink.go
@@ -14,6 +14,7 @@ import (
 	"github.com/keboola/keboola-as-code/internal/pkg/service/buffer/sink/tablesink/storage/level/local"
 	"github.com/keboola/keboola-as-code/internal/pkg/service/buffer/sink/tablesink/storage/level/local/writer/disksync"
 	"github.com/keboola/keboola-as-code/internal/pkg/service/buffer/sink/tablesink/storage/volume/assignment"
+	"github.com/keboola/keboola-as-code/internal/pkg/service/common/duration"
 )
 
 func NewSinkKey() key.SinkKey {
@@ -46,10 +47,10 @@ func NewSink(k key.SinkKey) definition.Sink {
 						DiskSync: &disksync.ConfigPatch{
 							Mode:            Ptr(disksync.ModeDisk),
 							Wait:            Ptr(false),
-							CheckInterval:   Ptr(1 * time.Millisecond),
+							CheckInterval:   Ptr(duration.From(1 * time.Millisecond)),
 							CountTrigger:    Ptr(uint(100)),
 							BytesTrigger:    Ptr(100 * datasize.KB),
-							IntervalTrigger: Ptr(100 * time.Millisecond),
+							IntervalTrigger: Ptr(duration.From(100 * time.Millisecond)),
 						},
 					},
 				},

--- a/internal/pkg/service/buffer/sink/tablesink/storage/test/slice.go
+++ b/internal/pkg/service/buffer/sink/tablesink/storage/test/slice.go
@@ -11,6 +11,7 @@ import (
 	"github.com/keboola/keboola-as-code/internal/pkg/service/buffer/sink/tablesink/storage/level/local"
 	"github.com/keboola/keboola-as-code/internal/pkg/service/buffer/sink/tablesink/storage/level/local/writer/disksync"
 	"github.com/keboola/keboola-as-code/internal/pkg/service/buffer/sink/tablesink/storage/level/staging"
+	"github.com/keboola/keboola-as-code/internal/pkg/service/common/duration"
 	"github.com/keboola/keboola-as-code/internal/pkg/service/common/utctime"
 )
 
@@ -53,10 +54,10 @@ func NewSliceOpenedAt(openedAt string) *storage.Slice {
 			DiskSync: disksync.Config{
 				Mode:            disksync.ModeDisk,
 				Wait:            true,
-				CheckInterval:   1 * time.Millisecond,
+				CheckInterval:   duration.From(1 * time.Millisecond),
 				CountTrigger:    500,
 				BytesTrigger:    1 * datasize.MB,
-				IntervalTrigger: 50 * time.Millisecond,
+				IntervalTrigger: duration.From(50 * time.Millisecond),
 			},
 		},
 		StagingStorage: staging.Slice{

--- a/internal/pkg/service/common/duration/duration.go
+++ b/internal/pkg/service/common/duration/duration.go
@@ -1,0 +1,58 @@
+// Package duration provides a wrapper for time.Duration type,
+// to serialize duration as string instead of int64 nanoseconds.
+//
+// This cannot be changed in Go 1.X, it would break backward compatibility, see:
+// https://github.com/golang/go/issues/10275
+// "This isn't possible to change now, as it would change the encodings produced by programs that exist today."
+package duration
+
+import (
+	"bytes"
+	"encoding/json"
+	"strings"
+	"time"
+
+	"gopkg.in/yaml.v3"
+)
+
+type Duration time.Duration
+
+func From(duration time.Duration) Duration {
+	return Duration(duration)
+}
+
+func (v Duration) Duration() time.Duration {
+	return time.Duration(v)
+}
+
+func (v Duration) String() string {
+	return v.Duration().String()
+}
+
+func (v Duration) MarshalText() (text []byte, err error) {
+	return []byte(v.String()), nil
+}
+
+func (v *Duration) UnmarshalText(text []byte) error {
+	duration, err := time.ParseDuration(string(text))
+	*v = Duration(duration)
+	return err
+}
+
+func (v *Duration) UnmarshalJSON(b []byte) (err error) {
+	// String, for example, "1h20s"
+	if bytes.HasPrefix(b, []byte(`"`)) && bytes.HasSuffix(b, []byte(`"`)) {
+		return v.UnmarshalText(bytes.Trim(b, `"`))
+	}
+	// Nanoseconds int64 - backward compatibility
+	return json.Unmarshal(b, (*time.Duration)(v))
+}
+
+func (v *Duration) UnmarshalYAML(n *yaml.Node) error {
+	// String, for example, "1h20s"
+	if n.Kind == yaml.ScalarNode && n.Tag == "!!str" {
+		return v.UnmarshalText([]byte(strings.Trim(n.Value, `"`)))
+	}
+	// Nanoseconds int64 - backward compatibility
+	return n.Decode((*int64)(v))
+}

--- a/internal/pkg/service/common/duration/duration_test.go
+++ b/internal/pkg/service/common/duration/duration_test.go
@@ -1,0 +1,61 @@
+package duration_test
+
+import (
+	"encoding/json"
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	"gopkg.in/yaml.v3"
+
+	"github.com/keboola/keboola-as-code/internal/pkg/service/common/duration"
+)
+
+type Data struct {
+	Duration duration.Duration `json:"duration" yaml:"duration"`
+}
+
+func TestDuration_MarshalText_JSON(t *testing.T) {
+	t.Parallel()
+	data := Data{Duration: duration.From(123 * time.Hour)}
+	jsonOut, err := json.Marshal(data)
+	require.NoError(t, err)
+	assert.Equal(t, `{"duration":"123h0m0s"}`, string(jsonOut))
+}
+
+func TestDuration_MarshalText_YAML(t *testing.T) {
+	t.Parallel()
+	data := Data{Duration: duration.From(123 * time.Hour)}
+	yamlOut, err := yaml.Marshal(data)
+	require.NoError(t, err)
+	assert.Equal(t, "duration: 123h0m0s\n", string(yamlOut))
+}
+
+func TestDuration_UnmarshalText_JSON(t *testing.T) {
+	t.Parallel()
+	var data Data
+	require.NoError(t, json.Unmarshal([]byte(`{"duration":"123h0m0s"}`), &data))
+	assert.Equal(t, "123h0m0s", data.Duration.String())
+}
+
+func TestDuration_UnmarshalText_YAML(t *testing.T) {
+	t.Parallel()
+	var data Data
+	require.NoError(t, yaml.Unmarshal([]byte("duration: 123h0m0s\n"), &data))
+	assert.Equal(t, "123h0m0s", data.Duration.String())
+}
+
+func TestDuration_UnmarshalInt_JSON(t *testing.T) {
+	t.Parallel()
+	var data Data
+	require.NoError(t, json.Unmarshal([]byte(`{"duration":456}`), &data))
+	assert.Equal(t, "456ns", data.Duration.String())
+}
+
+func TestDuration_UnmarshalInt_YAML(t *testing.T) {
+	t.Parallel()
+	var data Data
+	require.NoError(t, yaml.Unmarshal([]byte("duration: 456\n"), &data))
+	assert.Equal(t, "456ns", data.Duration.String())
+}

--- a/internal/pkg/validator/custom.go
+++ b/internal/pkg/validator/custom.go
@@ -11,6 +11,7 @@ import (
 	"github.com/go-playground/validator/v10"
 	"github.com/umisama/go-regexpcache"
 
+	"github.com/keboola/keboola-as-code/internal/pkg/service/common/duration"
 	"github.com/keboola/keboola-as-code/internal/pkg/utils/errors"
 	"github.com/keboola/keboola-as-code/internal/pkg/utils/strhelper"
 )
@@ -139,17 +140,20 @@ func (v *wrapper) registerCustomRules() {
 		Rule{
 			Tag: "minDuration",
 			FuncCtx: func(ctx context.Context, fl validator.FieldLevel) bool {
-				value, ok := fl.Field().Interface().(time.Duration)
-				if !ok {
+				var value time.Duration
+				if v, ok := fl.Field().Interface().(time.Duration); ok {
+					value = v
+				} else if v, ok := fl.Field().Interface().(duration.Duration); ok {
+					value = v.Duration()
+				} else {
 					panic(errors.Errorf(`unexpected type "%T"`, fl.Field().Interface()))
 				}
+
 				param, err := time.ParseDuration(fl.Param())
-				if !ok {
+				if err != nil {
 					panic(errors.Errorf(`param "%s" is not valid: %w`, fl.Param(), err))
 				}
-				if param == 0 {
-					panic(errors.Errorf(`param "%s" is not valid`, fl.Param()))
-				}
+
 				return value >= param
 			},
 			ErrorMsgFunc: func(fe validator.FieldError) string {
@@ -160,17 +164,20 @@ func (v *wrapper) registerCustomRules() {
 		Rule{
 			Tag: "maxDuration",
 			FuncCtx: func(ctx context.Context, fl validator.FieldLevel) bool {
-				value, ok := fl.Field().Interface().(time.Duration)
-				if !ok {
+				var value time.Duration
+				if v, ok := fl.Field().Interface().(time.Duration); ok {
+					value = v
+				} else if v, ok := fl.Field().Interface().(duration.Duration); ok {
+					value = v.Duration()
+				} else {
 					panic(errors.Errorf(`unexpected type "%T"`, fl.Field().Interface()))
 				}
+
 				param, err := time.ParseDuration(fl.Param())
-				if !ok {
+				if err != nil {
 					panic(errors.Errorf(`param "%s" is not valid: %w`, fl.Param(), err))
 				}
-				if param == 0 {
-					panic(errors.Errorf(`param "%s" is not valid`, fl.Param()))
-				}
+
 				return value <= param
 			},
 			ErrorMsgFunc: func(fe validator.FieldError) string {

--- a/internal/pkg/validator/custom_test.go
+++ b/internal/pkg/validator/custom_test.go
@@ -6,11 +6,18 @@ import (
 
 	"github.com/c2h5oh/datasize"
 	"github.com/stretchr/testify/assert"
+
+	"github.com/keboola/keboola-as-code/internal/pkg/service/common/duration"
 )
 
 func TestValidateMinDuration(t *testing.T) {
 	t.Parallel()
+
 	err := New().ValidateValue(10*time.Millisecond, "minDuration=100ms")
+	assert.Error(t, err)
+	assert.Equal(t, `must be 100ms or greater`, err.Error())
+
+	err = New().ValidateValue(duration.From(10*time.Millisecond), "minDuration=100ms")
 	assert.Error(t, err)
 	assert.Equal(t, `must be 100ms or greater`, err.Error())
 }
@@ -27,10 +34,15 @@ func TestValidateMaxDuration(t *testing.T) {
 	err := New().ValidateValue(200*time.Millisecond, "maxDuration=100ms")
 	assert.Error(t, err)
 	assert.Equal(t, `must be 100ms or less`, err.Error())
+
+	err = New().ValidateValue(duration.From(200*time.Millisecond), "maxDuration=100ms")
+	assert.Error(t, err)
+	assert.Equal(t, `must be 100ms or less`, err.Error())
 }
 
 func TestValidateMaxBytes(t *testing.T) {
 	t.Parallel()
+
 	err := New().ValidateValue(datasize.ByteSize(2000), "maxBytes=1KB")
 	assert.Error(t, err)
 	assert.Equal(t, `must be 1KB or less`, err.Error())


### PR DESCRIPTION
Part of: https://keboola.atlassian.net/browse/PSGO-388

**Changes:**
- **`time.Duration` is by default serialized as `int64`, as number of nanoseconds.**
- It is acceptable for database, but it complicates E2E tests.
- **It is not acceptable for API, we had some conversions implemented on the API layer.**
- **Now, we have in the API much more `time.Duration` values that need to be handled.**
- So I created `duration.Duration` type, that serializes as string, for example: `100ms`, `1h0m`, ...
- It is not implemented in the Go in this ways, to keep BC:
  - https://github.com/golang/go/issues/10275
  - > This isn't possible to change now, as it would change the encodings produced by programs that exist today.
- We have similar package for the time serialization, see [utctime](https://github.com/keboola/keboola-as-code/blob/michaljurecko-PSGO-387-duration-pkg/internal/pkg/service/common/utctime/utctime.go) pkg.

-----------
