### PR TITLE
tests: Rename MustReplaceEnvsDir to ReplaceEnvsDir. Return error instead of panicing.

### DIFF
--- a/internal/pkg/fixtures/fixtures.go
+++ b/internal/pkg/fixtures/fixtures.go
@@ -9,6 +9,7 @@ import (
 
 	"github.com/keboola/go-client/pkg/keboola"
 	"github.com/keboola/go-utils/pkg/orderedmap"
+	"github.com/stretchr/testify/require"
 
 	"github.com/keboola/keboola-as-code/internal/pkg/env"
 	"github.com/keboola/keboola-as-code/internal/pkg/filesystem"
@@ -206,7 +207,9 @@ func MinimalProjectFs(t *testing.T) filesystem.Fs {
 	envs.Set("TEST_KBC_STORAGE_API_HOST", "foo.bar")
 	envs.Set("LOCAL_STATE_MAIN_BRANCH_ID", "123")
 	envs.Set("LOCAL_STATE_GENERIC_CONFIG_ID", "456")
-	testhelper.MustReplaceEnvsDir(context.Background(), fs, `/`, envs)
+	err := testhelper.ReplaceEnvsDir(context.Background(), fs, `/`, envs)
+	require.NoError(t, err)
+
 	return fs
 }
 

--- a/internal/pkg/fixtures/local/local.go
+++ b/internal/pkg/fixtures/local/local.go
@@ -20,9 +20,9 @@ func LoadFS(ctx context.Context, dirName string, envs testhelper.EnvProvider) (f
 
 	// Create Fs
 	fs := aferofs.NewMemoryFsFrom(stateDir)
-	testhelper.MustReplaceEnvsDir(ctx, fs, `/`, envs)
+	err := testhelper.ReplaceEnvsDir(ctx, fs, `/`, envs)
 
-	return fs, nil
+	return fs, err
 }
 
 func LoadManifest(ctx context.Context, dirName string, envs testhelper.EnvProvider) (*manifest.Manifest, filesystem.Fs, error) {

--- a/internal/pkg/plan/persist/persist_test.go
+++ b/internal/pkg/plan/persist/persist_test.go
@@ -11,6 +11,7 @@ import (
 	"github.com/keboola/go-utils/pkg/orderedmap"
 	"github.com/spf13/cast"
 	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
 
 	"github.com/keboola/keboola-as-code/internal/pkg/encoding/json"
 	"github.com/keboola/keboola-as-code/internal/pkg/env"
@@ -921,7 +922,8 @@ func (tc *testCase) run(t *testing.T) {
 	fs := aferofs.NewMemoryFsFrom(inputDir)
 	envs := env.Empty()
 	envs.Set(`LOCAL_PROJECT_ID`, `12345`)
-	testhelper.MustReplaceEnvsDir(ctx, fs, `/`, envs)
+	err := testhelper.ReplaceEnvsDir(ctx, fs, `/`, envs)
+	require.NoError(t, err)
 
 	// Container
 	d := dependencies.NewMocked(t)

--- a/internal/pkg/plan/rename/plan_test.go
+++ b/internal/pkg/plan/rename/plan_test.go
@@ -7,6 +7,7 @@ import (
 
 	"github.com/jarcoal/httpmock"
 	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
 
 	"github.com/keboola/keboola-as-code/internal/pkg/env"
 	"github.com/keboola/keboola-as-code/internal/pkg/filesystem"
@@ -93,6 +94,8 @@ func testFs(t *testing.T, inputDir string) filesystem.Fs {
 	envs := env.Empty()
 	envs.Set("LOCAL_PROJECT_ID", "12345")
 	envs.Set("TEST_KBC_STORAGE_API_HOST", "foo.bar")
-	testhelper.MustReplaceEnvsDir(context.Background(), fs, `/`, envs)
+	err := testhelper.ReplaceEnvsDir(context.Background(), fs, `/`, envs)
+	require.NoError(t, err)
+
 	return fs
 }

--- a/internal/pkg/state/load_test.go
+++ b/internal/pkg/state/load_test.go
@@ -9,6 +9,7 @@ import (
 	"github.com/keboola/go-utils/pkg/orderedmap"
 	"github.com/spf13/cast"
 	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
 
 	"github.com/keboola/keboola-as-code/internal/pkg/env"
 	"github.com/keboola/keboola-as-code/internal/pkg/filesystem"
@@ -165,7 +166,8 @@ func loadTestManifest(t *testing.T, envs *env.Map, localState string) (*projectM
 
 	// Create Fs
 	fs := aferofs.NewMemoryFsFrom(stateDir)
-	testhelper.MustReplaceEnvsDir(context.Background(), fs, `/`, envs)
+	err := testhelper.ReplaceEnvsDir(context.Background(), fs, `/`, envs)
+	require.NoError(t, err)
 
 	// Load manifest
 	m, err := projectManifest.Load(context.Background(), log.NewNopLogger(), fs, env.Empty(), false)

--- a/internal/pkg/state/local/manager_test.go
+++ b/internal/pkg/state/local/manager_test.go
@@ -9,6 +9,7 @@ import (
 
 	"github.com/keboola/go-utils/pkg/orderedmap"
 	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
 
 	"github.com/keboola/keboola-as-code/internal/pkg/encoding/json"
 	"github.com/keboola/keboola-as-code/internal/pkg/env"
@@ -135,7 +136,8 @@ func TestLocalLoadMapper(t *testing.T) {
 	envs.Set("LOCAL_PROJECT_ID", "12345")
 	envs.Set("LOCAL_STATE_MAIN_BRANCH_ID", "111")
 	envs.Set("LOCAL_STATE_GENERIC_CONFIG_ID", "456")
-	testhelper.MustReplaceEnvsDir(context.Background(), fs, `/`, envs)
+	err := testhelper.ReplaceEnvsDir(context.Background(), fs, `/`, envs)
+	require.NoError(t, err)
 
 	// Load objects
 	m, err := projectManifest.Load(context.Background(), log.NewNopLogger(), fs, env.Empty(), false)

--- a/internal/pkg/utils/testhelper/runner/test.go
+++ b/internal/pkg/utils/testhelper/runner/test.go
@@ -22,6 +22,7 @@ import (
 	"github.com/keboola/go-utils/pkg/wildcards"
 	"github.com/spf13/cast"
 	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
 	"github.com/umisama/go-regexpcache"
 	goValuate "gopkg.in/Knetic/govaluate.v3"
 
@@ -180,7 +181,8 @@ func (t *Test) Run(opts ...Options) {
 	}
 
 	// Replace all %%ENV_VAR%% in all files of the working directory.
-	testhelper.MustReplaceEnvsDir(t.ctx, t.workingDirFS, `/`, t.envProvider)
+	err := testhelper.ReplaceEnvsDir(t.ctx, t.workingDirFS, `/`, t.envProvider)
+	require.NoError(t.t, err)
 
 	if c.cliBinaryPath != "" {
 		// Run a CLI binary
@@ -619,7 +621,8 @@ func (t *Test) assertDirContent() {
 
 	// Copy expected state and replace ENVs
 	expectedDirFS := aferofs.NewMemoryFsFrom(filesystem.Join(t.testDirFS.BasePath(), expectedDir))
-	testhelper.MustReplaceEnvsDir(t.ctx, expectedDirFS, `/`, t.envProvider)
+	err := testhelper.ReplaceEnvsDir(t.ctx, expectedDirFS, `/`, t.envProvider)
+	require.NoError(t.t, err)
 
 	// Compare actual and expected dirs
 	testhelper.AssertDirectoryContentsSame(t.t, expectedDirFS, `/`, t.workingDirFS, `/`)

--- a/pkg/lib/operation/template/local/test/run/operation.go
+++ b/pkg/lib/operation/template/local/test/run/operation.go
@@ -143,14 +143,23 @@ func runLocalTest(ctx context.Context, test *template.Test, tmpl *template.Templ
 	replaceEnvs.Set("PROJECT_ID", strconv.Itoa(testPrj.ID()))
 	replaceEnvs.Set("MAIN_BRANCH_ID", strconv.Itoa(branchID))
 	envProvider := storageenvmock.CreateStorageEnvMockTicketProvider(ctx, replaceEnvs)
-	testhelper.MustReplaceEnvsDir(ctx, prjState.Fs(), `/`, envProvider)
-	testhelper.MustReplaceEnvsDirWithSeparator(ctx, expectedDirFs, `/`, envProvider, "__")
+	err = testhelper.ReplaceEnvsDir(ctx, prjState.Fs(), `/`, envProvider)
+	if err != nil {
+		return err
+	}
+	err = testhelper.ReplaceEnvsDirWithSeparator(ctx, expectedDirFs, `/`, envProvider, "__")
+	if err != nil {
+		return err
+	}
 	// Replace secrets from env vars
 	osEnvs, err := env.FromOs()
 	if err != nil {
 		return err
 	}
-	testhelper.MustReplaceEnvsDirWithSeparator(ctx, expectedDirFs, `/`, osEnvs, "##")
+	err = testhelper.ReplaceEnvsDirWithSeparator(ctx, expectedDirFs, `/`, osEnvs, "##")
+	if err != nil {
+		return err
+	}
 
 	// Compare actual and expected dirs
 	return testhelper.DirectoryContentsSame(ctx, expectedDirFs, `/`, prjState.Fs(), `/`)
@@ -206,14 +215,23 @@ func runRemoteTest(ctx context.Context, test *template.Test, tmpl *template.Temp
 	replaceEnvs.Set("PROJECT_ID", strconv.Itoa(testPrj.ID()))
 	replaceEnvs.Set("MAIN_BRANCH_ID", prjState.MainBranch().ID.String())
 	envProvider := storageenvmock.CreateStorageEnvMockTicketProvider(ctx, replaceEnvs)
-	testhelper.MustReplaceEnvsDir(ctx, prjState.Fs(), `/`, envProvider)
-	testhelper.MustReplaceEnvsDirWithSeparator(ctx, expectedDirFs, `/`, envProvider, "__")
+	err = testhelper.ReplaceEnvsDir(ctx, prjState.Fs(), `/`, envProvider)
+	if err != nil {
+		return err
+	}
+	err = testhelper.ReplaceEnvsDirWithSeparator(ctx, expectedDirFs, `/`, envProvider, "__")
+	if err != nil {
+		return err
+	}
 	// Replace secrets from env vars
 	osEnvs, err := env.FromOs()
 	if err != nil {
 		return err
 	}
-	testhelper.MustReplaceEnvsDirWithSeparator(ctx, expectedDirFs, `/`, osEnvs, "##")
+	err = testhelper.ReplaceEnvsDirWithSeparator(ctx, expectedDirFs, `/`, osEnvs, "##")
+	if err != nil {
+		return err
+	}
 
 	// E2E test
 	// Push the project


### PR DESCRIPTION
Jira: [540](https://keboola.atlassian.net/browse/PSGO-540)

**Changes:**
- Change usage of MustReplaceEnvsDir to ReplaceEnvsDir.
- Return error instead of panic.
- Use require.NoError for catching newly returned error.

-----------
