### PR TITLE
docs: Fix double quotes to single so the .env works correctly

### DIFF
--- a/docs/development.md
+++ b/docs/development.md
@@ -16,7 +16,7 @@ docker compose build
 
 Create `.env` file with definition of testing projects:
 ```
-TEST_KBC_PROJECTS="[{"host":"connection.keboola.com","project":1234,"stagingStorage":"s3","backend":"snowflake/bigquery","token":"<token>"},...]"
+TEST_KBC_PROJECTS='[{"host":"connection.keboola.com","project":1234,"stagingStorage":"s3","backend":"snowflake/bigquery","token":"<token>"},...]'
 ```
 
 Staging storage can be `s3`, `abs` or `gcs`, according to the stack.

--- a/internal/pkg/service/common/etcdop/mutex_test.go
+++ b/internal/pkg/service/common/etcdop/mutex_test.go
@@ -20,7 +20,7 @@ import (
 func TestMutex_LockUnlock(t *testing.T) {
 	t.Parallel()
 
-	ctx, cancel := context.WithTimeout(context.Background(), 10*time.Second)
+	ctx, cancel := context.WithTimeout(context.Background(), 30*time.Second)
 	defer cancel()
 
 	wg := &sync.WaitGroup{}


### PR DESCRIPTION
Jira: https://keboola.atlassian.net/jira/software/projects/PSGO/boards/189?selectedIssue=PSGO-510

**Changes:**
- typo double quotes in .env

-----------
