### PR TITLE
build: Fix Go cache

### DIFF
--- a/.github/actions/go-cache/action.yml
+++ b/.github/actions/go-cache/action.yml
@@ -4,6 +4,8 @@ inputs:
   key:
     description: Cache key
     required: true
+env:
+  CACHE_VERSION: v7
 runs:
   using: "composite"
   steps:
@@ -14,16 +16,27 @@ runs:
 
     - name: Load Go cache
       uses: actions/cache@v4
+      if: runner.os == 'Windows'
+      with:
+        path: |
+          ~\go\pkg
+          ~\go\bin
+          ~\AppData\Local\golangci-lint
+        key: ${{ runner.os }}-go-${{ env.GO_VERSION }}-{{ env.CACHE_VERSION }}-${{ inputs.key }}-${{ hashFiles('**/go.sum') }}
+        restore-keys: |
+          ${{ runner.os }}-go-${{ env.GO_VERSION }}-{{ env.CACHE_VERSION }}-
+          ${{ runner.os }}-go-${{ env.GO_VERSION }}-{{ env.CACHE_VERSION }}-${{ inputs.key }}-
+
+    - name: Load Go cache
+      uses: actions/cache@v4
+      if: runner.os != 'Windows'
       with:
         path: |
           ~/go/pkg
-          ~\go\pkg
           ~/go/bin
-          ~\go\bin
           ~/.cache/golangci-lint
           ~/Library/Caches/golangci-lint
-          ~\AppData\Local\golangci-lint
-        key: ${{ runner.os }}-go-${{ env.GO_VERSION }}-v6-${{ inputs.key }}-${{ hashFiles('**/go.sum') }}
+        key: ${{ runner.os }}-go-${{ env.GO_VERSION }}-{{ env.CACHE_VERSION }}-${{ inputs.key }}-${{ hashFiles('**/go.sum') }}
         restore-keys: |
-          ${{ runner.os }}-go-${{ env.GO_VERSION }}-v6-
-          ${{ runner.os }}-go-${{ env.GO_VERSION }}-v6-${{ inputs.key }}-
+          ${{ runner.os }}-go-${{ env.GO_VERSION }}-{{ env.CACHE_VERSION }}-
+          ${{ runner.os }}-go-${{ env.GO_VERSION }}-{{ env.CACHE_VERSION }}-${{ inputs.key }}-


### PR DESCRIPTION
Right now the Go cache action shows a lot of errors `Cannot open: File exists`. I'm not sure but my first guess is that it might be because of the duplication of directory names with `\` and `/`. So I wanna try splitting Windows from the rest to mitigate this.