### PR TITLE
feat: Create distribution.GroupNode (improve pkg interface)

### DIFF
--- a/internal/pkg/service/common/dependencies/distribution.go
+++ b/internal/pkg/service/common/dependencies/distribution.go
@@ -18,18 +18,15 @@ type distributionScopeDeps interface {
 	TaskScope
 }
 
-func NewDistributionScope(ctx context.Context, nodeID, group string, d distributionScopeDeps) (DistributionScope, error) {
-	return newDistributionScope(ctx, nodeID, group, d)
+func NewDistributionScope(ctx context.Context, nodeID string, d distributionScopeDeps) (DistributionScope, error) {
+	return newDistributionScope(ctx, nodeID, d)
 }
 
-func newDistributionScope(ctx context.Context, nodeID, group string, d distributionScopeDeps) (v *distributionScope, err error) {
+func newDistributionScope(ctx context.Context, nodeID string, d distributionScopeDeps) (v *distributionScope, err error) {
 	ctx, span := d.Telemetry().Tracer().Start(ctx, "keboola.go.common.dependencies.NewDistributionScope")
 	defer span.End(&err)
 
-	node, err := distributionPkg.NewNode(nodeID, group, distributionPkg.NewConfig(), d)
-	if err != nil {
-		return nil, err
-	}
+	node := distributionPkg.NewNode(nodeID, distributionPkg.NewConfig(), d)
 
 	return &distributionScope{node: node}, nil
 }

--- a/internal/pkg/service/common/dependencies/mocked.go
+++ b/internal/pkg/service/common/dependencies/mocked.go
@@ -34,10 +34,6 @@ import (
 	"github.com/keboola/keboola-as-code/internal/pkg/utils/testproject"
 )
 
-const (
-	distributionGroup = "my-group"
-)
-
 // mocked dependencies container implements Mocked interface.
 type mocked struct {
 	*baseScope
@@ -341,7 +337,7 @@ func NewMocked(t *testing.T, opts ...MockedOption) Mocked {
 	}
 
 	if cfg.enableDistribution {
-		d.distributionScope, err = newDistributionScope(cfg.ctx, cfg.nodeID, distributionGroup, d)
+		d.distributionScope, err = newDistributionScope(cfg.ctx, cfg.nodeID, d)
 		require.NoError(t, err)
 	}
 

--- a/internal/pkg/service/common/dependencies/orchestrator.go
+++ b/internal/pkg/service/common/dependencies/orchestrator.go
@@ -15,7 +15,6 @@ type orchestratorScopeDeps interface {
 	BaseScope
 	EtcdClientScope
 	TaskScope
-	DistributionScope
 }
 
 func NewOrchestratorScope(ctx context.Context, d orchestratorScopeDeps) OrchestratorScope {

--- a/internal/pkg/service/common/distribution/listener.go
+++ b/internal/pkg/service/common/distribution/listener.go
@@ -5,10 +5,8 @@ import (
 	"sync"
 	"time"
 
-	"go.opentelemetry.io/otel/attribute"
-
 	"github.com/keboola/keboola-as-code/internal/pkg/idgenerator"
-	"github.com/keboola/keboola-as-code/internal/pkg/service/common/ctxattr"
+	"github.com/keboola/keboola-as-code/internal/pkg/log"
 )
 
 // Listener listens for distribution changes, when a node is added or removed.
@@ -31,20 +29,19 @@ type listeners struct {
 
 type listenerID string
 
-func newListeners(n *Node) *listeners {
-	logger := n.logger.WithComponent("listeners")
+func newListeners(ctx context.Context, cfg Config, logger log.Logger, d dependencies) *listeners {
+	logger = logger.WithComponent("listeners")
 
 	v := &listeners{
-		config:    n.config,
+		config:    cfg,
 		lock:      &sync.Mutex{},
 		listeners: make(map[listenerID]*Listener),
 	}
 
 	// Graceful shutdown
-	ctx, cancel := context.WithCancel(context.Background()) // nolint: contextcheck
+	ctx, cancel := context.WithCancel(ctx)
 	wg := &sync.WaitGroup{}
-	n.proc.OnShutdown(func(ctx context.Context) {
-		ctx = ctxattr.ContextWith(ctx, attribute.String("node", n.nodeID))
+	d.Process().OnShutdown(func(ctx context.Context) {
 		logger.Info(ctx, "received shutdown request")
 		cancel()
 		wg.Wait()
@@ -60,7 +57,7 @@ func newListeners(n *Node) *listeners {
 		// Otherwise, trigger is called immediately, see Notify method.
 		var tickerC <-chan time.Time
 		if v.config.EventsGroupInterval > 0 {
-			ticker := n.clock.Ticker(v.config.EventsGroupInterval)
+			ticker := d.Clock().Ticker(v.config.EventsGroupInterval)
 			defer ticker.Stop()
 			tickerC = ticker.C
 		}

--- a/internal/pkg/service/common/distribution/listener.go
+++ b/internal/pkg/service/common/distribution/listener.go
@@ -29,7 +29,7 @@ type listeners struct {
 
 type listenerID string
 
-func newListeners(ctx context.Context, cfg Config, logger log.Logger, d dependencies) *listeners {
+func newListeners(ctx context.Context, wg *sync.WaitGroup, cfg Config, logger log.Logger, d dependencies) *listeners {
 	logger = logger.WithComponent("listeners")
 
 	v := &listeners{
@@ -37,16 +37,6 @@ func newListeners(ctx context.Context, cfg Config, logger log.Logger, d dependen
 		lock:      &sync.Mutex{},
 		listeners: make(map[listenerID]*Listener),
 	}
-
-	// Graceful shutdown
-	ctx, cancel := context.WithCancel(ctx)
-	wg := &sync.WaitGroup{}
-	d.Process().OnShutdown(func(ctx context.Context) {
-		logger.Info(ctx, "received shutdown request")
-		cancel()
-		wg.Wait()
-		logger.Info(ctx, "shutdown done")
-	})
 
 	wg.Add(1)
 	go func() {

--- a/internal/pkg/service/common/distribution/listener_test.go
+++ b/internal/pkg/service/common/distribution/listener_test.go
@@ -25,7 +25,7 @@ func TestOnChangeListener(t *testing.T) {
 	ctx, cancel := context.WithTimeout(context.Background(), 30*time.Second)
 	defer cancel()
 
-	var node1 *distribution.Node
+	var node1 *distribution.GroupNode
 	var d1, d2, d3, d4 dependencies.Mocked
 
 	listenerLogs := ioutil.NewAtomicWriter()

--- a/internal/pkg/service/common/distribution/node.go
+++ b/internal/pkg/service/common/distribution/node.go
@@ -121,7 +121,7 @@ func newGroupMember(nodeID, groupID string, cfg Config, d dependencies) (*GroupN
 	}
 
 	// Create listeners handler
-	g.listeners = newListeners(ctx, cfg, g.logger, d)
+	g.listeners = newListeners(watchCtx, wg, cfg, g.logger, d)
 
 	// Watch for nodes
 	if err := g.watch(watchCtx, wg); err != nil {

--- a/internal/pkg/service/common/distribution/node.go
+++ b/internal/pkg/service/common/distribution/node.go
@@ -18,21 +18,28 @@ import (
 	"github.com/keboola/keboola-as-code/internal/pkg/utils/errors"
 )
 
-// Node is created within each node in the group.
+// Node is factory for GroupNode.
+type Node struct {
+	id           string
+	config       Config
+	dependencies dependencies
+	groups       map[string]*GroupNode
+}
+
+// GroupNode is created within each node in the group.
+// One physical cluster node can be present in multiple independent distribution groups.
 //
 // It is responsible for:
 // - Registration/un-registration of the node in the cluster, see register and unregister methods.
 // - Discovery of the self and other nodes in the cluster, see watch method.
 // - Embedded Assigner locally assigns a owner for a key, see documentation of the Assigner.
 // - Embedded listeners listen for distribution changes, when a node is added or removed.
-type Node struct {
+type GroupNode struct {
 	*assigner
-	groupPrefix etcdop.Prefix
-	clock       clock.Clock
 	logger      log.Logger
-	proc        *servicectx.Process
-	client      *etcd.Client
 	config      Config
+	client      *etcd.Client
+	groupPrefix etcdop.Prefix
 	listeners   *listeners
 }
 
@@ -45,83 +52,103 @@ type dependencies interface {
 	Process() *servicectx.Process
 }
 
-func NewNode(nodeID, group string, cfg Config, d dependencies) (*Node, error) {
-	// Validate
+func NewNode(nodeID string, cfg Config, d dependencies) *Node {
 	if nodeID == "" {
 		panic(errors.New("distribution.Node: node ID cannot be empty"))
 	}
-	if group == "" {
-		panic(errors.New("distribution.Node: group cannot be empty"))
+	return &Node{id: nodeID, config: cfg, dependencies: d, groups: make(map[string]*GroupNode)}
+}
+
+func (n *Node) Group(group string) (*GroupNode, error) {
+	if _, ok := n.groups[group]; ok {
+		return nil, errors.Errorf(`group "%s" has already been initialized`, group)
 	}
 
+	g, err := newGroupMember(n.id, group, n.config, n.dependencies)
+	if err != nil {
+		return nil, err
+	}
+
+	n.groups[group] = g
+	return g, nil
+}
+
+func newGroupMember(nodeID, groupID string, cfg Config, d dependencies) (*GroupNode, error) {
+	// Validate
+	if groupID == "" {
+		return nil, errors.Errorf("distribution group cannot be empty")
+	}
+
+	ctx := ctxattr.ContextWith(
+		context.Background(), // nolint: contextcheck
+		attribute.String("distribution.node", nodeID),
+		attribute.String("distribution.group", groupID),
+	)
+
 	// Create instance
-	n := &Node{
+	g := &GroupNode{
 		assigner:    newAssigner(nodeID),
-		groupPrefix: etcdop.NewPrefix(fmt.Sprintf("runtime/distribution/group/%s/nodes", group)),
-		clock:       d.Clock(),
-		logger:      d.Logger().WithComponent("distribution." + group),
-		proc:        d.Process(),
-		client:      d.EtcdClient(),
+		logger:      d.Logger().WithComponent("distribution"),
 		config:      cfg,
+		client:      d.EtcdClient(),
+		groupPrefix: etcdop.NewPrefix(fmt.Sprintf("runtime/distribution/group/%s/nodes", groupID)),
 	}
 
 	// Graceful shutdown
-	bgContext := ctxattr.ContextWith(context.Background(), attribute.String("node", nodeID)) // nolint: contextcheck
-	watchCtx, watchCancel := context.WithCancel(bgContext)
-	sessionCtx, sessionCancel := context.WithCancel(bgContext)
+	watchCtx, watchCancel := context.WithCancel(ctx)
+	sessionCtx, sessionCancel := context.WithCancel(ctx)
 	wg := &sync.WaitGroup{}
-	n.proc.OnShutdown(func(ctx context.Context) {
-		ctx = ctxattr.ContextWith(ctx, attribute.String("node", n.nodeID))
-		n.logger.Info(ctx, "received shutdown request")
+	d.Process().OnShutdown(func(ctx context.Context) {
+		g.logger.Info(ctx, "received shutdown request")
 		watchCancel()
-		n.unregister(ctx, cfg.ShutdownTimeout)
+		g.unregister(ctx, cfg.ShutdownTimeout)
 		sessionCancel()
 		wg.Wait()
-		n.logger.Info(ctx, "shutdown done")
+		g.logger.Info(ctx, "shutdown done")
 	})
 
 	// Log node ID
-	n.logger.Infof(watchCtx, `node ID "%s"`, nodeID)
+	g.logger.Info(ctx, "starting")
 
 	// Register node
 	_, errCh := etcdop.
 		NewSessionBuilder().
 		WithTTLSeconds(cfg.TTLSeconds).
-		WithOnSession(func(session *concurrency.Session) error { return n.register(session, cfg.StartupTimeout) }).
-		Start(sessionCtx, wg, n.logger, n.client)
+		WithOnSession(g.register).
+		Start(sessionCtx, wg, g.logger, d.EtcdClient())
 	if err := <-errCh; err != nil {
 		return nil, err
 	}
 
 	// Create listeners handler
-	n.listeners = newListeners(n)
+	g.listeners = newListeners(ctx, cfg, g.logger, d)
 
 	// Watch for nodes
-	if err := n.watch(watchCtx, wg); err != nil {
+	if err := g.watch(watchCtx, wg); err != nil {
 		return nil, err
 	}
 
 	// Reset events created during the initialization.
-	// There is no listener yet, and some events can be buffered by grouping interval.
-	n.listeners.Reset()
+	// There is no listener yet, but some events can be buffered by grouping interval.
+	g.listeners.Reset()
 
-	return n, nil
+	return g, nil
 }
 
 // OnChangeListener returns a new listener, it contains channel C with streamed distribution change Events.
-func (n *Node) OnChangeListener() *Listener {
+func (n *GroupNode) OnChangeListener() *Listener {
 	return n.listeners.add()
 }
 
 // CloneAssigner returns cloned Assigner frozen in the actual distribution.
-func (n *Node) CloneAssigner() *Assigner {
+func (n *GroupNode) CloneAssigner() *Assigner {
 	return n.assigner.clone()
 }
 
 // register node in the etcd prefix,
-// Deregistration is ensured double: by OnShutdown callback and by the lease.
-func (n *Node) register(session *concurrency.Session, timeout time.Duration) error {
-	ctx, cancel := context.WithTimeout(n.client.Ctx(), timeout)
+// Un-registration is ensured double: by OnShutdown callback and by the lease.
+func (n *GroupNode) register(session *concurrency.Session) error {
+	ctx, cancel := context.WithTimeout(session.Client().Ctx(), n.config.StartupTimeout)
 	defer cancel()
 
 	ctx = ctxattr.ContextWith(ctx, attribute.String("node", n.nodeID))
@@ -138,7 +165,7 @@ func (n *Node) register(session *concurrency.Session, timeout time.Duration) err
 	return nil
 }
 
-func (n *Node) unregister(ctx context.Context, timeout time.Duration) {
+func (n *GroupNode) unregister(ctx context.Context, timeout time.Duration) {
 	ctx, cancel := context.WithTimeout(ctx, timeout)
 	defer cancel()
 
@@ -154,7 +181,7 @@ func (n *Node) unregister(ctx context.Context, timeout time.Duration) {
 }
 
 // watch for other nodes.
-func (n *Node) watch(ctx context.Context, wg *sync.WaitGroup) error {
+func (n *GroupNode) watch(ctx context.Context, wg *sync.WaitGroup) error {
 	n.logger.Info(ctx, "watching for other nodes")
 	init := n.groupPrefix.
 		GetAllAndWatch(ctx, n.client, etcd.WithPrevKV()).
@@ -179,7 +206,7 @@ func (n *Node) watch(ctx context.Context, wg *sync.WaitGroup) error {
 }
 
 // updateNodesFrom events. The operation is atomic.
-func (n *Node) updateNodesFrom(ctx context.Context, events []etcdop.WatchEvent, reset bool) Events {
+func (n *GroupNode) updateNodesFrom(ctx context.Context, events []etcdop.WatchEvent, reset bool) Events {
 	n.assigner.lock()
 	defer n.assigner.unlock()
 

--- a/internal/pkg/service/common/distribution/node_test.go
+++ b/internal/pkg/service/common/distribution/node_test.go
@@ -33,7 +33,7 @@ func TestNodesDiscovery(t *testing.T) {
 	// Create 3 nodes and (pseudo) processes
 	nodesCount := 3
 	lock := &sync.Mutex{}
-	nodes := make(map[int]*distribution.Node)
+	nodes := make(map[int]*distribution.GroupNode)
 	loggers := make(map[int]log.DebugLogger)
 	processes := make(map[int]*servicectx.Process)
 
@@ -173,72 +173,75 @@ node3
 
 	// Logs differs in number of "the node ... gone" messages
 	loggers[0].AssertJSONMessages(t, `
-{"level":"info","message":"creating etcd session","node":"node1","component":"distribution.my-group.etcd.session"}
-{"level":"info","message":"created etcd session","node":"node1","component":"distribution.my-group.etcd.session"}
-{"level":"info","message":"registering the node \"node1\"","node":"node1","component":"distribution.my-group"}
-{"level":"info","message":"the node \"node1\" registered","node":"node1","component":"distribution.my-group"}
-{"level":"info","message":"watching for other nodes","node":"node1","component":"distribution.my-group"}
-{"level":"info","message":"found a new node \"node%d\"","node":"node1","component":"distribution.my-group"}
-{"level":"info","message":"found a new node \"node%d\"","node":"node1","component":"distribution.my-group"}
-{"level":"info","message":"found a new node \"node%d\"","node":"node1","component":"distribution.my-group"}
+{"level":"info","message":"starting","component":"distribution","distribution.node":"node1","distribution.group":"my-group"}
+{"level":"info","message":"creating etcd session"}
+{"level":"info","message":"created etcd session"}
+{"level":"info","message":"registering the node \"node1\""}
+{"level":"info","message":"the node \"node1\" registered"}
+{"level":"info","message":"watching for other nodes"}
+{"level":"info","message":"found a new node \"node%d\""}
+{"level":"info","message":"found a new node \"node%d\""}
+{"level":"info","message":"found a new node \"node%d\""}
 {"level":"info","message":"exiting (bye bye 1)"}
-{"level":"info","message":"received shutdown request","node":"node1","component":"distribution.my-group.listeners"}
-{"level":"info","message":"shutdown done","node":"node1","component":"distribution.my-group.listeners"}
-{"level":"info","message":"received shutdown request","node":"node1","component":"distribution.my-group"}
-{"level":"info","message":"unregistering the node \"node1\"","node":"node1","component":"distribution.my-group"}
-{"level":"info","message":"the node \"node1\" unregistered","node":"node1","component":"distribution.my-group"}
-{"level":"info","message":"closing etcd session: context canceled","node":"node1","component":"distribution.my-group.etcd.session"}
-{"level":"info","message":"closed etcd session","node":"node1","component":"distribution.my-group.etcd.session"}
-{"level":"info","message":"shutdown done","node":"node1","component":"distribution.my-group"}
+{"level":"info","message":"received shutdown request"}
+{"level":"info","message":"shutdown done"}
+{"level":"info","message":"received shutdown request"}
+{"level":"info","message":"unregistering the node \"node1\""}
+{"level":"info","message":"the node \"node1\" unregistered"}
+{"level":"info","message":"closing etcd session: context canceled"}
+{"level":"info","message":"closed etcd session"}
+{"level":"info","message":"shutdown done"}
 {"level":"info","message":"closing etcd connection","component":"etcd.client"}
 {"level":"info","message":"closed etcd connection","component":"etcd.client"}
 {"level":"info","message":"exited"}
 `)
 
 	loggers[1].AssertJSONMessages(t, `
-{"level":"info","message":"creating etcd session","node":"node2","component":"distribution.my-group.etcd.session"}
-{"level":"info","message":"created etcd session","node":"node2","component":"distribution.my-group.etcd.session"}
-{"level":"info","message":"registering the node \"node2\"","node":"node2","component":"distribution.my-group"}
-{"level":"info","message":"the node \"node2\" registered","node":"node2","component":"distribution.my-group"}
-{"level":"info","message":"watching for other nodes","node":"node2","component":"distribution.my-group"}
-{"level":"info","message":"found a new node \"node%d\"","node":"node2","component":"distribution.my-group"}
-{"level":"info","message":"found a new node \"node%d\"","node":"node2","component":"distribution.my-group"}
-{"level":"info","message":"found a new node \"node%d\"","node":"node2","component":"distribution.my-group"}
-{"level":"info","message":"the node \"node1\" gone","node":"node2","component":"distribution.my-group"}
+{"level":"info","message":"starting","component":"distribution","distribution.node":"node2","distribution.group":"my-group"}
+{"level":"info","message":"creating etcd session"}
+{"level":"info","message":"created etcd session"}
+{"level":"info","message":"registering the node \"node2\""}
+{"level":"info","message":"the node \"node2\" registered"}
+{"level":"info","message":"watching for other nodes"}
+{"level":"info","message":"found a new node \"node%d\""}
+{"level":"info","message":"found a new node \"node%d\""}
+{"level":"info","message":"found a new node \"node%d\""}
+{"level":"info","message":"the node \"node1\" gone"}
 {"level":"info","message":"exiting (bye bye 2)"}
-{"level":"info","message":"received shutdown request","node":"node2","component":"distribution.my-group.listeners"}
-{"level":"info","message":"shutdown done","node":"node2","component":"distribution.my-group.listeners"}
-{"level":"info","message":"received shutdown request","node":"node2","component":"distribution.my-group"}
-{"level":"info","message":"unregistering the node \"node2\"","node":"node2","component":"distribution.my-group"}
-{"level":"info","message":"the node \"node2\" unregistered","node":"node2","component":"distribution.my-group"}
-{"level":"info","message":"closing etcd session: context canceled","node":"node2","component":"distribution.my-group.etcd.session"}
-{"level":"info","message":"closed etcd session","node":"node2","component":"distribution.my-group.etcd.session"}
-{"level":"info","message":"shutdown done","node":"node2","component":"distribution.my-group"}
+{"level":"info","message":"received shutdown request"}
+{"level":"info","message":"shutdown done"}
+{"level":"info","message":"received shutdown request"}
+{"level":"info","message":"unregistering the node \"node2\""}
+{"level":"info","message":"the node \"node2\" unregistered"}
+{"level":"info","message":"closing etcd session: context canceled"}
+{"level":"info","message":"closed etcd session"}
+{"level":"info","message":"shutdown done"}
 {"level":"info","message":"closing etcd connection","component":"etcd.client"}
 {"level":"info","message":"closed etcd connection","component":"etcd.client"}
 {"level":"info","message":"exited"}
 `)
 
 	loggers[2].AssertJSONMessages(t, `
-{"level":"info","message":"creating etcd session","node":"node3","component":"distribution.my-group.etcd.session"}
-{"level":"info","message":"created etcd session","node":"node3","component":"distribution.my-group.etcd.session"}
-{"level":"info","message":"registering the node \"node3\"","node":"node3","component":"distribution.my-group"}
-{"level":"info","message":"the node \"node3\" registered","node":"node3","component":"distribution.my-group"}
-{"level":"info","message":"watching for other nodes","node":"node3","component":"distribution.my-group"}
-{"level":"info","message":"found a new node \"node%d\"","node":"node3","component":"distribution.my-group"}
-{"level":"info","message":"found a new node \"node%d\"","node":"node3","component":"distribution.my-group"}
-{"level":"info","message":"found a new node \"node%d\"","node":"node3","component":"distribution.my-group"}
-{"level":"info","message":"the node \"node1\" gone","node":"node3","component":"distribution.my-group"}
-{"level":"info","message":"the node \"node2\" gone","node":"node3","component":"distribution.my-group"}
+{"level":"info","message":"starting","component":"distribution","distribution.node":"node3","distribution.group":"my-group"}
+{"level":"info","message":"creating etcd session"}
+{"level":"info","message":"created etcd session"}
+{"level":"info","message":"registering the node \"node3\""}
+{"level":"info","message":"the node \"node3\" registered"}
+{"level":"info","message":"watching for other nodes"}
+{"level":"info","message":"found a new node \"node%d\""}
+{"level":"info","message":"found a new node \"node%d\""}
+{"level":"info","message":"found a new node \"node%d\""}
+{"level":"info","message":"the node \"node1\" gone"}
+{"level":"info","message":"the node \"node2\" gone"}
 {"level":"info","message":"exiting (bye bye 3)"}
-{"level":"info","message":"received shutdown request","node":"node3","component":"distribution.my-group.listeners"}
-{"level":"info","message":"shutdown done","node":"node3","component":"distribution.my-group.listeners"}
-{"level":"info","message":"received shutdown request","node":"node3","component":"distribution.my-group"}
-{"level":"info","message":"unregistering the node \"node3\"","node":"node3","component":"distribution.my-group"}
-{"level":"info","message":"the node \"node3\" unregistered","node":"node3","component":"distribution.my-group"}
-{"level":"info","message":"closing etcd session: context canceled","node":"node3","component":"distribution.my-group.etcd.session"}
-{"level":"info","message":"closed etcd session","node":"node3","component":"distribution.my-group.etcd.session"}
-{"level":"info","message":"shutdown done","node":"node3","component":"distribution.my-group"}
+{"level":"info","message":"received shutdown request"}
+{"level":"info","message":"shutdown done"}
+{"level":"info","message":"received shutdown request"}
+{"level":"info","message":"unregistering the node \"node3\""}
+{"level":"info","message":"the node \"node3\" unregistered"}
+{"level":"info","message":"closing etcd session: context canceled"}
+{"level":"info","message":"closed etcd session"}
+{"level":"info","message":"shutdown done"}
 {"level":"info","message":"closing etcd connection","component":"etcd.client"}
 {"level":"info","message":"closed etcd connection","component":"etcd.client"}
 {"level":"info","message":"exited"}
@@ -266,28 +269,29 @@ node4
 	etcdhelper.AssertKVsString(t, client, "")
 
 	d4.DebugLogger().AssertJSONMessages(t, `
-{"level":"info","message":"creating etcd session","node":"node4","component":"distribution.my-group.etcd.session"}
-{"level":"info","message":"created etcd session","node":"node4","component":"distribution.my-group.etcd.session"}
-{"level":"info","message":"registering the node \"node4\"","node":"node4","component":"distribution.my-group"}
-{"level":"info","message":"the node \"node4\" registered","node":"node4","component":"distribution.my-group"}
-{"level":"info","message":"watching for other nodes","node":"node4","component":"distribution.my-group"}
-{"level":"info","message":"found a new node \"node4\"","node":"node4","component":"distribution.my-group"}
+{"level":"info","message":"starting","component":"distribution","distribution.node":"node4","distribution.group":"my-group"}
+{"level":"info","message":"creating etcd session"}
+{"level":"info","message":"created etcd session"}
+{"level":"info","message":"registering the node \"node4\""}
+{"level":"info","message":"the node \"node4\" registered"}
+{"level":"info","message":"watching for other nodes"}
+{"level":"info","message":"found a new node \"node4\""}
 {"level":"info","message":"exiting (bye bye 4)"}
-{"level":"info","message":"received shutdown request","node":"node4","component":"distribution.my-group.listeners"}
-{"level":"info","message":"shutdown done","node":"node4","component":"distribution.my-group.listeners"}
-{"level":"info","message":"received shutdown request","node":"node4","component":"distribution.my-group"}
-{"level":"info","message":"unregistering the node \"node4\"","node":"node4","component":"distribution.my-group"}
-{"level":"info","message":"the node \"node4\" unregistered","node":"node4","component":"distribution.my-group"}
-{"level":"info","message":"closing etcd session: context canceled","node":"node4","component":"distribution.my-group.etcd.session"}
-{"level":"info","message":"closed etcd session","node":"node4","component":"distribution.my-group.etcd.session"}
-{"level":"info","message":"shutdown done","node":"node4","component":"distribution.my-group"}
+{"level":"info","message":"received shutdown request"}
+{"level":"info","message":"shutdown done"}
+{"level":"info","message":"received shutdown request"}
+{"level":"info","message":"unregistering the node \"node4\""}
+{"level":"info","message":"the node \"node4\" unregistered"}
+{"level":"info","message":"closing etcd session: context canceled"}
+{"level":"info","message":"closed etcd session"}
+{"level":"info","message":"shutdown done"}
 {"level":"info","message":"closing etcd connection","component":"etcd.client"}
 {"level":"info","message":"closed etcd connection","component":"etcd.client"}
 {"level":"info","message":"exited"}
 `)
 }
 
-func createNode(t *testing.T, clk clock.Clock, etcdCfg etcdclient.Config, nodeID string) (*distribution.Node, dependencies.Mocked) {
+func createNode(t *testing.T, clk clock.Clock, etcdCfg etcdclient.Config, nodeID string) (*distribution.GroupNode, dependencies.Mocked) {
 	t.Helper()
 
 	// Create dependencies
@@ -306,9 +310,9 @@ func createNode(t *testing.T, clk clock.Clock, etcdCfg etcdclient.Config, nodeID
 	cfg.StartupTimeout = time.Second
 	cfg.ShutdownTimeout = time.Second
 	cfg.EventsGroupInterval = groupInterval
-	node, err := distribution.NewNode(nodeID, "my-group", cfg, d)
+	groupNode, err := distribution.NewNode(nodeID, cfg, d).Group("my-group")
 	require.NoError(t, err)
-	return node, d
+	return groupNode, d
 }
 
 func createDeps(t *testing.T, clk clock.Clock, logs io.Writer, etcdCfg etcdclient.Config, nodeID string) dependencies.Mocked {

--- a/internal/pkg/service/common/distribution/node_test.go
+++ b/internal/pkg/service/common/distribution/node_test.go
@@ -184,8 +184,6 @@ node3
 {"level":"info","message":"found a new node \"node%d\""}
 {"level":"info","message":"exiting (bye bye 1)"}
 {"level":"info","message":"received shutdown request"}
-{"level":"info","message":"shutdown done"}
-{"level":"info","message":"received shutdown request"}
 {"level":"info","message":"unregistering the node \"node1\""}
 {"level":"info","message":"the node \"node1\" unregistered"}
 {"level":"info","message":"closing etcd session: context canceled"}
@@ -208,8 +206,6 @@ node3
 {"level":"info","message":"found a new node \"node%d\""}
 {"level":"info","message":"the node \"node1\" gone"}
 {"level":"info","message":"exiting (bye bye 2)"}
-{"level":"info","message":"received shutdown request"}
-{"level":"info","message":"shutdown done"}
 {"level":"info","message":"received shutdown request"}
 {"level":"info","message":"unregistering the node \"node2\""}
 {"level":"info","message":"the node \"node2\" unregistered"}
@@ -234,8 +230,6 @@ node3
 {"level":"info","message":"the node \"node1\" gone"}
 {"level":"info","message":"the node \"node2\" gone"}
 {"level":"info","message":"exiting (bye bye 3)"}
-{"level":"info","message":"received shutdown request"}
-{"level":"info","message":"shutdown done"}
 {"level":"info","message":"received shutdown request"}
 {"level":"info","message":"unregistering the node \"node3\""}
 {"level":"info","message":"the node \"node3\" unregistered"}
@@ -277,8 +271,6 @@ node4
 {"level":"info","message":"watching for other nodes"}
 {"level":"info","message":"found a new node \"node4\""}
 {"level":"info","message":"exiting (bye bye 4)"}
-{"level":"info","message":"received shutdown request"}
-{"level":"info","message":"shutdown done"}
 {"level":"info","message":"received shutdown request"}
 {"level":"info","message":"unregistering the node \"node4\""}
 {"level":"info","message":"the node \"node4\" unregistered"}

--- a/internal/pkg/service/common/task/orchestrator/orchestrator.go
+++ b/internal/pkg/service/common/task/orchestrator/orchestrator.go
@@ -8,6 +8,7 @@ import (
 	"go.opentelemetry.io/otel/trace"
 
 	"github.com/keboola/keboola-as-code/internal/pkg/log"
+	"github.com/keboola/keboola-as-code/internal/pkg/service/common/distribution"
 	"github.com/keboola/keboola-as-code/internal/pkg/service/common/etcdop"
 	"github.com/keboola/keboola-as-code/internal/pkg/service/common/task"
 	"github.com/keboola/keboola-as-code/internal/pkg/telemetry"
@@ -21,6 +22,7 @@ const (
 type orchestrator[T any] struct {
 	config Config[T]
 	node   *Node
+	dist   *distribution.GroupNode
 	logger log.Logger
 }
 
@@ -127,7 +129,7 @@ func (o orchestrator[T]) startTask(ctx context.Context, event etcdop.WatchEventT
 	distributionKey := o.config.DistributionKey(event)
 
 	// Error is not expected, there is present always at least one node - self.
-	if !o.node.dist.MustCheckIsOwner(distributionKey) {
+	if !o.dist.MustCheckIsOwner(distributionKey) {
 		// Another node handles the resource.
 		o.logger.Debugf(ctx, `not assigned "%s", distribution key "%s"`, taskKey.String(), distributionKey)
 		return

--- a/internal/pkg/service/templates/dependencies/api.go
+++ b/internal/pkg/service/templates/dependencies/api.go
@@ -18,8 +18,7 @@ import (
 )
 
 const (
-	userAgent             = "keboola-templates-api"
-	distributionGroupName = "templates-api"
+	userAgent = "keboola-templates-api"
 )
 
 // apiScope implements APIScope interface.
@@ -37,7 +36,6 @@ type parentScopes interface {
 	dependencies.PublicScope
 	dependencies.EtcdClientScope
 	dependencies.TaskScope
-	dependencies.DistributionScope
 }
 
 type parentScopesImpl struct {
@@ -45,7 +43,6 @@ type parentScopesImpl struct {
 	dependencies.PublicScope
 	dependencies.EtcdClientScope
 	dependencies.TaskScope
-	dependencies.DistributionScope
 }
 
 func NewAPIScope(
@@ -108,11 +105,6 @@ func newParentScopes(
 	}
 
 	d.TaskScope, err = dependencies.NewTaskScope(ctx, cfg.NodeID, d)
-	if err != nil {
-		return nil, err
-	}
-
-	d.DistributionScope, err = dependencies.NewDistributionScope(ctx, cfg.NodeID, distributionGroupName, d)
 	if err != nil {
 		return nil, err
 	}

--- a/internal/pkg/service/templates/dependencies/dependencies.go
+++ b/internal/pkg/service/templates/dependencies/dependencies.go
@@ -53,7 +53,6 @@ type APIScope interface {
 	dependencies.PublicScope
 	dependencies.EtcdClientScope
 	dependencies.TaskScope
-	dependencies.DistributionScope
 	APIConfig() config.Config
 	Schema() *schema.Schema
 	Store() *store.Store

--- a/test/templates/api/base/api-startup/expected-server-stdout
+++ b/test/templates/api/base/api-startup/expected-server-stdout
@@ -6,12 +6,6 @@
 {"level":"info","message":"connected to etcd cluster \"%s\"","component":"templatesApi.etcd.client"}
 {"level":"info","message":"creating etcd session","component":"templatesApi.task.etcd.session"}
 {"level":"info","message":"created etcd session","component":"templatesApi.task.etcd.session"}
-{"level":"info","message":"creating etcd session","component":"templatesApi.distribution.templates-api.etcd.session"}
-{"level":"info","message":"created etcd session","component":"templatesApi.distribution.templates-api.etcd.session"}
-{"level":"info","message":"registering the node \"%s\"","component":"templatesApi.distribution.templates-api"}
-{"level":"info","message":"the node \"%s\" registered","component":"templatesApi.distribution.templates-api"}
-{"level":"info","message":"watching for other nodes","component":"templatesApi.distribution.templates-api"}
-{"level":"info","message":"found a new node \"%s\"","component":"templatesApi.distribution.templates-api"}
 {"level":"info","message":"checking out repository \"https://github.com/keboola/keboola-as-code-templates.git:main\"","component":"templatesApi"}
 {"level":"info","message":"checked out repository \"https://github.com/keboola/keboola-as-code-templates.git:main\"","component":"templatesApi"}
 {"level":"info","message":"loading all templates from repository \"https://github.com/keboola/keboola-as-code-templates.git:main:%s\"","component":"templatesApi"}
@@ -32,14 +26,6 @@
 {"level":"info","message":"shutdown done","component":"templatesApi"}
 {"level":"info","message":"cleaned repository cache \"https://github.com/keboola/keboola-as-code-templates.git:main:%s\"","component":"templatesApi"}
 {"level":"info","message":"repository manager cleaned up","component":"templatesApi"}
-{"level":"info","message":"received shutdown request","component":"templatesApi.distribution.templates-api.listeners"}
-{"level":"info","message":"shutdown done","component":"templatesApi.distribution.templates-api.listeners"}
-{"level":"info","message":"received shutdown request","component":"templatesApi.distribution.templates-api"}
-{"level":"info","message":"unregistering the node \"%s\"","component":"templatesApi.distribution.templates-api"}
-{"level":"info","message":"the node \"%s\" unregistered","component":"templatesApi.distribution.templates-api"}
-{"level":"info","message":"closing etcd session: context canceled","component":"templatesApi.distribution.templates-api.etcd.session"}
-{"level":"info","message":"closed etcd session","component":"templatesApi.distribution.templates-api.etcd.session"}
-{"level":"info","message":"shutdown done","component":"templatesApi.distribution.templates-api"}
 {"level":"info","message":"received shutdown request","component":"templatesApi.task"}
 {"level":"info","message":"closing etcd session: context canceled","component":"templatesApi.task.etcd.session"}
 {"level":"info","message":"closed etcd session","component":"templatesApi.task.etcd.session"}


### PR DESCRIPTION
Jira: https://keboola.atlassian.net/browse/PSGO-416

**Changes:**
- Created `distribution.Node.Group(<name>)` method.

-----------

Before: 
- You had to create `distribution.Node` multiple times, for each distribution group.
- Each group had a separate getter in the `dependencies`.

After:
- Now, there is only the one dependency `DistributionNode() *distribution.Node`.
- New group can be created in a application part using `distribution.Node.Group(<name>)`.
- This simplifies dependencies.

-----

Package docs:
https://github.com/keboola/keboola-as-code/blob/b382721ea4a1ad99a2cc8ac704be01cd93e651fe/internal/pkg/service/common/distribution/doc.go#L1-L69
