### PR TITLE
feat: Add configpatch.DumpPatch function

### DIFF
--- a/internal/pkg/service/common/configpatch/apply.go
+++ b/internal/pkg/service/common/configpatch/apply.go
@@ -20,3 +20,13 @@ func Apply(configStruct, patchStruct any, opts ...Option) error {
 		}
 	})
 }
+
+// ApplyKVs applies a patch key-value pairs to a config structure.
+// The patch structure is used to detect all modifiable fields.
+// The config structure is modified in place.
+func ApplyKVs(configStruct, patchStruct any, kvs PatchKVs, opts ...Option) error {
+	if err := BindKVs(patchStruct, kvs); err != nil {
+		return err
+	}
+	return Apply(configStruct, patchStruct, opts...)
+}

--- a/internal/pkg/service/common/configpatch/bind.go
+++ b/internal/pkg/service/common/configpatch/bind.go
@@ -11,14 +11,6 @@ import (
 	"github.com/keboola/keboola-as-code/internal/pkg/utils/strhelper"
 )
 
-// BindKV is input of the bind operation for a one configuration key.
-type BindKV struct {
-	// KeyPath is a configuration key, parts are joined with a dot "." separator.
-	KeyPath string `json:"key"`
-	// Value is a patched value of the configuration key.
-	Value any `json:"value"`
-}
-
 // BindKVs binds flattened key-value pairs from a client request to a patch structure.
 // The patch structure is modified in place.
 func BindKVs(patchStruct any, kvs []BindKV, opts ...Option) error {

--- a/internal/pkg/service/common/configpatch/bind.go
+++ b/internal/pkg/service/common/configpatch/bind.go
@@ -13,7 +13,7 @@ import (
 
 // BindKVs binds flattened key-value pairs from a client request to a patch structure.
 // The patch structure is modified in place.
-func BindKVs(patchStruct any, kvs []BindKV, opts ...Option) error {
+func BindKVs(patchStruct any, kvs PatchKVs, opts ...Option) error {
 	cfg := newConfig(opts)
 
 	rootPtr := reflect.ValueOf(patchStruct)

--- a/internal/pkg/service/common/configpatch/bind_test.go
+++ b/internal/pkg/service/common/configpatch/bind_test.go
@@ -62,12 +62,13 @@ func TestBindKVs_Multiple(t *testing.T) {
 	t.Parallel()
 	patch := ConfigPatch{}
 	kvs := []configpatch.BindKV{
-		{KeyPath: "foo1", Value: "bar1"},
+	kvs := []configpatch.PatchKV{
+		{KeyPath: "foo1", Value: []any{"bar1"}}, // slice []any -> []string
 		{KeyPath: "foo3.foo5", Value: 789},
 	}
 	require.NoError(t, configpatch.BindKVs(&patch, kvs))
 	assert.Equal(t, patch, ConfigPatch{
-		Key1: ptr("bar1"),
+		Key1: ptr([]string{"bar1"}),
 		Key3: &ConfigNested1Patch{Key5: ptr(789)},
 	})
 }

--- a/internal/pkg/service/common/configpatch/bind_test.go
+++ b/internal/pkg/service/common/configpatch/bind_test.go
@@ -17,7 +17,7 @@ type ConfigPatchTextUnmarshaller struct {
 func TestBindKVs_NoStructPointer(t *testing.T) {
 	t.Parallel()
 	assert.PanicsWithError(t, `patch struct must be a pointer to a struct, found "configpatch_test.ConfigPatch"`, func() {
-		var kvs []configpatch.BindKV
+		var kvs []configpatch.PatchKV
 		_ = configpatch.BindKVs(ConfigPatch{}, kvs)
 	})
 }
@@ -25,7 +25,7 @@ func TestBindKVs_NoStructPointer(t *testing.T) {
 func TestBindKVs_Empty(t *testing.T) {
 	t.Parallel()
 	patch := ConfigPatch{}
-	var kvs []configpatch.BindKV
+	var kvs []configpatch.PatchKV
 	require.NoError(t, configpatch.BindKVs(&patch, kvs))
 	assert.Equal(t, patch, ConfigPatch{})
 }
@@ -33,7 +33,7 @@ func TestBindKVs_Empty(t *testing.T) {
 func TestBindKVs_One(t *testing.T) {
 	t.Parallel()
 	patch := ConfigPatch{}
-	kvs := []configpatch.BindKV{
+	kvs := []configpatch.PatchKV{
 		{KeyPath: "foo3.foo5", Value: 789},
 	}
 	require.NoError(t, configpatch.BindKVs(&patch, kvs))
@@ -45,7 +45,7 @@ func TestBindKVs_One(t *testing.T) {
 func TestBindKVs_DeepNested(t *testing.T) {
 	t.Parallel()
 	patch := ConfigPatch{}
-	kvs := []configpatch.BindKV{
+	kvs := []configpatch.PatchKV{
 		{KeyPath: "foo3.foo6.foo8", Value: false},
 	}
 	require.NoError(t, configpatch.BindKVs(&patch, kvs))
@@ -61,7 +61,6 @@ func TestBindKVs_DeepNested(t *testing.T) {
 func TestBindKVs_Multiple(t *testing.T) {
 	t.Parallel()
 	patch := ConfigPatch{}
-	kvs := []configpatch.BindKV{
 	kvs := []configpatch.PatchKV{
 		{KeyPath: "foo1", Value: []any{"bar1"}}, // slice []any -> []string
 		{KeyPath: "foo3.foo5", Value: 789},
@@ -76,7 +75,7 @@ func TestBindKVs_Multiple(t *testing.T) {
 func TestBindKVs_UnmarshalText_Ok(t *testing.T) {
 	t.Parallel()
 	patch := ConfigPatchTextUnmarshaller{}
-	kvs := []configpatch.BindKV{
+	kvs := []configpatch.PatchKV{
 		{KeyPath: "duration", Value: "1h20m"},
 	}
 	require.NoError(t, configpatch.BindKVs(&patch, kvs))
@@ -88,7 +87,7 @@ func TestBindKVs_UnmarshalText_Ok(t *testing.T) {
 func TestBindKVs_UnmarshalText_Error(t *testing.T) {
 	t.Parallel()
 	patch := ConfigPatchTextUnmarshaller{}
-	kvs := []configpatch.BindKV{
+	kvs := []configpatch.PatchKV{
 		{KeyPath: "duration", Value: "invalid value"},
 	}
 	if err := configpatch.BindKVs(&patch, kvs); assert.Error(t, err) {
@@ -99,7 +98,7 @@ func TestBindKVs_UnmarshalText_Error(t *testing.T) {
 func TestBindKVs_CompatibleType(t *testing.T) {
 	t.Parallel()
 	patch := ConfigPatch{}
-	kvs := []configpatch.BindKV{
+	kvs := []configpatch.PatchKV{
 		{KeyPath: "foo3.foo5", Value: float64(789)}, // different, but compatible type
 	}
 	require.NoError(t, configpatch.BindKVs(&patch, kvs))
@@ -111,7 +110,7 @@ func TestBindKVs_CompatibleType(t *testing.T) {
 func TestBindKVs_IncompatibleType(t *testing.T) {
 	t.Parallel()
 	patch := ConfigPatch{}
-	kvs := []configpatch.BindKV{
+	kvs := []configpatch.PatchKV{
 		{KeyPath: "foo3.foo5", Value: "789"},
 	} // incompatible type, expected int
 	if err := configpatch.BindKVs(&patch, kvs); assert.Error(t, err) {
@@ -122,7 +121,7 @@ func TestBindKVs_IncompatibleType(t *testing.T) {
 func TestBindKVs_DuplicateKV(t *testing.T) {
 	t.Parallel()
 	patch := ConfigPatch{}
-	kvs := []configpatch.BindKV{
+	kvs := []configpatch.PatchKV{
 		{KeyPath: "foo3.foo5", Value: 789},
 		{KeyPath: "foo3.foo5", Value: 789},
 	}
@@ -134,7 +133,7 @@ func TestBindKVs_DuplicateKV(t *testing.T) {
 func TestBindKVs_KeyNotFound(t *testing.T) {
 	t.Parallel()
 	patch := ConfigPatch{}
-	kvs := []configpatch.BindKV{
+	kvs := []configpatch.PatchKV{
 		{KeyPath: `foo.bar.1`, Value: 123},
 		{KeyPath: `foo.bar.2`, Value: 234},
 	}
@@ -146,7 +145,7 @@ func TestBindKVs_KeyNotFound(t *testing.T) {
 func TestBindKVs_InvalidPatchStruct(t *testing.T) {
 	t.Parallel()
 	patch := ConfigPatchInvalid{}
-	var kvs []configpatch.BindKV
+	var kvs []configpatch.PatchKV
 	if err := configpatch.BindKVs(&patch, kvs); assert.Error(t, err) {
 		assert.Equal(t, `patch field "foo1" is not a pointer, but "string"`, err.Error())
 	}

--- a/internal/pkg/service/common/configpatch/dump.go
+++ b/internal/pkg/service/common/configpatch/dump.go
@@ -5,22 +5,6 @@ import (
 	"sort"
 )
 
-// DumpKV is result of the patch operation for a one configuration key.
-type DumpKV struct {
-	// KeyPath is a configuration key, parts are joined with a dot "." separator.
-	KeyPath string `json:"key"`
-	// Value is an actual value of the configuration key.
-	Value any `json:"value"`
-	// DefaultValue of the configuration key.
-	DefaultValue any `json:"defaultValue"`
-	// Overwritten is true, if the DefaultValue was replaced by a value from the path.
-	Overwritten bool `json:"overwritten"`
-	// Protected configuration key can be modified only by a super-admin.
-	Protected bool `json:"protected"`
-	// Validation contains validation rules of the field, if any.
-	Validation string `json:"validation,omitempty"`
-}
-
 // DumpKVs generates key-value pairs from a configuration structure and a patch structure.
 // Only keys found in both, configuration and patch structure, are processed.
 // The structure is flattened, keys are joined with a dot "." separator.

--- a/internal/pkg/service/common/configpatch/dump.go
+++ b/internal/pkg/service/common/configpatch/dump.go
@@ -29,6 +29,16 @@ func DumpKVs(configStruct, patchStruct any, opts ...Option) (kvs []DumpKV, err e
 	err = visitConfigAndPatch(reflect.ValueOf(configStruct), reflect.ValueOf(patchStruct), opts, func(vc *visitContext) {
 		// Generate DumpKV
 		kvs = append(kvs, DumpKV{
+		var value any
+		if vc.Value.IsValid() {
+			value = vc.Value.Interface()
+		}
+
+		var defaultValue any
+		if vc.ConfigValue.IsValid() {
+			defaultValue = vc.ConfigValue.Interface()
+		}
+
 			KeyPath:      vc.Config.MappedPath.String(),
 			Value:        vc.Value.Interface(),
 			DefaultValue: vc.ConfigValue.Interface(),

--- a/internal/pkg/service/common/configpatch/dump_test.go
+++ b/internal/pkg/service/common/configpatch/dump_test.go
@@ -50,16 +50,16 @@ type ConfigPatchInvalid struct {
 	Key9 *int    `json:"foo9"`
 }
 
-func TestDumpKVs_EmptyPatch(t *testing.T) {
+func TestDumpAll_EmptyPatch(t *testing.T) {
 	t.Parallel()
 
-	kvs, err := configpatch.DumpKVs(
+	kvs, err := configpatch.DumpAll(
 		newConfig(),
 		ConfigPatch{},
 	)
 
 	require.NoError(t, err)
-	assert.Equal(t, []configpatch.DumpKV{
+	assert.Equal(t, []configpatch.ConfigKV{
 		{
 			KeyPath:      "foo1",
 			Value:        []string{"bar1"},
@@ -90,16 +90,16 @@ func TestDumpKVs_EmptyPatch(t *testing.T) {
 	}, kvs)
 }
 
-func TestDumpKVs_Ok(t *testing.T) {
+func TestDumpAll_Ok(t *testing.T) {
 	t.Parallel()
 
-	kvs, err := configpatch.DumpKVs(
+	kvs, err := configpatch.DumpAll(
 		newConfig(),
 		newConfigPatch(),
 	)
 
 	require.NoError(t, err)
-	assert.Equal(t, []configpatch.DumpKV{
+	assert.Equal(t, []configpatch.ConfigKV{
 		{
 			KeyPath:      "foo1",
 			Value:        []string{"patch1"},
@@ -133,16 +133,16 @@ func TestDumpKVs_Ok(t *testing.T) {
 	}, kvs)
 }
 
-func TestDumpKVs_EmptyPatchPointer(t *testing.T) {
+func TestDumpAll_EmptyPatchPointer(t *testing.T) {
 	t.Parallel()
 
-	kvs, err := configpatch.DumpKVs(
+	kvs, err := configpatch.DumpAll(
 		newConfig(),
 		(*ConfigPatch)(nil),
 	)
 
 	require.NoError(t, err)
-	assert.Equal(t, []configpatch.DumpKV{
+	assert.Equal(t, []configpatch.ConfigKV{
 		{
 			KeyPath:      "foo1",
 			Value:        []string{"bar1"},
@@ -173,10 +173,10 @@ func TestDumpKVs_EmptyPatchPointer(t *testing.T) {
 	}, kvs)
 }
 
-func TestDumpKVs_CustomTags(t *testing.T) {
+func TestDumpAll_CustomTags(t *testing.T) {
 	t.Parallel()
 
-	kvs, err := configpatch.DumpKVs(
+	kvs, err := configpatch.DumpAll(
 		newConfig(),
 		ConfigPatch{
 			Key2: ptr(234),
@@ -189,7 +189,7 @@ func TestDumpKVs_CustomTags(t *testing.T) {
 	)
 
 	require.NoError(t, err)
-	assert.Equal(t, []configpatch.DumpKV{
+	assert.Equal(t, []configpatch.ConfigKV{
 		{
 			KeyPath:      "baz2",
 			Value:        234,
@@ -205,10 +205,10 @@ func TestDumpKVs_CustomTags(t *testing.T) {
 	}, kvs)
 }
 
-func TestDumpKVs_InvalidPatch(t *testing.T) {
+func TestDumpAll_InvalidPatch(t *testing.T) {
 	t.Parallel()
 
-	_, err := configpatch.DumpKVs(
+	_, err := configpatch.DumpAll(
 		newConfig(),
 		newConfigPatchInvalid(),
 	)
@@ -222,17 +222,17 @@ func TestDumpKVs_InvalidPatch(t *testing.T) {
 	}
 }
 
-func TestDumpKVs_Protected_Ok(t *testing.T) {
+func TestDumpAll_Protected_Ok(t *testing.T) {
 	t.Parallel()
 
-	kvs, err := configpatch.DumpKVs(
+	kvs, err := configpatch.DumpAll(
 		newConfig(),
 		newConfigPatchProtected(),
 		configpatch.WithModifyProtected(), // <<<<<
 	)
 
 	require.NoError(t, err)
-	assert.Equal(t, []configpatch.DumpKV{
+	assert.Equal(t, []configpatch.ConfigKV{
 		{
 			KeyPath:      "foo1",
 			Value:        []string{"bar1"},
@@ -267,9 +267,9 @@ func TestDumpKVs_Protected_Ok(t *testing.T) {
 	}, kvs)
 }
 
-func TestDumpKVs_Protected_Error(t *testing.T) {
+func TestDumpAll_Protected_Error(t *testing.T) {
 	t.Parallel()
-	_, err := configpatch.DumpKVs(newConfig(), newConfigPatchProtected())
+	_, err := configpatch.DumpAll(newConfig(), newConfigPatchProtected())
 	if assert.Error(t, err) {
 		assert.Equal(t, `cannot modify protected fields: "foo2", "foo3.foo6.foo8"`, err.Error())
 	}

--- a/internal/pkg/service/common/configpatch/dump_test.go
+++ b/internal/pkg/service/common/configpatch/dump_test.go
@@ -133,6 +133,46 @@ func TestDumpKVs_Ok(t *testing.T) {
 	}, kvs)
 }
 
+func TestDumpKVs_EmptyPatchPointer(t *testing.T) {
+	t.Parallel()
+
+	kvs, err := configpatch.DumpKVs(
+		newConfig(),
+		(*ConfigPatch)(nil),
+	)
+
+	require.NoError(t, err)
+	assert.Equal(t, []configpatch.DumpKV{
+		{
+			KeyPath:      "foo1",
+			Value:        "bar1",
+			DefaultValue: "bar1",
+		},
+		{
+			KeyPath:      "foo2",
+			Value:        123,
+			DefaultValue: 123,
+			Protected:    true,
+		},
+		{
+			KeyPath:      "foo3.foo5",
+			Value:        234,
+			DefaultValue: 234,
+		},
+		{
+			KeyPath:      "foo3.foo6.foo7",
+			Value:        []string{"bar7"},
+			DefaultValue: []string{"bar7"},
+		},
+		{
+			KeyPath:      "foo3.foo6.foo8",
+			Value:        true,
+			DefaultValue: true,
+			Protected:    true,
+		},
+	}, kvs)
+}
+
 func TestDumpKVs_CustomTags(t *testing.T) {
 	t.Parallel()
 

--- a/internal/pkg/service/common/configpatch/dump_test.go
+++ b/internal/pkg/service/common/configpatch/dump_test.go
@@ -11,7 +11,7 @@ import (
 )
 
 type Config struct {
-	Key1 string        `json:"foo1"`
+	Key1 []string      `json:"foo1"`
 	Key2 int           `json:"foo2" alternative:"baz2" protected:"true"`
 	Key3 ConfigNested1 `json:"foo3,omitempty" alternative:"baz3"`
 }
@@ -28,7 +28,7 @@ type ConfigNested2 struct {
 }
 
 type ConfigPatch struct {
-	Key1 *string             `json:"foo1"`
+	Key1 *[]string           `json:"foo1"`
 	Key2 *int                `json:"foo2" alternative:"baz2"`
 	Key3 *ConfigNested1Patch `json:"foo3,omitempty" alternative:"baz3"`
 }
@@ -62,8 +62,8 @@ func TestDumpKVs_EmptyPatch(t *testing.T) {
 	assert.Equal(t, []configpatch.DumpKV{
 		{
 			KeyPath:      "foo1",
-			Value:        "bar1",
-			DefaultValue: "bar1",
+			Value:        []string{"bar1"},
+			DefaultValue: []string{"bar1"},
 		},
 		{
 			KeyPath:      "foo2",
@@ -102,8 +102,8 @@ func TestDumpKVs_Ok(t *testing.T) {
 	assert.Equal(t, []configpatch.DumpKV{
 		{
 			KeyPath:      "foo1",
-			Value:        "patch1",
-			DefaultValue: "bar1",
+			Value:        []string{"patch1"},
+			DefaultValue: []string{"bar1"},
 			Overwritten:  true,
 		},
 		{
@@ -145,8 +145,8 @@ func TestDumpKVs_EmptyPatchPointer(t *testing.T) {
 	assert.Equal(t, []configpatch.DumpKV{
 		{
 			KeyPath:      "foo1",
-			Value:        "bar1",
-			DefaultValue: "bar1",
+			Value:        []string{"bar1"},
+			DefaultValue: []string{"bar1"},
 		},
 		{
 			KeyPath:      "foo2",
@@ -235,8 +235,8 @@ func TestDumpKVs_Protected_Ok(t *testing.T) {
 	assert.Equal(t, []configpatch.DumpKV{
 		{
 			KeyPath:      "foo1",
-			Value:        "bar1",
-			DefaultValue: "bar1",
+			Value:        []string{"bar1"},
+			DefaultValue: []string{"bar1"},
 		},
 		{
 			KeyPath:      "foo2",
@@ -277,7 +277,7 @@ func TestDumpKVs_Protected_Error(t *testing.T) {
 
 func newConfig() Config {
 	return Config{
-		Key1: "bar1",
+		Key1: []string{"bar1"},
 		Key2: 123,
 		Key3: ConfigNested1{
 			Key4: "bar4",
@@ -292,7 +292,7 @@ func newConfig() Config {
 
 func newConfigPatch() ConfigPatch {
 	return ConfigPatch{
-		Key1: ptr("patch1"),
+		Key1: ptr([]string{"patch1"}),
 		Key3: &ConfigNested1Patch{
 			Key5: ptr(789),
 			Key6: &ConfigNested2Patch{

--- a/internal/pkg/service/common/configpatch/dump_test.go
+++ b/internal/pkg/service/common/configpatch/dump_test.go
@@ -275,6 +275,55 @@ func TestDumpAll_Protected_Error(t *testing.T) {
 	}
 }
 
+func TestDumpPatch_EmptyPatch(t *testing.T) {
+	t.Parallel()
+
+	kvs, err := configpatch.DumpPatch(
+		newConfig(),
+		ConfigPatch{},
+	)
+
+	require.NoError(t, err)
+	assert.Empty(t, kvs)
+}
+
+func TestDumpPatch_EmptyPatchPointer(t *testing.T) {
+	t.Parallel()
+
+	kvs, err := configpatch.DumpPatch(
+		newConfig(),
+		&ConfigPatch{},
+	)
+
+	require.NoError(t, err)
+	assert.Empty(t, kvs)
+}
+
+func TestDumpPatch_Ok(t *testing.T) {
+	t.Parallel()
+
+	kvs, err := configpatch.DumpPatch(
+		newConfig(),
+		newConfigPatch(),
+	)
+
+	require.NoError(t, err)
+	assert.Equal(t, configpatch.PatchKVs{
+		{
+			KeyPath: "foo1",
+			Value:   []string{"patch1"},
+		},
+		{
+			KeyPath: "foo3.foo5",
+			Value:   789,
+		},
+		{
+			KeyPath: "foo3.foo6.foo7",
+			Value:   []string{"patch7"},
+		},
+	}, kvs)
+}
+
 func newConfig() Config {
 	return Config{
 		Key1: []string{"bar1"},

--- a/internal/pkg/service/common/configpatch/model.go
+++ b/internal/pkg/service/common/configpatch/model.go
@@ -1,0 +1,75 @@
+package configpatch
+
+import (
+	"sort"
+	"strings"
+)
+
+// ConfigKV is result of the patch operation for a one configuration key.
+type ConfigKV struct {
+	// KeyPath is a configuration key, parts are joined with a dot "." separator.
+	KeyPath string `json:"key"`
+	// Value is an actual value of the configuration key.
+	Value any `json:"value"`
+	// DefaultValue of the configuration key.
+	DefaultValue any `json:"defaultValue"`
+	// Overwritten is true, if the DefaultValue was replaced by a value from the path.
+	Overwritten bool `json:"overwritten"`
+	// Protected configuration key can be modified only by a super-admin.
+	Protected bool `json:"protected"`
+	// Validation contains validation rules of the field, if any.
+	Validation string `json:"validation,omitempty"`
+}
+
+// PatchKV is a one configuration key from a configuration patch.
+type PatchKV struct {
+	// KeyPath is a configuration key, parts are joined with a dot "." separator.
+	KeyPath string `json:"key"`
+	// Value is a patched value of the configuration key.
+	Value any `json:"value"`
+}
+
+type PatchKVs []PatchKV
+
+func (v PatchKVs) With(slices ...PatchKVs) (out PatchKVs) {
+	// Merge and deduplicate, the later value has priority
+	keys := make(map[string]PatchKV)
+	for _, item := range v {
+		keys[item.KeyPath] = item
+	}
+	for _, slice := range slices {
+		for _, item := range slice {
+			keys[item.KeyPath] = item
+		}
+	}
+
+	// Map -> slice
+	for _, item := range keys {
+		out = append(out, item)
+	}
+
+	// Sort
+	sort.SliceStable(out, func(i, j int) bool {
+		return out[i].KeyPath < out[j].KeyPath
+	})
+
+	return out
+}
+
+// In descents and returns only keys in the prefix.
+func (v PatchKVs) In(prefix string) (out PatchKVs) {
+	prefix = strings.TrimSuffix(prefix, ".") + "."
+	for _, item := range v {
+		if strings.HasPrefix(item.KeyPath, prefix) {
+			item.KeyPath = strings.TrimPrefix(item.KeyPath, prefix)
+			out = append(out, item)
+		}
+	}
+
+	// Sort
+	sort.SliceStable(out, func(i, j int) bool {
+		return out[i].KeyPath < out[j].KeyPath
+	})
+
+	return out
+}

--- a/internal/pkg/service/common/configpatch/model_test.go
+++ b/internal/pkg/service/common/configpatch/model_test.go
@@ -1,0 +1,31 @@
+package configpatch
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+)
+
+func TestPatchKVs_With(t *testing.T) {
+	t.Parallel()
+
+	v1 := PatchKVs{
+		{KeyPath: "key1", Value: "value1"},
+		{KeyPath: "key2", Value: "value2"},
+		{KeyPath: "key3", Value: "value3"},
+	}
+	v2 := PatchKVs{
+		{KeyPath: "key3", Value: "FINAL"},
+		{KeyPath: "key1", Value: "REWRITTEN"},
+	}
+	v3 := PatchKVs{
+		{KeyPath: "key1", Value: "FINAL"},
+	}
+
+	// Merge and deduplicate, the later value has priority
+	assert.Equal(t, PatchKVs{
+		{KeyPath: "key1", Value: "FINAL"},
+		{KeyPath: "key2", Value: "value2"},
+		{KeyPath: "key3", Value: "FINAL"},
+	}, v1.With(v2, v3))
+}

--- a/internal/pkg/service/common/configpatch/visit.go
+++ b/internal/pkg/service/common/configpatch/visit.go
@@ -83,16 +83,16 @@ func visitConfigAndPatch(configStruct, patchStruct reflect.Value, opts []Option,
 					return nil
 				}
 
-				// Config field cannot be a pointer
-				keyPath := configVc.MappedPath.String()
-				if configVc.Type.Kind() == reflect.Pointer {
-					errs.Append(errors.Errorf(`config field "%s" is a pointer, it is not allowed`, keyPath))
-				}
-
 				// Ignore fields which are not present in the patch
+				keyPath := configVc.MappedPath.String()
 				patchVc, ok := patchKeys[keyPath]
 				if !ok {
 					return nil
+				}
+
+				// Config field cannot be a pointer
+				if configVc.Type.Kind() == reflect.Pointer {
+					errs.Append(errors.Errorf(`config field "%s" is a pointer, it is not allowed`, keyPath))
 				}
 
 				// Get patched value, if any

--- a/internal/pkg/service/stream/sink/tablesink/config_test.go
+++ b/internal/pkg/service/stream/sink/tablesink/config_test.go
@@ -22,7 +22,7 @@ import (
 func TestConfig_ToKVs(t *testing.T) {
 	t.Parallel()
 
-	kvs, err := configpatch.DumpKVs(
+	kvs, err := configpatch.DumpAll(
 		tablesink.NewRuntimeConfig(storage.NewConfig()),
 		tablesink.ConfigPatch{
 			Storage: &storage.ConfigPatch{
@@ -258,7 +258,7 @@ func TestConfig_BindKVs_Ok(t *testing.T) {
 	t.Parallel()
 
 	patch := tablesink.ConfigPatch{}
-	require.NoError(t, configpatch.BindKVs(&patch, []configpatch.BindKV{
+	require.NoError(t, configpatch.BindKVs(&patch, []configpatch.PatchKV{
 		{
 			KeyPath: "storage.level.local.volume.allocation.static",
 			Value:   "456MB",
@@ -283,7 +283,7 @@ func TestConfig_BindKVs_Ok(t *testing.T) {
 func TestConfig_BindKVs_InvalidType(t *testing.T) {
 	t.Parallel()
 
-	err := configpatch.BindKVs(&tablesink.ConfigPatch{}, []configpatch.BindKV{
+	err := configpatch.BindKVs(&tablesink.ConfigPatch{}, []configpatch.PatchKV{
 		{
 			KeyPath: "storage.level.local.compression.gzip.level",
 			Value:   "foo",
@@ -298,7 +298,7 @@ func TestConfig_BindKVs_InvalidType(t *testing.T) {
 func TestConfig_BindKVs_InvalidValue(t *testing.T) {
 	t.Parallel()
 
-	err := configpatch.BindKVs(&tablesink.ConfigPatch{}, []configpatch.BindKV{
+	err := configpatch.BindKVs(&tablesink.ConfigPatch{}, []configpatch.PatchKV{
 		{
 			KeyPath: "storage.level.local.volume.allocation.static",
 			Value:   "foo",


### PR DESCRIPTION
Jira: https://keboola.atlassian.net/jira/software/projects/PSGO/boards/189?selectedIssue=PSGO-416

**Changes:**
- Added `configpatch.DumpPatch` method, to dump a patch as KV pairs.
  - It is used when saving to the database, it will be easier to maintain/migrate.

-----------

Difference in the `Sink` entity, in DB, see next PR:

![image](https://github.com/keboola/keboola-as-code/assets/19371734/2ce324c5-6e67-435f-a86f-e902d49c1c8c)

