### PR TITLE
feat: Add configpatch.BindKV function

### DIFF
--- a/internal/pkg/service/common/configmap/flags.go
+++ b/internal/pkg/service/common/configmap/flags.go
@@ -103,7 +103,7 @@ func StructToFlags(fs *pflag.FlagSet, v any, outFlagToField map[string]orderedma
 	})
 }
 
-func mapAndFilterField() func(field reflect.StructField, path orderedmap.Path) (fieldName string, ok bool) {
+func mapAndFilterField() OnField {
 	return func(field reflect.StructField, path orderedmap.Path) (fieldName string, ok bool) {
 		// Field must have tag
 		if tag, found := field.Tag.Lookup(configKeyTag); found {

--- a/internal/pkg/service/common/configmap/visit.go
+++ b/internal/pkg/service/common/configmap/visit.go
@@ -12,12 +12,16 @@ type OnField func(field reflect.StructField, path orderedmap.Path) (fieldName st
 
 type OnValue func(vc *VisitContext) error
 
+type AfterValue func(vc *VisitContext) error
+
 type VisitConfig struct {
 	// OnField maps field to a custom field name, for example from a tag.
 	// If ok == false, then the field is ignored.
 	OnField OnField
 	// OnValue is called on each field
 	OnValue OnValue
+	// AfterValue is called after all nested fields are processed, if any. Can be nil.
+	AfterValue AfterValue
 }
 
 type VisitContext struct {
@@ -130,6 +134,13 @@ func doVisit(vc *VisitContext, cfg VisitConfig) error {
 
 			// Step down
 			if err := doVisit(field, cfg); err != nil {
+				return err
+			}
+		}
+
+		// Call AfterValue callback
+		if cfg.AfterValue != nil {
+			if err := cfg.AfterValue(vc); err != nil {
 				return err
 			}
 		}

--- a/internal/pkg/service/common/configmap/visit.go
+++ b/internal/pkg/service/common/configmap/visit.go
@@ -8,12 +8,16 @@ import (
 	"github.com/keboola/keboola-as-code/internal/pkg/utils/errors"
 )
 
+type OnField func(field reflect.StructField, path orderedmap.Path) (fieldName string, ok bool)
+
+type OnValue func(vc *VisitContext) error
+
 type VisitConfig struct {
 	// OnField maps field to a custom field name, for example from a tag.
 	// If ok == false, then the field is ignored.
-	OnField func(field reflect.StructField, path orderedmap.Path) (fieldName string, ok bool)
+	OnField OnField
 	// OnValue is called on each field
-	OnValue func(vc *VisitContext) error
+	OnValue OnValue
 }
 
 type VisitContext struct {

--- a/internal/pkg/service/common/configmap/visit.go
+++ b/internal/pkg/service/common/configmap/visit.go
@@ -57,6 +57,13 @@ func Visit(value reflect.Value, cfg VisitConfig) error {
 	return doVisit(vc, cfg)
 }
 
+// MustVisit is similar to the Visit method, but no error is expected.
+func MustVisit(value reflect.Value, cfg VisitConfig) {
+	if err := Visit(value, cfg); err != nil {
+		panic(errors.New("no error expected"))
+	}
+}
+
 func doVisit(vc *VisitContext, cfg VisitConfig) error {
 	onLeaf := func(primitiveValue reflect.Value) error {
 		vc.PrimitiveValue = primitiveValue

--- a/internal/pkg/service/common/configpatch/bind_test.go
+++ b/internal/pkg/service/common/configpatch/bind_test.go
@@ -1,0 +1,152 @@
+package configpatch_test
+
+import (
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+
+	"github.com/keboola/keboola-as-code/internal/pkg/service/common/configpatch"
+)
+
+type ConfigPatchTextUnmarshaller struct {
+	Duration *time.Duration `json:"duration"`
+}
+
+func TestBindKVs_NoStructPointer(t *testing.T) {
+	t.Parallel()
+	assert.PanicsWithError(t, `patch struct must be a pointer to a struct, found "configpatch_test.ConfigPatch"`, func() {
+		var kvs []configpatch.BindKV
+		_ = configpatch.BindKVs(ConfigPatch{}, kvs)
+	})
+}
+
+func TestBindKVs_Empty(t *testing.T) {
+	t.Parallel()
+	patch := ConfigPatch{}
+	var kvs []configpatch.BindKV
+	require.NoError(t, configpatch.BindKVs(&patch, kvs))
+	assert.Equal(t, patch, ConfigPatch{})
+}
+
+func TestBindKVs_One(t *testing.T) {
+	t.Parallel()
+	patch := ConfigPatch{}
+	kvs := []configpatch.BindKV{
+		{KeyPath: "foo3.foo5", Value: 789},
+	}
+	require.NoError(t, configpatch.BindKVs(&patch, kvs))
+	assert.Equal(t, patch, ConfigPatch{
+		Key3: &ConfigNested1Patch{Key5: ptr(789)},
+	})
+}
+
+func TestBindKVs_DeepNested(t *testing.T) {
+	t.Parallel()
+	patch := ConfigPatch{}
+	kvs := []configpatch.BindKV{
+		{KeyPath: "foo3.foo6.foo8", Value: false},
+	}
+	require.NoError(t, configpatch.BindKVs(&patch, kvs))
+	assert.Equal(t, patch, ConfigPatch{
+		Key3: &ConfigNested1Patch{
+			Key6: &ConfigNested2Patch{
+				Key8: ptr(false),
+			},
+		},
+	})
+}
+
+func TestBindKVs_Multiple(t *testing.T) {
+	t.Parallel()
+	patch := ConfigPatch{}
+	kvs := []configpatch.BindKV{
+		{KeyPath: "foo1", Value: "bar1"},
+		{KeyPath: "foo3.foo5", Value: 789},
+	}
+	require.NoError(t, configpatch.BindKVs(&patch, kvs))
+	assert.Equal(t, patch, ConfigPatch{
+		Key1: ptr("bar1"),
+		Key3: &ConfigNested1Patch{Key5: ptr(789)},
+	})
+}
+
+func TestBindKVs_UnmarshalText_Ok(t *testing.T) {
+	t.Parallel()
+	patch := ConfigPatchTextUnmarshaller{}
+	kvs := []configpatch.BindKV{
+		{KeyPath: "duration", Value: "1h20m"},
+	}
+	require.NoError(t, configpatch.BindKVs(&patch, kvs))
+	assert.Equal(t, patch, ConfigPatchTextUnmarshaller{
+		Duration: ptr(time.Hour + 20*time.Minute),
+	})
+}
+
+func TestBindKVs_UnmarshalText_Error(t *testing.T) {
+	t.Parallel()
+	patch := ConfigPatchTextUnmarshaller{}
+	kvs := []configpatch.BindKV{
+		{KeyPath: "duration", Value: "invalid value"},
+	}
+	if err := configpatch.BindKVs(&patch, kvs); assert.Error(t, err) {
+		assert.Equal(t, `invalid "duration": time: invalid duration "invalid value"`, err.Error())
+	}
+}
+
+func TestBindKVs_CompatibleType(t *testing.T) {
+	t.Parallel()
+	patch := ConfigPatch{}
+	kvs := []configpatch.BindKV{
+		{KeyPath: "foo3.foo5", Value: float64(789)}, // different, but compatible type
+	}
+	require.NoError(t, configpatch.BindKVs(&patch, kvs))
+	assert.Equal(t, patch, ConfigPatch{
+		Key3: &ConfigNested1Patch{Key5: ptr(789)},
+	})
+}
+
+func TestBindKVs_IncompatibleType(t *testing.T) {
+	t.Parallel()
+	patch := ConfigPatch{}
+	kvs := []configpatch.BindKV{
+		{KeyPath: "foo3.foo5", Value: "789"},
+	} // incompatible type, expected int
+	if err := configpatch.BindKVs(&patch, kvs); assert.Error(t, err) {
+		assert.Equal(t, `invalid "foo3.foo5" value: found type "string", expected "int"`, err.Error())
+	}
+}
+
+func TestBindKVs_DuplicateKV(t *testing.T) {
+	t.Parallel()
+	patch := ConfigPatch{}
+	kvs := []configpatch.BindKV{
+		{KeyPath: "foo3.foo5", Value: 789},
+		{KeyPath: "foo3.foo5", Value: 789},
+	}
+	if err := configpatch.BindKVs(&patch, kvs); assert.Error(t, err) {
+		assert.Equal(t, `key "foo3.foo5" is defined multiple times`, err.Error())
+	}
+}
+
+func TestBindKVs_KeyNotFound(t *testing.T) {
+	t.Parallel()
+	patch := ConfigPatch{}
+	kvs := []configpatch.BindKV{
+		{KeyPath: `foo.bar.1`, Value: 123},
+		{KeyPath: `foo.bar.2`, Value: 234},
+	}
+	if err := configpatch.BindKVs(&patch, kvs); assert.Error(t, err) {
+		assert.Equal(t, `key not found: "foo.bar.1", "foo.bar.2"`, err.Error())
+	}
+}
+
+func TestBindKVs_InvalidPatchStruct(t *testing.T) {
+	t.Parallel()
+	patch := ConfigPatchInvalid{}
+	var kvs []configpatch.BindKV
+	if err := configpatch.BindKVs(&patch, kvs); assert.Error(t, err) {
+		assert.Equal(t, `patch field "foo1" is not a pointer, but "string"`, err.Error())
+	}
+}

--- a/internal/pkg/service/common/configpatch/visit.go
+++ b/internal/pkg/service/common/configpatch/visit.go
@@ -1,0 +1,23 @@
+package configpatch
+
+import (
+	"reflect"
+	"strings"
+
+	"github.com/keboola/go-utils/pkg/orderedmap"
+
+	"github.com/keboola/keboola-as-code/internal/pkg/service/common/configmap"
+)
+
+func matchTaggedFields(nameTags []string) configmap.OnField {
+	return func(field reflect.StructField, path orderedmap.Path) (fieldName string, ok bool) {
+		for _, nameTag := range nameTags {
+			tagValue := field.Tag.Get(nameTag)
+			fieldName, _, _ = strings.Cut(tagValue, ",")
+			if fieldName != "" {
+				break
+			}
+		}
+		return fieldName, fieldName != ""
+	}
+}


### PR DESCRIPTION
Jira: https://keboola.atlassian.net/browse/PSGO-388

**Changes:**
- Added `configpatch.BindKV` function.

-------------------

**In the previous PR: https://github.com/keboola/keboola-as-code/pull/1543**, we implemented conversion of a `Config + ConfigPatch` structs to `Key-Value` pairs, it will be used by the `GET` requests - to convert database entities to API responses.

**In this PR is a reverse part**,  we bind `Key-Value` pairs from a `PATCH` request, to a `ConfigPatch` struct. It will be used to validate and apply modifications provided by the user.

Real world example:
https://github.com/keboola/keboola-as-code/blob/e1ae4009ae2b3679d470d8f44fde32c75188fd3d/internal/pkg/service/buffer/sink/tablesink/config_test.go#L251-L271

-----------
