### PR TITLE
feat: Create aux struct AtomicOpCore

### DIFF
--- a/internal/pkg/service/common/etcdop/op/atomic_core.go
+++ b/internal/pkg/service/common/etcdop/op/atomic_core.go
@@ -1,0 +1,113 @@
+package op
+
+import (
+	"context"
+
+	etcd "go.etcd.io/etcd/client/v3"
+)
+
+// AtomicOpCore provides a common interface of the atomic operation, without result type specific methods.
+// See the AtomicOp.Core method for details.
+type AtomicOpCore struct {
+	client     etcd.KV
+	locks      []mutex
+	readPhase  []HighLevelFactory
+	writePhase []HighLevelFactory
+}
+
+func (v *AtomicOpCore) AddFrom(ops ...AtomicOpInterface) *AtomicOpCore {
+	for _, op := range ops {
+		v.readPhase = append(v.readPhase, op.ReadPhaseOps()...)
+		v.writePhase = append(v.writePhase, op.WritePhaseOps()...)
+	}
+	return v
+}
+
+func (v *AtomicOpCore) RequireLock(lock mutex) *AtomicOpCore {
+	v.locks = append(v.locks, lock)
+	return v
+}
+
+func (v *AtomicOpCore) ReadOp(ops ...Op) *AtomicOpCore {
+	for _, op := range ops {
+		v.Read(func(ctx context.Context) Op {
+			return op
+		})
+	}
+	return v
+}
+
+func (v *AtomicOpCore) Read(factories ...func(ctx context.Context) Op) *AtomicOpCore {
+	for _, fn := range factories {
+		v.ReadOrErr(func(ctx context.Context) (Op, error) {
+			return fn(ctx), nil
+		})
+	}
+	return v
+}
+
+func (v *AtomicOpCore) OnRead(fns ...func(ctx context.Context)) *AtomicOpCore {
+	for _, fn := range fns {
+		v.ReadOrErr(func(ctx context.Context) (Op, error) {
+			fn(ctx)
+			return nil, nil
+		})
+	}
+	return v
+}
+
+func (v *AtomicOpCore) OnReadOrErr(fns ...func(ctx context.Context) error) *AtomicOpCore {
+	for _, fn := range fns {
+		v.ReadOrErr(func(ctx context.Context) (Op, error) {
+			return nil, fn(ctx)
+		})
+	}
+	return v
+}
+
+func (v *AtomicOpCore) ReadOrErr(factories ...HighLevelFactory) *AtomicOpCore {
+	v.readPhase = append(v.readPhase, factories...)
+	return v
+}
+
+func (v *AtomicOpCore) Write(factories ...func(ctx context.Context) Op) *AtomicOpCore {
+	for _, fn := range factories {
+		v.WriteOrErr(func(ctx context.Context) (Op, error) {
+			return fn(ctx), nil
+		})
+	}
+	return v
+}
+
+func (v *AtomicOpCore) BeforeWrite(fns ...func(ctx context.Context)) *AtomicOpCore {
+	for _, fn := range fns {
+		v.WriteOrErr(func(ctx context.Context) (Op, error) {
+			fn(ctx)
+			return nil, nil
+		})
+	}
+	return v
+}
+
+func (v *AtomicOpCore) BeforeWriteOrErr(fns ...func(ctx context.Context) error) *AtomicOpCore {
+	for _, fn := range fns {
+		v.WriteOrErr(func(ctx context.Context) (Op, error) {
+			return nil, fn(ctx)
+		})
+	}
+	return v
+}
+
+func (v *AtomicOpCore) WriteOp(ops ...Op) *AtomicOpCore {
+	for _, op := range ops {
+		v.Write(func(context.Context) Op {
+			return op
+		})
+	}
+	return v
+}
+
+func (v *AtomicOpCore) WriteOrErr(factories ...HighLevelFactory) *AtomicOpCore {
+	v.writePhase = append(v.writePhase, factories...)
+	return v
+}

--- a/internal/pkg/service/common/etcdop/op/atomic_test.go
+++ b/internal/pkg/service/common/etcdop/op/atomic_test.go
@@ -280,8 +280,10 @@ func (tc atomicOpTestCase) RunOk(t *testing.T) {
 	// Run AtomicOp
 	atomicOp := op.
 		Atomic(client, &op.NoResult{}).
-		ReadOp(tc.ReadPhase(t, client)...).
-		WriteOp(etcdop.Key("foo").Put(client, "bar"))
+		ReadOp(tc.ReadPhase(t, client)...)
+
+	// Test core method
+	atomicOp.Core().WriteOp(etcdop.Key("foo").Put(client, "bar"))
 
 	if tc.SkipPrefixKeysCheck {
 		atomicOp.SkipPrefixKeysCheck()
@@ -310,8 +312,10 @@ func (tc atomicOpTestCase) RunBreakingChange(t *testing.T) {
 			// Modify a key loaded by the Read Phase
 			require.NoError(t, op.MergeToTxn(client, tc.BreakingChange(t, client)...).Do(ctx).Err())
 			logs.Reset()
-		}).
-		WriteOp(etcdop.Key("foo").Put(client, "bar"))
+		})
+
+	// Test Core method
+	atomicOp.Core().WriteOp(etcdop.Key("foo").Put(client, "bar"))
 
 	if tc.SkipPrefixKeysCheck {
 		atomicOp.SkipPrefixKeysCheck()


### PR DESCRIPTION
Jira: https://keboola.atlassian.net/browse/PSGO-287

**Changes:**
- Created `AtomicOpCore` struct, without generic type.
  - Generic `AtomicOp[T]` are greate, but sometimes I need write a common code for different `T` types.
    - So I moved the core of the implementation to the `AtomicOpCore` struct, and it can be get by the `AtomicOp.Core()` method.

-----------
