### PR TITLE
feat: Add configpatch.ToKVs - dump config as key-value pairs

### DIFF
--- a/internal/pkg/service/buffer/config/config_test.go
+++ b/internal/pkg/service/buffer/config/config_test.go
@@ -77,7 +77,7 @@ sink:
             volumeAssignment:
                 # Volumes count simultaneously utilized per sink. Validation rules: required,min=1,max=100
                 count: 1
-                # List of preferred volume types, start with the most preferred. Validation rules: min=1
+                # List of preferred volume types, start with the most preferred. Validation rules: required,min=1
                 preferredTypes:
                     - default
             volumeRegistration:
@@ -110,7 +110,7 @@ sink:
                     wait: true
                     # Minimal interval between syncs. Validation rules: min=0,maxDuration=2s,required_if=Mode disk,required_if=Mode cache
                     checkInterval: 5ms
-                    # Written records count to trigger sync. Validation rules: max=1000000,required_if=Mode disk,required_if=Mode cache
+                    # Written records count to trigger sync. Validation rules: min=0,max=1000000,required_if=Mode disk,required_if=Mode cache
                     countTrigger: 500
                     # Written size to trigger sync. Validation rules: maxBytes=100MB,required_if=Mode disk,required_if=Mode cache
                     bytesTrigger: 1MB

--- a/internal/pkg/service/buffer/sink/tablesink/config_test.go
+++ b/internal/pkg/service/buffer/sink/tablesink/config_test.go
@@ -1,0 +1,249 @@
+package tablesink_test
+
+import (
+	"strings"
+	"testing"
+
+	"github.com/c2h5oh/datasize"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+
+	"github.com/keboola/keboola-as-code/internal/pkg/encoding/json"
+	"github.com/keboola/keboola-as-code/internal/pkg/service/buffer/sink/tablesink"
+	"github.com/keboola/keboola-as-code/internal/pkg/service/buffer/sink/tablesink/storage"
+	"github.com/keboola/keboola-as-code/internal/pkg/service/buffer/sink/tablesink/storage/level/local"
+	"github.com/keboola/keboola-as-code/internal/pkg/service/buffer/sink/tablesink/storage/level/local/writer/diskalloc"
+	"github.com/keboola/keboola-as-code/internal/pkg/service/buffer/sink/tablesink/storage/test"
+	"github.com/keboola/keboola-as-code/internal/pkg/service/common/configpatch"
+)
+
+func TestConfig_ToKVs(t *testing.T) {
+	t.Parallel()
+
+	kvs, err := configpatch.DumpKVs(
+		tablesink.NewConfig(),
+		tablesink.ConfigPatch{
+			Storage: &storage.ConfigPatch{
+				Local: &local.ConfigPatch{
+					DiskAllocation: &diskalloc.ConfigPatch{
+						Size: test.Ptr(456 * datasize.MB),
+					},
+				},
+			},
+		},
+	)
+	require.NoError(t, err)
+
+	assert.Equal(t, strings.TrimSpace(`
+[
+  {
+    "key": "storage.local.compression.gzip.blockSize",
+    "value": "256KB",
+    "defaultValue": "256KB",
+    "overwritten": false,
+    "protected": false,
+    "validation": "required,minBytes=16kB,maxBytes=100MB"
+  },
+  {
+    "key": "storage.local.compression.gzip.concurrency",
+    "value": 0,
+    "defaultValue": 0,
+    "overwritten": false,
+    "protected": false
+  },
+  {
+    "key": "storage.local.compression.gzip.implementation",
+    "value": "parallel",
+    "defaultValue": "parallel",
+    "overwritten": false,
+    "protected": false,
+    "validation": "required,oneof=standard fast parallel"
+  },
+  {
+    "key": "storage.local.compression.gzip.level",
+    "value": 1,
+    "defaultValue": 1,
+    "overwritten": false,
+    "protected": false,
+    "validation": "min=1,max=9"
+  },
+  {
+    "key": "storage.local.compression.type",
+    "value": "gzip",
+    "defaultValue": "gzip",
+    "overwritten": false,
+    "protected": false,
+    "validation": "required,oneof=none gzip zstd"
+  },
+  {
+    "key": "storage.local.compression.zstd.concurrency",
+    "value": 0,
+    "defaultValue": 0,
+    "overwritten": false,
+    "protected": false
+  },
+  {
+    "key": "storage.local.compression.zstd.level",
+    "value": 1,
+    "defaultValue": 1,
+    "overwritten": false,
+    "protected": false,
+    "validation": "min=1,max=4"
+  },
+  {
+    "key": "storage.local.compression.zstd.windowSize",
+    "value": "1MB",
+    "defaultValue": "1MB",
+    "overwritten": false,
+    "protected": false,
+    "validation": "required,minBytes=1kB,maxBytes=512MB"
+  },
+  {
+    "key": "storage.local.diskAllocation.enabled",
+    "value": true,
+    "defaultValue": true,
+    "overwritten": false,
+    "protected": false
+  },
+  {
+    "key": "storage.local.diskAllocation.size",
+    "value": "456MB",
+    "defaultValue": "100MB",
+    "overwritten": true,
+    "protected": false,
+    "validation": "required"
+  },
+  {
+    "key": "storage.local.diskAllocation.sizePercent",
+    "value": 110,
+    "defaultValue": 110,
+    "overwritten": false,
+    "protected": false,
+    "validation": "min=100,max=500"
+  },
+  {
+    "key": "storage.local.diskSync.bytesTrigger",
+    "value": "1MB",
+    "defaultValue": "1MB",
+    "overwritten": false,
+    "protected": false,
+    "validation": "maxBytes=100MB,required_if=Mode disk,required_if=Mode cache"
+  },
+  {
+    "key": "storage.local.diskSync.checkInterval",
+    "value": "5ms",
+    "defaultValue": "5ms",
+    "overwritten": false,
+    "protected": false,
+    "validation": "min=0,maxDuration=2s,required_if=Mode disk,required_if=Mode cache"
+  },
+  {
+    "key": "storage.local.diskSync.countTrigger",
+    "value": 500,
+    "defaultValue": 500,
+    "overwritten": false,
+    "protected": false,
+    "validation": "min=0,max=1000000,required_if=Mode disk,required_if=Mode cache"
+  },
+  {
+    "key": "storage.local.diskSync.intervalTrigger",
+    "value": "50ms",
+    "defaultValue": "50ms",
+    "overwritten": false,
+    "protected": false,
+    "validation": "min=0,maxDuration=2s,required_if=Mode disk,required_if=Mode cache"
+  },
+  {
+    "key": "storage.local.diskSync.mode",
+    "value": "disk",
+    "defaultValue": "disk",
+    "overwritten": false,
+    "protected": false,
+    "validation": "required,oneof=disabled disk cache"
+  },
+  {
+    "key": "storage.local.diskSync.wait",
+    "value": true,
+    "defaultValue": true,
+    "overwritten": false,
+    "protected": false
+  },
+  {
+    "key": "storage.staging.maxSlicesPerFile",
+    "value": 100,
+    "defaultValue": 100,
+    "overwritten": false,
+    "protected": false,
+    "validation": "required,min=1,max=50000"
+  },
+  {
+    "key": "storage.staging.upload.trigger.count",
+    "value": 10000,
+    "defaultValue": 10000,
+    "overwritten": false,
+    "protected": false,
+    "validation": "required,min=1,max=10000000"
+  },
+  {
+    "key": "storage.staging.upload.trigger.interval",
+    "value": "1m0s",
+    "defaultValue": "1m0s",
+    "overwritten": false,
+    "protected": false,
+    "validation": "required,minDuration=1s,maxDuration=30m"
+  },
+  {
+    "key": "storage.staging.upload.trigger.size",
+    "value": "1MB",
+    "defaultValue": "1MB",
+    "overwritten": false,
+    "protected": false,
+    "validation": "required,minBytes=100B,maxBytes=50MB"
+  },
+  {
+    "key": "storage.target.import.trigger.count",
+    "value": 50000,
+    "defaultValue": 50000,
+    "overwritten": false,
+    "protected": false,
+    "validation": "required,min=1,max=10000000"
+  },
+  {
+    "key": "storage.target.import.trigger.interval",
+    "value": "5m0s",
+    "defaultValue": "5m0s",
+    "overwritten": false,
+    "protected": false,
+    "validation": "required,minDuration=60s,maxDuration=24h"
+  },
+  {
+    "key": "storage.target.import.trigger.size",
+    "value": "5MB",
+    "defaultValue": "5MB",
+    "overwritten": false,
+    "protected": false,
+    "validation": "required,minBytes=100B,maxBytes=500MB"
+  },
+  {
+    "key": "storage.volumeAssignment.count",
+    "value": 1,
+    "defaultValue": 1,
+    "overwritten": false,
+    "protected": false,
+    "validation": "required,min=1,max=100"
+  },
+  {
+    "key": "storage.volumeAssignment.preferredTypes",
+    "value": [
+      "default"
+    ],
+    "defaultValue": [
+      "default"
+    ],
+    "overwritten": false,
+    "protected": false,
+    "validation": "required,min=1"
+  }
+]
+`), strings.TrimSpace(json.MustEncodeString(kvs, true)))
+}

--- a/internal/pkg/service/buffer/sink/tablesink/storage/file_test.go
+++ b/internal/pkg/service/buffer/sink/tablesink/storage/file_test.go
@@ -131,7 +131,7 @@ func TestFile_Validation(t *testing.T) {
 - "state" is a required field
 - "columns" is a required field
 - "assignment.config.count" is a required field
-- "assignment.config.preferredTypes" must contain at least 1 item
+- "assignment.config.preferredTypes" is a required field
 - "assignment.volumes" must contain at least 1 item
 `,
 			Value: File{

--- a/internal/pkg/service/buffer/sink/tablesink/storage/level/local/writer/disksync/config.go
+++ b/internal/pkg/service/buffer/sink/tablesink/storage/level/local/writer/disksync/config.go
@@ -47,7 +47,7 @@ type Config struct {
 	CheckInterval duration.Duration `json:"checkInterval,omitempty" configKey:"checkInterval" validate:"min=0,maxDuration=2s,required_if=Mode disk,required_if=Mode cache" configUsage:"Minimal interval between syncs."`
 	// CountTrigger defines the writes count after the sync will be triggered.
 	// The number is count of the high-level writers, e.g., one table row = one write operation.
-	CountTrigger uint `json:"countTrigger,omitempty" configKey:"countTrigger" validate:"max=1000000,required_if=Mode disk,required_if=Mode cache" configUsage:"Written records count to trigger sync."`
+	CountTrigger uint `json:"countTrigger,omitempty" configKey:"countTrigger" validate:"min=0,max=1000000,required_if=Mode disk,required_if=Mode cache" configUsage:"Written records count to trigger sync."`
 	// BytesTrigger defines the size after the sync will be triggered.
 	// Bytes are measured at the beginning of the writers chain.
 	BytesTrigger datasize.ByteSize `json:"bytesTrigger,omitempty" configKey:"bytesTrigger" validate:"maxBytes=100MB,required_if=Mode disk,required_if=Mode cache" configUsage:"Written size to trigger sync."`

--- a/internal/pkg/service/buffer/sink/tablesink/storage/volume/assignment/config.go
+++ b/internal/pkg/service/buffer/sink/tablesink/storage/volume/assignment/config.go
@@ -10,7 +10,7 @@ type Config struct {
 	// PreferredTypes contains a list of preferred volume types,
 	// the value is used when assigning volumes to the file slices, see writer.Volumes.VolumesFor.
 	// The first value is the most preferred volume type.
-	PreferredTypes []string `json:"preferredTypes" configKey:"preferredTypes" validate:"min=1" configUsage:"List of preferred volume types, start with the most preferred."`
+	PreferredTypes []string `json:"preferredTypes" configKey:"preferredTypes" validate:"required,min=1" configUsage:"List of preferred volume types, start with the most preferred."`
 }
 
 // ConfigPatch is same as the Config, but with optional/nullable fields.

--- a/internal/pkg/service/common/configmap/flags.go
+++ b/internal/pkg/service/common/configmap/flags.go
@@ -74,7 +74,7 @@ func StructToFlags(fs *pflag.FlagSet, v any, outFlagToField map[string]orderedma
 			case bool:
 				fs.Bool(flagName, v, usage)
 			case string:
-				if vc.Value.IsZero() {
+				if !vc.Value.IsValid() || vc.Value.IsZero() {
 					// Don't set the default Value, if the original Value is empty.
 					// For example empty time.Duration(0) is represented as not empty string "0s",
 					// but we don't want to show the empty string, as we do not do in other empty cases either.
@@ -103,8 +103,8 @@ func StructToFlags(fs *pflag.FlagSet, v any, outFlagToField map[string]orderedma
 	})
 }
 
-func mapAndFilterField() func(field reflect.StructField) (fieldName string, ok bool) {
-	return func(field reflect.StructField) (fieldName string, ok bool) {
+func mapAndFilterField() func(field reflect.StructField, path orderedmap.Path) (fieldName string, ok bool) {
+	return func(field reflect.StructField, path orderedmap.Path) (fieldName string, ok bool) {
 		// Field must have tag
 		if tag, found := field.Tag.Lookup(configKeyTag); found {
 			parts := strings.Split(tag, tagValuesSeparator)

--- a/internal/pkg/service/common/configmap/visit_test.go
+++ b/internal/pkg/service/common/configmap/visit_test.go
@@ -1,0 +1,51 @@
+package configmap
+
+import (
+	"github.com/keboola/go-utils/pkg/orderedmap"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	"reflect"
+	"testing"
+)
+
+type VisitStruct struct {
+	String  Value[CustomStringType]
+	Int     Value[CustomIntType]
+	Nested1 Nested
+	Nested2 *Nested
+}
+
+func TestVisit(t *testing.T) {
+	t.Parallel()
+
+	var keys []string
+	err := Visit(reflect.ValueOf(VisitStruct{}), VisitConfig{
+		OnField: func(field reflect.StructField, path orderedmap.Path) (fieldName string, ok bool) {
+			return field.Name, true
+		},
+		OnValue: func(vc *VisitContext) error {
+			keys = append(keys, vc.MappedPath.String())
+			return nil
+		},
+	})
+
+	require.NoError(t, err)
+	assert.Equal(t, []string{
+		"",
+		"String",
+		"String.Value",
+		"String.SetBy",
+		"Int",
+		"Int.Value",
+		"Int.SetBy",
+		"Nested1",
+		"Nested1.Ignored",
+		"Nested1.Foo",
+		"Nested1.Bar",
+		// Visit function visits also empty pointers, see Nested2 field
+		"Nested2",
+		"Nested2.Ignored",
+		"Nested2.Foo",
+		"Nested2.Bar",
+	}, keys)
+}

--- a/internal/pkg/service/common/configmap/visit_test.go
+++ b/internal/pkg/service/common/configmap/visit_test.go
@@ -1,11 +1,12 @@
 package configmap
 
 import (
+	"reflect"
+	"testing"
+
 	"github.com/keboola/go-utils/pkg/orderedmap"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
-	"reflect"
-	"testing"
 )
 
 type VisitStruct struct {

--- a/internal/pkg/service/common/configpatch/doc.go
+++ b/internal/pkg/service/common/configpatch/doc.go
@@ -1,0 +1,19 @@
+// Package configpatch provides tools to replace part of a configuration structure from a patch structure.
+//
+// Fields are matched by a name tag value, see the WithNameTag option.
+//
+// Fields marked with a protected tag can only be modified if the WithModifyProtected option is used.
+// Name of the protected tag can be modified with the WithProtectedTag option.
+//
+// # Example structures
+//
+//	type Config struct {
+//	  Foo string `configKey:"foo"`
+//	  Bar int    `configKey:"bar" protected:"true" validation:"required"`
+//	}
+//
+//	type ConfigPatch struct {
+//	  Foo *string `json:"foo"`
+//	  Bar *int    `json:"bar"`
+//	}
+package configpatch

--- a/internal/pkg/service/common/configpatch/dump.go
+++ b/internal/pkg/service/common/configpatch/dump.go
@@ -1,0 +1,174 @@
+package configpatch
+
+import (
+	"reflect"
+	"sort"
+	"strings"
+
+	"github.com/keboola/go-utils/pkg/orderedmap"
+
+	"github.com/keboola/keboola-as-code/internal/pkg/service/common/configmap"
+	"github.com/keboola/keboola-as-code/internal/pkg/utils/errors"
+	"github.com/keboola/keboola-as-code/internal/pkg/utils/strhelper"
+)
+
+// DumpKV is result of the patch operation for a one configuration key.
+type DumpKV struct {
+	// KeyPath is a configuration key, parts are joined with a dot "." separator.
+	KeyPath string `json:"key"`
+	// Value is an actual value of the configuration key.
+	Value any `json:"value"`
+	// DefaultValue of the configuration key.
+	DefaultValue any `json:"defaultValue"`
+	// Overwritten is true, if the DefaultValue was replaced by a value from the path.
+	Overwritten bool `json:"overwritten"`
+	// Protected configuration keys can be modified only by a super-admin.
+	Protected bool `json:"protected"`
+	// Validation contains validation rules of the field, if any.
+	Validation string `json:"validation,omitempty"`
+}
+
+// DumpKVs generates key-value pairs from a configuration structure and a patch structure.
+// Only keys found in both, configuration and patch structure, are processed.
+// The structure is flattened, keys are joined with a dot "." separator.
+// Each key-value pair contains information whether the value was overwritten from the patch or not.
+func DumpKVs(configStruct, patchStruct any, opts ...Option) ([]DumpKV, error) {
+	cfg := newConfig(opts)
+
+	var kvs []DumpKV
+	errs := errors.NewMultiError()
+
+	// Visit patch, get patched values
+	patchKeys := make(map[string]bool)
+	patchedValues := make(map[string]reflect.Value)
+	visitStruct(cfg.nameTags, patchStruct, func(vc *configmap.VisitContext) {
+		// Process only leaf values with a field name
+		if !vc.Leaf || vc.MappedPath.Last().String() == "" {
+			return
+		}
+
+		// Patch field must be a pointer
+		keyPath := vc.MappedPath.String()
+		if vc.Type.Kind() != reflect.Pointer {
+			errs.Append(errors.Errorf(`patch field "%s" is not a pointer, but "%s"`, keyPath, vc.Type))
+			return
+		}
+
+		// Store found key
+		patchKeys[keyPath] = true
+
+		// Nil means not set
+		if vc.Value.IsValid() && !vc.Value.IsNil() {
+			patchedValues[keyPath] = vc.Value.Elem()
+		}
+	})
+
+	// Visit config, generate output key-value pairs
+	var patchedProtected []string
+	visitStruct(cfg.nameTags, configStruct, func(vc *configmap.VisitContext) {
+		// Process only leaf values with a field name
+		if !vc.Leaf || vc.MappedPath.Last().String() == "" {
+			return
+		}
+
+		// Ignore fields which are not present in the patch
+		keyPath := vc.MappedPath.String()
+		if !patchKeys[keyPath] {
+			return
+		}
+
+		// Get patched value, if any
+		defaultValue := vc.Value
+		value, overwritten := patchedValues[keyPath]
+		if overwritten {
+			// Deleted the map key, so unused patch keys can be processed bellow
+			delete(patchedValues, keyPath)
+
+			// Validate type
+			if value.Type() != defaultValue.Type() {
+				errs.Append(errors.Errorf(
+					`patch field "%s" type "%s" doesn't match config field type "%s"`,
+					keyPath,
+					value.Type().String(),
+					defaultValue.Type().String(),
+				))
+				return
+			}
+		} else {
+			// The key is not overwritten by the patch, use default value
+			value = defaultValue
+		}
+
+		// Note overwritten protected field
+		protected := vc.StructField.Tag.Get(cfg.protectedTag) == cfg.protectedTagValue
+		if overwritten && protected && !cfg.modifyProtected {
+			patchedProtected = append(patchedProtected, keyPath)
+		}
+
+		// Generate DumpKV
+		kvs = append(kvs, DumpKV{
+			KeyPath:      keyPath,
+			Value:        value.Interface(),
+			DefaultValue: defaultValue.Interface(),
+			Overwritten:  overwritten,
+			Protected:    protected,
+			Validation:   vc.Validate,
+		})
+	})
+
+	// Check unexpected patch keys
+	if len(patchedValues) > 0 {
+		var unused []string
+		for keyPath := range patchedValues {
+			unused = append(unused, keyPath)
+		}
+		sort.Strings(unused)
+		errs.Append(errors.Errorf(
+			`patch contains unexpected keys: "%s"`,
+			strhelper.Truncate(strings.Join(unused, `", "`), 50, "…"),
+		))
+	}
+
+	// Check overwritten protected keys
+	if len(patchedProtected) > 0 {
+		errs.Append(errors.Errorf(`cannot modify protected fields: "%s"`, strings.Join(patchedProtected, `", "`)))
+	}
+
+	// Check errors
+	if err := errs.ErrorOrNil(); err != nil {
+		return nil, err
+	}
+
+	// Sort
+	sort.SliceStable(kvs, func(i, j int) bool {
+		return kvs[i].KeyPath < kvs[j].KeyPath
+	})
+
+	return kvs, nil
+}
+
+func visitStruct(nameTags []string, root any, onValue func(vc *configmap.VisitContext)) {
+	err := configmap.Visit(
+		reflect.ValueOf(root),
+		configmap.VisitConfig{
+			OnField: func(field reflect.StructField, path orderedmap.Path) (fieldName string, ok bool) {
+				for _, nameTag := range nameTags {
+					tagValue := field.Tag.Get(nameTag)
+					fieldName, _, _ = strings.Cut(tagValue, ",")
+					if fieldName != "" {
+						break
+					}
+				}
+				return fieldName, fieldName != ""
+			},
+			OnValue: func(vc *configmap.VisitContext) error {
+				onValue(vc)
+				return nil
+			},
+		},
+	)
+	// OnValue function returns no error, so no error is expected at all
+	if err != nil {
+		panic(errors.New("no error expected"))
+	}
+}

--- a/internal/pkg/service/common/configpatch/dump_test.go
+++ b/internal/pkg/service/common/configpatch/dump_test.go
@@ -1,0 +1,288 @@
+package configpatch_test
+
+import (
+	"strings"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+
+	"github.com/keboola/keboola-as-code/internal/pkg/service/common/configpatch"
+)
+
+type Config struct {
+	Key1 string        `json:"foo1"`
+	Key2 int           `json:"foo2" alternative:"baz2" protected:"true"`
+	Key3 ConfigNested1 `json:"foo3,omitempty" alternative:"baz3"`
+}
+
+type ConfigNested1 struct {
+	Key4 string        `json:"foo4"`
+	Key5 int           `json:"foo5" alternative:"baz5"`
+	Key6 ConfigNested2 `json:"foo6,omitempty"`
+}
+
+type ConfigNested2 struct {
+	Key7 []string `json:"foo7"`
+	Key8 bool     `json:"foo8" protected:"true"`
+}
+
+type ConfigPatch struct {
+	Key1 *string             `json:"foo1"`
+	Key2 *int                `json:"foo2" alternative:"baz2"`
+	Key3 *ConfigNested1Patch `json:"foo3,omitempty" alternative:"baz3"`
+}
+
+type ConfigNested1Patch struct {
+	Key5 *int                `json:"foo5" alternative:"baz5"`
+	Key6 *ConfigNested2Patch `json:"foo6,omitempty"`
+}
+
+type ConfigNested2Patch struct {
+	Key7 *[]string `json:"foo7"`
+	Key8 *bool     `json:"foo8"`
+}
+
+type ConfigPatchInvalid struct {
+	Key1 string  `json:"foo1"`
+	Key2 *string `json:"foo2"`
+	Key8 *string `json:"foo8"`
+	Key9 *int    `json:"foo9"`
+}
+
+func TestDumpKVs_EmptyPatch(t *testing.T) {
+	t.Parallel()
+
+	kvs, err := configpatch.DumpKVs(
+		newConfig(),
+		ConfigPatch{},
+	)
+
+	require.NoError(t, err)
+	assert.Equal(t, []configpatch.DumpKV{
+		{
+			KeyPath:      "foo1",
+			Value:        "bar1",
+			DefaultValue: "bar1",
+		},
+		{
+			KeyPath:      "foo2",
+			Value:        123,
+			DefaultValue: 123,
+			Protected:    true,
+		},
+		{
+			KeyPath:      "foo3.foo5",
+			Value:        234,
+			DefaultValue: 234,
+		},
+		{
+			KeyPath:      "foo3.foo6.foo7",
+			Value:        []string{"bar7"},
+			DefaultValue: []string{"bar7"},
+		},
+		{
+			KeyPath:      "foo3.foo6.foo8",
+			Value:        true,
+			DefaultValue: true,
+			Protected:    true,
+		},
+	}, kvs)
+}
+
+func TestDumpKVs_Ok(t *testing.T) {
+	t.Parallel()
+
+	kvs, err := configpatch.DumpKVs(
+		newConfig(),
+		newConfigPatch(),
+	)
+
+	require.NoError(t, err)
+	assert.Equal(t, []configpatch.DumpKV{
+		{
+			KeyPath:      "foo1",
+			Value:        "patch1",
+			DefaultValue: "bar1",
+			Overwritten:  true,
+		},
+		{
+			KeyPath:      "foo2",
+			Value:        123,
+			DefaultValue: 123,
+			Protected:    true,
+		},
+		{
+			KeyPath:      "foo3.foo5",
+			Value:        789,
+			DefaultValue: 234,
+			Overwritten:  true,
+		},
+		{
+			KeyPath:      "foo3.foo6.foo7",
+			Value:        []string{"patch7"},
+			DefaultValue: []string{"bar7"},
+			Overwritten:  true,
+		},
+		{
+			KeyPath:      "foo3.foo6.foo8",
+			Value:        true,
+			DefaultValue: true,
+			Protected:    true,
+		},
+	}, kvs)
+}
+
+func TestDumpKVs_CustomTags(t *testing.T) {
+	t.Parallel()
+
+	kvs, err := configpatch.DumpKVs(
+		newConfig(),
+		ConfigPatch{
+			Key2: ptr(234),
+			Key3: &ConfigNested1Patch{
+				Key5: ptr(345),
+			},
+		},
+		configpatch.WithNameTag("alternative"),   // <<<<<
+		configpatch.WithProtectedTag("notfound"), // <<<<<
+	)
+
+	require.NoError(t, err)
+	assert.Equal(t, []configpatch.DumpKV{
+		{
+			KeyPath:      "baz2",
+			Value:        234,
+			DefaultValue: 123,
+			Overwritten:  true,
+		},
+		{
+			KeyPath:      "baz3.baz5",
+			Value:        345,
+			DefaultValue: 234,
+			Overwritten:  true,
+		},
+	}, kvs)
+}
+
+func TestDumpKVs_InvalidPatch(t *testing.T) {
+	t.Parallel()
+
+	_, err := configpatch.DumpKVs(
+		newConfig(),
+		newConfigPatchInvalid(),
+	)
+
+	if assert.Error(t, err) {
+		assert.Equal(t, strings.TrimSpace(`
+- patch field "foo1" is not a pointer, but "string"
+- patch field "foo2" type "string" doesn't match config field type "int"
+- patch contains unexpected keys: "foo8", "foo9"
+`), err.Error())
+	}
+}
+
+func TestDumpKVs_Protected_Ok(t *testing.T) {
+	t.Parallel()
+
+	kvs, err := configpatch.DumpKVs(
+		newConfig(),
+		newConfigPatchProtected(),
+		configpatch.WithModifyProtected(), // <<<<<
+	)
+
+	require.NoError(t, err)
+	assert.Equal(t, []configpatch.DumpKV{
+		{
+			KeyPath:      "foo1",
+			Value:        "bar1",
+			DefaultValue: "bar1",
+		},
+		{
+			KeyPath:      "foo2",
+			Value:        567,
+			DefaultValue: 123,
+			Overwritten:  true,
+			Protected:    true,
+		},
+		{
+			KeyPath:      "foo3.foo5",
+			Value:        789,
+			DefaultValue: 234,
+			Overwritten:  true,
+		},
+		{
+			KeyPath:      "foo3.foo6.foo7",
+			Value:        []string{"bar7"},
+			DefaultValue: []string{"bar7"},
+			Overwritten:  false,
+		},
+		{
+			KeyPath:      "foo3.foo6.foo8",
+			Value:        true,
+			DefaultValue: true,
+			Overwritten:  true,
+			Protected:    true,
+		},
+	}, kvs)
+}
+
+func TestDumpKVs_Protected_Error(t *testing.T) {
+	t.Parallel()
+	_, err := configpatch.DumpKVs(newConfig(), newConfigPatchProtected())
+	if assert.Error(t, err) {
+		assert.Equal(t, `cannot modify protected fields: "foo2", "foo3.foo6.foo8"`, err.Error())
+	}
+}
+
+func newConfig() Config {
+	return Config{
+		Key1: "bar1",
+		Key2: 123,
+		Key3: ConfigNested1{
+			Key4: "bar4",
+			Key5: 234,
+			Key6: ConfigNested2{
+				Key7: []string{"bar7"},
+				Key8: true,
+			},
+		},
+	}
+}
+
+func newConfigPatch() ConfigPatch {
+	return ConfigPatch{
+		Key1: ptr("patch1"),
+		Key3: &ConfigNested1Patch{
+			Key5: ptr(789),
+			Key6: &ConfigNested2Patch{
+				Key7: ptr([]string{"patch7"}),
+			},
+		},
+	}
+}
+
+func newConfigPatchProtected() ConfigPatch {
+	return ConfigPatch{
+		Key2: ptr(567),
+		Key3: &ConfigNested1Patch{
+			Key5: ptr(789),
+			Key6: &ConfigNested2Patch{
+				Key8: ptr(true),
+			},
+		},
+	}
+}
+
+func newConfigPatchInvalid() ConfigPatchInvalid {
+	return ConfigPatchInvalid{
+		Key1: "patch1",
+		Key2: ptr("patch2"),
+		Key8: ptr("patch8"),
+		Key9: ptr(789),
+	}
+}
+
+func ptr[T any](v T) *T {
+	return &v
+}

--- a/internal/pkg/service/common/configpatch/option.go
+++ b/internal/pkg/service/common/configpatch/option.go
@@ -1,0 +1,47 @@
+package configpatch
+
+type Option func(*config)
+
+type config struct {
+	// modifyProtected enables modification of configuration fields tagged as protected from a patch.
+	modifyProtected bool
+	// nameTags field provides tags which may contain the field name.
+	nameTags []string
+	// protectedTag is a tag that marks the field on which it is defined as protected.
+	protectedTag      string
+	protectedTagValue string
+}
+
+func newConfig(opts []Option) config {
+	cfg := config{
+		modifyProtected:   false,
+		nameTags:          []string{"configKey", "json"},
+		protectedTag:      "protected",
+		protectedTagValue: "true",
+	}
+	for _, o := range opts {
+		o(&cfg)
+	}
+	return cfg
+}
+
+// WithModifyProtected enables modification of configuration fields tagged as protected from a patch.
+func WithModifyProtected() Option {
+	return func(c *config) {
+		c.modifyProtected = true
+	}
+}
+
+// WithNameTag sets the tags which may contain the field name.
+func WithNameTag(v ...string) Option {
+	return func(c *config) {
+		c.nameTags = v
+	}
+}
+
+// WithProtectedTag sets the tag that marks the field on which it is defined as protected.
+func WithProtectedTag(v string) Option {
+	return func(c *config) {
+		c.protectedTag = v
+	}
+}


### PR DESCRIPTION
Jira: https://keboola.atlassian.net/browse/PSGO-388

**Changes:**
- `configmap.Visit` utility visits also `nil` pointers to deep.
-  Added `configpatch.ToKVs` function.

-----------

#### What do we need to achieve?

- There is a global Stream Service configuration, see [here](https://github.com/keboola/keboola-as-code/blob/7aad8567ea8075608724c21e265cbfbd96b25d8b/internal/pkg/service/buffer/config/config_test.go#L21-L39).
- These settings can be customized per Sink - **via the API**. 
  - Some settings cannot be patched - they are not in the `ConfigPatch` structure. 
  - Some settings can only be changed by the superadmin - `protected:true` tag.
  - And other: a normal user can change them.


In this PR, I want to achieve that we can present the status of these settings **via the API**:
- Default value.
- Actual value.
- Is the key overwritten by in the Sink definition? Or is the default value used?
- Is the key protected? Or can a normal user modify it?
- Plus, list of validation rules, maybe it will be used dynamically in the UI.

See dump of the Stream API config, in the new test bellow:
https://github.com/keboola/keboola-as-code/blob/1bceaecd1d8572a9cc6e0d544682c4db189e6024/internal/pkg/service/buffer/sink/tablesink/config_test.go#L37-L93
