### PR TITLE
feat: Data Apps Proxy finalization

### DIFF
--- a/internal/pkg/service/appsproxy/dataapps/appconfig/appconfig.go
+++ b/internal/pkg/service/appsproxy/dataapps/appconfig/appconfig.go
@@ -3,6 +3,7 @@ package appconfig
 
 import (
 	"context"
+	"fmt"
 	"net/http"
 	"sync"
 	"time"
@@ -109,9 +110,13 @@ func (l *Loader) GetConfig(ctx context.Context, appID api.AppID) (out api.AppCon
 		//  - It is not found error.
 		//  - There is no cached version.
 		//  - The staleCacheFallbackDuration has been exceeded.
-		return api.AppConfig{}, false, svcErrors.NewServiceUnavailableError(errors.PrefixErrorf(err,
-			`unable to load configuration for application "%s"`, appID,
-		))
+		return api.AppConfig{}, false, svcErrors.
+			NewServiceUnavailableError(errors.PrefixErrorf(err,
+				`unable to load configuration for application "%s"`, appID,
+			)).
+			WithUserMessage(fmt.Sprintf(
+				`Unable to load configuration for application "%s".`, appID,
+			))
 	}
 
 	// Cache the loaded configuration

--- a/internal/pkg/service/appsproxy/dataapps/auth/provider/oidc.go
+++ b/internal/pkg/service/appsproxy/dataapps/auth/provider/oidc.go
@@ -25,6 +25,14 @@ func (v OIDC) ToProxyProvider() (proxyOptions.Provider, error) {
 		ClientID:            v.ClientID,
 		ClientSecret:        v.ClientSecret,
 		BackendLogoutURL:    v.LogoutURL,
+		LoginURLParameters: []proxyOptions.LoginURLParameter{
+			{
+				// https://openid.net/specs/openid-connect-core-1_0.html#AuthRequest
+				// See "prompt" options: none, login, consent, select_account
+				Name:    "prompt", // the user can choose a different account on each login attempt
+				Default: []string{"select_account"},
+			},
+		},
 		OIDCConfig: proxyOptions.OIDCOptions{
 			IssuerURL:      v.IssuerURL,
 			EmailClaim:     proxyOptions.OIDCEmailClaim,

--- a/internal/pkg/service/appsproxy/dataapps/auth/provider/oidc_test.go
+++ b/internal/pkg/service/appsproxy/dataapps/auth/provider/oidc_test.go
@@ -67,5 +67,11 @@ func TestOIDC(t *testing.T) {
 			AudienceClaims: []string{"aud"},
 			UserIDClaim:    "email",
 		},
+		LoginURLParameters: []proxyOptions.LoginURLParameter{
+			{
+				Name:    "prompt",
+				Default: []string{"select_account"},
+			},
+		},
 	}, oAuth2ProxyProvider)
 }

--- a/internal/pkg/service/appsproxy/proxy/apphandler/authproxy/config.go
+++ b/internal/pkg/service/appsproxy/proxy/apphandler/authproxy/config.go
@@ -73,6 +73,7 @@ func (m *Manager) proxyConfig(app api.AppConfig, authProvider provider.Provider,
 	domain := app.CookieDomain(m.config.API.PublicURL)
 	redirectURL := m.config.API.PublicURL.Scheme + "://" + domain + config.InternalPrefix + "/callback"
 	v.Logging.RequestIDHeader = config.RequestIDHeader
+	v.Logging.RequestEnabled = false // we have log middleware for all requests
 	v.Cookie.Secret = secret
 	v.Cookie.Domains = []string{domain}
 	v.Cookie.SameSite = "strict"

--- a/internal/pkg/service/appsproxy/proxy/apphandler/authproxy/selector.go
+++ b/internal/pkg/service/appsproxy/proxy/apphandler/authproxy/selector.go
@@ -124,6 +124,7 @@ func (s *SelectorForAppRule) ServeHTTPOrError(w http.ResponseWriter, req *http.R
 }
 
 func (s *SelectorForAppRule) writeSelectorPage(w http.ResponseWriter, req *http.Request, status int) error {
+	// Mark provider selected
 	id := provider.ID(req.URL.Query().Get(providerQueryParam))
 	if selected, found := s.handlers[id]; found {
 		// Set cookie with the same expiration as other provider cookies
@@ -132,7 +133,7 @@ func (s *SelectorForAppRule) writeSelectorPage(w http.ResponseWriter, req *http.
 		// Get path for redirect after sign in, it must not refer to an external URL
 		query := make(url.Values)
 		callback := req.URL.Query().Get(callbackQueryParam)
-		if callback != "" && strings.HasPrefix(callback, "/") {
+		if isAcceptedCallbackURL(callback) {
 			query.Set(callbackQueryParam, callback)
 		}
 
@@ -161,7 +162,7 @@ func (s *SelectorForAppRule) selectorPageData(req *http.Request) *pagewriter.Sel
 	for _, handler := range s.handlers {
 		query := make(url.Values)
 		query.Set(providerQueryParam, handler.ID().String())
-		if callback != "" {
+		if isAcceptedCallbackURL(callback) {
 			query.Set(callbackQueryParam, callback)
 		}
 		data.Providers = append(data.Providers, pagewriter.ProviderData{
@@ -227,4 +228,8 @@ func (s *Selector) cookie(req *http.Request, value string, expires time.Duration
 	}
 
 	return v
+}
+
+func isAcceptedCallbackURL(callback string) bool {
+	return callback != "" && callback != "/" && callback != selectionPagePath && strings.HasPrefix(callback, "/")
 }

--- a/internal/pkg/service/appsproxy/proxy/apphandler/authproxy/selector.go
+++ b/internal/pkg/service/appsproxy/proxy/apphandler/authproxy/selector.go
@@ -91,6 +91,11 @@ func (s *SelectorForAppRule) ServeHTTPOrError(w http.ResponseWriter, req *http.R
 		s.clearCookie(w, req)
 	}
 
+	// Render selector page, if it is accessed directly
+	if req.URL.Path == selectionPagePath {
+		return s.writeSelectorPage(w, req, http.StatusOK)
+	}
+
 	// Skip selector page, if there is only one provider
 	if len(s.handlers) == 1 {
 		// The handlers variable is a map, use the first handler via a for cycle
@@ -101,11 +106,6 @@ func (s *SelectorForAppRule) ServeHTTPOrError(w http.ResponseWriter, req *http.R
 			}
 			return handler.ServeHTTPOrError(w, req)
 		}
-	}
-
-	// Render selector page, if it is accessed directly
-	if req.URL.Path == selectionPagePath {
-		return s.writeSelectorPage(w, req, http.StatusOK)
 	}
 
 	// Ignore cookie if we have already tried this provider, but the provider requires login.

--- a/internal/pkg/service/appsproxy/proxy/pagewriter/error.go
+++ b/internal/pkg/service/appsproxy/proxy/pagewriter/error.go
@@ -89,7 +89,7 @@ func (pw *Writer) WriteError(w http.ResponseWriter, req *http.Request, app *api.
 	if status != http.StatusInternalServerError && userMsgProvider != nil {
 		details = errors.Format(err, errors.FormatAsSentences())
 		if errName != "" {
-			details = errName + ": " + details
+			details = errName + ":\n" + details
 		}
 	}
 

--- a/internal/pkg/service/appsproxy/proxy/pagewriter/template/error.gohtml
+++ b/internal/pkg/service/appsproxy/proxy/pagewriter/template/error.gohtml
@@ -101,6 +101,50 @@
         .icon-primary {
             fill: var(--icon);
         }
+
+        ul.message {
+            list-style-type: none;
+            text-align: left;
+        }
+
+        pre {
+            text-align: left;
+            white-space: break-spaces;
+        }
+
+        .collapsible {
+            margin-top: 24px;
+        }
+
+        .collapsible input {
+            display: none;
+        }
+
+        .collapsible label{
+            text-align: center;
+            font-weight: bold;
+            font-size: 14px;
+            cursor: pointer;
+        }
+
+        .collapsible-content {
+            max-height: 0;
+            overflow: hidden;
+        }
+
+        input:not(:checked) ~ label::before {
+            content: "▸ ";
+        }
+
+        input:checked ~ label::before {
+            content: "▾ ";
+        }
+
+        input:checked ~ .collapsible-content {
+            max-height: 100%;
+        }
+
+
         small {
             font-size: 12px;
         }
@@ -149,14 +193,26 @@
     <br>
 
     {{ if eq (len .Messages) 1 }}
-        <p>{{index .Messages 0 }}</p>
+        <p class="message">{{index .Messages 0 }}</p>
     {{ else }}
-        <ul>
+        <ul class="message">
             {{range .Messages}}
                 <li>{{.}}</li>
             {{end}}
         </ul>
     {{ end }}
+
+    {{ if .Details }}
+        <div class="collapsible">
+            <input type="checkbox" id="more">
+            <label for="more">More info</label>
+            <div class="collapsible-content">
+                <pre>{{ .Details }}</pre>
+            </div>
+        </div>
+    {{ end}}
+
+    <br>
 
     <p>
     <small>

--- a/internal/pkg/service/appsproxy/proxy/pagewriter/template/error.gohtml
+++ b/internal/pkg/service/appsproxy/proxy/pagewriter/template/error.gohtml
@@ -101,6 +101,9 @@
         .icon-primary {
             fill: var(--icon);
         }
+        small {
+            font-size: 12px;
+        }
     </style>
 </head>
 <body>

--- a/internal/pkg/service/appsproxy/proxy/pagewriter/template/selector.gohtml
+++ b/internal/pkg/service/appsproxy/proxy/pagewriter/template/selector.gohtml
@@ -133,6 +133,10 @@
         .icon-primary {
             fill: var(--icon);
         }
+
+        small {
+            font-size: 12px;
+        }
     </style>
 </head>
 <body>

--- a/internal/pkg/service/appsproxy/proxy/pagewriter/template/spinner.gohtml
+++ b/internal/pkg/service/appsproxy/proxy/pagewriter/template/spinner.gohtml
@@ -115,10 +115,15 @@
         .icon-primary {
             fill: var(--icon);
         }
+
         main img {
             width: 200px;
             height: 144px;
             object-fit: cover;
+        }
+
+        small {
+            font-size: 12px;
         }
     </style>
 </head>

--- a/internal/pkg/service/appsproxy/proxy/proxy_test.go
+++ b/internal/pkg/service/appsproxy/proxy/proxy_test.go
@@ -4,6 +4,7 @@ package proxy_test
 import (
 	"context"
 	"crypto/rand"
+	"fmt"
 	"html"
 	"io"
 	"net"
@@ -745,9 +746,9 @@ func TestAppProxyRouter(t *testing.T) {
 				require.Equal(t, http.StatusUnauthorized, response.StatusCode)
 				body, err := io.ReadAll(response.Body)
 				require.NoError(t, err)
-				assert.Contains(t, string(body), html.EscapeString(`https://multi.hub.keboola.local/_proxy/selection?provider=oidc0&rd=%2Fsome%2Fpath`))
-				assert.Contains(t, string(body), html.EscapeString(`https://multi.hub.keboola.local/_proxy/selection?provider=oidc1&rd=%2Fsome%2Fpath`))
-				assert.Contains(t, string(body), html.EscapeString(`https://multi.hub.keboola.local/_proxy/selection?provider=oidc2&rd=%2Fsome%2Fpath`))
+				assert.Contains(t, string(body), htmlLinkTo(`https://multi.hub.keboola.local/_proxy/selection?provider=oidc0&rd=%2Fsome%2Fpath`))
+				assert.Contains(t, string(body), htmlLinkTo(`https://multi.hub.keboola.local/_proxy/selection?provider=oidc1&rd=%2Fsome%2Fpath`))
+				assert.Contains(t, string(body), htmlLinkTo(`https://multi.hub.keboola.local/_proxy/selection?provider=oidc2&rd=%2Fsome%2Fpath`))
 
 				// Select provider
 				request, err = http.NewRequestWithContext(context.Background(), http.MethodGet, "https://multi.hub.keboola.local/_proxy/selection?provider=oidc1&rd=%2Fsome%2Fpath", nil)
@@ -860,9 +861,9 @@ func TestAppProxyRouter(t *testing.T) {
 				require.Equal(t, http.StatusUnauthorized, response.StatusCode)
 				body, err := io.ReadAll(response.Body)
 				require.NoError(t, err)
-				assert.Contains(t, string(body), html.EscapeString(`https://multi.hub.keboola.local/_proxy/selection?provider=oidc0`))
-				assert.Contains(t, string(body), html.EscapeString(`https://multi.hub.keboola.local/_proxy/selection?provider=oidc1`))
-				assert.Contains(t, string(body), html.EscapeString(`https://multi.hub.keboola.local/_proxy/selection?provider=oidc2`))
+				assert.Contains(t, string(body), htmlLinkTo(`https://multi.hub.keboola.local/_proxy/selection?provider=oidc0`))
+				assert.Contains(t, string(body), htmlLinkTo(`https://multi.hub.keboola.local/_proxy/selection?provider=oidc1`))
+				assert.Contains(t, string(body), htmlLinkTo(`https://multi.hub.keboola.local/_proxy/selection?provider=oidc2`))
 			},
 			expectedNotifications: map[string]int{},
 			expectedWakeUps:       map[string]int{},
@@ -954,9 +955,9 @@ func TestAppProxyRouter(t *testing.T) {
 				require.Equal(t, http.StatusUnauthorized, response.StatusCode)
 				body, err := io.ReadAll(response.Body)
 				require.NoError(t, err)
-				assert.Contains(t, string(body), html.EscapeString(`https://multi.hub.keboola.local/_proxy/selection?provider=oidc0`))
-				assert.Contains(t, string(body), html.EscapeString(`https://multi.hub.keboola.local/_proxy/selection?provider=oidc1`))
-				assert.Contains(t, string(body), html.EscapeString(`https://multi.hub.keboola.local/_proxy/selection?provider=oidc2`))
+				assert.Contains(t, string(body), htmlLinkTo(`https://multi.hub.keboola.local/_proxy/selection?provider=oidc0`))
+				assert.Contains(t, string(body), htmlLinkTo(`https://multi.hub.keboola.local/_proxy/selection?provider=oidc1`))
+				assert.Contains(t, string(body), htmlLinkTo(`https://multi.hub.keboola.local/_proxy/selection?provider=oidc2`))
 
 				// Provider selection
 				request, err = http.NewRequestWithContext(context.Background(), http.MethodGet, "https://multi.hub.keboola.local/_proxy/selection?provider=oidc1", nil)
@@ -1178,9 +1179,9 @@ func TestAppProxyRouter(t *testing.T) {
 				require.Equal(t, http.StatusUnauthorized, response.StatusCode)
 				body, err := io.ReadAll(response.Body)
 				require.NoError(t, err)
-				assert.Contains(t, string(body), html.EscapeString(`https://multi.hub.keboola.local/_proxy/selection?provider=oidc0`))
-				assert.Contains(t, string(body), html.EscapeString(`https://multi.hub.keboola.local/_proxy/selection?provider=oidc1`))
-				assert.Contains(t, string(body), html.EscapeString(`https://multi.hub.keboola.local/_proxy/selection?provider=oidc2`))
+				assert.Contains(t, string(body), htmlLinkTo(`https://multi.hub.keboola.local/_proxy/selection?provider=oidc0`))
+				assert.Contains(t, string(body), htmlLinkTo(`https://multi.hub.keboola.local/_proxy/selection?provider=oidc1`))
+				assert.Contains(t, string(body), htmlLinkTo(`https://multi.hub.keboola.local/_proxy/selection?provider=oidc2`))
 
 				// Provider selection
 				request, err = http.NewRequestWithContext(context.Background(), http.MethodGet, "https://multi.hub.keboola.local/_proxy/selection?provider=oidc1", nil)
@@ -1370,8 +1371,8 @@ func TestAppProxyRouter(t *testing.T) {
 				require.Equal(t, http.StatusUnauthorized, response.StatusCode)
 				body, err := io.ReadAll(response.Body)
 				require.NoError(t, err)
-				assert.Contains(t, string(body), html.EscapeString(`https://prefix.hub.keboola.local/_proxy/selection?provider=oidc0&rd=%2Fweb`))
-				assert.Contains(t, string(body), html.EscapeString(`https://prefix.hub.keboola.local/_proxy/selection?provider=oidc1&rd=%2Fweb`))
+				assert.Contains(t, string(body), htmlLinkTo(`https://prefix.hub.keboola.local/_proxy/selection?provider=oidc0&rd=%2Fweb`))
+				assert.Contains(t, string(body), htmlLinkTo(`https://prefix.hub.keboola.local/_proxy/selection?provider=oidc1&rd=%2Fweb`))
 
 				// Provider selection
 				request, err = http.NewRequestWithContext(context.Background(), http.MethodGet, "https://prefix.hub.keboola.local/_proxy/selection?provider=oidc1&rd=%2Fweb", nil)

--- a/internal/pkg/service/appsproxy/proxy/transport/dns/client.go
+++ b/internal/pkg/service/appsproxy/proxy/transport/dns/client.go
@@ -57,6 +57,10 @@ func NewClient(dialer *net.Dialer, dnsServer string) *Client {
 	}
 }
 
+func (c *Client) DNSServer() string {
+	return c.dnsServer
+}
+
 func (c *Client) Resolve(ctx context.Context, host string) (string, error) {
 	msg := &dns.Msg{}
 	msg.SetQuestion(dns.Fqdn(host), dns.TypeA)

--- a/internal/pkg/service/appsproxy/proxy/transport/transport.go
+++ b/internal/pkg/service/appsproxy/proxy/transport/transport.go
@@ -84,7 +84,7 @@ func NewWithDNSServer(d dependencies, dnsServerAddress string) (http.RoundTrippe
 		ctx, dnsSpan := tel.Tracer().Start(ctx, "keboola.go.apps-proxy.transport.dns.resolve")
 		dnsSpan.SetAttributes(
 			attribute.String("transport.dns.resolve.host", host),
-			attribute.String("transport.dns.resolve.server", dnsServerAddress),
+			attribute.String("transport.dns.resolve.server", dnsClient.DNSServer()),
 		)
 		if trace != nil && trace.DNSStart != nil {
 			trace.DNSStart(httptrace.DNSStartInfo{Host: host})


### PR DESCRIPTION
Jira: https://keboola.atlassian.net/browse/PSGO-559

**Changes:**
- Improved error pages.
- Disabled duplicate OAuth2Proxy access log.
- Set login parameter `prompt=select_account`.
- `/_proxy/selection` page is rendered also if there is only one provider, for consistency.

-----------
