### PR TITLE
fix: Use usage and shorthand for configkey:",squash" field

### DIFF
--- a/internal/pkg/service/common/configmap/configmap_test.go
+++ b/internal/pkg/service/common/configmap/configmap_test.go
@@ -85,7 +85,7 @@ type TestConfigWithValueStruct struct {
 	StringWithUsage  Value[string]           `configKey:"stringWithUsage" configUsage:"An usage text."`
 	Duration         Value[time.Duration]    `configKey:"duration"`
 	DurationNullable Value[*time.Duration]   `configKey:"durationNullable"`
-	URL              Value[*url.URL]         `configKey:"url"`
+	URL              Value[*url.URL]         `configKey:"url" configShorthand:"u"`
 	Addr             Value[netip.Addr]       `configKey:"address"`         // TextUnmarshaler/BinaryUnmarshaler interface
 	AddrNullable     Value[*netip.Addr]      `configKey:"addressNullable"` // TextUnmarshaler/BinaryUnmarshaler interface
 	Nested           NestedValue             `configKey:"nested"`

--- a/internal/pkg/service/common/configmap/flags.go
+++ b/internal/pkg/service/common/configmap/flags.go
@@ -47,8 +47,8 @@ func GenerateFlags(fs *pflag.FlagSet, v any) error {
 				return nil
 			}
 
-			shorthand := vc.StructField.Tag.Get(configShorthandTag)
-			usage := vc.StructField.Tag.Get(configUsageTag)
+			shorthand := vc.Shorthand
+			usage := vc.Usage
 
 			switch v := vc.PrimitiveValue.Interface().(type) {
 			case int:

--- a/internal/pkg/service/common/configmap/flags.go
+++ b/internal/pkg/service/common/configmap/flags.go
@@ -10,6 +10,12 @@ import (
 	"github.com/keboola/keboola-as-code/internal/pkg/utils/errors"
 )
 
+func MustGenerateFlags(fs *pflag.FlagSet, v any) {
+	if err := GenerateFlags(fs, v); err != nil {
+		panic(err)
+	}
+}
+
 // GenerateFlags generates FlagSet from the provided configuration structure.
 // Each field tagged by "configKey" tag is mapped to a flag.
 // Field can optionally have the "configUsage" tag.

--- a/internal/pkg/service/common/configmap/visit.go
+++ b/internal/pkg/service/common/configmap/visit.go
@@ -46,6 +46,8 @@ type VisitContext struct {
 	Sensitive bool
 	// Usage contains value from the "configUsage" tag, if any.
 	Usage string
+	// Usage contains value from the "configShorthand" tag, if any.
+	Shorthand string
 	// Validate contains value from the "validate" tag, if any.
 	Validate string
 }
@@ -131,10 +133,16 @@ func doVisit(vc *VisitContext, cfg VisitConfig) error {
 			// Mark field and all its children as sensitive according to the tag
 			field.Sensitive = vc.Sensitive || field.StructField.Tag.Get(sensitiveTag) == "true"
 
-			// Set usage from the tag, or use parent usage text
+			// Set usage from the tag, or use parent value
 			field.Usage = vc.Usage
 			if usage := field.StructField.Tag.Get(configUsageTag); usage != "" {
 				field.Usage = usage
+			}
+
+			// Set shorthand from the tag, or use parent value
+			field.Shorthand = vc.Shorthand
+			if shorthand := field.StructField.Tag.Get(configShorthandTag); shorthand != "" {
+				field.Shorthand = shorthand
 			}
 
 			// Set validate from the tag


### PR DESCRIPTION
Jira: https://keboola.atlassian.net/browse/PSGO-440

**Changes:**
- Fixed bug in the `configmap` package: there were no usage and shorthand flag metadata for `configmap.Value` type.

-----------
