### PR TITLE
feat: Improve interface of the resistant etcd session

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -43,6 +43,7 @@ require (
 	github.com/relvacode/iso8601 v1.3.0
 	github.com/santhosh-tekuri/jsonschema/v5 v5.3.0
 	github.com/schollz/progressbar/v3 v3.13.1
+	github.com/shopify/toxiproxy v2.1.4+incompatible
 	github.com/sirupsen/logrus v1.9.3
 	github.com/spf13/afero v1.9.5
 	github.com/spf13/cast v1.5.1
@@ -146,6 +147,7 @@ require (
 	github.com/DataDog/go-libddwaf/v2 v2.2.3 // indirect
 	github.com/DataDog/go-tuf v1.0.2-0.5.2 // indirect
 	github.com/MichaelMure/go-term-text v0.3.1 // indirect
+	github.com/Shopify/toxiproxy v2.1.4+incompatible // indirect
 	github.com/agext/levenshtein v1.2.1 // indirect
 	github.com/alecthomas/chroma v0.10.0 // indirect
 	github.com/andybalholm/brotli v1.0.6 // indirect
@@ -194,6 +196,7 @@ require (
 	github.com/google/wire v0.5.0 // indirect
 	github.com/googleapis/enterprise-certificate-proxy v0.3.2 // indirect
 	github.com/googleapis/gax-go/v2 v2.12.0 // indirect
+	github.com/gorilla/mux v1.8.0 // indirect
 	github.com/grpc-ecosystem/go-grpc-middleware v1.3.0 // indirect
 	github.com/grpc-ecosystem/go-grpc-prometheus v1.2.0 // indirect
 	github.com/grpc-ecosystem/grpc-gateway v1.16.0 // indirect
@@ -246,5 +249,6 @@ require (
 	google.golang.org/genproto/googleapis/api v0.0.0-20231212172506-995d672761c0 // indirect
 	google.golang.org/genproto/googleapis/rpc v0.0.0-20240108191215-35c7eff3a6b1 // indirect
 	gopkg.in/natefinch/lumberjack.v2 v2.0.0 // indirect
+	gopkg.in/tomb.v1 v1.0.0-20141024135613-dd632973f1e7 // indirect
 	inet.af/netaddr v0.0.0-20230525184311-b8eac61e914a // indirect
 )

--- a/go.sum
+++ b/go.sum
@@ -556,6 +556,7 @@ github.com/PuerkitoBio/urlesc v0.0.0-20160726150825-5bd2802263f2/go.mod h1:uGdko
 github.com/PuerkitoBio/urlesc v0.0.0-20170810143723-de5bf2ad4578/go.mod h1:uGdkoq3SwY9Y+13GIhn11/XLaGBb4BfwItxLd5jeuXE=
 github.com/Shopify/logrus-bugsnag v0.0.0-20171204204709-577dee27f20d/go.mod h1:HI8ITrYtUY+O+ZhtlqUnD8+KwNPOyugEhfP9fdUIaEQ=
 github.com/Shopify/sarama v1.19.0/go.mod h1:FVkBWblsNy7DGZRfXLU0O9RCGt5g3g3yEuWXgklEdEo=
+github.com/Shopify/toxiproxy v2.1.4+incompatible h1:TKdv8HiTLgE5wdJuEML90aBgNWsokNbMijUGhmcoBJc=
 github.com/Shopify/toxiproxy v2.1.4+incompatible/go.mod h1:OXgGpZ6Cli1/URJOF1DMxUHB2q5Ap20/P/eIdh4G0pI=
 github.com/VividCortex/gohistogram v1.0.0/go.mod h1:Pf5mBqqDxYaXu3hDrrU+w6nw50o/4+TcAqDqk/vUH7g=
 github.com/acarl005/stripansi v0.0.0-20180116102854-5a71ef0e047d h1:licZJFw2RwpHMqeKTCYkitsPqHNxTmd4SNR5r94FGM8=
@@ -1334,6 +1335,7 @@ github.com/gorilla/handlers v0.0.0-20150720190736-60c7bfde3e33/go.mod h1:Qkdc/uu
 github.com/gorilla/mux v1.6.2/go.mod h1:1lud6UwP+6orDFRuTfBEV8e9/aOM/c4fVVCaMa2zaAs=
 github.com/gorilla/mux v1.7.2/go.mod h1:1lud6UwP+6orDFRuTfBEV8e9/aOM/c4fVVCaMa2zaAs=
 github.com/gorilla/mux v1.7.3/go.mod h1:1lud6UwP+6orDFRuTfBEV8e9/aOM/c4fVVCaMa2zaAs=
+github.com/gorilla/mux v1.8.0 h1:i40aqfkR1h2SlN9hojwV5ZA91wcXFOvkdNIeFDP5koI=
 github.com/gorilla/mux v1.8.0/go.mod h1:DVbg23sWSpFRCP0SfiEN6jmj59UnW/n46BH5rLB71So=
 github.com/gorilla/securecookie v1.1.1/go.mod h1:ra0sb63/xPlUeL+yeDciTfxMRAA+MP+HVt/4epWDjd4=
 github.com/gorilla/sessions v1.2.1/go.mod h1:dk2InVEVJ0sfLlnXv9EAgkf6ecYs/i80K/zI+bUmuGM=
@@ -1975,6 +1977,8 @@ github.com/sergi/go-diff v1.0.0/go.mod h1:0CfEIISq7TuYL3j771MWULgwwjU+GofnZX9QAm
 github.com/sergi/go-diff v1.3.1 h1:xkr+Oxo4BOQKmkn/B9eMK0g5Kg/983T9DqqPHwYqD+8=
 github.com/sergi/go-diff v1.3.1/go.mod h1:aMJSSKb2lpPvRNec0+w3fl7LP9IOFzdc9Pa4NFbPK1I=
 github.com/shoenig/test v0.6.0/go.mod h1:xYtyGBC5Q3kzCNyJg/SjgNpfAa2kvmgA0i5+lQso8x0=
+github.com/shopify/toxiproxy v2.1.4+incompatible h1:m0/O5ZSAoRoW/VXjA2hrg/R3K8ejn0l06yLRJaeD1GM=
+github.com/shopify/toxiproxy v2.1.4+incompatible/go.mod h1:wOxzWRaigOvl4N7H/m7Us9Wn6MazQ1drsQw6OUdLlWk=
 github.com/shopspring/decimal v0.0.0-20180709203117-cd690d0c9e24/go.mod h1:M+9NzErvs504Cn4c5DxATwIqPbtswREoFCre64PpcG4=
 github.com/shopspring/decimal v1.2.0/go.mod h1:DKyhrW/HYNuLGql+MJL6WCR6knT2jwCFRcu2hWCYk4o=
 github.com/shurcooL/httpfs v0.0.0-20190707220628-8d4bc4ba7749/go.mod h1:ZY1cvUeJuFPAdZ/B6v7RHavJWZn2YPVFQ1OSXhCGOkg=
@@ -3167,6 +3171,7 @@ gopkg.in/square/go-jose.v2 v2.3.1/go.mod h1:M9dMgbHiYLoDGQrXy7OpJDJWiKiU//h+vD76
 gopkg.in/square/go-jose.v2 v2.5.1/go.mod h1:M9dMgbHiYLoDGQrXy7OpJDJWiKiU//h+vD76mk0e1AI=
 gopkg.in/telebot.v3 v3.0.0/go.mod h1:7rExV8/0mDDNu9epSrDm/8j22KLaActH1Tbee6YjzWg=
 gopkg.in/telebot.v3 v3.1.2/go.mod h1:GJKwwWqp9nSkIVN51eRKU78aB5f5OnQuWdwiIZfPbko=
+gopkg.in/tomb.v1 v1.0.0-20141024135613-dd632973f1e7 h1:uRGJdciOHaEIrze2W8Q3AKkepLTh2hOroT7a+7czfdQ=
 gopkg.in/tomb.v1 v1.0.0-20141024135613-dd632973f1e7/go.mod h1:dt/ZhP58zS4L8KSrWDmTeBkI65Dw0HsyUHuEVlX15mw=
 gopkg.in/warnings.v0 v0.1.2/go.mod h1:jksf8JmL6Qr/oQM2OXTHunEvvTAsrWBLb6OOjuVWRNI=
 gopkg.in/yaml.v2 v2.0.0-20170812160011-eb3733d160e7/go.mod h1:JAlM8MvJe8wmxCU4Bli9HhUf9+ttbYbLASfIpnQbh74=

--- a/internal/pkg/model/component.go
+++ b/internal/pkg/model/component.go
@@ -62,7 +62,7 @@ func (p *ComponentsProvider) Update(ctx context.Context) error {
 	p.updateLock.Lock()
 	defer p.updateLock.Unlock()
 	p.value = NewComponentsMap(index.Components)
-	p.logger.Infof(ctx, "components update finished | %s", time.Since(startTime))
+	p.logger.WithDuration(time.Since(startTime)).Infof(ctx, "components update finished")
 	return nil
 }
 

--- a/internal/pkg/service/common/dependencies/public.go
+++ b/internal/pkg/service/common/dependencies/public.go
@@ -81,14 +81,14 @@ func newPublicScope(ctx context.Context, baseScp BaseScope, storageAPIHost strin
 			return nil, err
 		}
 		index = &indexWithComponents.Index
-		logger.Infof(ctx, `loaded Storage API index with "%d" components | %s`, len(indexWithComponents.Components), time.Since(startTime))
+		logger.WithDuration(time.Since(startTime)).Infof(ctx, `loaded Storage API index with "%d" components`, len(indexWithComponents.Components))
 	} else {
 		logger.Info(ctx, "loading Storage API index without components")
 		index, err = keboola.APIIndex(ctx, storageAPIHost, keboola.WithClient(&baseHTTPClient))
 		if err != nil {
 			return nil, err
 		}
-		logger.Infof(ctx, "loaded Storage API index without components | %s", time.Since(startTime))
+		logger.WithDuration(time.Since(startTime)).Infof(ctx, "loaded Storage API index without component")
 	}
 
 	// Create API
@@ -115,7 +115,7 @@ func storageAPIIndexWithComponents(ctx context.Context, d BaseScope, keboolaPubl
 	if err != nil {
 		return nil, err
 	}
-	d.Logger().Debugf(ctx, "Storage API index with components loaded | %s", time.Since(startTime))
+	d.Logger().WithDuration(time.Since(startTime)).Debugf(ctx, "Storage API index with components loaded")
 	return index, nil
 }
 

--- a/internal/pkg/service/common/distribution/node.go
+++ b/internal/pkg/service/common/distribution/node.go
@@ -72,8 +72,9 @@ func NewNode(nodeID, group string, d dependencies, opts ...NodeOption) (*Node, e
 	}
 
 	// Graceful shutdown
-	watchCtx, watchCancel := context.WithCancel(context.Background())     // nolint: contextcheck
-	sessionCtx, sessionCancel := context.WithCancel(context.Background()) // nolint: contextcheck
+	bgContext := ctxattr.ContextWith(context.Background(), attribute.String("node", nodeID)) // nolint: contextcheck
+	watchCtx, watchCancel := context.WithCancel(bgContext)
+	sessionCtx, sessionCancel := context.WithCancel(bgContext)
 	wg := &sync.WaitGroup{}
 	n.proc.OnShutdown(func(ctx context.Context) {
 		ctx = ctxattr.ContextWith(ctx, attribute.String("node", n.nodeID))

--- a/internal/pkg/service/common/distribution/node.go
+++ b/internal/pkg/service/common/distribution/node.go
@@ -140,7 +140,7 @@ func (n *Node) register(session *concurrency.Session, timeout time.Duration) err
 		return errors.Errorf(`cannot register the node "%s": %w`, n.nodeID, err)
 	}
 
-	n.logger.Infof(ctx, `the node "%s" registered | %s`, n.nodeID, time.Since(startTime))
+	n.logger.WithDuration(time.Since(startTime)).Infof(ctx, `the node "%s" registered`, n.nodeID)
 	return nil
 }
 
@@ -156,7 +156,7 @@ func (n *Node) unregister(ctx context.Context, timeout time.Duration) {
 		n.logger.Warnf(ctx, `cannot unregister the node "%s": %s`, n.nodeID, err)
 	}
 
-	n.logger.Infof(ctx, `the node "%s" unregistered | %s`, n.nodeID, time.Since(startTime))
+	n.logger.WithDuration(time.Since(startTime)).Infof(ctx, `the node "%s" unregistered`, n.nodeID)
 }
 
 // watch for other nodes.

--- a/internal/pkg/service/common/distribution/node_test.go
+++ b/internal/pkg/service/common/distribution/node_test.go
@@ -172,8 +172,8 @@ node3
 
 	// Logs differs in number of "the node ... gone" messages
 	loggers[0].AssertJSONMessages(t, `
-{"level":"info","message":"creating etcd session","node":"node1","component":"distribution.my-group.etcd-session"}
-{"level":"info","message":"created etcd session | %s","node":"node1","component":"distribution.my-group.etcd-session"}
+{"level":"info","message":"creating etcd session","node":"node1","component":"distribution.my-group.etcd.session"}
+{"level":"info","message":"created etcd session","node":"node1","component":"distribution.my-group.etcd.session"}
 {"level":"info","message":"registering the node \"node1\"","node":"node1","component":"distribution.my-group"}
 {"level":"info","message":"the node \"node1\" registered | %s","node":"node1","component":"distribution.my-group"}
 {"level":"info","message":"watching for other nodes","node":"node1","component":"distribution.my-group"}
@@ -186,17 +186,17 @@ node3
 {"level":"info","message":"received shutdown request","node":"node1","component":"distribution.my-group"}
 {"level":"info","message":"unregistering the node \"node1\"","node":"node1","component":"distribution.my-group"}
 {"level":"info","message":"the node \"node1\" unregistered | %s","node":"node1","component":"distribution.my-group"}
-{"level":"info","message":"closing etcd session","node":"node1","component":"distribution.my-group.etcd-session"}
-{"level":"info","message":"closed etcd session | %s","node":"node1","component":"distribution.my-group.etcd-session"}
+{"level":"info","message":"closing etcd session: context canceled","node":"node1","component":"distribution.my-group.etcd.session"}
+{"level":"info","message":"closed etcd session","node":"node1","component":"distribution.my-group.etcd.session"}
 {"level":"info","message":"shutdown done","node":"node1","component":"distribution.my-group"}
-{"level":"info","message":"closing etcd connection","component":"etcd-client"}
-{"level":"info","message":"closed etcd connection | %s","component":"etcd-client"}
+{"level":"info","message":"closing etcd connection","component":"etcd.client"}
+{"level":"info","message":"closed etcd connection","component":"etcd.client"}
 {"level":"info","message":"exited"}
 `)
 
 	loggers[1].AssertJSONMessages(t, `
-{"level":"info","message":"creating etcd session","node":"node2","component":"distribution.my-group.etcd-session"}
-{"level":"info","message":"created etcd session | %s","node":"node2","component":"distribution.my-group.etcd-session"}
+{"level":"info","message":"creating etcd session","node":"node2","component":"distribution.my-group.etcd.session"}
+{"level":"info","message":"created etcd session","node":"node2","component":"distribution.my-group.etcd.session"}
 {"level":"info","message":"registering the node \"node2\"","node":"node2","component":"distribution.my-group"}
 {"level":"info","message":"the node \"node2\" registered | %s","node":"node2","component":"distribution.my-group"}
 {"level":"info","message":"watching for other nodes","node":"node2","component":"distribution.my-group"}
@@ -210,17 +210,17 @@ node3
 {"level":"info","message":"received shutdown request","node":"node2","component":"distribution.my-group"}
 {"level":"info","message":"unregistering the node \"node2\"","node":"node2","component":"distribution.my-group"}
 {"level":"info","message":"the node \"node2\" unregistered | %s","node":"node2","component":"distribution.my-group"}
-{"level":"info","message":"closing etcd session","node":"node2","component":"distribution.my-group.etcd-session"}
-{"level":"info","message":"closed etcd session | %s","node":"node2","component":"distribution.my-group.etcd-session"}
+{"level":"info","message":"closing etcd session: context canceled","node":"node2","component":"distribution.my-group.etcd.session"}
+{"level":"info","message":"closed etcd session","node":"node2","component":"distribution.my-group.etcd.session"}
 {"level":"info","message":"shutdown done","node":"node2","component":"distribution.my-group"}
-{"level":"info","message":"closing etcd connection","component":"etcd-client"}
-{"level":"info","message":"closed etcd connection | %s","component":"etcd-client"}
+{"level":"info","message":"closing etcd connection","component":"etcd.client"}
+{"level":"info","message":"closed etcd connection","component":"etcd.client"}
 {"level":"info","message":"exited"}
 `)
 
 	loggers[2].AssertJSONMessages(t, `
-{"level":"info","message":"creating etcd session","node":"node3","component":"distribution.my-group.etcd-session"}
-{"level":"info","message":"created etcd session | %s","node":"node3","component":"distribution.my-group.etcd-session"}
+{"level":"info","message":"creating etcd session","node":"node3","component":"distribution.my-group.etcd.session"}
+{"level":"info","message":"created etcd session","node":"node3","component":"distribution.my-group.etcd.session"}
 {"level":"info","message":"registering the node \"node3\"","node":"node3","component":"distribution.my-group"}
 {"level":"info","message":"the node \"node3\" registered | %s","node":"node3","component":"distribution.my-group"}
 {"level":"info","message":"watching for other nodes","node":"node3","component":"distribution.my-group"}
@@ -235,11 +235,11 @@ node3
 {"level":"info","message":"received shutdown request","node":"node3","component":"distribution.my-group"}
 {"level":"info","message":"unregistering the node \"node3\"","node":"node3","component":"distribution.my-group"}
 {"level":"info","message":"the node \"node3\" unregistered | %s","node":"node3","component":"distribution.my-group"}
-{"level":"info","message":"closing etcd session","node":"node3","component":"distribution.my-group.etcd-session"}
-{"level":"info","message":"closed etcd session | %s","node":"node3","component":"distribution.my-group.etcd-session"}
+{"level":"info","message":"closing etcd session: context canceled","node":"node3","component":"distribution.my-group.etcd.session"}
+{"level":"info","message":"closed etcd session","node":"node3","component":"distribution.my-group.etcd.session"}
 {"level":"info","message":"shutdown done","node":"node3","component":"distribution.my-group"}
-{"level":"info","message":"closing etcd connection","component":"etcd-client"}
-{"level":"info","message":"closed etcd connection | %s","component":"etcd-client"}
+{"level":"info","message":"closing etcd connection","component":"etcd.client"}
+{"level":"info","message":"closed etcd connection","component":"etcd.client"}
 {"level":"info","message":"exited"}
 `)
 
@@ -265,8 +265,8 @@ node4
 	etcdhelper.AssertKVsString(t, client, "")
 
 	d4.DebugLogger().AssertJSONMessages(t, `
-{"level":"info","message":"creating etcd session","node":"node4","component":"distribution.my-group.etcd-session"}
-{"level":"info","message":"created etcd session | %s","node":"node4","component":"distribution.my-group.etcd-session"}
+{"level":"info","message":"creating etcd session","node":"node4","component":"distribution.my-group.etcd.session"}
+{"level":"info","message":"created etcd session","node":"node4","component":"distribution.my-group.etcd.session"}
 {"level":"info","message":"registering the node \"node4\"","node":"node4","component":"distribution.my-group"}
 {"level":"info","message":"the node \"node4\" registered | %s","node":"node4","component":"distribution.my-group"}
 {"level":"info","message":"watching for other nodes","node":"node4","component":"distribution.my-group"}
@@ -277,11 +277,11 @@ node4
 {"level":"info","message":"received shutdown request","node":"node4","component":"distribution.my-group"}
 {"level":"info","message":"unregistering the node \"node4\"","node":"node4","component":"distribution.my-group"}
 {"level":"info","message":"the node \"node4\" unregistered | %s","node":"node4","component":"distribution.my-group"}
-{"level":"info","message":"closing etcd session","node":"node4","component":"distribution.my-group.etcd-session"}
-{"level":"info","message":"closed etcd session | %s","node":"node4","component":"distribution.my-group.etcd-session"}
+{"level":"info","message":"closing etcd session: context canceled","node":"node4","component":"distribution.my-group.etcd.session"}
+{"level":"info","message":"closed etcd session","node":"node4","component":"distribution.my-group.etcd.session"}
 {"level":"info","message":"shutdown done","node":"node4","component":"distribution.my-group"}
-{"level":"info","message":"closing etcd connection","component":"etcd-client"}
-{"level":"info","message":"closed etcd connection | %s","component":"etcd-client"}
+{"level":"info","message":"closing etcd connection","component":"etcd.client"}
+{"level":"info","message":"closed etcd connection","component":"etcd.client"}
 {"level":"info","message":"exited"}
 `)
 }

--- a/internal/pkg/service/common/distribution/node_test.go
+++ b/internal/pkg/service/common/distribution/node_test.go
@@ -175,7 +175,7 @@ node3
 {"level":"info","message":"creating etcd session","node":"node1","component":"distribution.my-group.etcd.session"}
 {"level":"info","message":"created etcd session","node":"node1","component":"distribution.my-group.etcd.session"}
 {"level":"info","message":"registering the node \"node1\"","node":"node1","component":"distribution.my-group"}
-{"level":"info","message":"the node \"node1\" registered | %s","node":"node1","component":"distribution.my-group"}
+{"level":"info","message":"the node \"node1\" registered","node":"node1","component":"distribution.my-group"}
 {"level":"info","message":"watching for other nodes","node":"node1","component":"distribution.my-group"}
 {"level":"info","message":"found a new node \"node%d\"","node":"node1","component":"distribution.my-group"}
 {"level":"info","message":"found a new node \"node%d\"","node":"node1","component":"distribution.my-group"}
@@ -185,7 +185,7 @@ node3
 {"level":"info","message":"shutdown done","node":"node1","component":"distribution.my-group.listeners"}
 {"level":"info","message":"received shutdown request","node":"node1","component":"distribution.my-group"}
 {"level":"info","message":"unregistering the node \"node1\"","node":"node1","component":"distribution.my-group"}
-{"level":"info","message":"the node \"node1\" unregistered | %s","node":"node1","component":"distribution.my-group"}
+{"level":"info","message":"the node \"node1\" unregistered","node":"node1","component":"distribution.my-group"}
 {"level":"info","message":"closing etcd session: context canceled","node":"node1","component":"distribution.my-group.etcd.session"}
 {"level":"info","message":"closed etcd session","node":"node1","component":"distribution.my-group.etcd.session"}
 {"level":"info","message":"shutdown done","node":"node1","component":"distribution.my-group"}
@@ -198,7 +198,7 @@ node3
 {"level":"info","message":"creating etcd session","node":"node2","component":"distribution.my-group.etcd.session"}
 {"level":"info","message":"created etcd session","node":"node2","component":"distribution.my-group.etcd.session"}
 {"level":"info","message":"registering the node \"node2\"","node":"node2","component":"distribution.my-group"}
-{"level":"info","message":"the node \"node2\" registered | %s","node":"node2","component":"distribution.my-group"}
+{"level":"info","message":"the node \"node2\" registered","node":"node2","component":"distribution.my-group"}
 {"level":"info","message":"watching for other nodes","node":"node2","component":"distribution.my-group"}
 {"level":"info","message":"found a new node \"node%d\"","node":"node2","component":"distribution.my-group"}
 {"level":"info","message":"found a new node \"node%d\"","node":"node2","component":"distribution.my-group"}
@@ -209,7 +209,7 @@ node3
 {"level":"info","message":"shutdown done","node":"node2","component":"distribution.my-group.listeners"}
 {"level":"info","message":"received shutdown request","node":"node2","component":"distribution.my-group"}
 {"level":"info","message":"unregistering the node \"node2\"","node":"node2","component":"distribution.my-group"}
-{"level":"info","message":"the node \"node2\" unregistered | %s","node":"node2","component":"distribution.my-group"}
+{"level":"info","message":"the node \"node2\" unregistered","node":"node2","component":"distribution.my-group"}
 {"level":"info","message":"closing etcd session: context canceled","node":"node2","component":"distribution.my-group.etcd.session"}
 {"level":"info","message":"closed etcd session","node":"node2","component":"distribution.my-group.etcd.session"}
 {"level":"info","message":"shutdown done","node":"node2","component":"distribution.my-group"}
@@ -222,7 +222,7 @@ node3
 {"level":"info","message":"creating etcd session","node":"node3","component":"distribution.my-group.etcd.session"}
 {"level":"info","message":"created etcd session","node":"node3","component":"distribution.my-group.etcd.session"}
 {"level":"info","message":"registering the node \"node3\"","node":"node3","component":"distribution.my-group"}
-{"level":"info","message":"the node \"node3\" registered | %s","node":"node3","component":"distribution.my-group"}
+{"level":"info","message":"the node \"node3\" registered","node":"node3","component":"distribution.my-group"}
 {"level":"info","message":"watching for other nodes","node":"node3","component":"distribution.my-group"}
 {"level":"info","message":"found a new node \"node%d\"","node":"node3","component":"distribution.my-group"}
 {"level":"info","message":"found a new node \"node%d\"","node":"node3","component":"distribution.my-group"}
@@ -234,7 +234,7 @@ node3
 {"level":"info","message":"shutdown done","node":"node3","component":"distribution.my-group.listeners"}
 {"level":"info","message":"received shutdown request","node":"node3","component":"distribution.my-group"}
 {"level":"info","message":"unregistering the node \"node3\"","node":"node3","component":"distribution.my-group"}
-{"level":"info","message":"the node \"node3\" unregistered | %s","node":"node3","component":"distribution.my-group"}
+{"level":"info","message":"the node \"node3\" unregistered","node":"node3","component":"distribution.my-group"}
 {"level":"info","message":"closing etcd session: context canceled","node":"node3","component":"distribution.my-group.etcd.session"}
 {"level":"info","message":"closed etcd session","node":"node3","component":"distribution.my-group.etcd.session"}
 {"level":"info","message":"shutdown done","node":"node3","component":"distribution.my-group"}
@@ -268,7 +268,7 @@ node4
 {"level":"info","message":"creating etcd session","node":"node4","component":"distribution.my-group.etcd.session"}
 {"level":"info","message":"created etcd session","node":"node4","component":"distribution.my-group.etcd.session"}
 {"level":"info","message":"registering the node \"node4\"","node":"node4","component":"distribution.my-group"}
-{"level":"info","message":"the node \"node4\" registered | %s","node":"node4","component":"distribution.my-group"}
+{"level":"info","message":"the node \"node4\" registered","node":"node4","component":"distribution.my-group"}
 {"level":"info","message":"watching for other nodes","node":"node4","component":"distribution.my-group"}
 {"level":"info","message":"found a new node \"node4\"","node":"node4","component":"distribution.my-group"}
 {"level":"info","message":"exiting (bye bye 4)"}
@@ -276,7 +276,7 @@ node4
 {"level":"info","message":"shutdown done","node":"node4","component":"distribution.my-group.listeners"}
 {"level":"info","message":"received shutdown request","node":"node4","component":"distribution.my-group"}
 {"level":"info","message":"unregistering the node \"node4\"","node":"node4","component":"distribution.my-group"}
-{"level":"info","message":"the node \"node4\" unregistered | %s","node":"node4","component":"distribution.my-group"}
+{"level":"info","message":"the node \"node4\" unregistered","node":"node4","component":"distribution.my-group"}
 {"level":"info","message":"closing etcd session: context canceled","node":"node4","component":"distribution.my-group.etcd.session"}
 {"level":"info","message":"closed etcd session","node":"node4","component":"distribution.my-group.etcd.session"}
 {"level":"info","message":"shutdown done","node":"node4","component":"distribution.my-group"}

--- a/internal/pkg/service/common/etcdclient/etcdclient.go
+++ b/internal/pkg/service/common/etcdclient/etcdclient.go
@@ -43,7 +43,7 @@ func New(ctx context.Context, proc *servicectx.Process, tel telemetry.Telemetry,
 	if logger == nil {
 		logger = log.NewNopLogger()
 	}
-	logger = logger.WithComponent("etcd-client")
+	logger = logger.WithComponent("etcd.client")
 
 	// Create a zap logger for etcd client
 	encoder := zapcore.NewJSONEncoder(zap.NewProductionEncoderConfig())
@@ -53,8 +53,8 @@ func New(ctx context.Context, proc *servicectx.Process, tel telemetry.Telemetry,
 			return
 		}
 
-		// Add component=etcd-client field
-		fields = append(fields, zapcore.Field{Key: "component", String: "etcd-client", Type: zapcore.StringType})
+		// Add component=etcd.client field
+		fields = append(fields, zapcore.Field{Key: "component", String: "etcd.client", Type: zapcore.StringType})
 
 		// Encode and log message
 		if bytes, err := encoder.EncodeEntry(entry, fields); err == nil {
@@ -120,10 +120,10 @@ func New(ctx context.Context, proc *servicectx.Process, tel telemetry.Telemetry,
 		if err := c.Close(); err != nil {
 			logger.Warnf(ctx, "cannot close etcd connection: %s", err)
 		} else {
-			logger.Infof(ctx, "closed etcd connection | %s", time.Since(startTime))
+			logger.WithDuration(time.Since(startTime)).Infof(ctx, "closed etcd connection")
 		}
 	})
 
-	logger.Infof(ctx, `connected to etcd cluster "%s" | %s`, strings.Join(c.Endpoints(), ";"), time.Since(startTime))
+	logger.WithDuration(time.Since(startTime)).Infof(ctx, `connected to etcd cluster "%s"`, strings.Join(c.Endpoints(), ";"))
 	return c, nil
 }

--- a/internal/pkg/service/common/etcdop/session.go
+++ b/internal/pkg/service/common/etcdop/session.go
@@ -10,112 +10,289 @@ import (
 	"go.etcd.io/etcd/client/v3/concurrency"
 
 	"github.com/keboola/keboola-as-code/internal/pkg/log"
+	"github.com/keboola/keboola-as-code/internal/pkg/utils/errors"
 )
 
-// ResistantSession creates an etcd session with retries.
+const (
+	sessionDefaultGrantTimeout = 5 * time.Second
+	sessionDefaultTTLSeconds   = 15
+)
+
+// Session wraps an etcd session with retries.
 // If there is a longer network outage and the session expires, then a new session is created.
 //
-// Each session creation is reported via the onSession callback.
+// Each session creation is reported via the OnSession callback.
 // The callback must not be blocking.
+// In the work you start in the OnSession callback, you should check <-session.Done().
 //
-// In the work you start in the onSession callback, you should check <-session.Done().
-//
-// The ResistantSession function waits for:
+// The Session function waits for:
 // - The first session creation.
 // - The first keep-alive request.
-// - The completion of the first OnSession callback call.
+// - The completion of the OnSession callbacks call.
 //
 // Any initialization error is reported via the error channel.
 // After successful initialization, a new session is created after each failure until the context ends.
-func ResistantSession(ctx context.Context, wg *sync.WaitGroup, logger log.Logger, client *etcd.Client, ttlSeconds int, onSession func(session *concurrency.Session) error) <-chan error {
-	b := newSessionBackoff()
-	startTime := time.Now()
-	logger = logger.WithComponent("etcd-session")
-	logger.Infof(ctx, `creating etcd session`)
+type Session struct {
+	sessionBuilder
+	logger  log.Logger
+	client  *etcd.Client
+	backoff *backoff.ExponentialBackOff
+
+	lock    *sync.Mutex
+	created chan struct{} // see WaitForSession
+	actual  *concurrency.Session
+}
+
+type SessionBuilder struct {
+	grantTimeout time.Duration
+	ttlSeconds   int
+	onSession    []onSession
+}
+
+type onSession func(session *concurrency.Session) error
+
+type sessionBuilder = SessionBuilder
+
+type NoSessionError struct{}
+
+func (e NoSessionError) Error() string {
+	return "no active concurrent.Session"
+}
+
+// WithGrantTimeout configures the maximum time to wait for creating a new session.
+func (b SessionBuilder) WithGrantTimeout(v time.Duration) SessionBuilder {
+	if v <= 0 {
+		panic(errors.New("grant timeout must be > 0"))
+	}
+	b.grantTimeout = v
+	return b
+}
+
+// WithTTLSeconds configures the session's TTL in seconds.
+func (b SessionBuilder) WithTTLSeconds(v int) SessionBuilder {
+	if v <= 0 {
+		panic(errors.New("TTL must be > 0"))
+	}
+	b.ttlSeconds = v
+	return b
+}
+
+// WithOnSession registers a callback that is called on each session creation.
+// The callback must not be blocking.
+// In the work you start in the OnSession callback, you should check <-session.Done().
+func (b SessionBuilder) WithOnSession(fn onSession) SessionBuilder {
+	b.onSession = append([]onSession(nil), b.onSession...)
+	b.onSession = append(b.onSession, fn)
+	return b
+}
+
+// Start the resistant Session.
+// Any initialization error is reported via the error channel.
+// After successful initialization, a new session is created after each failure until the context ends.
+func (b SessionBuilder) Start(ctx context.Context, wg *sync.WaitGroup, logger log.Logger, client *etcd.Client) (*Session, <-chan error) {
+	initDoneOut := make(chan error, 1)
+	s := &Session{
+		sessionBuilder: b,
+		logger:         logger.WithComponent("etcd.session"),
+		client:         client,
+		backoff:        newSessionBackoff(),
+		lock:           &sync.Mutex{},
+		created:        make(chan struct{}),
+	}
 
 	wg.Add(1)
-	initDone := make(chan error, 1)
-	initDoneOut := initDone
 	go func() {
 		defer wg.Done()
+		initDone := initDoneOut
+
 		for {
-			// Wait before re-creation attempt, except the initialization
-			if initDone == nil {
-				delay := b.NextBackOff()
-				logger.Infof(ctx, "re-creating etcd session, backoff delay %s", delay)
-				<-time.After(delay)
+			// Check context
+			if err := ctx.Err(); err != nil {
+				_ = s.closeSession(ctx, err.Error())
+				return
 			}
 
 			// Create session
-			session, err := concurrency.NewSession(client, concurrency.WithTTL(ttlSeconds))
-			if err != nil {
-				if initDone == nil {
-					// Try again
-					logger.Errorf(ctx, `cannot create etcd session: %s`, err)
-					continue
-				} else {
-					// Stop initialization
-					initDone <- err
-					close(initDone)
-					return
-				}
+			s.logger.Infof(ctx, `creating etcd session`)
+			session, err := s.newSession(ctx)
+
+			// Ok, replace the reference
+			if err == nil {
+				s.lock.Lock()
+				created := s.created
+				s.created = make(chan struct{})
+				s.actual = session
+				s.lock.Unlock()
+				close(created) // notify WaitForSession
 			}
 
-			// Check connection, wait for the first keep-alive.
-			// It prevents weird warnings if a test ends before the first keep alive is completed.
+			// Notify about initialization, the first iteration
 			if initDone != nil {
-				if _, err = session.Client().KeepAliveOnce(ctx, session.Lease()); err != nil {
-					// Stop initialization
-					_ = session.Close()
-					initDone <- err
+				if err == nil {
+					// Initialization has been successful
 					close(initDone)
-					return
-				}
-			}
-
-			// Reset session backoff
-			b.Reset()
-			logger.Infof(ctx, "created etcd session | %s", time.Since(startTime))
-
-			// Start session dependent work
-			err = onSession(session)
-			if err != nil {
-				if initDone == nil {
-					logger.Errorf(ctx, `etcd session callback failed: %s`, err)
+					initDone = nil
 				} else {
-					// Stop initialization
-					_ = session.Close()
+					// Notify and stop on an initialization error
 					initDone <- err
 					close(initDone)
 					return
 				}
 			}
 
-			// Mark initialization done
-			if initDone != nil {
-				close(initDone)
-				initDone = nil
+			// Retry on error
+			if err != nil {
+				s.logger.Infof(ctx, "cannot create etcd session: %s", err.Error())
+				if !errors.Is(err, context.Canceled) {
+					delay := s.backoff.NextBackOff()
+					s.logger.Infof(ctx, "waiting %s before the retry", delay)
+					<-time.After(delay)
+				}
+				continue // retry
 			}
 
-			// Check ctx and session
+			// Wait for context or session cancellation
 			select {
 			case <-ctx.Done():
-				// Context cancelled
-				startTime := time.Now()
-				logger.Info(ctx, "closing etcd session")
-				if err := session.Close(); err != nil {
-					logger.Warnf(ctx, "cannot close etcd session: %s", err)
-				} else {
-					logger.Infof(ctx, "closed etcd session | %s", time.Since(startTime))
-				}
-				return
 			case <-session.Done():
-				// Re-create ...
+				s.logger.Info(ctx, "etcd session canceled")
 			}
 		}
 	}()
 
-	return initDoneOut
+	return s, initDoneOut
+}
+
+// Session returns active session or NoSessionError on a network outage.
+func (s *Session) Session() (*concurrency.Session, error) {
+	s.lock.Lock()
+	session := s.actual
+	s.lock.Unlock()
+
+	select {
+	case <-session.Done():
+		// there is no active session during an outage
+		return nil, NoSessionError{}
+	default:
+		// ok
+		return session, nil
+	}
+}
+
+// WaitForSession returns active session or waits for a new session on a network outage.
+// The error is returned only if the context is cancelled.
+func (s *Session) WaitForSession(ctx context.Context) (*concurrency.Session, error) {
+	for {
+		s.lock.Lock()
+		session := s.actual
+		ready := s.created
+		s.lock.Unlock()
+
+		select {
+		case <-ctx.Done():
+			// stop on the context cancellation
+			return nil, ctx.Err()
+		case <-session.Done():
+			// wait for the session re-creation
+			<-ready
+			continue
+		default:
+			// ok
+			return session, nil
+		}
+	}
+}
+
+// NewMutex returns *concurrency.Mutex that implements the sync Locker interface with etcd.
+// IsOwner().
+func (s *Session) NewMutex(name string) (*concurrency.Mutex, error) {
+	if session, err := s.Session(); err == nil {
+		return concurrency.NewMutex(session, name), nil
+	} else {
+		return nil, err
+	}
+}
+
+// newSession underlying low-level *concurrency.Session.
+func (s *Session) newSession(ctx context.Context) (_ *concurrency.Session, err error) {
+	startTime := time.Now()
+
+	// Obtain the LeaseID
+	// The concurrency.NewSession bellow can do it by itself, but we need a separate context with a timeout here.
+	grantCtx, grantCancel := context.WithTimeout(ctx, s.grantTimeout)
+	defer grantCancel()
+	grantResp, err := s.client.Grant(grantCtx, int64(s.ttlSeconds))
+	if err != nil {
+		return nil, err
+	}
+
+	// Create session
+	session, err := concurrency.NewSession(s.client, concurrency.WithTTL(s.ttlSeconds), concurrency.WithLease(grantResp.ID))
+	if err != nil {
+		return nil, err
+	}
+
+	// Close session on an error bellow
+	defer func() {
+		if err != nil {
+			_ = session.Close()
+		}
+	}()
+
+	// Check connection, wait for the first keep-alive.
+	// It prevents weird warnings if a test ends before the first keep alive is completed.
+	if _, err = session.Client().KeepAliveOnce(ctx, session.Lease()); err != nil {
+		return nil, err
+	}
+
+	// Invoke callbacks - start session dependent work
+	s.logger.WithDuration(time.Since(startTime)).Infof(ctx, "created etcd session")
+	for i, fn := range s.onSession {
+		if err := fn(session); err != nil {
+			err = errors.Errorf(`callback OnSession[%d] failed: %s`, i, err)
+			s.logger.Error(ctx, err.Error())
+			return nil, err
+		}
+	}
+
+	// Reset retry backoff
+	s.backoff.Reset()
+
+	return session, nil
+}
+
+// closeSession closes underlying low-level *concurrency.Session.
+func (s *Session) closeSession(ctx context.Context, reason string) error {
+	// Get session
+	session, err := s.Session()
+	if session == nil || err != nil {
+		return err // the session is already closed or expired
+	}
+
+	// Close session
+	startTime := time.Now()
+	if reason == "" {
+		s.logger.Info(ctx, "closing etcd session")
+	} else {
+		s.logger.Infof(ctx, "closing etcd session: %s", reason)
+	}
+	if err := session.Close(); err != nil {
+		err = errors.PrefixError(err, "cannot close etcd session")
+		s.logger.Warnf(ctx, err.Error())
+		return err
+	}
+
+	// Ok
+	s.logger.WithDuration(time.Since(startTime)).Info(ctx, "closed etcd session")
+	return nil
+}
+
+// NewSessionBuilder creates a builder for the resistant Session.
+func NewSessionBuilder() *SessionBuilder {
+	return &SessionBuilder{
+		grantTimeout: sessionDefaultGrantTimeout,
+		ttlSeconds:   sessionDefaultTTLSeconds,
+	}
 }
 
 func newSessionBackoff() *backoff.ExponentialBackOff {

--- a/internal/pkg/service/common/etcdop/session_test.go
+++ b/internal/pkg/service/common/etcdop/session_test.go
@@ -2,64 +2,158 @@ package etcdop
 
 import (
 	"context"
-	"runtime"
 	"sync"
 	"testing"
 	"time"
 
 	"github.com/cenkalti/backoff/v4"
+	"github.com/shopify/toxiproxy"
 	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
 	"go.etcd.io/etcd/client/v3/concurrency"
-	"go.etcd.io/etcd/tests/v3/integration"
 
 	"github.com/keboola/keboola-as-code/internal/pkg/log"
+	"github.com/keboola/keboola-as-code/internal/pkg/utils/errors"
+	"github.com/keboola/keboola-as-code/internal/pkg/utils/etcdhelper"
 )
 
-func TestResistantSession(t *testing.T) {
+func TestSession_Retries(t *testing.T) {
 	t.Parallel()
-	if runtime.GOOS != "linux" {
-		t.Skipf(`etcd session is tested only on Linux`)
-	}
 
 	ctx, cancel := context.WithTimeout(context.Background(), 30*time.Second)
-	defer cancel()
 	wg := &sync.WaitGroup{}
 
-	// Create etcd cluster for test
-	integration.BeforeTestExternal(t)
-	cluster := integration.NewClusterV3(t, &integration.ClusterConfig{Size: 1, UseBridge: true})
-	defer cluster.Terminate(t)
-	cluster.WaitLeader(t)
-	member := cluster.Members[0]
-	client := cluster.Client(0)
+	// Get credentials
+	etcdCfg := etcdhelper.TmpNamespace(t)
 
-	// Setup resistant session
+	// Setup proxy to drop etcd connection
+	proxy := toxiproxy.NewProxy()
+	proxy.Name = "etcd-bridge"
+	proxy.Upstream = etcdCfg.Endpoint
+	require.NoError(t, proxy.Start())
+	defer proxy.Stop()
+
+	// Use proxy
+	etcdCfg.Endpoint = proxy.Listen
+
+	// Create client
+	client := etcdhelper.ClientForTest(t, etcdCfg)
+
+	// Setup session
 	logger := log.NewDebugLogger()
-	ttlSeconds := 1
-	assert.NoError(t, <-ResistantSession(ctx, wg, logger, client, ttlSeconds, func(session *concurrency.Session) error {
-		logger.Info(ctx, "----> new session")
-		return nil
-	}))
+	session, errCh := NewSessionBuilder().
+		WithGrantTimeout(1*time.Second).
+		WithTTLSeconds(1).
+		WithOnSession(func(session *concurrency.Session) error {
+			require.NotNil(t, session)
+			logger.Info(ctx, "----> new session (1)")
+			return nil
+		}).
+		WithOnSession(func(session *concurrency.Session) error {
+			require.NotNil(t, session)
+			logger.Info(ctx, "----> new session (2)")
+			return nil
+		}).
+		Start(ctx, wg, logger, client)
+	require.NoError(t, <-errCh)
+	lowLevelSession, err := session.Session()
+	require.NotNil(t, lowLevelSession)
+	require.NoError(t, err)
 
-	// Drop connection for 7 seconds (dial timeout is 5 seconds)
-	member.Bridge().PauseConnections()
-	member.Bridge().DropConnections()
-	time.Sleep(7 * time.Second)
-	member.Bridge().UnpauseConnections()
+	// Drop connection
+	proxy.Stop()
+	assert.Eventually(t, func() bool {
+		return logger.CompareJSONMessages(`
+{"level":"info","message":"etcd session canceled"}
+{"level":"info","message":"creating etcd session"}
+{"level":"info","message":"cannot create etcd session: context deadline exceeded"}
+{"level":"info","message":"waiting %s before the retry"}
+`) == nil
+	}, 15*time.Second, 100*time.Millisecond)
+
+	// There is no active session
+	lowLevelSession, err = session.Session()
+	assert.Nil(t, lowLevelSession)
+	if assert.Error(t, err) {
+		assert.True(t, errors.As(err, &NoSessionError{}))
+	}
+
+	// Resume connection
+	require.NoError(t, proxy.Start())
+
+	// Wait for the new session
+	_, err = session.WaitForSession(ctx)
+	assert.NoError(t, err)
+	lowLevelSession, err = session.Session()
+	assert.NotNil(t, lowLevelSession)
+	assert.NoError(t, err)
 
 	// Stop and check logs
 	cancel()
 	wg.Wait()
 	logger.AssertJSONMessages(t, `
-{"level":"info","message":"creating etcd session","component":"etcd-session"}
-{"level":"info","message":"created etcd session | %s","component":"etcd-session"}
-{"level":"info","message":"----> new session"}
-{"level":"info","message":"re-creating etcd session, backoff delay %s","component":"etcd-session"}
-{"level":"info","message":"created etcd session | %s","component":"etcd-session"}
-{"level":"info","message":"----> new session"}
-{"level":"info","message":"closing etcd session","component":"etcd-session"}
-{"level":"info","message":"closed etcd session | %s","component":"etcd-session"}
+{"level":"info","message":"creating etcd session","component":"etcd.session"}
+{"level":"info","message":"created etcd session","duration":"%s"}
+{"level":"info","message":"----> new session (1)"}
+{"level":"info","message":"----> new session (2)"}
+{"level":"info","message":"etcd session canceled"}
+{"level":"info","message":"creating etcd session"}
+{"level":"info","message":"cannot create etcd session: context deadline exceeded"}
+{"level":"info","message":"waiting %s before the retry"}
+{"level":"info","message":"creating etcd session"}
+{"level":"info","message":"created etcd session"}
+{"level":"info","message":"----> new session (1)"}
+{"level":"info","message":"----> new session (2)"}
+{"level":"info","message":"closing etcd session: context canceled"}
+{"level":"info","message":"closed etcd session","duration":"%s"}
 `)
+}
+
+func TestSession_NewMutex(t *testing.T) {
+	t.Parallel()
+
+	ctx, cancel := context.WithTimeout(context.Background(), 10*time.Second)
+	wg := &sync.WaitGroup{}
+
+	// Setup
+	logger := log.NewDebugLogger()
+	client := etcdhelper.ClientForTest(t, etcdhelper.TmpNamespace(t))
+
+	// Setup sessions
+	session1, errCh := NewSessionBuilder().Start(ctx, wg, logger, client)
+	require.NotNil(t, session1)
+	require.NoError(t, <-errCh)
+	session2, errCh := NewSessionBuilder().Start(ctx, wg, logger, client)
+	require.NotNil(t, session2)
+	require.NoError(t, <-errCh)
+
+	// Locks
+	lock1, err := session1.NewMutex("lock")
+	require.NoError(t, err)
+	lock2, err := session2.NewMutex("lock")
+	require.NoError(t, err)
+
+	// Lock - same session - ok
+	require.NoError(t, lock1.TryLock(ctx))
+	require.NoError(t, lock1.TryLock(ctx))
+	err = lock2.TryLock(ctx)
+
+	// Lock - different session - fail
+	require.Error(t, err)
+	require.True(t, errors.Is(err, concurrency.ErrLocked))
+
+	// Unlock
+	require.NoError(t, lock1.Unlock(ctx))
+
+	// Lock - different session - ok
+	require.NoError(t, lock2.TryLock(ctx))
+	require.NoError(t, lock2.TryLock(ctx))
+
+	// Close session
+	cancel()
+	wg.Wait()
+	assert.True(t, errors.Is(lock1.TryLock(ctx), context.Canceled))
+	assert.True(t, errors.Is(lock2.TryLock(ctx), context.Canceled))
 }
 
 func TestSessionBackoff(t *testing.T) {

--- a/internal/pkg/service/common/servicectx/servicectx_test.go
+++ b/internal/pkg/service/common/servicectx/servicectx_test.go
@@ -84,7 +84,6 @@ func TestProcess_Add(t *testing.T) {
 
 	// Check logs
 	expected := `
-{"level":"info","message":"process unique id \"<id>\""}
 {"level":"info","message":"exiting (operation failed)"}
 {"level":"info","message":"end"}
 {"level":"info","message":"end"}
@@ -154,7 +153,6 @@ func TestProcess_Shutdown(t *testing.T) {
 
 	// Check logs
 	expected := `
-{"level":"info","message":"process unique id \"<id>\""}
 {"level":"info","message":"exiting (some error)"}
 {"level":"info","message":"end1"}
 {"level":"info","message":"end2"}

--- a/internal/pkg/service/common/task/cleanup_test.go
+++ b/internal/pkg/service/common/task/cleanup_test.go
@@ -111,11 +111,11 @@ func TestCleanup(t *testing.T) {
 {"level":"debug","message":"lock released \"runtime/lock/task/tasks.cleanup\"","component":"task","task":"_system_/tasks.cleanup/%s","node":"node1"}
 {"level":"info","message":"exiting (bye bye)"}
 {"level":"info","message":"received shutdown request","component":"task","node":"node1"}
-{"level":"info","message":"closing etcd session","component":"task.etcd-session","node":"node1"}
-{"level":"info","message":"closed etcd session | %s","component":"task.etcd-session","node":"node1"}
+{"level":"info","message":"closing etcd session: context canceled","component":"task.etcd.session","node":"node1"}
+{"level":"info","message":"closed etcd session","component":"task.etcd.session","node":"node1"}
 {"level":"info","message":"shutdown done","component":"task","node":"node1"}
-{"level":"info","message":"closing etcd connection","component":"etcd-client"}
-{"level":"info","message":"closed etcd connection | %s","component":"etcd-client"}
+{"level":"info","message":"closing etcd connection","component":"etcd.client"}
+{"level":"info","message":"closed etcd connection","component":"etcd.client"}
 {"level":"info","message":"exited"}
 `)
 

--- a/internal/pkg/service/common/task/node_test.go
+++ b/internal/pkg/service/common/task/node_test.go
@@ -888,11 +888,11 @@ task/123/my-receiver/my-export/some.task/%s
 {"level":"info","message":"some message from the task","component":"task","task":"123/my-receiver/my-export/some.task/%s","node":"node1"}
 {"level":"info","message":"task succeeded (%s): some result","component":"task","task":"123/my-receiver/my-export/some.task/%s","node":"node1"}
 {"level":"debug","message":"lock released \"runtime/lock/task/my-lock\"","component":"task","task":"123/my-receiver/my-export/some.task/%s","node":"node1"}
-{"level":"info","message":"closing etcd session","component":"task.etcd-session","node":"node1"}
-{"level":"info","message":"closed etcd session | %s","component":"task.etcd-session","node":"node1"}
+{"level":"info","message":"closing etcd session: context canceled","component":"task.etcd.session","node":"node1"}
+{"level":"info","message":"closed etcd session","component":"task.etcd.session","node":"node1"}
 {"level":"info","message":"shutdown done","component":"task","node":"node1"}
-{"level":"info","message":"closing etcd connection","component":"etcd-client"}
-{"level":"info","message":"closed etcd connection | %s","component":"etcd-client"}
+{"level":"info","message":"closing etcd connection","component":"etcd.client"}
+{"level":"info","message":"closed etcd connection","component":"etcd.client"}
 {"level":"info","message":"exited"}
 `, logs.String())
 }

--- a/internal/pkg/service/common/task/orchestrator/orchestrator_test.go
+++ b/internal/pkg/service/common/task/orchestrator/orchestrator_test.go
@@ -113,18 +113,18 @@ func TestOrchestrator(t *testing.T) {
 
 	expected := `
 {"level":"info","message":"ready","component":"orchestrator","task":"some.task"}
-{"level":"info","message":"assigned \"1000/my-receiver/some.task/ResourceID\"","component":"orchestrator","task":"some.task"}
-{"level":"info","message":"started task","component":"task","task":"1000/my-receiver/some.task/ResourceID/%s"}
-{"level":"debug","message":"lock acquired \"runtime/lock/task/1000/my-receiver/ResourceID\"","component":"task","task":"1000/my-receiver/some.task/ResourceID/%s"}
-{"level":"info","message":"message from the task","component":"task","task":"1000/my-receiver/some.task/ResourceID/%s"}
-{"level":"info","message":"task succeeded (%s): ResourceID","component":"task","task":"1000/my-receiver/some.task/ResourceID/%s"}
-{"level":"debug","message":"lock released \"runtime/lock/task/1000/my-receiver/ResourceID\"","component":"task","task":"1000/my-receiver/some.task/ResourceID/%s"}
+{"level":"info","message":"assigned \"1000/my-prefix/some.task/ResourceID\"","component":"orchestrator","task":"some.task"}
+{"level":"info","message":"started task","component":"task","task":"1000/my-prefix/some.task/ResourceID/%s"}
+{"level":"debug","message":"lock acquired \"runtime/lock/task/custom-lock\"","component":"task","task":"1000/my-prefix/some.task/ResourceID/%s"}
+{"level":"info","message":"message from the task","component":"task","task":"1000/my-prefix/some.task/ResourceID/%s"}
+{"level":"info","message":"task succeeded (%s): ResourceID","component":"task","task":"1000/my-prefix/some.task/ResourceID/%s"}
+{"level":"debug","message":"lock released \"runtime/lock/task/custom-lock\"","component":"task","task":"1000/my-prefix/some.task/ResourceID/%s"}
 `
 	d2.DebugLogger().AssertJSONMessages(t, expected)
 
 	expected = `
 {"level":"info","message":"ready","component":"orchestrator","task":"some.task"}
-{"level":"debug","message":"not assigned \"1000/my-receiver/some.task/ResourceID\", distribution key \"1000/my-receiver\"","component":"orchestrator","task":"some.task"}
+{"level":"debug","message":"not assigned \"1000/my-prefix/some.task/ResourceID\", distribution key \"foo\"","component":"orchestrator","task":"some.task"}
 `
 	d1.DebugLogger().AssertJSONMessages(t, expected)
 }
@@ -199,13 +199,13 @@ func TestOrchestrator_StartTaskIf(t *testing.T) {
 
 	expected := `
 {"level":"info","message":"ready","component":"orchestrator","task":"some.task"}
-{"level":"debug","message":"skipped \"1000/my-receiver/some.task/BadID\", StartTaskIf condition evaluated as false","component":"orchestrator","task":"some.task"}
-{"level":"info","message":"assigned \"1000/my-receiver/some.task/GoodID\"","component":"orchestrator","task":"some.task"}
-{"level":"info","message":"started task","component":"task","task":"1000/my-receiver/some.task/GoodID/%s"}
-{"level":"debug","message":"lock acquired \"runtime/lock/task/1000/my-receiver/some.task/GoodID\"","component":"task","task":"1000/my-receiver/some.task/GoodID/%s"}
-{"level":"info","message":"message from the task","component":"task","task":"1000/my-receiver/some.task/GoodID/%s"}
-{"level":"info","message":"task succeeded (%s): GoodID","component":"task","task":"1000/my-receiver/some.task/GoodID/%s"}
-{"level":"debug","message":"lock released \"runtime/lock/task/1000/my-receiver/some.task/GoodID\"","component":"task","task":"1000/my-receiver/some.task/GoodID/%s"}
+{"level":"debug","message":"skipped \"1000/my-prefix/some.task/BadID\", StartTaskIf condition evaluated as false","component":"orchestrator","task":"some.task"}
+{"level":"info","message":"assigned \"1000/my-prefix/some.task/GoodID\"","component":"orchestrator","task":"some.task"}
+{"level":"info","message":"started task","component":"task","task":"1000/my-prefix/some.task/GoodID/%s"}
+{"level":"debug","message":"lock acquired \"runtime/lock/task/1000/my-prefix/some.task/GoodID\"","component":"task","task":"1000/my-prefix/some.task/GoodID/%s"}
+{"level":"info","message":"message from the task","component":"task","task":"1000/my-prefix/some.task/GoodID/%s"}
+{"level":"info","message":"task succeeded (%s): GoodID","component":"task","task":"1000/my-prefix/some.task/GoodID/%s"}
+{"level":"debug","message":"lock released \"runtime/lock/task/1000/my-prefix/some.task/GoodID\"","component":"task","task":"1000/my-prefix/some.task/GoodID/%s"}
 `
 	d.DebugLogger().AssertJSONMessages(t, expected)
 }
@@ -291,12 +291,12 @@ func TestOrchestrator_RestartInterval(t *testing.T) {
 
 	expected := `
 {"level":"debug","message":"restart","component":"orchestrator","task":"some.task"}
-{"level":"info","message":"assigned \"1000/my-receiver/some.task/ResourceID1\"","component":"orchestrator","task":"some.task"}
-{"level":"info","message":"started task","component":"task","task":"1000/my-receiver/some.task/ResourceID1/%s"}
-{"level":"debug","message":"lock acquired \"runtime/lock/task/1000/my-receiver/some.task/ResourceID1\"","component":"task","task":"1000/my-receiver/some.task/ResourceID1/%s"}
-{"level":"info","message":"message from the task","component":"task","task":"1000/my-receiver/some.task/ResourceID1/%s"}
-{"level":"info","message":"task succeeded (0s): ResourceID1","component":"task","task":"1000/my-receiver/some.task/ResourceID1/%s"}
-{"level":"debug","message":"lock released \"runtime/lock/task/1000/my-receiver/some.task/ResourceID1\"","component":"task","task":"1000/my-receiver/some.task/ResourceID1/%s"}
+{"level":"info","message":"assigned \"1000/my-prefix/some.task/ResourceID\"","component":"orchestrator","task":"some.task"}
+{"level":"info","message":"started task","component":"task","task":"1000/my-prefix/some.task/ResourceID/%s"}
+{"level":"debug","message":"lock acquired \"runtime/lock/task/1000/my-prefix/some.task/ResourceID\"","component":"task","task":"1000/my-prefix/some.task/ResourceID/%s"}
+{"level":"info","message":"message from the task","component":"task","task":"1000/my-prefix/some.task/ResourceID/%s"}
+{"level":"info","message":"task succeeded (0s): ResourceID","component":"task","task":"1000/my-prefix/some.task/ResourceID/%s"}
+{"level":"debug","message":"lock released \"runtime/lock/task/1000/my-prefix/some.task/ResourceID\"","component":"task","task":"1000/my-prefix/some.task/ResourceID/%s"}
 `
 	d.DebugLogger().AssertJSONMessages(t, expected)
 }

--- a/internal/pkg/template/repository/manager/manager.go
+++ b/internal/pkg/template/repository/manager/manager.go
@@ -247,7 +247,7 @@ func (m *Manager) repository(ctx context.Context, ref model.TemplateRepository) 
 			}
 
 			// Checkout done
-			m.logger.Infof(ctx, `checked out repository "%s" | %s`, gitRepo, time.Since(startTime))
+			m.logger.WithDuration(time.Since(startTime)).Infof(ctx, `checked out repository "%s"`, gitRepo)
 		} else {
 			// Local directory
 			fs, err := aferofs.NewLocalFs(ref.URL, filesystem.WithLogger(m.deps.Logger()))

--- a/internal/pkg/template/repository/manager/repository.go
+++ b/internal/pkg/template/repository/manager/repository.go
@@ -118,7 +118,7 @@ func (r *CachedRepository) Template(ctx context.Context, reference model.Templat
 		r.templatesLock.Unlock()
 
 		// Load done
-		r.d.Logger().Infof(ctx, `loaded template "%s/%s" | %s`, reference.FullName(), r.git.CommitHash(), time.Since(startTime))
+		r.d.Logger().WithDuration(time.Since(startTime)).Infof(ctx, `loaded template "%s/%s"`, reference.FullName(), r.git.CommitHash())
 		return tmpl, nil
 	})
 
@@ -147,9 +147,9 @@ func (r *CachedRepository) update(ctx context.Context) (*CachedRepository, bool,
 
 		// Done
 		if result.Changed {
-			r.d.Logger().Infof(ctx, `repository "%s" updated from %s to %s | %s`, r.URLAndRef(), result.OldHash, result.NewHash, time.Since(startTime))
+			r.d.Logger().WithDuration(time.Since(startTime)).Infof(ctx, `repository "%s" updated from %s to %s`, r.URLAndRef(), result.OldHash, result.NewHash)
 		} else {
-			r.d.Logger().Infof(ctx, `repository "%s" update finished, no change found (%s) | %s`, r.URLAndRef(), result.NewHash, time.Since(startTime))
+			r.d.Logger().WithDuration(time.Since(startTime)).Infof(ctx, `repository "%s" update finished, no change found (%s)`, r.URLAndRef(), result.NewHash)
 		}
 
 		// No change
@@ -206,9 +206,9 @@ func (r *CachedRepository) loadAllTemplates(ctx context.Context) error {
 
 	wg.Wait()
 	if errs.Len() > 0 {
-		r.d.Logger().Errorf(ctx, `cannot load all templates from repository "%s", see previous errors | %s`, r.String(), time.Since(startTime))
+		r.d.Logger().WithDuration(time.Since(startTime)).Errorf(ctx, `cannot load all templates from repository "%s", see previous errors`, r.String())
 	} else {
-		r.d.Logger().Infof(ctx, `loaded all templates from repository "%s" | %s`, r.String(), time.Since(startTime))
+		r.d.Logger().WithDuration(time.Since(startTime)).Infof(ctx, `loaded all templates from repository "%s"`, r.String())
 	}
 
 	return errs.ErrorOrNil()

--- a/internal/pkg/utils/etcdhelper/fortest.go
+++ b/internal/pkg/utils/etcdhelper/fortest.go
@@ -107,7 +107,7 @@ func clientForTest(t testOrBenchmark, ctx context.Context, cfg etcdclient.Config
 				BaseDelay:  100 * time.Millisecond,
 				Multiplier: 1.5,
 				Jitter:     0.2,
-				MaxDelay:   15 * time.Second,
+				MaxDelay:   5 * time.Second,
 			},
 		}),
 	)
@@ -116,7 +116,7 @@ func clientForTest(t testOrBenchmark, ctx context.Context, cfg etcdclient.Config
 	etcdClient, err := etcd.New(etcd.Config{
 		Context:              ctx,
 		Endpoints:            []string{cfg.Endpoint},
-		DialTimeout:          10 * time.Second,
+		DialTimeout:          5 * time.Second,
 		DialKeepAliveTimeout: 5 * time.Second,
 		DialKeepAliveTime:    10 * time.Second,
 		Username:             cfg.Username, // optional

--- a/test/templates/api/base/api-startup/expected-server-stdout
+++ b/test/templates/api/base/api-startup/expected-server-stdout
@@ -1,21 +1,21 @@
 {"level":"info","message":"Configuration: {\"debug-log\":false,\"debugHTTPClient\":false,\"cpuProfilePath\":\"\",\"nodeID\":\"test-node\",\"datadog\":{\"enabled\":false,\"debug\":false},\"etcd\":{\"endpoint\":\"%s\",\"namespace\":\"%s\",\"username\":\"%s\",\"password\":\"*****\",\"connectTimeout\":\"30s\",\"keepAliveTimeout\":\"5s\",\"keepAliveInterval\":\"10s\",\"debugLog\":false},\"metrics\":{\"listen\":\"%s\"},\"api\":{\"listen\":\"%s\",\"publicURL\":\"https://templates.keboola.local\"},\"storage-api-host\":\"%s\",\"repositories\":\"keboola|https://github.com/keboola/keboola-as-code-templates.git|main\",\"tasks-cleanup-enabled\":true,\"tasks-cleanup-interval\":\"1h0m0s\"}","component":"templatesApi"}
 {"level":"info","message":"HTTP server listening on \"localhost:%d/metrics\"","component":"templatesApi.metrics"}
 {"level":"info","message":"loading Storage API index with components","component":"templatesApi"}
-{"level":"info","message":"loaded Storage API index with \"%s\" components | %s","component":"templatesApi"}
-{"level":"info","message":"connecting to etcd, connectTimeout=30s, keepAliveTimeout=5s, keepAliveInterval=10s","component":"templatesApi.etcd-client"}
-{"level":"info","message":"connected to etcd cluster \"%s\" | %s","component":"templatesApi.etcd-client"}
-{"level":"info","message":"creating etcd session","component":"templatesApi.task.etcd-session"}
-{"level":"info","message":"created etcd session | %s","component":"templatesApi.task.etcd-session"}
-{"level":"info","message":"creating etcd session","component":"templatesApi.distribution.templates-api.etcd-session"}
-{"level":"info","message":"created etcd session | %s","component":"templatesApi.distribution.templates-api.etcd-session"}
+{"level":"info","message":"loaded Storage API index with \"%s\" components","component":"templatesApi"}
+{"level":"info","message":"connecting to etcd, connectTimeout=30s, keepAliveTimeout=5s, keepAliveInterval=10s","component":"templatesApi.etcd.client"}
+{"level":"info","message":"connected to etcd cluster \"%s\"","component":"templatesApi.etcd.client"}
+{"level":"info","message":"creating etcd session","component":"templatesApi.task.etcd.session"}
+{"level":"info","message":"created etcd session","component":"templatesApi.task.etcd.session"}
+{"level":"info","message":"creating etcd session","component":"templatesApi.distribution.templates-api.etcd.session"}
+{"level":"info","message":"created etcd session","component":"templatesApi.distribution.templates-api.etcd.session"}
 {"level":"info","message":"registering the node \"%s\"","component":"templatesApi.distribution.templates-api"}
-{"level":"info","message":"the node \"%s\" registered | %s","component":"templatesApi.distribution.templates-api"}
+{"level":"info","message":"the node \"%s\" registered","component":"templatesApi.distribution.templates-api"}
 {"level":"info","message":"watching for other nodes","component":"templatesApi.distribution.templates-api"}
 {"level":"info","message":"found a new node \"%s\"","component":"templatesApi.distribution.templates-api"}
 {"level":"info","message":"checking out repository \"https://github.com/keboola/keboola-as-code-templates.git:main\"","component":"templatesApi"}
-{"level":"info","message":"checked out repository \"https://github.com/keboola/keboola-as-code-templates.git:main\" | %s","component":"templatesApi"}
+{"level":"info","message":"checked out repository \"https://github.com/keboola/keboola-as-code-templates.git:main\"","component":"templatesApi"}
 {"level":"info","message":"loading all templates from repository \"https://github.com/keboola/keboola-as-code-templates.git:main:%s\"","component":"templatesApi"}
-{"level":"info","message":"loaded all templates from repository \"https://github.com/keboola/keboola-as-code-templates.git:main:%s\" | %s","component":"templatesApi"}
+{"level":"info","message":"loaded all templates from repository \"https://github.com/keboola/keboola-as-code-templates.git:main:%s\"","component":"templatesApi"}
 {"level":"info","message":"components update cron ready","component":"templatesApi"}
 {"level":"info","message":"repository pull cron ready","component":"templatesApi"}
 {"level":"info","message":"ready","component":"templatesApi.cleanup"}
@@ -36,16 +36,16 @@
 {"level":"info","message":"shutdown done","component":"templatesApi.distribution.templates-api.listeners"}
 {"level":"info","message":"received shutdown request","component":"templatesApi.distribution.templates-api"}
 {"level":"info","message":"unregistering the node \"%s\"","component":"templatesApi.distribution.templates-api"}
-{"level":"info","message":"the node \"%s\" unregistered | %s","component":"templatesApi.distribution.templates-api"}
-{"level":"info","message":"closing etcd session","component":"templatesApi.distribution.templates-api.etcd-session"}
-{"level":"info","message":"closed etcd session | %s","component":"templatesApi.distribution.templates-api.etcd-session"}
+{"level":"info","message":"the node \"%s\" unregistered","component":"templatesApi.distribution.templates-api"}
+{"level":"info","message":"closing etcd session: context canceled","component":"templatesApi.distribution.templates-api.etcd.session"}
+{"level":"info","message":"closed etcd session","component":"templatesApi.distribution.templates-api.etcd.session"}
 {"level":"info","message":"shutdown done","component":"templatesApi.distribution.templates-api"}
 {"level":"info","message":"received shutdown request","component":"templatesApi.task"}
-{"level":"info","message":"closing etcd session","component":"templatesApi.task.etcd-session"}
-{"level":"info","message":"closed etcd session | %s","component":"templatesApi.task.etcd-session"}
+{"level":"info","message":"closing etcd session: context canceled","component":"templatesApi.task.etcd.session"}
+{"level":"info","message":"closed etcd session","component":"templatesApi.task.etcd.session"}
 {"level":"info","message":"shutdown done","component":"templatesApi.task"}
-{"level":"info","message":"closing etcd connection","component":"templatesApi.etcd-client"}
-{"level":"info","message":"closed etcd connection | %s","component":"templatesApi.etcd-client"}
+{"level":"info","message":"closing etcd connection","component":"templatesApi.etcd.client"}
+{"level":"info","message":"closed etcd connection","component":"templatesApi.etcd.client"}
 {"level":"info","message":"shutting down HTTP server at \"localhost:%d\"","component":"templatesApi.metrics"}
 {"level":"info","message":"HTTP server shutdown finished","component":"templatesApi.metrics"}
 {"level":"info","message":"exited","component":"templatesApi"}

--- a/test/templates/api/index/index/expected-server-stdout
+++ b/test/templates/api/index/index/expected-server-stdout
@@ -1,1 +1,1 @@
-{"level":"info","message":"loaded Storage API index with \"%d\" components | %s","component":"templatesApi"}
+{"level":"info","message":"loaded Storage API index with \"%d\" components","component":"templatesApi"}


### PR DESCRIPTION
Jira: https://keboola.atlassian.net/browse/PSGO-416

**Changes:**
- Improved interface of the `etcdop.Session`:
  - Multiple `OnSession` callbacks.
  - `Session` and `WaitForSession` getters.
  - Default configuration values for TTL seconds and grant timeout.

-----------

**Intro**

There is a "resistent session" in the `etcdop` package.

The `Session` wraps etcd low-level `*concurrency.Session` - it provides: `LeaseID`, distributed locks, ... 


The problem with  etcd low-level `*concurrency.Session` is, that if there is an network outage, if TTL seconds expire, the session is canceled.

But in our apps: we need a retry and the session recreation, so we created "resistant session" implementation.

In this PR, I improved the package interface, so it can be used better.

----------------

