### PR TITLE
fix: Invalid link

### DIFF
--- a/docs/e2e_tests.md
+++ b/docs/e2e_tests.md
@@ -250,7 +250,7 @@ Wildcards can be used in `/expected-stdout`, `/expected-stderr` and `/out/*.*` f
 - `%c`: A single character of any sort.
 - `%%`: A literal percent character: %.
 
-Inspired by [PhpUnit](https://docs.phpunit.de/en/10.0/assertions.html#assertstringmatchesformat).
+Inspired by [PhpUnit](https://docs.phpunit.de/en/11.0/assertions.html#assertstringmatchesformat).
 
 ## Environment Placeholders
 Environment placeholders can be used in `/expected-stdout`, `/expected-stderr`, `/in/*.*` and `/out/*.*`.


### PR DESCRIPTION
Pipelines are [failing](https://github.com/keboola/keboola-as-code/actions/runs/7784399276/job/21224868229) because one of the links used in documentation is no longer valid. Apparently PHPUnit author took down the documentation for the old version.

