### PR TITLE
ci: add build and test cache into github actions cache

### DIFF
--- a/.github/actions/go-cache/action.yml
+++ b/.github/actions/go-cache/action.yml
@@ -20,10 +20,9 @@ runs:
           ~\go\pkg
           ~/go/bin
           ~\go\bin
-          ~/.cache/golangci-lint
           ~/.cache/go-build
-          ~/Library/Caches/golangci-lint
-          ~\AppData\Local\golangci-lint
+          ~/Library/Caches/go-build
+          ~\AppData\Local\go-build
         key: ${{ runner.os }}-go-${{ env.GO_VERSION }}-v6-${{ inputs.key }}-${{ hashFiles('**/go.sum') }}
         restore-keys: |
           ${{ runner.os }}-go-${{ env.GO_VERSION }}-v6-

--- a/.github/actions/go-cache/action.yml
+++ b/.github/actions/go-cache/action.yml
@@ -21,6 +21,7 @@ runs:
           ~/go/bin
           ~\go\bin
           ~/.cache/golangci-lint
+          ~/.cache/go-build
           ~/Library/Caches/golangci-lint
           ~\AppData\Local\golangci-lint
         key: ${{ runner.os }}-go-${{ env.GO_VERSION }}-v6-${{ inputs.key }}-${{ hashFiles('**/go.sum') }}

--- a/.github/actions/go-cache/action.yml
+++ b/.github/actions/go-cache/action.yml
@@ -13,17 +13,14 @@ runs:
       run: echo 'C:\Program Files\Git\usr\bin' >> $GITHUB_PATH
 
     - name: Load Go cache
+      id: load-go-cache
       uses: actions/cache@v4
       with:
         path: |
-          ~/go/pkg
-          ~\go\pkg
-          ~/go/bin
-          ~\go\bin
           ~/.cache/go-build
           ~/Library/Caches/go-build
           ~\AppData\Local\go-build
         key: ${{ runner.os }}-go-${{ env.GO_VERSION }}-v6-${{ inputs.key }}-${{ hashFiles('**/go.sum') }}
         restore-keys: |
-          ${{ runner.os }}-go-${{ env.GO_VERSION }}-v6-
           ${{ runner.os }}-go-${{ env.GO_VERSION }}-v6-${{ inputs.key }}-
+          ${{ runner.os }}-go-${{ env.GO_VERSION }}-v6-

--- a/.github/actions/go-tools-cache/action.yml
+++ b/.github/actions/go-tools-cache/action.yml
@@ -1,0 +1,27 @@
+name: 'Load Go tools cache'
+description: 'Load Go tools cache'
+runs:
+  using: "composite"
+  steps:
+    - name: Use GNU tar instead BSD tar
+      if: runner.os == 'Windows'
+      shell: bash
+      run: echo 'C:\Program Files\Git\usr\bin' >> $GITHUB_PATH
+
+    - name: Install Go modules
+      shell: bash
+      run: go mod download
+
+    - name: Load Go tools cache
+      id: go-tools-cache
+      uses: actions/cache@v4
+      with:
+        path: |
+          ~/go/pkg
+          ~\go\pkg
+          ~/go/bin
+          ~\go\bin
+        key: ${{ runner.os }}-go-${{ env.GO_VERSION }}-v6-tools-${{ hashFiles('**/go.sum') }}
+        restore-keys: |
+          ${{ runner.os }}-go-${{ env.GO_VERSION }}-v6-tools-
+

--- a/.github/actions/go-tools-cache/action.yml
+++ b/.github/actions/go-tools-cache/action.yml
@@ -8,10 +8,6 @@ runs:
       shell: bash
       run: echo 'C:\Program Files\Git\usr\bin' >> $GITHUB_PATH
 
-    - name: Install Go modules
-      shell: bash
-      run: go mod download
-
     - name: Load Go tools cache
       id: go-tools-cache
       uses: actions/cache@v4
@@ -24,4 +20,12 @@ runs:
         key: ${{ runner.os }}-go-${{ env.GO_VERSION }}-v6-tools-${{ hashFiles('**/go.sum') }}
         restore-keys: |
           ${{ runner.os }}-go-${{ env.GO_VERSION }}-v6-tools-
+
+    - name: Install Go modules
+      shell: bash
+      run: go mod download
+
+    - name: Install tools
+      run: . ./scripts/tools.sh
+      shell: bash
 

--- a/.github/workflows/check-licenses.yml
+++ b/.github/workflows/check-licenses.yml
@@ -14,20 +14,14 @@ jobs:
       - name: Checkout code
         uses: actions/checkout@v4
 
-      - name: Load Go cache
-        uses: ./.github/actions/go-cache
-        with:
-          key: lint
-
       - name: Install Go
         uses: actions/setup-go@v5
         with:
           go-version: ${{ env.GO_VERSION }}
           cache: false
 
-      - name: Install tools
-        run: ./scripts/tools.sh
-        shell: bash
+      - name: Load Go tools cache
+        uses: ./.github/actions/go-tools-cache
 
       #####################
       ### License Types ###

--- a/.github/workflows/test-e2e-cli.yml
+++ b/.github/workflows/test-e2e-cli.yml
@@ -11,6 +11,8 @@ env:
   GO_VERSION: 1.22.2
   TEST_PARALLELISM: 16
   TEST_PARALLELISM_PKG: 1
+  TEST_COVERAGE: false
+
 jobs:
   test:
     name: ${{ matrix.name }}
@@ -28,7 +30,11 @@ jobs:
     steps:
       - name: Setup line endings
         run: git config --global core.autocrlf false
-      
+
+      - name: Change default TEST_COVERAGE when on main branch
+        if: github.ref == 'refs/heads/main'
+        run: echo "TEST_COVERAGE=true" >> $GITHUB_ENV
+
       - name: Checkout code
         uses: actions/checkout@v4
 
@@ -38,20 +44,19 @@ jobs:
           secrets: ${{ toJSON(secrets) }}
           projects: ${{ vars.TEST_KBC_PROJECTS }}
 
-      - name: Load Go cache
-        uses: ./.github/actions/go-cache
-        with:
-          key: e2e
-
       - name: Install Go
         uses: actions/setup-go@v5
         with:
           go-version: ${{ env.GO_VERSION }}
           cache: false
 
-      - name: Install tools
-        run: . ./scripts/tools.sh
-        shell: bash
+      - name: Load Go build cache
+        uses: ./.github/actions/go-cache
+        with:
+          key: e2e-cli
+
+      - name: Load Go tools cache
+        uses: ./.github/actions/go-tools-cache
 
       - name: Run tests
         run: make tests-cli

--- a/.github/workflows/test-e2e-service-stream.yml
+++ b/.github/workflows/test-e2e-service-stream.yml
@@ -7,6 +7,7 @@ env:
   GO_VERSION: 1.22.2
   TEST_PARALLELISM: 16
   TEST_PARALLELISM_PKG: 1
+  TEST_COVERAGE: false
 
 jobs:
   test:
@@ -17,7 +18,11 @@ jobs:
     steps:
       - name: Setup line endings
         run: git config --global core.autocrlf false
-      
+
+      - name: Change default TEST_COVERAGE when on main branch
+        if: github.ref == 'refs/heads/main'
+        run: echo "TEST_COVERAGE=true" >> $GITHUB_ENV
+
       - name: Checkout code
         uses: actions/checkout@v4
 
@@ -27,20 +32,19 @@ jobs:
           secrets: ${{ toJSON(secrets) }}
           projects: ${{ vars.TEST_KBC_PROJECTS }}
 
-      - name: Load Go cache
-        uses: ./.github/actions/go-cache
-        with:
-          key: e2e
-
       - name: Install Go
         uses: actions/setup-go@v5
         with:
           go-version: ${{ env.GO_VERSION }}
           cache: false
 
-      - name: Install tools
-        run: . ./scripts/tools.sh
-        shell: bash
+      - name: Load Go build cache
+        uses: ./.github/actions/go-cache
+        with:
+          key: e2e
+
+      - name: Load Go tools cache
+        uses: ./.github/actions/go-tools-cache
 
       - name: Start etcd database
         run: |

--- a/.github/workflows/test-e2e-service-templates.yml
+++ b/.github/workflows/test-e2e-service-templates.yml
@@ -7,6 +7,7 @@ env:
   GO_VERSION: 1.22.2
   TEST_PARALLELISM: 16
   TEST_PARALLELISM_PKG: 1
+  TEST_COVERAGE: false
 
 jobs:
   test:
@@ -18,6 +19,10 @@ jobs:
       - name: Setup line endings
         run: git config --global core.autocrlf false
 
+      - name: Change default TEST_COVERAGE when on main branch
+        if: github.ref == 'refs/heads/main'
+        run: echo "TEST_COVERAGE=true" >> $GITHUB_ENV
+
       - name: Checkout code
         uses: actions/checkout@v4
 
@@ -27,20 +32,19 @@ jobs:
           secrets: ${{ toJSON(secrets) }}
           projects: ${{ vars.TEST_KBC_PROJECTS }}
 
-      - name: Load Go cache
-        uses: ./.github/actions/go-cache
-        with:
-          key: e2e
-
       - name: Install Go
         uses: actions/setup-go@v5
         with:
           go-version: ${{ env.GO_VERSION }}
           cache: false
 
-      - name: Install tools
-        run: . ./scripts/tools.sh
-        shell: bash
+      - name: Load Go build cache
+        uses: ./.github/actions/go-cache
+        with:
+          key: build
+
+      - name: Load Go tools cache
+        uses: ./.github/actions/go-tools-cache
 
       - name: Start etcd database
         run: |

--- a/.github/workflows/test-k8s-service-apps-proxy.yml
+++ b/.github/workflows/test-k8s-service-apps-proxy.yml
@@ -86,9 +86,8 @@ jobs:
           emptyReplicaSets=$(kubectl get replicasets --ignore-not-found | tail --lines=+2 | awk '{if ($2 + $3 + $4 == 0) print $1}')
           echo -e "Found empty replica sets:"
           echo "$emptyReplicaSets"
-          echo "-------------------------" 
+          echo "-------------------------"
           echo "$emptyReplicaSets" | xargs --no-run-if-empty -I {} kubectl delete replicaset "{}"
-          
           # Wait for pod startup/termination
           sleep 10
           # Dump objects
@@ -159,7 +158,7 @@ jobs:
       - name: Dump logs
         if: always()
         run: |
-          /tmp/latest-scripts/minikube/logs.sh /tmp/artifacts && 
+          /tmp/latest-scripts/minikube/logs.sh /tmp/artifacts &&
           /tmp/latest-scripts/k8s/logs.sh /tmp/artifacts
 
       - name: Upload artifacts

--- a/.github/workflows/test-k8s-service-buffer.yml
+++ b/.github/workflows/test-k8s-service-buffer.yml
@@ -90,9 +90,8 @@ jobs:
           emptyReplicaSets=$(kubectl get replicasets --ignore-not-found | tail --lines=+2 | awk '{if ($2 + $3 + $4 == 0) print $1}')
           echo -e "Found empty replica sets:"
           echo "$emptyReplicaSets"
-          echo "-------------------------" 
+          echo "-------------------------"
           echo "$emptyReplicaSets" | xargs --no-run-if-empty -I {} kubectl delete replicaset "{}"
-          
           # Wait for pod startup/termination
           sleep 10
           # Dump objects
@@ -223,10 +222,8 @@ jobs:
         if: always()
         run: |
           set -Eeuo pipefail
-          
           # Create a job from the cron job
           kubectl create job "--from=cronjob/${ETCD_RELEASE_NAME}-defrag" test-defrag-job
-          
           # Wait for the job
           if kubectl wait --for=condition=complete --timeout=30s job/test-defrag-job; then
             echo "The job succeed, logs:"
@@ -242,16 +239,13 @@ jobs:
         if: always()
         run: |
           set -Eeuo pipefail
-          
           # Diff JSON states
           /tmp/latest-scripts/k8s/diff.sh \
             /tmp/artifacts/test-k8s-state.old.json \
             /tmp/artifacts/test-k8s-state.new.json \
             /tmp/artifacts/test-k8s-state.diff
-          
           # Remove ANSI sequences
           sed -e 's/\x1b\[[0-9;]*m//g' -i /tmp/artifacts/test-k8s-state.diff || true
-          
           # Prepare PR comment message
           echo -e "### ${{ env.SERVICE_NAME }} Kubernetes Diff [CI]\n\n" >> /tmp/artifacts/test-k8s-state.diff.message
           echo -e "Between \`base\` ${{ github.event.pull_request.base.sha }} :arrow_left:  \`head\` ${{ github.event.pull_request.head.sha }}.\n\n" >> /tmp/artifacts/test-k8s-state.diff.message
@@ -262,7 +256,7 @@ jobs:
       - name: Dump logs
         if: always()
         run: |
-          /tmp/latest-scripts/minikube/logs.sh /tmp/artifacts && 
+          /tmp/latest-scripts/minikube/logs.sh /tmp/artifacts &&
           /tmp/latest-scripts/k8s/logs.sh /tmp/artifacts
 
       - name: Upload artifacts

--- a/.github/workflows/test-k8s-service-templates.yml
+++ b/.github/workflows/test-k8s-service-templates.yml
@@ -88,9 +88,9 @@ jobs:
           emptyReplicaSets=$(kubectl get replicasets --ignore-not-found | tail --lines=+2 | awk '{if ($2 + $3 + $4 == 0) print $1}')
           echo -e "Found empty replica sets:"
           echo "$emptyReplicaSets"
-          echo "-------------------------" 
+          echo "-------------------------"
           echo "$emptyReplicaSets" | xargs --no-run-if-empty -I {} kubectl delete replicaset "{}"
-          
+
           # Wait for pod startup/termination
           sleep 10
           # Dump objects
@@ -184,10 +184,8 @@ jobs:
         if: always()
         run: |
           set -Eeuo pipefail
-          
           # Create a job from the cron job
           kubectl create job "--from=cronjob/${ETCD_RELEASE_NAME}-defrag" test-defrag-job
-          
           # Wait for the job
           if kubectl wait --for=condition=complete --timeout=30s job/test-defrag-job; then
             echo "The job succeed, logs:"
@@ -203,16 +201,13 @@ jobs:
         if: always()
         run: |
           set -Eeuo pipefail
-          
           # Diff JSON states
           /tmp/latest-scripts/k8s/diff.sh \
             /tmp/artifacts/test-k8s-state.old.json \
             /tmp/artifacts/test-k8s-state.new.json \
             /tmp/artifacts/test-k8s-state.diff
-          
           # Remove ANSI sequences
           sed -e 's/\x1b\[[0-9;]*m//g' -i /tmp/artifacts/test-k8s-state.diff || true
-          
           # Prepare PR comment message
           echo -e "### ${{ env.SERVICE_NAME }} Kubernetes Diff [CI]\n\n" >> /tmp/artifacts/test-k8s-state.diff.message
           echo -e "Between \`base\` ${{ github.event.pull_request.base.sha }} :arrow_left:  \`head\` ${{ github.event.pull_request.head.sha }}.\n\n" >> /tmp/artifacts/test-k8s-state.diff.message
@@ -223,7 +218,7 @@ jobs:
       - name: Dump logs
         if: always()
         run: |
-          /tmp/latest-scripts/minikube/logs.sh /tmp/artifacts && 
+          /tmp/latest-scripts/minikube/logs.sh /tmp/artifacts &&
           /tmp/latest-scripts/k8s/logs.sh /tmp/artifacts
 
       - name: Upload artifacts

--- a/.github/workflows/test-lint.yml
+++ b/.github/workflows/test-lint.yml
@@ -28,20 +28,14 @@ jobs:
             --exclude '^https://community.chocolatey.org/.*'
             --exclude '^https://packages.debian.org/$'
 
-      - name: Load Go cache
-        uses: ./.github/actions/go-cache
-        with:
-          key: lint
-
       - name: Install Go
         uses: actions/setup-go@v5
         with:
           go-version: ${{ env.GO_VERSION }}
           cache: false
 
-      - name: Install tools
-        run: ./scripts/tools.sh
-        shell: bash
+      - name: Load Go tools cache
+        uses: ./.github/actions/go-tools-cache
 
       - name: Run code linters
         run: make lint

--- a/.github/workflows/test-lint.yml
+++ b/.github/workflows/test-lint.yml
@@ -19,11 +19,11 @@ jobs:
         with:
           fail: true
           args: |
-            './**/*.md' 
+            './**/*.md'
             --verbose
-            --exclude-path 'vendor' 
-            --exclude-path 'test' 
-            --exclude '^http://localhost.*' 
+            --exclude-path 'vendor'
+            --exclude-path 'test'
+            --exclude '^http://localhost.*'
             --exclude '^https://app.datadoghq.eu/.*'
             --exclude '^https://community.chocolatey.org/.*'
             --exclude '^https://packages.debian.org/$'

--- a/.github/workflows/test-unit.yml
+++ b/.github/workflows/test-unit.yml
@@ -40,6 +40,12 @@ jobs:
           secrets: ${{ toJSON(secrets) }}
           projects: ${{ vars.TEST_KBC_PROJECTS }}
 
+      - name: Install Go
+        uses: actions/setup-go@v5
+        with:
+          go-version: ${{ env.GO_VERSION }}
+          cache: false
+
       - name: Load Go build cache
         uses: ./.github/actions/go-cache
         with:
@@ -52,17 +58,6 @@ jobs:
 
       - name: Load Go tools cache
         uses: ./.github/actions/go-tools-cache
-
-      - name: Install Go
-        uses: actions/setup-go@v5
-        with:
-          go-version: ${{ env.GO_VERSION }}
-          cache: false
-
-      - name: Load Go build cache
-        uses: ./.github/actions/go-cache
-        with:
-          key: unit-${{ matrix.name }}
 
       - name: Start etcd database (only on linux)
         if: matrix.name == 'linux'

--- a/.github/workflows/test-unit.yml
+++ b/.github/workflows/test-unit.yml
@@ -40,6 +40,19 @@ jobs:
           secrets: ${{ toJSON(secrets) }}
           projects: ${{ vars.TEST_KBC_PROJECTS }}
 
+      - name: Load Go build cache
+        uses: ./.github/actions/go-cache
+        with:
+          key: unit
+
+      - name: Change modtime of files to 1 unix timestamp
+        shell: bash
+        run: |
+          find . -type f,d -exec touch -r {} -d '1970-01-01T00:00:01' {} \; || true
+
+      - name: Load Go tools cache
+        uses: ./.github/actions/go-tools-cache
+
       - name: Install Go
         uses: actions/setup-go@v5
         with:

--- a/.github/workflows/test-unit.yml
+++ b/.github/workflows/test-unit.yml
@@ -7,6 +7,7 @@ env:
   GO_VERSION: 1.22.2
   TEST_PARALLELISM: 12
   TEST_PARALLELISM_PKG: 6
+  TEST_COVERAGE: false
 
 jobs:
   test:
@@ -26,19 +27,18 @@ jobs:
       - name: Setup line endings
         run: git config --global core.autocrlf false
 
+      - name: Change default TEST_COVERAGE when on main branch
+        if: github.ref == 'refs/heads/main'
+        run: echo "TEST_COVERAGE=true" >> $GITHUB_ENV
+
       - name: Checkout code
         uses: actions/checkout@v4
-      
+
       - name: Set TEST_KBC_PROJECTS
         uses: ./.github/actions/export-kbc-projects
         with:
           secrets: ${{ toJSON(secrets) }}
           projects: ${{ vars.TEST_KBC_PROJECTS }}
-
-      - name: Load Go cache
-        uses: ./.github/actions/go-cache
-        with:
-          key: unit-${{ matrix.name }}
 
       - name: Install Go
         uses: actions/setup-go@v5
@@ -46,9 +46,10 @@ jobs:
           go-version: ${{ env.GO_VERSION }}
           cache: false
 
-      - name: Install tools
-        run: . ./scripts/tools.sh
-        shell: bash
+      - name: Load Go build cache
+        uses: ./.github/actions/go-cache
+        with:
+          key: unit-${{ matrix.name }}
 
       - name: Start etcd database (only on linux)
         if: matrix.name == 'linux'
@@ -69,3 +70,4 @@ jobs:
           UNIT_ETCD_USERNAME: root
           UNIT_ETCD_PASSWORD: toor
           UNIT_ETCD_NAMESPACE: buffer
+

--- a/scripts/tests.sh
+++ b/scripts/tests.sh
@@ -19,6 +19,9 @@ TEST_DETECT_RACE="${TEST_DETECT_RACE:=true}"
 TEST_COVERAGE="${TEST_COVERAGE:=true}"
 TEST_PACKAGE="${TEST_PACKAGE:=./...}"
 TEST_ARGS="${TEST_ARGS:=}"
+if [[ $TEST_VERBOSE == "true" ]]; then
+  TEST_ARGS="$TEST_ARGS -v"
+fi
 if [[ $TEST_DETECT_RACE == "true" ]]; then
   TEST_ARGS="$TEST_ARGS -race"
 fi
@@ -29,7 +32,7 @@ fi
 # Run tests, sequentially because the API is shared resource
 echo "Running tests ..."
 export KBC_VERSION_CHECK=false # do not check the latest version in the tests
-cmd="gotestsum --no-color=false --format \"$TEST_LOG_FORMAT\" -- -timeout 1200s -p $TEST_PARALLELISM_PKG -parallel $TEST_PARALLELISM -v $TEST_ARGS  "$TEST_PACKAGE" $@"
+cmd="gotestsum --no-color=false --format \"$TEST_LOG_FORMAT\" -- -timeout 1200s -p $TEST_PARALLELISM_PKG -parallel $TEST_PARALLELISM $TEST_ARGS "$TEST_PACKAGE" $@"
 echo $cmd
 eval $cmd
 echo "Ok. All tests passed."

--- a/scripts/tools.sh
+++ b/scripts/tools.sh
@@ -10,7 +10,10 @@ SCRIPT_DIR="$( cd -- "$( dirname -- "${BASH_SOURCE[0]}" )" &> /dev/null && pwd )
 cd "$SCRIPT_DIR"
 
 # go-licenses
-go install github.com/google/go-licenses@latest
+if ! command -v go-licenses &> /dev/null
+then
+  go install github.com/google/go-licenses@latest
+fi
 
 # gotestsum
 if ! command -v gotestsum &> /dev/null


### PR DESCRIPTION
Jira: [PSGO-561](https://keboola.atlassian.net/browse/PSGO-561)

**Changes:**
- Add caching of go build and tests into github actions cache.
- Change mod time of files due to caching issues of test cases, where it is based on mod time and each `git clone` pulls the files and changes mod time to current time.  https://github.com/golang/go/issues/58571
- Remove `-coverprofile` flag that prevents caching of tests.
- Add `-coverprofile` flag for release pipeline. Tagged commits and `main`.
- Create `go tools` cache to reduce size of cache per step.
- Cache of `e2e`  tests is already injected but not evaluated. **Will be done in next PR**.
- Add `go mod download` step to cache also packages in tools cache.
-----------


[PSGO-561]: https://keboola.atlassian.net/browse/PSGO-561?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ