### PR TITLE
feat: Add AtomicOp.RequireLock

### DIFF
--- a/internal/pkg/service/common/etcdop/op/atomic_lock.go
+++ b/internal/pkg/service/common/etcdop/op/atomic_lock.go
@@ -1,0 +1,23 @@
+package op
+
+import "go.etcd.io/etcd/client/v3/concurrency"
+
+// NotLockedError occurs if the lock is not locked during the entire operation.
+// See AtomicOp.RequireLock for details.
+type NotLockedError struct{}
+
+// LockedError occurs if the lock is locked by another session.
+// See AtomicOp.RequireLock for details.
+type LockedError struct{}
+
+func (e NotLockedError) Error() string {
+	return "lock is not locked"
+}
+
+func (e LockedError) Error() string {
+	return "lock is locked by another session"
+}
+
+func (e LockedError) Unwrap() error {
+	return concurrency.ErrLocked
+}


### PR DESCRIPTION
Jira: https://keboola.atlassian.net/browse/PSGO-416

**Changes:**
- Added `AtomicOp.RequireLock` method.
  - This PR adds support for etcd locks, used in etcd transaction, to our high-level `AtomicOp`.

-----------

### Example

Low-level etcd transaction:
```go
mutex, err := concurrency.NewMutex(session, "lock123")

err = mutex.Lock(ctx)
defer mutex.Unlock(ctx)

err = client.Txn(ctx).If(mutex.IsOwner()).Then(...).Else(...).Commit()
```

High-level `etcdop.AtomicOp` (generates read and write transaction)
 ```go
mutex, err := concurrency.NewMutex(session, "lock123")

err = mutex.Lock(ctx)
defer mutex.Unlock(ctx)

atomicOp := op.Atomic(client, &op.NoResult{}).RequireLock(mutex).ReadOp(...).WriteOp(...)
err = atomicOp.Do(ctx).Err()
```

### Intro

:warning: It's a complicated topic, I'll explain on standup.

**TLDR:** 
 - We are adding to our high-level `etcdop` pkg, a functionality that is present in the low-level etcd interface. 
 - Nothing interesting happens in our code.
 - There are tests for it.

Problem:
- We need distributed locks in our app.
- etcd provides distributed locks.
- But in reality there is no such thing as a distributed lock (see read more bellow).
- It is impossible to keep multiple nodes in a cluster in the same state under all conditions.
  - See `CAP`, `PACELC` theorems, etc.
- _For example_, `client 3` thinks it still owns the lock, but the rest of the cluster doesn't think it.
  - The lock has `time-to-live=5sec`, 
    but it is not possible to have the clocks on all nodes fully synchronized.
  - Other examples could be given, but this is the simplest.
- 100% exclusivity of an operation can only be ensured within one node - in our case it is the `Leader` of the etcd cluster.
  - So, if we want to perform some etcd operation under a lock ....
  - **We have to add some IF condition to the etcd transaction, which verifies that we still hold the lock.**
  - If we hold the lock, the operation will pass, otherwise it will not.
  - The fact that the Go code thinks we hold the lock is not enough itself, it must be checked in the DB.
​

![image](https://github.com/keboola/keboola-as-code/assets/19371734/397a3d1d-c6c8-44f1-9081-e7654819d7af)


### Read more

**API reference: concurrency**
https://etcd.io/docs/v3.5/dev-guide/api_concurrency_reference_v3/
> Lock acquires a distributed shared lock on a given named lock. On success, it will return a unique key that exists so long as the lock is held by the caller. **This key can be used in conjunction with transactions to safely ensure updates to etcd only occur while holding lock ownership**. The lock is held until Unlock is called on the key or the lease associate with the owner expires.

**There is no such thing as a distributed lock**
https://jolynch.github.io/posts/distsys_shibboleths/
> **There is no such thing as a distributed lock** because a true distributed lock would require a CA system and we should remember those are not possible. ...

**Document that locks aren't really locks**
https://github.com/etcd-io/etcd/issues/11457
> As a part of our Jepsen testing, we've demonstrated that etcd's locks aren't actually locks: **like all "distributed locks" they cannot guarantee mutual exclusion when** processes are allowed to run slow or fast, or crash, or messages are delayed, or their clocks are unstable, etc. 

**Notes on the usage of lock and lease**
https://etcd.io/docs/v3.5/learning/why/#notes-on-the-usage-of-lock-and-lease

> etcd provides lock APIs which are based on the lease mechanism and its implementation in etcd. The basic idea of the lease mechanism is: a server grants a token, which is called a lease, to a requesting client. When the server grants a lease, it associates a TTL with the lease. When the server detects the passage of time longer than the TTL, it revokes the lease. While the client holds a non revoked lease it can claim that it owns access to a resource associated with the lease. In the case of etcd, the resource is a key in the etcd keyspace. etcd provides lock APIs with this scheme. **However, the lock APIs cannot be used as mutual exclusion mechanism by themselves. The APIs are called lock because for historical reasons. The lock APIs can, however, be used as an optimization mechanism of mutual exclusion as described below.**

> Why do etcd and other systems provide lease if they provide mutual exclusion based on version number validation? **Well, leases provide an optimization mechanism for reducing a number of aborted requests.**
- This means that the 100% solution is only via an etcd transaction.
- But we don't want e.g. 50% of our transactions to fail (among other things, it would has poor performance).
- So `99.9%` of operations are covered by a distributed "lock".
- And remaining `0.1%` - edge cases - are covered by the IF condition in the transaction.

> Note that in the case of etcd keys, it can be locked efficiently because of the mechanisms of lease and version number validation. If users need to protect resources which aren’t related to etcd, the resources must provide the version number validation mechanism and consistency of replicas like keys of etcd. **The lock feature of etcd itself cannot be used for protecting external resources.**

**Making the lock safe with fencing**
https://martin.kleppmann.com/2016/02/08/how-to-do-distributed-locking.html
- etcd implementation (lock + IF in txn)  is a variation to the `fencing token` approach.
- `etcd key revision` == `fencing token`

**It worked OK 99.9% the time**
https://news.ycombinator.com/item?id=31229783
> At our job someone decided to use a ready-to-use Go library which used Redis for distributed locking. But I found that it was broken by design and completely unreliable, and we had random transient errors stemming from it. **It worked OK 99.9% the time**, ...