### PR TITLE
ci: Add support for legacyTransformation for projects on old stacks.

### DIFF
--- a/.github/workflows/test-e2e-cli.yml
+++ b/.github/workflows/test-e2e-cli.yml
@@ -13,39 +13,39 @@ env:
   TEST_PARALLELISM_PKG: 1
   TEST_PROJECTS_LINUX: |
     [
-      {"host":"connection.keboola.com","project":8764,"stagingStorage":"s3","backend":"snowflake","token":"${{ secrets.TEST_KBC_PROJECT_8764_TOKEN }}"},
-      {"host":"connection.keboola.com","project":8765,"stagingStorage":"s3","backend":"snowflake","token":"${{ secrets.TEST_KBC_PROJECT_8765_TOKEN }}"},
-      {"host":"connection.keboola.com","project":8766,"stagingStorage":"s3","backend":"snowflake","token":"${{ secrets.TEST_KBC_PROJECT_8766_TOKEN }}"},
+      {"host":"connection.keboola.com","project":8764,"stagingStorage":"s3","backend":"snowflake","token":"${{ secrets.TEST_KBC_PROJECT_8764_TOKEN }}", "legacyTransformation": true},
+      {"host":"connection.keboola.com","project":8765,"stagingStorage":"s3","backend":"snowflake","token":"${{ secrets.TEST_KBC_PROJECT_8765_TOKEN }}", "legacyTransformation": true},
+      {"host":"connection.keboola.com","project":8766,"stagingStorage":"s3","backend":"snowflake","token":"${{ secrets.TEST_KBC_PROJECT_8766_TOKEN }}", "legacyTransformation": true},
       {"host":"connection.europe-west3.gcp.keboola.com","project":45,"stagingStorage":"gcs","backend":"bigquery","token":"${{ secrets.TEST_KBC_PROJECT_45_TOKEN }}"},
       {"host":"connection.europe-west3.gcp.keboola.com","project":46,"stagingStorage":"gcs","backend":"bigquery","token":"${{ secrets.TEST_KBC_PROJECT_46_TOKEN }}"},
-      {"host":"connection.north-europe.azure.keboola.com","project":10890,"stagingStorage":"abs","backend":"snowflake","token":"${{ secrets.TEST_KBC_PROJECT_10890_TOKEN }}"},
-      {"host":"connection.north-europe.azure.keboola.com","project":10891,"stagingStorage":"abs","backend":"snowflake","token":"${{ secrets.TEST_KBC_PROJECT_10891_TOKEN }}"},
-      {"host":"connection.north-europe.azure.keboola.com","project":10892,"stagingStorage":"abs","backend":"snowflake","token":"${{ secrets.TEST_KBC_PROJECT_10892_TOKEN }}"}
+      {"host":"connection.north-europe.azure.keboola.com","project":10890,"stagingStorage":"abs","backend":"snowflake","token":"${{ secrets.TEST_KBC_PROJECT_10890_TOKEN }}", "legacyTransformation": true},
+      {"host":"connection.north-europe.azure.keboola.com","project":10891,"stagingStorage":"abs","backend":"snowflake","token":"${{ secrets.TEST_KBC_PROJECT_10891_TOKEN }}", "legacyTransformation": true},
+      {"host":"connection.north-europe.azure.keboola.com","project":10892,"stagingStorage":"abs","backend":"snowflake","token":"${{ secrets.TEST_KBC_PROJECT_10892_TOKEN }}", "legacyTransformation": true}
     ]
   TEST_PROJECTS_MACOS: |
     [
-      {"host":"connection.keboola.com","project":8771,"stagingStorage":"s3","backend":"snowflake","token":"${{ secrets.TEST_KBC_PROJECT_8771_TOKEN }}"},
-      {"host":"connection.keboola.com","project":8772,"stagingStorage":"s3","backend":"snowflake","token":"${{ secrets.TEST_KBC_PROJECT_8772_TOKEN }}"},
-      {"host":"connection.keboola.com","project":8773,"stagingStorage":"s3","backend":"snowflake","token":"${{ secrets.TEST_KBC_PROJECT_8773_TOKEN }}"},
+      {"host":"connection.keboola.com","project":8771,"stagingStorage":"s3","backend":"snowflake","token":"${{ secrets.TEST_KBC_PROJECT_8771_TOKEN }}", "legacyTransformation": true},
+      {"host":"connection.keboola.com","project":8772,"stagingStorage":"s3","backend":"snowflake","token":"${{ secrets.TEST_KBC_PROJECT_8772_TOKEN }}", "legacyTransformation": true},
+      {"host":"connection.keboola.com","project":8773,"stagingStorage":"s3","backend":"snowflake","token":"${{ secrets.TEST_KBC_PROJECT_8773_TOKEN }}", "legacyTransformation": true},
       {"host":"connection.europe-west3.gcp.keboola.com","project":47,"stagingStorage":"gcs","backend":"bigquery","token":"${{ secrets.TEST_KBC_PROJECT_47_TOKEN }}"},
       {"host":"connection.europe-west3.gcp.keboola.com","project":48,"stagingStorage":"gcs","backend":"bigquery","token":"${{ secrets.TEST_KBC_PROJECT_48_TOKEN }}"},
-      {"host":"connection.north-europe.azure.keboola.com","project":10893,"stagingStorage":"abs","backend":"snowflake","token":"${{ secrets.TEST_KBC_PROJECT_10893_TOKEN }}"},
-      {"host":"connection.north-europe.azure.keboola.com","project":10896,"stagingStorage":"abs","backend":"snowflake","token":"${{ secrets.TEST_KBC_PROJECT_10896_TOKEN }}"},
-      {"host":"connection.north-europe.azure.keboola.com","project":10897,"stagingStorage":"abs","backend":"snowflake","token":"${{ secrets.TEST_KBC_PROJECT_10897_TOKEN }}"},
-      {"host":"connection.north-europe.azure.keboola.com","project":10898,"stagingStorage":"abs","backend":"snowflake","token":"${{ secrets.TEST_KBC_PROJECT_10898_TOKEN }}"}
+      {"host":"connection.north-europe.azure.keboola.com","project":10893,"stagingStorage":"abs","backend":"snowflake","token":"${{ secrets.TEST_KBC_PROJECT_10893_TOKEN }}", "legacyTransformation": true},
+      {"host":"connection.north-europe.azure.keboola.com","project":10896,"stagingStorage":"abs","backend":"snowflake","token":"${{ secrets.TEST_KBC_PROJECT_10896_TOKEN }}", "legacyTransformation": true},
+      {"host":"connection.north-europe.azure.keboola.com","project":10897,"stagingStorage":"abs","backend":"snowflake","token":"${{ secrets.TEST_KBC_PROJECT_10897_TOKEN }}", "legacyTransformation": true},
+      {"host":"connection.north-europe.azure.keboola.com","project":10898,"stagingStorage":"abs","backend":"snowflake","token":"${{ secrets.TEST_KBC_PROJECT_10898_TOKEN }}", "legacyTransformation": true}
     ]
   TEST_PROJECTS_WINDOWS: |
     [
-      {"host":"connection.keboola.com","project":8778,"stagingStorage":"s3","backend":"snowflake","token":"${{ secrets.TEST_KBC_PROJECT_8778_TOKEN }}"},
-      {"host":"connection.keboola.com","project":8779,"stagingStorage":"s3","backend":"snowflake","token":"${{ secrets.TEST_KBC_PROJECT_8779_TOKEN }}"},
-      {"host":"connection.keboola.com","project":8780,"stagingStorage":"s3","backend":"snowflake","token":"${{ secrets.TEST_KBC_PROJECT_8780_TOKEN }}"},
-      {"host":"connection.keboola.com","project":8782,"stagingStorage":"s3","backend":"snowflake","token":"${{ secrets.TEST_KBC_PROJECT_8782_TOKEN }}"},
+      {"host":"connection.keboola.com","project":8778,"stagingStorage":"s3","backend":"snowflake","token":"${{ secrets.TEST_KBC_PROJECT_8778_TOKEN }}", "legacyTransformation": true},
+      {"host":"connection.keboola.com","project":8779,"stagingStorage":"s3","backend":"snowflake","token":"${{ secrets.TEST_KBC_PROJECT_8779_TOKEN }}", "legacyTransformation": true},
+      {"host":"connection.keboola.com","project":8780,"stagingStorage":"s3","backend":"snowflake","token":"${{ secrets.TEST_KBC_PROJECT_8780_TOKEN }}", "legacyTransformation": true},
+      {"host":"connection.keboola.com","project":8782,"stagingStorage":"s3","backend":"snowflake","token":"${{ secrets.TEST_KBC_PROJECT_8782_TOKEN }}", "legacyTransformation": true},
       {"host":"connection.europe-west3.gcp.keboola.com","project":49,"stagingStorage":"gcs","backend":"bigquery","token":"${{ secrets.TEST_KBC_PROJECT_49_TOKEN }}"},
       {"host":"connection.europe-west3.gcp.keboola.com","project":50,"stagingStorage":"gcs","backend":"bigquery","token":"${{ secrets.TEST_KBC_PROJECT_50_TOKEN }}"},
-      {"host":"connection.north-europe.azure.keboola.com","project":10894,"stagingStorage":"abs","backend":"snowflake","token":"${{ secrets.TEST_KBC_PROJECT_10894_TOKEN }}"},
-      {"host":"connection.north-europe.azure.keboola.com","project":10902,"stagingStorage":"abs","backend":"snowflake","token":"${{ secrets.TEST_KBC_PROJECT_10902_TOKEN }}"},
-      {"host":"connection.north-europe.azure.keboola.com","project":10903,"stagingStorage":"abs","backend":"snowflake","token":"${{ secrets.TEST_KBC_PROJECT_10903_TOKEN }}"},
-      {"host":"connection.north-europe.azure.keboola.com","project":10904,"stagingStorage":"abs","backend":"snowflake","token":"${{ secrets.TEST_KBC_PROJECT_10904_TOKEN }}"}
+      {"host":"connection.north-europe.azure.keboola.com","project":10894,"stagingStorage":"abs","backend":"snowflake","token":"${{ secrets.TEST_KBC_PROJECT_10894_TOKEN }}", "legacyTransformation": true},
+      {"host":"connection.north-europe.azure.keboola.com","project":10902,"stagingStorage":"abs","backend":"snowflake","token":"${{ secrets.TEST_KBC_PROJECT_10902_TOKEN }}", "legacyTransformation": true},
+      {"host":"connection.north-europe.azure.keboola.com","project":10903,"stagingStorage":"abs","backend":"snowflake","token":"${{ secrets.TEST_KBC_PROJECT_10903_TOKEN }}", "legacyTransformation": true},
+      {"host":"connection.north-europe.azure.keboola.com","project":10904,"stagingStorage":"abs","backend":"snowflake","token":"${{ secrets.TEST_KBC_PROJECT_10904_TOKEN }}", "legacyTransformation": true}
     ]
 
 jobs:

--- a/.github/workflows/test-unit.yml
+++ b/.github/workflows/test-unit.yml
@@ -9,31 +9,31 @@ env:
   TEST_PARALLELISM_PKG: 6
   TEST_PROJECTS_LINUX: |
     [
-      {"host":"connection.keboola.com","project":8763,"stagingStorage":"s3","backend":"snowflake","token":"${{ secrets.TEST_KBC_PROJECT_8763_TOKEN }}"},  
+      {"host":"connection.keboola.com","project":8763,"stagingStorage":"s3","backend":"snowflake","token":"${{ secrets.TEST_KBC_PROJECT_8763_TOKEN }}", "legacyTransformation": true},  
       {"host":"connection.europe-west3.gcp.keboola.com","project":35,"stagingStorage":"gcs","backend":"bigquery","token":"${{ secrets.TEST_KBC_PROJECT_35_TOKEN }}"},
       {"host":"connection.europe-west3.gcp.keboola.com","project":36,"stagingStorage":"gcs","backend":"bigquery","token":"${{ secrets.TEST_KBC_PROJECT_36_TOKEN }}"},
-      {"host":"connection.north-europe.azure.keboola.com","project":10889,"stagingStorage":"abs","backend":"snowflake","token":"${{ secrets.TEST_KBC_PROJECT_10889_TOKEN }}"},
-      {"host":"connection.north-europe.azure.keboola.com","project":10911,"stagingStorage":"abs","backend":"snowflake","token":"${{ secrets.TEST_KBC_PROJECT_10911_TOKEN }}"}
+      {"host":"connection.north-europe.azure.keboola.com","project":10889,"stagingStorage":"abs","backend":"snowflake","token":"${{ secrets.TEST_KBC_PROJECT_10889_TOKEN }}", "legacyTransformation": true},
+      {"host":"connection.north-europe.azure.keboola.com","project":10911,"stagingStorage":"abs","backend":"snowflake","token":"${{ secrets.TEST_KBC_PROJECT_10911_TOKEN }}", "legacyTransformation": true}
     ]
   TEST_PROJECTS_MACOS: |
     [
-      {"host":"connection.keboola.com","project":8770,"stagingStorage":"s3","backend":"snowflake","token":"${{ secrets.TEST_KBC_PROJECT_8770_TOKEN }}"},
-      {"host":"connection.keboola.com","project":9432,"stagingStorage":"s3","backend":"snowflake","token":"${{ secrets.TEST_KBC_PROJECT_9432_TOKEN }}"},
+      {"host":"connection.keboola.com","project":8770,"stagingStorage":"s3","backend":"snowflake","token":"${{ secrets.TEST_KBC_PROJECT_8770_TOKEN }}", "legacyTransformation": true},
+      {"host":"connection.keboola.com","project":9432,"stagingStorage":"s3","backend":"snowflake","token":"${{ secrets.TEST_KBC_PROJECT_9432_TOKEN }}", "legacyTransformation": true},
       {"host":"connection.europe-west3.gcp.keboola.com","project":37,"stagingStorage":"gcs","backend":"bigquery","token":"${{ secrets.TEST_KBC_PROJECT_37_TOKEN }}"},
       {"host":"connection.europe-west3.gcp.keboola.com","project":38,"stagingStorage":"gcs","backend":"bigquery","token":"${{ secrets.TEST_KBC_PROJECT_38_TOKEN }}"},
-      {"host":"connection.north-europe.azure.keboola.com","project":10895,"stagingStorage":"abs","backend":"snowflake","token":"${{ secrets.TEST_KBC_PROJECT_10895_TOKEN }}"},
-      {"host":"connection.north-europe.azure.keboola.com","project":10912,"stagingStorage":"abs","backend":"snowflake","token":"${{ secrets.TEST_KBC_PROJECT_10912_TOKEN }}"}
+      {"host":"connection.north-europe.azure.keboola.com","project":10895,"stagingStorage":"abs","backend":"snowflake","token":"${{ secrets.TEST_KBC_PROJECT_10895_TOKEN }}", "legacyTransformation": true},
+      {"host":"connection.north-europe.azure.keboola.com","project":10912,"stagingStorage":"abs","backend":"snowflake","token":"${{ secrets.TEST_KBC_PROJECT_10912_TOKEN }}", "legacyTransformation": true}
     ]
   TEST_PROJECTS_WINDOWS: |
     [
-      {"host":"connection.keboola.com","project":8777,"stagingStorage":"s3","backend":"snowflake","token":"${{ secrets.TEST_KBC_PROJECT_8777_TOKEN }}"},
-      {"host":"connection.keboola.com","project":9433,"stagingStorage":"s3","backend":"snowflake","token":"${{ secrets.TEST_KBC_PROJECT_9433_TOKEN }}"},
-      {"host":"connection.keboola.com","project":9431,"stagingStorage":"s3","backend":"snowflake","token":"${{ secrets.TEST_KBC_PROJECT_9431_TOKEN }}"},
-      {"host":"connection.keboola.com","project":8781,"stagingStorage":"s3","backend":"snowflake","token":"${{ secrets.TEST_KBC_PROJECT_8781_TOKEN }}"},
+      {"host":"connection.keboola.com","project":8777,"stagingStorage":"s3","backend":"snowflake","token":"${{ secrets.TEST_KBC_PROJECT_8777_TOKEN }}", "legacyTransformation": true},
+      {"host":"connection.keboola.com","project":9433,"stagingStorage":"s3","backend":"snowflake","token":"${{ secrets.TEST_KBC_PROJECT_9433_TOKEN }}", "legacyTransformation": true},
+      {"host":"connection.keboola.com","project":9431,"stagingStorage":"s3","backend":"snowflake","token":"${{ secrets.TEST_KBC_PROJECT_9431_TOKEN }}", "legacyTransformation": true},
+      {"host":"connection.keboola.com","project":8781,"stagingStorage":"s3","backend":"snowflake","token":"${{ secrets.TEST_KBC_PROJECT_8781_TOKEN }}", "legacyTransformation": true},
       {"host":"connection.europe-west3.gcp.keboola.com","project":39,"stagingStorage":"gcs","backend":"bigquery","token":"${{ secrets.TEST_KBC_PROJECT_39_TOKEN }}"},
       {"host":"connection.europe-west3.gcp.keboola.com","project":40,"stagingStorage":"gcs","backend":"bigquery","token":"${{ secrets.TEST_KBC_PROJECT_40_TOKEN }}"},
-      {"host":"connection.north-europe.azure.keboola.com","project":10901,"stagingStorage":"abs","backend":"snowflake","token":"${{ secrets.TEST_KBC_PROJECT_10901_TOKEN }}"},
-      {"host":"connection.north-europe.azure.keboola.com","project":10913,"stagingStorage":"abs","backend":"snowflake","token":"${{ secrets.TEST_KBC_PROJECT_10913_TOKEN }}"}
+      {"host":"connection.north-europe.azure.keboola.com","project":10901,"stagingStorage":"abs","backend":"snowflake","token":"${{ secrets.TEST_KBC_PROJECT_10901_TOKEN }}", "legacyTransformation": true},
+      {"host":"connection.north-europe.azure.keboola.com","project":10913,"stagingStorage":"abs","backend":"snowflake","token":"${{ secrets.TEST_KBC_PROJECT_10913_TOKEN }}", "legacyTransformation": true}
     ]
 
 jobs:

--- a/docs/e2e_tests.md
+++ b/docs/e2e_tests.md
@@ -67,6 +67,8 @@ Contain a snapshot of a project before or after the operations run in the test.
 - `buckets` - List of all buckets and their tables in the project.
 - `sandboxes` - List of all workspaces.
 - `schedules` - List of all schedules.
+- `backend` - Backend that the tests should run on only. Test fails when backend in TEST_KBC_PROJECTS has incompatible backend.
+- `legacyTransformation` - Boolean indication that the stack supports legacyTransformation. For `gcp` stack the legacyTransformation has to be set always to `false`.
 - `branches/.../configs` - List of all configs (by filename without extension) available in a branch. They are created from fixtures defined in [internal/pkg/fixtures/configs](https://github.com/keboola/keboola-as-code/tree/main/internal/pkg/fixtures/configs). The `name` field of the fixture is used to generate an environment variable which contains the ID of the config, e.g. `%%TEST_BRANCH_MAIN_CONFIG_EMPTY_ID%%` where `MAIN` is the branch, and `EMPTY` is the name.
   - You can get a list of the generated environment variables by running the test with `TEST_VERBOSE=true`, e.g. `TEST_VERBOSE=true TEST_PACKAGE=./test/cli/... bash ./scripts/tests.sh -run TestCliE2E/job`
 
@@ -74,6 +76,10 @@ Example:
 
 ```json
 {
+  "backend": {
+    "type": "snowflake"
+  },
+  "legacyTransformation": true,
   "branches": [
     {
       "branch": {

--- a/go.mod
+++ b/go.mod
@@ -36,7 +36,7 @@ require (
 	github.com/jpillora/longestcommon v0.0.0-20161227235612-adb9d91ee629
 	github.com/justinas/alice v1.2.0
 	github.com/keboola/go-client v1.26.2
-	github.com/keboola/go-utils v0.8.6
+	github.com/keboola/go-utils v0.9.0
 	github.com/klauspost/compress v1.17.8
 	github.com/klauspost/pgzip v1.2.6
 	github.com/kylelemons/godebug v1.1.0

--- a/go.sum
+++ b/go.sum
@@ -389,8 +389,8 @@ github.com/keboola/go-mockoidc v0.0.0-20240405064136-5229d2b53db6 h1:HcvX1VQkiav
 github.com/keboola/go-mockoidc v0.0.0-20240405064136-5229d2b53db6/go.mod h1:eDjgYHYDJbPLBLsyZ6qRaugP0mX8vePOhZ5id1fdzJw=
 github.com/keboola/go-oauth2-proxy/v7 v7.6.1-0.20240404125540-ac0aff7a6c75 h1:Rhu3PDH2w2qy6+EZ36r2aQGQW2rhNvpVeu2+mqawAgQ=
 github.com/keboola/go-oauth2-proxy/v7 v7.6.1-0.20240404125540-ac0aff7a6c75/go.mod h1:uPrZkzwsuFyIPP04hIt6TG2KvWujglvkOnUUnQJyIdw=
-github.com/keboola/go-utils v0.8.6 h1:ggweyzQScWzLiqBBp+KUPZDHFyR1Es45Ygul6oXKel0=
-github.com/keboola/go-utils v0.8.6/go.mod h1:5wkrBfGBpJ/COCkBO0JPckD0e9sdT1PQo09Phx+kqrw=
+github.com/keboola/go-utils v0.9.0 h1:1d/DQd7+c2+4mUFF+3cQqWxXgugityHCTYlV435LlQ0=
+github.com/keboola/go-utils v0.9.0/go.mod h1:5wkrBfGBpJ/COCkBO0JPckD0e9sdT1PQo09Phx+kqrw=
 github.com/kisielk/errcheck v1.5.0/go.mod h1:pFxgyoBC7bSaBwPgfKdkLd5X25qrDl4LWUI2bnpBCr8=
 github.com/kisielk/gotool v1.0.0/go.mod h1:XhKaO+MFFWcvkIS/tQcRk01m1F5IRFswLeQ+oQHNcck=
 github.com/klauspost/compress v1.17.8 h1:YcnTYrq7MikUT7k0Yb5eceMmALQPYBW/Xltxn0NAMnU=

--- a/internal/pkg/fixtures/fixtures.go
+++ b/internal/pkg/fixtures/fixtures.go
@@ -112,13 +112,14 @@ type BackendDefinition struct {
 }
 
 type StateFile struct {
-	Backend            *BackendDefinition `json:"backend,omitempty"`
-	AllBranchesConfigs []string           `json:"allBranchesConfigs" validate:"required"`
-	Branches           []*BranchState     `json:"branches" validate:"required"`
-	Buckets            []*Bucket          `json:"buckets,omitempty"`
-	Sandboxes          []*Sandbox         `json:"sandboxes,omitempty"`
-	Files              []*File            `json:"files,omitempty"`
-	Envs               map[string]string  `json:"envs,omitempty"` // additional ENVs
+	Backend              *BackendDefinition `json:"backend,omitempty"`
+	LegacyTransformation bool               `json:"legacyTransformation,omitempty"`
+	AllBranchesConfigs   []string           `json:"allBranchesConfigs" validate:"required"`
+	Branches             []*BranchState     `json:"branches" validate:"required"`
+	Buckets              []*Bucket          `json:"buckets,omitempty"`
+	Sandboxes            []*Sandbox         `json:"sandboxes,omitempty"`
+	Files                []*File            `json:"files,omitempty"`
+	Envs                 map[string]string  `json:"envs,omitempty"` // additional ENVs
 }
 
 // ToAPI maps fixture to model.Branch.

--- a/internal/pkg/utils/testhelper/runner/runner.go
+++ b/internal/pkg/utils/testhelper/runner/runner.go
@@ -71,6 +71,10 @@ func (r *Runner) newTest(t *testing.T, testDirName string) (*Test, context.Cance
 		backendOptions = append(backendOptions, GetBackendOption(t, state.Backend))
 	}
 
+	if state.LegacyTransformation {
+		backendOptions = append(backendOptions, tp.WithLegacyTransformation())
+	}
+
 	project := testproject.GetTestProjectForTest(t, backendOptions...)
 	// Create context with timeout.
 	// Acquiring a test project and setting it up is not part of the timeout.

--- a/internal/pkg/utils/testproject/project.go
+++ b/internal/pkg/utils/testproject/project.go
@@ -8,6 +8,7 @@ import (
 	"path/filepath"
 	"regexp"
 	"runtime"
+	"strconv"
 	"strings"
 	"sync"
 	"testing"
@@ -116,7 +117,7 @@ func GetTestProject(envs *env.Map, options ...testproject.Option) (*Project, Unl
 	p.setEnv(`TEST_KBC_STORAGE_API_HOST`, p.Project.StorageAPIHost())
 	p.setEnv(`TEST_KBC_STORAGE_API_TOKEN`, p.Project.StorageAPIToken())
 	p.setEnv(`TEST_KBC_PROJECT_BACKEND`, p.Project.Backend())
-	p.setEnv(`TEST_KBC_PROJECT_LEGACY_TRANSFORMATION`, p.Project.LegacyTransformation())
+	p.setEnv(`TEST_KBC_PROJECT_LEGACY_TRANSFORMATION`, strconv.FormatBool(p.Project.LegacyTransformation()))
 	p.logf(`■ ️Initialization done.`)
 
 	// Remove all objects

--- a/internal/pkg/utils/testproject/project.go
+++ b/internal/pkg/utils/testproject/project.go
@@ -116,6 +116,7 @@ func GetTestProject(envs *env.Map, options ...testproject.Option) (*Project, Unl
 	p.setEnv(`TEST_KBC_STORAGE_API_HOST`, p.Project.StorageAPIHost())
 	p.setEnv(`TEST_KBC_STORAGE_API_TOKEN`, p.Project.StorageAPIToken())
 	p.setEnv(`TEST_KBC_PROJECT_BACKEND`, p.Project.Backend())
+	p.setEnv(`TEST_KBC_PROJECT_LEGACY_TRANSFORMATION`, p.Project.LegacyTransformation())
 	p.logf(`■ ️Initialization done.`)
 
 	// Remove all objects

--- a/test/cli/diff/with-details/initial-state.json
+++ b/test/cli/diff/with-details/initial-state.json
@@ -2,6 +2,7 @@
   "backend": {
     "type": "snowflake"
   },
+  "legacyTransformation": true,
   "allBranchesConfigs": [
     "empty"
   ],

--- a/test/cli/diff/without-details/initial-state.json
+++ b/test/cli/diff/without-details/initial-state.json
@@ -2,6 +2,7 @@
   "backend": {
     "type": "snowflake"
   },
+  "legacyTransformation": true,
   "allBranchesConfigs": [
     "empty"
   ],

--- a/test/cli/pull/changed/initial-state.json
+++ b/test/cli/pull/changed/initial-state.json
@@ -2,6 +2,7 @@
   "backend": {
     "type": "snowflake"
   },
+  "legacyTransformation": true,
   "allBranchesConfigs": [
     "empty"
   ],

--- a/test/cli/pull/dry-run/initial-state.json
+++ b/test/cli/pull/dry-run/initial-state.json
@@ -2,6 +2,7 @@
   "backend": {
     "type": "snowflake"
   },
+  "legacyTransformation": true,
   "allBranchesConfigs": [
     "empty"
   ],

--- a/test/cli/pull/no-difference/initial-state.json
+++ b/test/cli/pull/no-difference/initial-state.json
@@ -2,6 +2,7 @@
   "backend": {
     "type": "snowflake"
   },
+  "legacyTransformation": true,
   "allBranchesConfigs": [
     "empty"
   ],

--- a/test/cli/pull/ok-legacy/initial-state.json
+++ b/test/cli/pull/ok-legacy/initial-state.json
@@ -2,6 +2,7 @@
   "backend": {
     "type": "snowflake"
   },
+  "legacyTransformation": true,
   "branches": [
     {
       "branch": {

--- a/test/cli/pull/only-allowed-branch/initial-state.json
+++ b/test/cli/pull/only-allowed-branch/initial-state.json
@@ -2,6 +2,7 @@
   "backend": {
     "type": "snowflake"
   },
+  "legacyTransformation": true,
   "allBranchesConfigs": [
     "empty"
   ],

--- a/test/cli/pull/rows-without-name/initial-state.json
+++ b/test/cli/pull/rows-without-name/initial-state.json
@@ -2,6 +2,7 @@
   "backend": {
     "type": "snowflake"
   },
+  "legacyTransformation": true,
   "allBranchesConfigs": [
     "rows-without-name"
   ],

--- a/test/cli/push/dry-run/initial-state.json
+++ b/test/cli/push/dry-run/initial-state.json
@@ -2,6 +2,7 @@
   "backend": {
     "type": "snowflake"
   },
+  "legacyTransformation": true,
   "allBranchesConfigs": [
     "empty"
   ],

--- a/test/cli/push/im-default-bucket-missing-row/initial-state.json
+++ b/test/cli/push/im-default-bucket-missing-row/initial-state.json
@@ -1,4 +1,5 @@
 {
+  "legacyTransformation": true,
   "allBranchesConfigs": [],
   "branches": [
     {

--- a/test/cli/push/im-default-bucket-row/initial-state.json
+++ b/test/cli/push/im-default-bucket-row/initial-state.json
@@ -1,4 +1,5 @@
 {
+  "legacyTransformation": true,
   "allBranchesConfigs": [],
   "branches": [
     {

--- a/test/cli/push/ok-legacy/initial-state.json
+++ b/test/cli/push/ok-legacy/initial-state.json
@@ -2,6 +2,7 @@
   "backend": {
     "type": "snowflake"
   },
+  "legacyTransformation": true,
   "branches": [
     {
       "branch": {

--- a/test/cli/push/only-allowed-branch/initial-state.json
+++ b/test/cli/push/only-allowed-branch/initial-state.json
@@ -2,6 +2,7 @@
   "backend": {
     "type": "snowflake"
   },
+  "legacyTransformation": true,
   "allBranchesConfigs": [
     "empty"
   ],

--- a/test/cli/remote-create/table-columns-flag/initial-state.json
+++ b/test/cli/remote-create/table-columns-flag/initial-state.json
@@ -2,6 +2,7 @@
   "backend": {
     "type": "snowflake"
   },
+  "legacyTransformation": true,
   "branches": [
     {
       "branch": {

--- a/test/cli/template-create/complex/initial-state.json
+++ b/test/cli/template-create/complex/initial-state.json
@@ -2,6 +2,7 @@
   "backend": {
     "type": "snowflake"
   },
+  "legacyTransformation": true,
   "allBranchesConfigs": [
     "empty"
   ],

--- a/test/cli/template-upgrade/complex/initial-state.json
+++ b/test/cli/template-upgrade/complex/initial-state.json
@@ -2,6 +2,7 @@
   "backend": {
     "type": "snowflake"
   },
+  "legacyTransformation": true,
   "branches": [
     {
       "branch": {

--- a/test/cli/template-use/complex/initial-state.json
+++ b/test/cli/template-use/complex/initial-state.json
@@ -2,6 +2,7 @@
   "backend": {
     "type": "snowflake"
   },
+  "legacyTransformation": true,
   "branches": [
     {
       "branch": {

--- a/test/cli/version/warning/initial-state.json
+++ b/test/cli/version/warning/initial-state.json
@@ -1,7 +1,8 @@
 {
   "backend": {
-        "type": "snowflake"
-    },
+    "type": "snowflake"
+  },
+  "legacyTransformation": true,
   "allBranchesConfigs": [
     "empty"
   ],


### PR DESCRIPTION
Jira: [PSGO-547](https://keboola.atlassian.net/browse/PSGO-547)

**Changes:**
- CI has support of new `legacyTransformation` field which indicates whether the project is working on old or new stack.
- Add the `legacyTransformation` into `initial-state.json` for tests. The tests should be skipped/executed based on project definitions.

-----------


[PSGO-547]: https://keboola.atlassian.net/browse/PSGO-547?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ