### PR TITLE
feat: Add configpatch.Apply function

### DIFF
--- a/internal/pkg/service/buffer/sink/tablesink/config.go
+++ b/internal/pkg/service/buffer/sink/tablesink/config.go
@@ -23,11 +23,3 @@ func NewConfig() Config {
 		Storage:    storage.NewConfig(),
 	}
 }
-
-// With copies values from the ConfigPatch, if any.
-func (c Config) With(v ConfigPatch) Config {
-	if v.Storage != nil {
-		c.Storage = c.Storage.With(*v.Storage)
-	}
-	return c
-}

--- a/internal/pkg/service/buffer/sink/tablesink/storage/compression/config.go
+++ b/internal/pkg/service/buffer/sink/tablesink/storage/compression/config.go
@@ -100,53 +100,6 @@ func NewZSTDConfig() Config {
 	}
 }
 
-// With copies values from the ConfigPatch, if any.
-func (c Config) With(v ConfigPatch) Config {
-	if v.Type != nil {
-		c.Type = *v.Type
-	}
-	if c.GZIP != nil && v.GZIP != nil {
-		patched := c.GZIP.With(*v.GZIP)
-		c.GZIP = &patched
-	}
-	if c.ZSTD != nil && v.ZSTD != nil {
-		patched := c.ZSTD.With(*v.ZSTD)
-		c.ZSTD = &patched
-	}
-	return c
-}
-
-// With copies values from the GZIPConfigPatch, if any.
-func (c GZIPConfig) With(v GZIPConfigPatch) GZIPConfig {
-	if v.Level != nil {
-		c.Level = *v.Level
-	}
-	if v.Implementation != nil {
-		c.Implementation = *v.Implementation
-	}
-	if v.BlockSize != nil {
-		c.BlockSize = *v.BlockSize
-	}
-	if v.Concurrency != nil {
-		c.Concurrency = *v.Concurrency
-	}
-	return c
-}
-
-// With copies values from the ZSTDConfigPatch, if any.
-func (c ZSTDConfig) With(v ZSTDConfigPatch) ZSTDConfig {
-	if v.Level != nil {
-		c.Level = *v.Level
-	}
-	if v.WindowSize != nil {
-		c.WindowSize = *v.WindowSize
-	}
-	if v.Concurrency != nil {
-		c.Concurrency = *v.Concurrency
-	}
-	return c
-}
-
 // Simplify removes unnecessary parts of the configuration.
 func (c Config) Simplify() Config {
 	if c.Type != TypeGZIP {

--- a/internal/pkg/service/buffer/sink/tablesink/storage/config.go
+++ b/internal/pkg/service/buffer/sink/tablesink/storage/config.go
@@ -27,24 +27,6 @@ type ConfigPatch struct {
 	Target           *target.ConfigPatch     `json:"target,omitempty"`
 }
 
-// With copies values from the ConfigPatch, if any.
-func (c Config) With(v ConfigPatch) Config {
-	// Copy values from the ConfigPatch, if any.
-	if v.VolumeAssignment != nil {
-		c.VolumeAssignment = c.VolumeAssignment.With(*v.VolumeAssignment)
-	}
-	if v.Local != nil {
-		c.Local = c.Local.With(*v.Local)
-	}
-	if v.Staging != nil {
-		c.Staging = c.Staging.With(*v.Staging)
-	}
-	if v.Target != nil {
-		c.Target = c.Target.With(*v.Target)
-	}
-	return c
-}
-
 func NewConfig() Config {
 	return Config{
 		VolumeAssignment:   assignment.NewConfig(),

--- a/internal/pkg/service/buffer/sink/tablesink/storage/config_test.go
+++ b/internal/pkg/service/buffer/sink/tablesink/storage/config_test.go
@@ -30,7 +30,7 @@ func TestConfig_With(t *testing.T) {
 
 	// Apply empty patch
 	patchedConfig1 := defaultConfig
-	require.NoError(t, configpatch.Apply(patchedConfig1, ConfigPatch{}))
+	require.NoError(t, configpatch.Apply(&patchedConfig1, ConfigPatch{}))
 	assert.Equal(t, defaultConfig, patchedConfig1)
 
 	// First patch
@@ -77,7 +77,7 @@ func TestConfig_With(t *testing.T) {
 	}
 	// Compare
 	patchedConfig2 := patchedConfig1
-	require.NoError(t, configpatch.Apply(patchedConfig2, ConfigPatch{
+	require.NoError(t, configpatch.Apply(&patchedConfig2, ConfigPatch{
 		Local:            localConfigPatch,
 		Staging:          stagingConfigPatch,
 		VolumeAssignment: volumeAssignmentPatch,
@@ -130,7 +130,7 @@ func TestConfig_With(t *testing.T) {
 	}
 	// Compare
 	patchedConfig3 := patchedConfig2
-	require.NoError(t, configpatch.Apply(patchedConfig3, ConfigPatch{
+	require.NoError(t, configpatch.Apply(&patchedConfig3, ConfigPatch{
 		Local:  localConfigPatch2,
 		Target: targetConfigPatch,
 	}))

--- a/internal/pkg/service/buffer/sink/tablesink/storage/level/local/config.go
+++ b/internal/pkg/service/buffer/sink/tablesink/storage/level/local/config.go
@@ -35,17 +35,3 @@ func NewConfig() Config {
 		DiskAllocation: diskalloc.NewConfig(),
 	}
 }
-
-// With copies values from the ConfigPatch, if any.
-func (c Config) With(v ConfigPatch) Config {
-	if v.Compression != nil {
-		c.Compression = c.Compression.With(*v.Compression)
-	}
-	if v.DiskSync != nil {
-		c.DiskSync = c.DiskSync.With(*v.DiskSync)
-	}
-	if v.DiskAllocation != nil {
-		c.DiskAllocation = c.DiskAllocation.With(*v.DiskAllocation)
-	}
-	return c
-}

--- a/internal/pkg/service/buffer/sink/tablesink/storage/level/local/config_test.go
+++ b/internal/pkg/service/buffer/sink/tablesink/storage/level/local/config_test.go
@@ -22,12 +22,12 @@ func TestConfig_With(t *testing.T) {
 
 	// Apply empty patch
 	patchedConfig1 := defaultConfig
-	require.NoError(t, configpatch.Apply(patchedConfig1, local.ConfigPatch{}))
+	require.NoError(t, configpatch.Apply(&patchedConfig1, local.ConfigPatch{}))
 	assert.Equal(t, defaultConfig, patchedConfig1)
 
 	// Apply full patch
 	patchedConfig2 := patchedConfig1
-	require.NoError(t, configpatch.Apply(patchedConfig2, local.ConfigPatch{
+	require.NoError(t, configpatch.Apply(&patchedConfig2, local.ConfigPatch{
 		Compression: &compression.ConfigPatch{
 			GZIP: &compression.GZIPConfigPatch{
 				Level:          test.Ptr(3),

--- a/internal/pkg/service/buffer/sink/tablesink/storage/level/local/writer/diskalloc/config.go
+++ b/internal/pkg/service/buffer/sink/tablesink/storage/level/local/writer/diskalloc/config.go
@@ -31,20 +31,6 @@ func NewConfig() Config {
 	}
 }
 
-// With copies values from the ConfigPatch, if any.
-func (c Config) With(v ConfigPatch) Config {
-	if v.Enabled != nil {
-		c.Enabled = *v.Enabled
-	}
-	if v.Size != nil {
-		c.Size = *v.Size
-	}
-	if v.SizePercent != nil {
-		c.SizePercent = *v.SizePercent
-	}
-	return c
-}
-
 func (c Config) ForNextSlice(prevSliceSize datasize.ByteSize) datasize.ByteSize {
 	// Calculated pre-allocated disk space
 	if c.Enabled {

--- a/internal/pkg/service/buffer/sink/tablesink/storage/level/local/writer/disksync/config.go
+++ b/internal/pkg/service/buffer/sink/tablesink/storage/level/local/writer/disksync/config.go
@@ -77,26 +77,3 @@ func NewConfig() Config {
 		IntervalTrigger: duration.From(50 * time.Millisecond),
 	}
 }
-
-// With copies values from the ConfigPatch, if any.
-func (c Config) With(v ConfigPatch) Config {
-	if v.Mode != nil {
-		c.Mode = *v.Mode
-	}
-	if v.Wait != nil {
-		c.Wait = *v.Wait
-	}
-	if v.CheckInterval != nil {
-		c.CheckInterval = *v.CheckInterval
-	}
-	if v.CountTrigger != nil {
-		c.CountTrigger = *v.CountTrigger
-	}
-	if v.BytesTrigger != nil {
-		c.BytesTrigger = *v.BytesTrigger
-	}
-	if v.IntervalTrigger != nil {
-		c.IntervalTrigger = *v.IntervalTrigger
-	}
-	return c
-}

--- a/internal/pkg/service/buffer/sink/tablesink/storage/level/staging/config.go
+++ b/internal/pkg/service/buffer/sink/tablesink/storage/level/staging/config.go
@@ -37,17 +37,6 @@ func NewConfig() Config {
 	}
 }
 
-// With copies values from the ConfigPatch, if any.
-func (c Config) With(v ConfigPatch) Config {
-	if v.MaxSlicesPerFile != nil {
-		c.MaxSlicesPerFile = *v.MaxSlicesPerFile
-	}
-	if v.Upload != nil {
-		c.Upload = c.Upload.With(*v.Upload)
-	}
-	return c
-}
-
 // ---------------------------------------------------------------------------------------------------------------------
 
 // UploadConfig configures the slice upload.
@@ -60,14 +49,6 @@ type UploadConfig struct {
 // It is part of the definition.TableSink structure to allow modification of the default configuration.
 type UploadConfigPatch struct {
 	Trigger *UploadTriggerPatch `json:"trigger,omitempty"`
-}
-
-// With copies values from the UploadConfigPatch, if any.
-func (c UploadConfig) With(v UploadConfigPatch) UploadConfig {
-	if v.Trigger != nil {
-		c.Trigger = c.Trigger.With(*v.Trigger)
-	}
-	return c
 }
 
 // ---------------------------------------------------------------------------------------------------------------------
@@ -85,18 +66,4 @@ type UploadTriggerPatch struct {
 	Count    *uint64            `json:"count,omitempty" configKey:"count"`
 	Size     *datasize.ByteSize `json:"size,omitempty" configKey:"size"`
 	Interval *duration.Duration `json:"interval,omitempty" configKey:"interval"`
-}
-
-// With copies values from the UploadTriggerPatch, if any.
-func (c UploadTrigger) With(v UploadTriggerPatch) UploadTrigger {
-	if v.Count != nil {
-		c.Count = *v.Count
-	}
-	if v.Size != nil {
-		c.Size = *v.Size
-	}
-	if v.Interval != nil {
-		c.Interval = *v.Interval
-	}
-	return c
 }

--- a/internal/pkg/service/buffer/sink/tablesink/storage/level/staging/config_test.go
+++ b/internal/pkg/service/buffer/sink/tablesink/storage/level/staging/config_test.go
@@ -22,12 +22,12 @@ func TestConfig_With(t *testing.T) {
 
 	// Apply empty patch
 	patchedConfig1 := defaultConfig
-	require.NoError(t, configpatch.Apply(patchedConfig1, staging.ConfigPatch{}))
+	require.NoError(t, configpatch.Apply(&patchedConfig1, staging.ConfigPatch{}))
 	assert.Equal(t, defaultConfig, patchedConfig1)
 
 	// Apply full patch
 	patchedConfig2 := patchedConfig1
-	require.NoError(t, configpatch.Apply(patchedConfig2, staging.ConfigPatch{
+	require.NoError(t, configpatch.Apply(&patchedConfig2, staging.ConfigPatch{
 		MaxSlicesPerFile: test.Ptr(123),
 		Upload: &staging.UploadConfigPatch{
 			Trigger: &staging.UploadTriggerPatch{

--- a/internal/pkg/service/buffer/sink/tablesink/storage/level/target/config.go
+++ b/internal/pkg/service/buffer/sink/tablesink/storage/level/target/config.go
@@ -32,14 +32,6 @@ func NewConfig() Config {
 	}
 }
 
-// With copies values from the ConfigPatch, if any.
-func (c Config) With(v ConfigPatch) Config {
-	if v.Import != nil {
-		c.Import = c.Import.With(*v.Import)
-	}
-	return c
-}
-
 // ---------------------------------------------------------------------------------------------------------------------
 
 // ImportConfig configures the file import.
@@ -52,14 +44,6 @@ type ImportConfig struct {
 // It is part of the definition.TableSink structure to allow modification of the default configuration.
 type ImportConfigPatch struct {
 	Trigger *ImportTriggerPatch `json:"trigger,omitempty"`
-}
-
-// With copies values from the ConfigPatch, if any.
-func (c ImportConfig) With(v ImportConfigPatch) ImportConfig {
-	if v.Trigger != nil {
-		c.Trigger = c.Trigger.With(*v.Trigger)
-	}
-	return c
 }
 
 // ---------------------------------------------------------------------------------------------------------------------
@@ -77,18 +61,4 @@ type ImportTriggerPatch struct {
 	Count    *uint64            `json:"count,omitempty" configKey:"count"`
 	Size     *datasize.ByteSize `json:"size,omitempty" configKey:"size"`
 	Interval *duration.Duration `json:"interval,omitempty" configKey:"interval"`
-}
-
-// With copies values from the ImportTriggerPatch, if any.
-func (c ImportTrigger) With(v ImportTriggerPatch) ImportTrigger {
-	if v.Count != nil {
-		c.Count = *v.Count
-	}
-	if v.Size != nil {
-		c.Size = *v.Size
-	}
-	if v.Interval != nil {
-		c.Interval = *v.Interval
-	}
-	return c
 }

--- a/internal/pkg/service/buffer/sink/tablesink/storage/level/target/config_test.go
+++ b/internal/pkg/service/buffer/sink/tablesink/storage/level/target/config_test.go
@@ -22,12 +22,12 @@ func TestConfig_With(t *testing.T) {
 
 	// Apply empty patch
 	patchedConfig1 := defaultConfig
-	require.NoError(t, configpatch.Apply(patchedConfig1, target.ConfigPatch{}))
+	require.NoError(t, configpatch.Apply(&patchedConfig1, target.ConfigPatch{}))
 	assert.Equal(t, defaultConfig, patchedConfig1)
 
 	// Apply full patch
 	patchedConfig2 := patchedConfig1
-	require.NoError(t, configpatch.Apply(patchedConfig2, target.ConfigPatch{
+	require.NoError(t, configpatch.Apply(&patchedConfig2, target.ConfigPatch{
 		Import: &target.ImportConfigPatch{
 			Trigger: &target.ImportTriggerPatch{
 				Interval: test.Ptr(duration.From(456 * time.Millisecond)),

--- a/internal/pkg/service/buffer/sink/tablesink/storage/level/target/config_test.go
+++ b/internal/pkg/service/buffer/sink/tablesink/storage/level/target/config_test.go
@@ -6,32 +6,37 @@ import (
 
 	"github.com/c2h5oh/datasize"
 	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
 
 	"github.com/keboola/keboola-as-code/internal/pkg/service/buffer/sink/tablesink/storage/level/target"
 	"github.com/keboola/keboola-as-code/internal/pkg/service/buffer/sink/tablesink/storage/test"
 	"github.com/keboola/keboola-as-code/internal/pkg/service/buffer/sink/tablesink/storage/test/testvalidation"
+	"github.com/keboola/keboola-as-code/internal/pkg/service/common/configpatch"
 	"github.com/keboola/keboola-as-code/internal/pkg/service/common/duration"
 )
 
 func TestConfig_With(t *testing.T) {
 	t.Parallel()
 
-	defaultCfg := target.NewConfig()
+	defaultConfig := target.NewConfig()
 
 	// Apply empty patch
-	assert.Equal(t, defaultCfg, defaultCfg.With(target.ConfigPatch{}))
+	patchedConfig1 := defaultConfig
+	require.NoError(t, configpatch.Apply(patchedConfig1, target.ConfigPatch{}))
+	assert.Equal(t, defaultConfig, patchedConfig1)
 
 	// Apply full patch
-	patchedCfg := defaultCfg.With(target.ConfigPatch{
+	patchedConfig2 := patchedConfig1
+	require.NoError(t, configpatch.Apply(patchedConfig2, target.ConfigPatch{
 		Import: &target.ImportConfigPatch{
 			Trigger: &target.ImportTriggerPatch{
 				Interval: test.Ptr(duration.From(456 * time.Millisecond)),
 			},
 		},
-	})
-	expectedCfg := defaultCfg
+	}))
+	expectedCfg := defaultConfig
 	expectedCfg.Import.Trigger.Interval = duration.From(456 * time.Millisecond)
-	assert.Equal(t, expectedCfg, patchedCfg)
+	assert.Equal(t, expectedCfg, patchedConfig2)
 }
 
 func TestConfig_Validation(t *testing.T) {

--- a/internal/pkg/service/buffer/sink/tablesink/storage/repository/file_repo.go
+++ b/internal/pkg/service/buffer/sink/tablesink/storage/repository/file_repo.go
@@ -14,6 +14,7 @@ import (
 	"github.com/keboola/keboola-as-code/internal/pkg/service/buffer/sink/tablesink"
 	"github.com/keboola/keboola-as-code/internal/pkg/service/buffer/sink/tablesink/storage"
 	"github.com/keboola/keboola-as-code/internal/pkg/service/buffer/sink/tablesink/storage/volume"
+	"github.com/keboola/keboola-as-code/internal/pkg/service/common/configpatch"
 	serviceError "github.com/keboola/keboola-as-code/internal/pkg/service/common/errors"
 	"github.com/keboola/keboola-as-code/internal/pkg/service/common/etcdop/iterator"
 	"github.com/keboola/keboola-as-code/internal/pkg/service/common/etcdop/op"
@@ -449,7 +450,9 @@ func (r *FileRepository) rotateSink(ctx context.Context, c rotateSinkContext) (*
 		// Apply configuration patch from the sink to the global config
 		cfg := r.config
 		if c.Sink.Table.Config != nil {
-			cfg = cfg.With(*c.Sink.Table.Config)
+			if err := configpatch.Apply(cfg, c.Sink.Table.Config); err != nil {
+				return nil, err
+			}
 		}
 
 		// Create file entity

--- a/internal/pkg/service/buffer/sink/tablesink/storage/repository/file_repo.go
+++ b/internal/pkg/service/buffer/sink/tablesink/storage/repository/file_repo.go
@@ -450,7 +450,7 @@ func (r *FileRepository) rotateSink(ctx context.Context, c rotateSinkContext) (*
 		// Apply configuration patch from the sink to the global config
 		cfg := r.config
 		if c.Sink.Table.Config != nil {
-			if err := configpatch.Apply(cfg, c.Sink.Table.Config); err != nil {
+			if err := configpatch.Apply(&cfg, c.Sink.Table.Config); err != nil {
 				return nil, err
 			}
 		}

--- a/internal/pkg/service/buffer/sink/tablesink/storage/volume/assignment/config.go
+++ b/internal/pkg/service/buffer/sink/tablesink/storage/volume/assignment/config.go
@@ -27,14 +27,3 @@ func NewConfig() Config {
 		PreferredTypes: []string{"default"},
 	}
 }
-
-// With copies values from the ConfigPatch, if any.
-func (c Config) With(v ConfigPatch) Config {
-	if v.Count != nil {
-		c.Count = *v.Count
-	}
-	if v.PreferredTypes != nil {
-		c.PreferredTypes = *v.PreferredTypes
-	}
-	return c
-}

--- a/internal/pkg/service/common/configpatch/apply.go
+++ b/internal/pkg/service/common/configpatch/apply.go
@@ -1,0 +1,22 @@
+package configpatch
+
+import (
+	"reflect"
+
+	"github.com/keboola/keboola-as-code/internal/pkg/utils/errors"
+)
+
+// Apply applies a patch structure to a config structure.
+// The config structure is modified in place.
+func Apply(configStruct, patchStruct any, opts ...Option) error {
+	configPtr := reflect.ValueOf(configStruct)
+	if configPtr.Kind() != reflect.Pointer || configPtr.IsNil() || configPtr.Elem().Kind() != reflect.Struct {
+		panic(errors.Errorf(`config struct must be a pointer to a struct, found "%T"`, configStruct))
+	}
+
+	return visitConfigAndPatch(configPtr, reflect.ValueOf(patchStruct), opts, func(vc *visitContext) {
+		if vc.Overwritten {
+			vc.ConfigValue.Set(*vc.PatchValue)
+		}
+	})
+}

--- a/internal/pkg/service/common/configpatch/bind.go
+++ b/internal/pkg/service/common/configpatch/bind.go
@@ -20,7 +20,7 @@ type BindKV struct {
 }
 
 // BindKVs binds flattened key-value pairs from a client request to a patch structure.
-// Patch structure is modified in place.
+// The patch structure is modified in place.
 func BindKVs(patchStruct any, kvs []BindKV, opts ...Option) error {
 	cfg := newConfig(opts)
 

--- a/internal/pkg/service/common/configpatch/dump.go
+++ b/internal/pkg/service/common/configpatch/dump.go
@@ -3,11 +3,6 @@ package configpatch
 import (
 	"reflect"
 	"sort"
-	"strings"
-
-	"github.com/keboola/keboola-as-code/internal/pkg/service/common/configmap"
-	"github.com/keboola/keboola-as-code/internal/pkg/utils/errors"
-	"github.com/keboola/keboola-as-code/internal/pkg/utils/strhelper"
 )
 
 // DumpKV is result of the patch operation for a one configuration key.
@@ -20,7 +15,7 @@ type DumpKV struct {
 	DefaultValue any `json:"defaultValue"`
 	// Overwritten is true, if the DefaultValue was replaced by a value from the path.
 	Overwritten bool `json:"overwritten"`
-	// Protected configuration keys can be modified only by a super-admin.
+	// Protected configuration key can be modified only by a super-admin.
 	Protected bool `json:"protected"`
 	// Validation contains validation rules of the field, if any.
 	Validation string `json:"validation,omitempty"`
@@ -30,126 +25,19 @@ type DumpKV struct {
 // Only keys found in both, configuration and patch structure, are processed.
 // The structure is flattened, keys are joined with a dot "." separator.
 // Each key-value pair contains information whether the value was overwritten from the patch or not.
-func DumpKVs(configStruct, patchStruct any, opts ...Option) ([]DumpKV, error) {
-	cfg := newConfig(opts)
-
-	var kvs []DumpKV
-	errs := errors.NewMultiError()
-
-	// Visit patch, get patched values
-	patchKeys := make(map[string]bool)
-	patchedValues := make(map[string]reflect.Value)
-	configmap.MustVisit(
-		reflect.ValueOf(patchStruct),
-		configmap.VisitConfig{
-			OnField: matchTaggedFields(cfg.nameTags),
-			OnValue: func(vc *configmap.VisitContext) error {
-				// Process only leaf values with a field name
-				if !vc.Leaf || vc.MappedPath.Last().String() == "" {
-					return nil
-				}
-
-				// Patch field must be a pointer
-				keyPath := vc.MappedPath.String()
-				if vc.Type.Kind() != reflect.Pointer {
-					errs.Append(errors.Errorf(`patch field "%s" is not a pointer, but "%s"`, keyPath, vc.Type))
-					return nil
-				}
-
-				// Store found key
-				patchKeys[keyPath] = true
-
-				// Nil means not set
-				if vc.Value.IsValid() && !vc.Value.IsNil() {
-					patchedValues[keyPath] = vc.Value.Elem()
-				}
-
-				return nil
-			},
-		},
-	)
-
-	// Visit config, generate output key-value pairs
-	var patchedProtected []string
-	configmap.MustVisit(
-		reflect.ValueOf(configStruct),
-		configmap.VisitConfig{
-			OnField: matchTaggedFields(cfg.nameTags),
-			OnValue: func(vc *configmap.VisitContext) error {
-				// Process only leaf values with a field name
-				if !vc.Leaf || vc.MappedPath.Last().String() == "" {
-					return nil
-				}
-
-				// Ignore fields which are not present in the patch
-				keyPath := vc.MappedPath.String()
-				if !patchKeys[keyPath] {
-					return nil
-				}
-
-				// Get patched value, if any
-				defaultValue := vc.Value
-				value, overwritten := patchedValues[keyPath]
-				if overwritten {
-					// Deleted the map key, so unused patch keys can be processed bellow
-					delete(patchedValues, keyPath)
-
-					// Validate type
-					if value.Type() != defaultValue.Type() {
-						errs.Append(errors.Errorf(
-							`patch field "%s" type "%s" doesn't match config field type "%s"`,
-							keyPath,
-							value.Type().String(),
-							defaultValue.Type().String(),
-						))
-						return nil
-					}
-				} else {
-					// The key is not overwritten by the patch, use default value
-					value = defaultValue
-				}
-
-				// Note overwritten protected field
-				protected := vc.StructField.Tag.Get(cfg.protectedTag) == cfg.protectedTagValue
-				if overwritten && protected && !cfg.modifyProtected {
-					patchedProtected = append(patchedProtected, keyPath)
-				}
-
-				// Generate DumpKV
-				kvs = append(kvs, DumpKV{
-					KeyPath:      keyPath,
-					Value:        value.Interface(),
-					DefaultValue: defaultValue.Interface(),
-					Overwritten:  overwritten,
-					Protected:    protected,
-					Validation:   vc.Validate,
-				})
-
-				return nil
-			},
-		},
-	)
-
-	// Check unexpected patch keys
-	if len(patchedValues) > 0 {
-		var unused []string
-		for keyPath := range patchedValues {
-			unused = append(unused, keyPath)
-		}
-		sort.Strings(unused)
-		errs.Append(errors.Errorf(
-			`patch contains unexpected keys: "%s"`,
-			strhelper.Truncate(strings.Join(unused, `", "`), 50, "…"),
-		))
-	}
-
-	// Check overwritten protected keys
-	if len(patchedProtected) > 0 {
-		errs.Append(errors.Errorf(`cannot modify protected fields: "%s"`, strings.Join(patchedProtected, `", "`)))
-	}
-
-	// Check errors
-	if err := errs.ErrorOrNil(); err != nil {
+func DumpKVs(configStruct, patchStruct any, opts ...Option) (kvs []DumpKV, err error) {
+	err = visitConfigAndPatch(reflect.ValueOf(configStruct), reflect.ValueOf(patchStruct), opts, func(vc *visitContext) {
+		// Generate DumpKV
+		kvs = append(kvs, DumpKV{
+			KeyPath:      vc.Config.MappedPath.String(),
+			Value:        vc.Value.Interface(),
+			DefaultValue: vc.ConfigValue.Interface(),
+			Overwritten:  vc.Overwritten,
+			Protected:    vc.Protected,
+			Validation:   vc.Config.Validate,
+		})
+	})
+	if err != nil {
 		return nil, err
 	}
 

--- a/internal/pkg/service/common/configpatch/visit.go
+++ b/internal/pkg/service/common/configpatch/visit.go
@@ -83,10 +83,14 @@ func visitConfigAndPatch(configStruct, patchStruct reflect.Value, opts []Option,
 					return nil
 				}
 
+				// Config field cannot be a pointer
 				keyPath := configVc.MappedPath.String()
-				patchVc, ok := patchKeys[keyPath]
+				if configVc.Type.Kind() == reflect.Pointer {
+					errs.Append(errors.Errorf(`config field "%s" is a pointer, it is not allowed`, keyPath))
+				}
 
 				// Ignore fields which are not present in the patch
+				patchVc, ok := patchKeys[keyPath]
 				if !ok {
 					return nil
 				}

--- a/internal/pkg/service/common/configpatch/visit.go
+++ b/internal/pkg/service/common/configpatch/visit.go
@@ -2,12 +2,166 @@ package configpatch
 
 import (
 	"reflect"
+	"sort"
 	"strings"
 
 	"github.com/keboola/go-utils/pkg/orderedmap"
 
 	"github.com/keboola/keboola-as-code/internal/pkg/service/common/configmap"
+	"github.com/keboola/keboola-as-code/internal/pkg/utils/errors"
+	"github.com/keboola/keboola-as-code/internal/pkg/utils/strhelper"
 )
+
+type visitContext struct {
+	// Config is visit context of the config field.
+	Config *configmap.VisitContext
+	// Patch is visit context of the patch field.
+	Patch *configmap.VisitContext
+	// Value is PatchValue if Overwritten==true, otherwise it is ConfigValue.
+	Value reflect.Value
+	// PatchValue, is value of the key defined in the config structure.
+	ConfigValue reflect.Value
+	// PatchValue, is value of the key defined in the patch structure, can be nil.
+	PatchValue *reflect.Value
+	// Overwritten is true, if the value is set in the patch and is valid.
+	Overwritten bool
+	// Protected configuration key can be modified only by a super-admin.
+	Protected bool
+}
+
+type onValue func(vc *visitContext)
+
+// visitConfigAndPatch visits all common nested field defined in config and patch structures.
+// The onValue callback is called for each found field, with actual visitContext.
+func visitConfigAndPatch(configStruct, patchStruct reflect.Value, opts []Option, fn onValue) error {
+	cfg := newConfig(opts)
+	errs := errors.NewMultiError()
+
+	// Visit patch
+	patchKeys := make(map[string]*configmap.VisitContext)
+	patchedValues := make(map[string]*reflect.Value)
+	configmap.MustVisit(
+		patchStruct,
+		configmap.VisitConfig{
+			OnField: matchTaggedFields(cfg.nameTags),
+			OnValue: func(vc *configmap.VisitContext) error {
+				// Process only leaf values with a field name
+				if !vc.Leaf || vc.MappedPath.Last().String() == "" {
+					return nil
+				}
+
+				// Patch field must be a pointer
+				keyPath := vc.MappedPath.String()
+				if vc.Type.Kind() != reflect.Pointer {
+					errs.Append(errors.Errorf(`patch field "%s" is not a pointer, but "%s"`, keyPath, vc.Type))
+					return nil
+				}
+
+				// Store found key
+				patchKeys[keyPath] = vc
+
+				// Nil means not set
+				if vc.Value.IsValid() && !vc.Value.IsNil() {
+					v := vc.Value.Elem()
+					patchedValues[keyPath] = &v
+				}
+
+				return nil
+			},
+		},
+	)
+
+	// Visit config
+	var patchedProtected []string
+	configmap.MustVisit(
+		configStruct,
+		configmap.VisitConfig{
+			OnField: matchTaggedFields(cfg.nameTags),
+			OnValue: func(configVc *configmap.VisitContext) error {
+				// Process only leaf values with a field name
+				if !configVc.Leaf || configVc.MappedPath.Last().String() == "" {
+					return nil
+				}
+
+				keyPath := configVc.MappedPath.String()
+				patchVc, ok := patchKeys[keyPath]
+
+				// Ignore fields which are not present in the patch
+				if !ok {
+					return nil
+				}
+
+				// Get patched value, if any
+				configValue := configVc.Value
+				patchValue := patchedValues[keyPath] // can be nil
+				var value reflect.Value
+				if patchValue == nil {
+					// The key is not overwritten by the patch, use config value
+					value = configValue
+				} else {
+					// Deleted the map key, so unused patch keys can be processed bellow
+					delete(patchedValues, keyPath)
+
+					// Validate type
+					if patchValue.Type() != configValue.Type() {
+						errs.Append(errors.Errorf(
+							`patch field "%s" type "%s" doesn't match config field type "%s"`,
+							keyPath,
+							patchValue.Type().String(),
+							configValue.Type().String(),
+						))
+						return nil
+					}
+
+					value = *patchValue
+				}
+
+				// Note overwritten protected field
+				protected := configVc.StructField.Tag.Get(cfg.protectedTag) == cfg.protectedTagValue
+				if patchValue != nil && protected && !cfg.modifyProtected {
+					patchedProtected = append(patchedProtected, keyPath)
+				}
+
+				// Invoke visit OnValue callback
+				fn(&visitContext{
+					Config:      configVc,
+					Patch:       patchVc,
+					Value:       value,
+					ConfigValue: configValue,
+					PatchValue:  patchValue,
+					Overwritten: patchValue != nil,
+					Protected:   protected,
+				})
+				return nil
+			},
+		},
+	)
+
+	// Check unexpected patch keys
+	if len(patchedValues) > 0 {
+		var unused []string
+		for keyPath := range patchedValues {
+			unused = append(unused, keyPath)
+		}
+		sort.Strings(unused)
+		errs.Append(errors.Errorf(
+			`patch contains unexpected keys: "%s"`,
+			strhelper.Truncate(strings.Join(unused, `", "`), 50, "…"),
+		))
+	}
+
+	// Check overwritten protected keys
+	if len(patchedProtected) > 0 {
+		errs.Append(errors.Errorf(`cannot modify protected fields: "%s"`, strings.Join(patchedProtected, `", "`)))
+	}
+
+	// Check errors
+	if err := errs.ErrorOrNil(); err != nil {
+		return err
+	}
+
+	return nil
+}
 
 func matchTaggedFields(nameTags []string) configmap.OnField {
 	return func(field reflect.StructField, path orderedmap.Path) (fieldName string, ok bool) {


### PR DESCRIPTION
Jira: https://keboola.atlassian.net/browse/PSGO-388

**Changes:**
- Added `configpatch.Apply` function,
- It replaces all `<config>.With` methods.

----------

As an unplanned side effect of the implementation of `configpatch.DumpKVs` and `configpatch.BindKVs` methods, we can now simply replace all `<config>.With` methods, with `configpatch.Apply`:

https://github.com/keboola/keboola-as-code/blob/9a6f82b0d3936a1506592e8b71a4ee02566c985c/internal/pkg/service/common/configpatch/apply.go#L17-L21