### PR TITLE
fix: Fix slow tests, disable statistics L2 cache, if clock.Mock is used

### DIFF
--- a/internal/pkg/service/buffer/config/config_test.go
+++ b/internal/pkg/service/buffer/config/config_test.go
@@ -71,8 +71,11 @@ sink:
                 # Statistics synchronization timeout. Validation rules: required,minDuration=1s,maxDuration=1m
                 timeout: 30s
             cache:
-                # Statistics L2 in-memory cache invalidation interval. Validation rules: required,minDuration=100ms,maxDuration=5s
-                invalidationInterval: 1s
+                L2:
+                    # Enable statistics L2 in-memory cache, otherwise only L1 cache is used.
+                    enabled: true
+                    # Statistics L2 in-memory cache invalidation interval. Validation rules: required,minDuration=100ms,maxDuration=5s
+                    invalidationInterval: 1s
         storage:
             volumeAssignment:
                 # Volumes count simultaneously utilized per sink. Validation rules: required,min=1,max=100

--- a/internal/pkg/service/buffer/dependencies/tablesink.go
+++ b/internal/pkg/service/buffer/dependencies/tablesink.go
@@ -52,7 +52,7 @@ func newTableSinkScope(defScope DefinitionScope, backoff storage.RetryBackoff) (
 		return nil, err
 	}
 
-	d.statisticsL2Cache, err = cache.NewL2Cache(d.Logger(), d.Clock(), d.statisticsL1Cache, d.Config().Sink.Table.Statistics.L2Cache)
+	d.statisticsL2Cache, err = cache.NewL2Cache(d.Logger(), d.Clock(), d.statisticsL1Cache, d.Config().Sink.Table.Statistics.Cache.L2)
 	if err != nil {
 		return nil, err
 	}

--- a/internal/pkg/service/buffer/sink/tablesink/statistics/cache/cache_test.go
+++ b/internal/pkg/service/buffer/sink/tablesink/statistics/cache/cache_test.go
@@ -40,7 +40,7 @@ func TestCaches(t *testing.T) {
 	require.NoError(t, err)
 	defer l1Cache.Stop()
 
-	l2Config := statistics.NewConfig().L2Cache
+	l2Config := statistics.NewConfig().Cache.L2
 	l2Cache, err := cache.NewL2Cache(d.Logger(), clk, l1Cache, l2Config)
 	require.NoError(t, err)
 	defer l2Cache.Stop()

--- a/internal/pkg/service/buffer/sink/tablesink/statistics/config.go
+++ b/internal/pkg/service/buffer/sink/tablesink/statistics/config.go
@@ -13,8 +13,12 @@ const (
 )
 
 type Config struct {
-	Collector SyncConfig    `configKey:"sync"`
-	L2Cache   L2CacheConfig `configKey:"cache"`
+	Collector SyncConfig  `configKey:"sync"`
+	Cache     CacheConfig `configKey:"cache"`
+}
+
+type CacheConfig struct {
+	L2 L2CacheConfig `configKey:"L2"`
 }
 
 type SyncConfig struct {
@@ -23,6 +27,7 @@ type SyncConfig struct {
 }
 
 type L2CacheConfig struct {
+	Enabled              bool              `configKey:"enabled" configUsage:"Enable statistics L2 in-memory cache, otherwise only L1 cache is used."`
 	InvalidationInterval duration.Duration `configKey:"invalidationInterval" configUsage:"Statistics L2 in-memory cache invalidation interval." validate:"required,minDuration=100ms,maxDuration=5s"`
 }
 
@@ -32,8 +37,11 @@ func NewConfig() Config {
 			SyncInterval: duration.From(DefaultSyncInterval),
 			SyncTimeout:  duration.From(DefaultSyncTimeout),
 		},
-		L2Cache: L2CacheConfig{
-			InvalidationInterval: duration.From(DefaultL2CacheInvalidationInterval),
+		Cache: CacheConfig{
+			L2: L2CacheConfig{
+				Enabled:              true,
+				InvalidationInterval: duration.From(DefaultL2CacheInvalidationInterval),
+			},
 		},
 	}
 }


### PR DESCRIPTION
Jira: https://keboola.atlassian.net/browse/PSGO-401

**Changes:**
- Fixed slow `sink/tablesink/storage/repository/...` tests:
  - L2 cache is disabled in tests, if `clock.Mock` is used.
  - Because, by default, the `invalidation interval` is set to `1s`, that means, the timer is invoked `3600` times per `clock.Add(time.Hour)`.
  - There is a lot of such calls in these tests.

-----------

`90s` -> `15s`
![image](https://github.com/keboola/keboola-as-code/assets/19371734/337ca084-3365-4063-bd8b-d0a73bc38a3b)

