### PR TITLE
fix: Order of callbacks invocations, if TxnOp.Merge is used 

### DIFF
--- a/internal/pkg/service/common/etcdop/key.go
+++ b/internal/pkg/service/common/etcdop/key.go
@@ -103,7 +103,7 @@ func (v Key) DeleteIfExists(client etcd.KV, opts ...etcd.OpOption) op.BoolOp {
 			return etcd.OpTxn(
 				[]etcd.Cmp{etcd.Compare(etcd.Version(v.Key()), "!=", 0)},
 				[]etcd.Op{etcd.OpDelete(v.Key(), opts...)},
-				[]etcd.Op{},
+				nil,
 			), nil
 		},
 		func(_ context.Context, raw op.RawResponse) (bool, error) {
@@ -132,7 +132,7 @@ func (v Key) PutIfNotExists(client etcd.KV, val string, opts ...etcd.OpOption) o
 			return etcd.OpTxn(
 				[]etcd.Cmp{etcd.Compare(etcd.Version(v.Key()), "=", 0)},
 				[]etcd.Op{etcd.OpPut(v.Key(), val, opts...)},
-				[]etcd.Op{},
+				nil,
 			), nil
 		},
 		func(_ context.Context, raw op.RawResponse) (bool, error) {
@@ -223,7 +223,7 @@ func (v KeyT[T]) PutIfNotExists(client etcd.KV, val T, opts ...etcd.OpOption) op
 			return etcd.OpTxn(
 				[]etcd.Cmp{etcd.Compare(etcd.Version(v.Key()), "=", 0)},
 				[]etcd.Op{etcd.OpPut(v.Key(), encoded, opts...)},
-				[]etcd.Op{},
+				nil,
 			), nil
 		},
 		func(_ context.Context, raw op.RawResponse) (bool, error) {

--- a/internal/pkg/service/common/etcdop/op/txn.go
+++ b/internal/pkg/service/common/etcdop/op/txn.go
@@ -8,6 +8,14 @@ import (
 	"github.com/keboola/keboola-as-code/internal/pkg/utils/errors"
 )
 
+const (
+	txnOpIf      = txnPartType("if")
+	txnOpThen    = txnPartType("then")
+	txnOpThenTxn = txnPartType("thenTxn") // thenTxnOps are separated from thenOps to avoid confusing between Then and Merge
+	txnOpElse    = txnPartType("else")
+	txnOpMerge   = txnPartType("merge")
+)
+
 // TxnOp provides a high-level interface built on top of etcd.Txn., see If, Then and Else methods.
 //
 // For more information on etcd transactions, please refer to:
@@ -26,13 +34,9 @@ import (
 type TxnOp[R any] struct {
 	result     *R
 	client     etcd.KV
-	processors []func(ctx context.Context, r *TxnResult[R])
 	errs       errors.MultiError
-	ifs        []etcd.Cmp
-	thenOps    []Op
-	thenTxnOps []Op // thenTxnOps are separated from thenOps to avoid confusing between Then and Merge
-	mergeOps   []Op
-	elseOps    []Op
+	parts      []txnPart[R]
+	processors []func(ctx context.Context, r *TxnResult[R])
 }
 
 // txnInterface is a marker interface for generic type TxnOp.
@@ -40,15 +44,22 @@ type txnInterface interface {
 	txn()
 }
 
+type txnPartType string
+
+type txnPart[R any] struct {
+	Type    txnPartType
+	If      etcd.Cmp
+	Factory Op
+}
+
 type lowLevelTxn[R any] struct {
-	result      *R
-	client      etcd.KV
-	processors  []func(ctx context.Context, r *TxnResult[R])
-	ifs         []etcd.Cmp
-	thenOps     []etcd.Op
-	elseOps     []etcd.Op
-	thenMappers []MapFn
-	elseMappers []MapFn
+	result     *R
+	client     etcd.KV
+	processors []func(ctx context.Context, r *TxnResult[R])
+	opCounter  map[txnPartType]int
+	ifs        []etcd.Cmp
+	thenOps    []etcd.Op
+	elseOps    []etcd.Op
 }
 
 // Txn creates an empty transaction with NoResult.
@@ -70,13 +81,16 @@ func MergeToTxn(client etcd.KV, ops ...Op) *TxnOp[NoResult] {
 func (v *TxnOp[R]) txn() {}
 
 func (v *TxnOp[R]) Empty() bool {
-	return len(v.ifs) == 0 && len(v.thenOps) == 0 && len(v.thenTxnOps) == 0 && len(v.mergeOps) == 0 && len(v.elseOps) == 0
+	return len(v.parts) == 0
 }
 
 // If takes a list of comparison.
 // If all comparisons succeed, the Then branch will be executed; otherwise, the Else branch will be executed.
 func (v *TxnOp[R]) If(cs ...etcd.Cmp) *TxnOp[R] {
-	v.ifs = append(v.ifs, cs...)
+	for _, c := range cs {
+		v.parts = append(v.parts, txnPart[R]{Type: txnOpIf, If: c})
+	}
+
 	return v
 }
 
@@ -84,39 +98,33 @@ func (v *TxnOp[R]) If(cs ...etcd.Cmp) *TxnOp[R] {
 // The Then operations will be executed if all If comparisons succeed.
 // To add a transaction to the Then branch, use ThenTxn, or use Merge to merge transactions.
 func (v *TxnOp[R]) Then(ops ...Op) *TxnOp[R] {
-	// Check common high-level transaction types.
-	// Bulletproof check of the low-level transaction is in the "lowLevelTxn" method.
 	for i, op := range ops {
+		// Check common high-level transaction types.
+		// Bulletproof check of the low-level transaction is in the "lowLevelTxn" method.
 		if _, ok := op.(txnInterface); ok {
 			panic(errors.Errorf(`invalid operation[%d]: op is a transaction, use Merge or ThenTxn, not Then`, i))
 		}
+		v.parts = append(v.parts, txnPart[R]{Type: txnOpThen, Factory: op})
 	}
 
-	v.thenOps = append(v.thenOps, ops...)
 	return v
 }
 
 // ThenTxn adds the transaction to the Then branch.
 // To merge a transaction, use Merge.
 func (v *TxnOp[R]) ThenTxn(ops ...Op) *TxnOp[R] {
-	v.thenTxnOps = append(v.thenTxnOps, ops...)
+	for _, op := range ops {
+		v.parts = append(v.parts, txnPart[R]{Type: txnOpThenTxn, Factory: op})
+	}
 	return v
 }
 
 // Else takes a list of operations.
 // The operations in the Else branch will be executed if any of the If comparisons fail.
 func (v *TxnOp[R]) Else(ops ...Op) *TxnOp[R] {
-	v.elseOps = append(v.elseOps, ops...)
-	return v
-}
-
-// AddError - all static errors are returned when the low level txn is composed.
-// It makes error handling easier and move it to one place.
-func (v *TxnOp[R]) AddError(errs ...error) *TxnOp[R] {
-	if v.errs == nil {
-		v.errs = errors.NewMultiError()
+	for _, op := range ops {
+		v.parts = append(v.parts, txnPart[R]{Type: txnOpElse, Factory: op})
 	}
-	v.errs.Append(errs...)
 	return v
 }
 
@@ -127,7 +135,19 @@ func (v *TxnOp[R]) AddError(errs ...error) *TxnOp[R] {
 // For non-transaction operations, the method behaves the same as Then.
 // To add a transaction to the Then branch without merging, use ThenTxn.
 func (v *TxnOp[R]) Merge(ops ...Op) *TxnOp[R] {
-	v.mergeOps = append(v.mergeOps, ops...)
+	for _, op := range ops {
+		v.parts = append(v.parts, txnPart[R]{Type: txnOpMerge, Factory: op})
+	}
+	return v
+}
+
+// AddError - all static errors are returned when the low level txn is composed.
+// It makes error handling easier and move it to one place.
+func (v *TxnOp[R]) AddError(errs ...error) *TxnOp[R] {
+	if v.errs == nil {
+		v.errs = errors.NewMultiError()
+	}
+	v.errs.Append(errs...)
 	return v
 }
 
@@ -199,7 +219,14 @@ func (v *TxnOp[R]) Op(ctx context.Context) (LowLevelOp, error) {
 }
 
 func (v *TxnOp[R]) lowLevelTxn(ctx context.Context) (*lowLevelTxn[R], error) {
-	out := &lowLevelTxn[R]{result: v.result, client: v.client, thenOps: make([]etcd.Op, 0), elseOps: make([]etcd.Op, 0)}
+	out := &lowLevelTxn[R]{
+		result:    v.result,
+		client:    v.client,
+		opCounter: make(map[txnPartType]int),
+		thenOps:   make([]etcd.Op, 0),
+		elseOps:   make([]etcd.Op, 0),
+	}
+
 	errs := errors.NewMultiError()
 
 	// Copy init errors
@@ -207,114 +234,11 @@ func (v *TxnOp[R]) lowLevelTxn(ctx context.Context) (*lowLevelTxn[R], error) {
 		errs.Append(v.errs.WrappedErrors()...)
 	}
 
-	// Copy IFs
-	out.ifs = make([]etcd.Cmp, len(v.ifs))
-	copy(out.ifs, v.ifs)
-
-	// Map Then and ThenTxn operations
-	for i, op := range v.thenOps {
-		// Create low-level operation
-		if lowLevel, err := op.Op(ctx); err != nil {
-			errs.Append(errors.PrefixErrorf(err, "cannot create operation [then][%d]", i))
-		} else if lowLevel.Op.IsTxn() {
-			errs.Append(errors.Errorf(`cannot create operation [then][%d]: operation is a transaction, use Merge or ThenTxn, not Then`, i))
-		} else {
-			out.addThen(lowLevel.Op, lowLevel.MapResponse)
+	// Process all transaction parts
+	for _, part := range v.parts {
+		if err := out.addPart(ctx, part); err != nil {
+			errs.Append(err)
 		}
-	}
-	for i, op := range v.thenTxnOps {
-		// Create low-level operation
-		if lowLevel, err := op.Op(ctx); err != nil {
-			errs.Append(errors.PrefixErrorf(err, "cannot create operation [thenTxn][%d]", i))
-		} else if !lowLevel.Op.IsTxn() {
-			errs.Append(errors.Errorf(`cannot create operation [thenTxn][%d]: operation is not a transaction, use Then, not ThenTxn`, i))
-		} else {
-			out.addThen(lowLevel.Op, lowLevel.MapResponse)
-		}
-	}
-
-	// Map Else operations
-	for i, op := range v.elseOps {
-		// Create low-level operation
-		if lowLevel, err := op.Op(ctx); err == nil {
-			out.addElse(lowLevel.Op, lowLevel.MapResponse)
-		} else {
-			errs.Append(errors.PrefixErrorf(err, "cannot create operation [else][%d]", i))
-		}
-	}
-
-	// Map Merge operations, merge transaction, otherwise add the operation to the Then branch
-	for i, op := range v.mergeOps {
-		// Create low-level operation
-		lowLevel, err := op.Op(ctx)
-		if err != nil {
-			errs.Append(errors.PrefixErrorf(err, "cannot create operation [merge][%d]", i))
-			continue
-		}
-
-		// If it is not a transaction, process it as Then
-		if !lowLevel.Op.IsTxn() {
-			out.addThen(lowLevel.Op, lowLevel.MapResponse)
-			continue
-		}
-
-		// Get transaction parts
-		ifs, thenOps, elseOps := lowLevel.Op.Txn()
-
-		// Merge IFs
-		out.ifs = append(out.ifs, ifs...)
-
-		// Merge THEN operations
-		// The THEN branch will be applied, if all conditions (from all sub-transactions) are met.
-		thenStart := len(out.thenOps)
-		thenEnd := thenStart + len(thenOps)
-		for _, item := range thenOps {
-			out.addThen(item, nil)
-		}
-
-		// Merge ELSE operations
-		// The ELSE branch will be applied only if the conditions of the sub-transaction are not met
-		elsePos := -1
-		if len(elseOps) > 0 || len(ifs) > 0 {
-			elsePos = out.addElse(etcd.OpTxn(ifs, []etcd.Op{}, elseOps), nil)
-		}
-
-		// There may be a situation where neither THEN nor ELSE branch is executed:
-		// It occurs, when the root transaction fails, but the reason is not in this sub-transaction.
-
-		// On result, compose and map response that corresponds to the original sub-transaction
-		// Processor from nested transactions must be invoked first.
-		out.processors = append(out.processors, func(ctx context.Context, r *TxnResult[R]) {
-			// Get sub-transaction response
-			var subTxnResponse *etcd.TxnResponse
-			switch {
-			case r.succeeded:
-				subTxnResponse = &etcd.TxnResponse{
-					// The entire transaction succeeded, which means that a partial transaction succeeded as well
-					Succeeded: true,
-					// Compose responses that corresponds to the original sub-transaction
-					Responses: r.Response().Txn().Responses[thenStart:thenEnd],
-				}
-			case elsePos >= 0:
-				subTxnResponse = (*etcd.TxnResponse)(r.Response().Txn().Responses[elsePos].GetResponseTxn())
-				if subTxnResponse.Succeeded {
-					// Skip mapper bellow, the transaction failed, but not due to a condition in the sub-transaction
-					r.AddSubResult(NoResult{})
-					return
-				}
-			default:
-				// Skip mapper bellow, the transaction failed, but there is no condition in the sub-transaction
-				r.AddSubResult(NoResult{})
-				return
-			}
-
-			// Call original mapper of the sub transaction
-			if subResult, err := lowLevel.MapResponse(ctx, r.Response().SubResponse(subTxnResponse.OpResponse())); err == nil {
-				r.AddSubResult(subResult)
-			} else {
-				r.AddSubResult(err).AddErr(err)
-			}
-		})
 	}
 
 	// Add top-level processors
@@ -354,15 +278,148 @@ func (v *lowLevelTxn[R]) Do(ctx context.Context, opts ...Option) *TxnResult[R] {
 	return v.mapResponse(ctx, response)
 }
 
-func (v *lowLevelTxn[R]) addThen(op etcd.Op, mapper MapFn) {
-	v.thenOps = append(v.thenOps, op)
-	v.thenMappers = append(v.thenMappers, mapper)
+func (v *lowLevelTxn[R]) addPart(ctx context.Context, part txnPart[R]) error {
+	opIndex := v.opCounter[part.Type]
+	v.opCounter[part.Type]++
+
+	// Add if
+	if part.Type == txnOpIf {
+		v.ifs = append(v.ifs, part.If)
+		return nil
+	}
+
+	// Create low-level operation
+	lowLevel, err := part.Factory.Op(ctx)
+	if err != nil {
+		return errors.PrefixErrorf(err, "cannot create operation [%s][%d]", part.Type, opIndex)
+	}
+	switch part.Type {
+	case txnOpThen:
+		if lowLevel.Op.IsTxn() {
+			return errors.Errorf(`cannot create operation [then][%d]: operation is a transaction, use Merge or ThenTxn, not Then`, opIndex)
+		}
+		v.addThen(lowLevel.Op, lowLevel.MapResponse)
+	case txnOpThenTxn:
+		if !lowLevel.Op.IsTxn() {
+			return errors.Errorf(`cannot create operation [thenTxn][%d]: operation is not a transaction, use Then, not ThenTxn`, opIndex)
+		}
+		v.addThen(lowLevel.Op, lowLevel.MapResponse)
+	case txnOpElse:
+		v.addElse(lowLevel.Op, lowLevel.MapResponse)
+	case txnOpMerge:
+		// If it is not a transaction, process it as Then
+		if !lowLevel.Op.IsTxn() {
+			v.addThen(lowLevel.Op, lowLevel.MapResponse)
+			return nil
+		}
+
+		// Get transaction parts
+		ifs, thenOps, elseOps := lowLevel.Op.Txn()
+
+		// Merge IFs
+		v.ifs = append(v.ifs, ifs...)
+
+		// Merge THEN operations
+		// The THEN branch will be applied, if all conditions (from all sub-transactions) are met.
+		thenStart := len(v.thenOps)
+		thenEnd := thenStart + len(thenOps)
+		for _, item := range thenOps {
+			v.addThen(item, nil)
+		}
+
+		// Merge ELSE operations
+		// The ELSE branch will be applied only if the conditions of the sub-transaction are not met
+		elsePos := -1
+		if len(elseOps) > 0 || len(ifs) > 0 {
+			elsePos = v.addElse(etcd.OpTxn(ifs, []etcd.Op{}, elseOps), nil)
+		}
+
+		// There may be a situation where neither THEN nor ELSE branch is executed:
+		// It occurs, when the root transaction fails, but the reason is not in this sub-transaction.
+
+		// On result, compose and map response that corresponds to the original sub-transaction
+		// Processor from nested transactions must be invoked first.
+		v.processors = append(v.processors, func(ctx context.Context, r *TxnResult[R]) {
+			// Get sub-transaction response
+			var subTxnResponse *etcd.TxnResponse
+			switch {
+			case r.succeeded:
+				subTxnResponse = &etcd.TxnResponse{
+					// The entire transaction succeeded, which means that a partial transaction succeeded as well
+					Succeeded: true,
+					// Compose responses that corresponds to the original sub-transaction
+					Responses: r.Response().Txn().Responses[thenStart:thenEnd],
+				}
+			case elsePos >= 0:
+				subTxnResponse = (*etcd.TxnResponse)(r.Response().Txn().Responses[elsePos].GetResponseTxn())
+				if subTxnResponse.Succeeded {
+					// Skip mapper bellow, the transaction failed, but not due to a condition in the sub-transaction
+					r.AddSubResult(NoResult{})
+					return
+				}
+			default:
+				// Skip mapper bellow, the transaction failed, but there is no condition in the sub-transaction
+				r.AddSubResult(NoResult{})
+				return
+			}
+
+			// Call original mapper of the sub transaction
+			if subResult, err := lowLevel.MapResponse(ctx, r.Response().SubResponse(subTxnResponse.OpResponse())); err == nil {
+				r.AddSubResult(subResult)
+			} else {
+				r.AddSubResult(err).AddErr(err)
+			}
+		})
+	default:
+		panic(errors.Errorf(`unexpected operation type "%s"`, part.Type))
+	}
+
+	return nil
 }
 
-func (v *lowLevelTxn[R]) addElse(op etcd.Op, mapper MapFn) (index int) {
-	index = len(v.elseOps)
+func (v *lowLevelTxn[R]) addThen(op etcd.Op, mapper MapFn) int {
+	v.thenOps = append(v.thenOps, op)
+
+	// If the transaction is successful (then branch), the OP result will be available in the Responses[INDEX],
+	// so we can call original mapper with the sub-response.
+	index := len(v.thenOps) - 1
+	if mapper != nil {
+		v.processors = append(v.processors, func(ctx context.Context, r *TxnResult[R]) {
+			if r.Succeeded() {
+				rawSubResponse := r.Response().Txn().Responses[index]
+				subResponse := r.Response().SubResponse(mapRawResponse(rawSubResponse))
+				if subResult, err := mapper(ctx, subResponse); err == nil {
+					r.AddSubResult(subResult)
+				} else {
+					r.AddErr(err)
+				}
+			}
+		})
+	}
+
+	return index
+}
+
+func (v *lowLevelTxn[R]) addElse(op etcd.Op, mapper MapFn) int {
 	v.elseOps = append(v.elseOps, op)
-	v.elseMappers = append(v.elseMappers, mapper)
+
+	// If the transaction is NOT successful (else branch), the OP result will be available in the Responses[INDEX],
+	// so we can call original mapper with the sub-response.
+	index := len(v.elseOps) - 1
+	if mapper != nil {
+		v.processors = append(v.processors, func(ctx context.Context, r *TxnResult[R]) {
+			if !r.Succeeded() {
+				rawSubResponse := r.Response().Txn().Responses[index]
+				subResponse := r.Response().SubResponse(mapRawResponse(rawSubResponse))
+				if subResult, err := mapper(ctx, subResponse); err == nil {
+					r.AddSubResult(subResult)
+				} else {
+					r.AddErr(err)
+				}
+			}
+		})
+	}
+
 	return index
 }
 
@@ -370,26 +427,6 @@ func (v *lowLevelTxn[R]) mapResponse(ctx context.Context, raw RawResponse) *TxnR
 	// Map transaction response
 	r := newTxnResult(&raw, v.result)
 	r.succeeded = raw.Txn().Succeeded
-
-	// Map sub-responses
-	for i, subResponse := range raw.Txn().Responses {
-		// Get mapper
-		var mapper MapFn
-		if r.succeeded {
-			mapper = v.thenMappers[i]
-		} else {
-			mapper = v.elseMappers[i]
-		}
-
-		// Use mapper
-		if mapper != nil {
-			if subResult, err := mapper(ctx, raw.SubResponse(mapRawResponse(subResponse))); err == nil {
-				r.AddSubResult(subResult)
-			} else {
-				r.AddErr(err)
-			}
-		}
-	}
 
 	// Use processors
 	for _, p := range v.processors {

--- a/internal/pkg/service/common/etcdop/op/txn.go
+++ b/internal/pkg/service/common/etcdop/op/txn.go
@@ -219,14 +219,7 @@ func (v *TxnOp[R]) Op(ctx context.Context) (LowLevelOp, error) {
 }
 
 func (v *TxnOp[R]) lowLevelTxn(ctx context.Context) (*lowLevelTxn[R], error) {
-	out := &lowLevelTxn[R]{
-		result:    v.result,
-		client:    v.client,
-		opCounter: make(map[txnPartType]int),
-		thenOps:   make([]etcd.Op, 0),
-		elseOps:   make([]etcd.Op, 0),
-	}
-
+	out := &lowLevelTxn[R]{result: v.result, client: v.client, opCounter: make(map[txnPartType]int)}
 	errs := errors.NewMultiError()
 
 	// Copy init errors
@@ -331,7 +324,7 @@ func (v *lowLevelTxn[R]) addPart(ctx context.Context, part txnPart[R]) error {
 		// The ELSE branch will be applied only if the conditions of the sub-transaction are not met
 		elsePos := -1
 		if len(elseOps) > 0 || len(ifs) > 0 {
-			elsePos = v.addElse(etcd.OpTxn(ifs, []etcd.Op{}, elseOps), nil)
+			elsePos = v.addElse(etcd.OpTxn(ifs, nil, elseOps), nil)
 		}
 
 		// There may be a situation where neither THEN nor ELSE branch is executed:

--- a/internal/pkg/service/common/etcdop/op/txn_error.go
+++ b/internal/pkg/service/common/etcdop/op/txn_error.go
@@ -1,7 +1,25 @@
 package op
 
+import (
+	"context"
+
+	"github.com/keboola/keboola-as-code/internal/pkg/utils/errors"
+)
+
 // ErrorTxn wraps a static error as TxnOp.
 // It makes error handling easier and move it to one place.
 func ErrorTxn[R any](err error) *TxnOp[R] {
 	return TxnWithResult[R](nil, nil).AddError(err)
+}
+
+// FirstErrorOnly will only keep the first error that occurred.
+func (v *TxnOp[R]) FirstErrorOnly() *TxnOp[R] {
+	return v.AddProcessor(func(_ context.Context, r *TxnResult[R]) {
+		if multi, ok := r.Err().(errors.MultiError); ok { //nolint:errorlint // root error must be multi error, errors.As is not used
+			if errs := multi.WrappedErrors(); len(errs) > 0 {
+				r.ResetErr()
+				r.AddErr(errs[0])
+			}
+		}
+	})
 }

--- a/internal/pkg/service/common/etcdop/op/txn_error_test.go
+++ b/internal/pkg/service/common/etcdop/op/txn_error_test.go
@@ -1,0 +1,45 @@
+package op_test
+
+import (
+	"context"
+	"strconv"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+
+	"github.com/keboola/keboola-as-code/internal/pkg/service/common/etcdop"
+	"github.com/keboola/keboola-as-code/internal/pkg/service/common/etcdop/op"
+	"github.com/keboola/keboola-as-code/internal/pkg/utils/errors"
+	"github.com/keboola/keboola-as-code/internal/pkg/utils/etcdhelper"
+)
+
+func TestTxnOp_FirstErrorOnly(t *testing.T) {
+	t.Parallel()
+
+	ctx := context.Background()
+	client := etcdhelper.ClientForTest(t, etcdhelper.TmpNamespace(t))
+
+	newOpWithErr := func(i int) op.Op {
+		return etcdop.
+			Key("key/"+strconv.Itoa(i)).
+			Put(client, "value").
+			WithProcessor(func(_ context.Context, r *op.Result[op.NoResult]) {
+				r.AddErr(errors.New("error" + strconv.Itoa(i)))
+			})
+	}
+
+	err := op.Txn(client).
+		Merge(
+			op.Txn(client).
+				Then(newOpWithErr(1)).
+				Merge(op.Txn(client).Then(newOpWithErr(2))).
+				Then(newOpWithErr(3)),
+		).
+		Then(newOpWithErr(4)).
+		Then(newOpWithErr(5)).
+		FirstErrorOnly().
+		Do(ctx).
+		Err()
+
+	assert.Equal(t, "error1", err.Error())
+}

--- a/internal/pkg/service/common/etcdop/op/txn_test.go
+++ b/internal/pkg/service/common/etcdop/op/txn_test.go
@@ -372,7 +372,7 @@ func TestTxnOp_Then_CalledWithTxn_2(t *testing.T) {
 
 	_, err := Txn(client).Then(txnOp).Op(context.Background())
 	if assert.Error(t, err) {
-		assert.Equal(t, "cannot create operation [then][0]: operation is a transaction, use Merge or ThenTxn, not Then", err.Error())
+		assert.Equal(t, "cannot create operation [then][0]:\n- operation is a transaction, use Merge or ThenTxn, not Then", err.Error())
 	}
 }
 
@@ -382,7 +382,7 @@ func TestTxnOp_ThenTxn_CalledWithoutTxn(t *testing.T) {
 	client := etcd.KV(nil)
 	_, err := Txn(client).ThenTxn(etcdop.Key("foo").Put(client, "bar")).Op(context.Background())
 	if assert.Error(t, err) {
-		assert.Equal(t, "cannot create operation [thenTxn][0]: operation is not a transaction, use Then, not ThenTxn", err.Error())
+		assert.Equal(t, "cannot create operation [thenTxn][0]:\n- operation is not a transaction, use Then, not ThenTxn", err.Error())
 	}
 }
 

--- a/internal/pkg/service/common/etcdop/op/txn_test.go
+++ b/internal/pkg/service/common/etcdop/op/txn_test.go
@@ -50,11 +50,11 @@ func TestTxnOp_Empty(t *testing.T) {
 	if lowLevel, err := txn.Op(ctx); assert.NoError(t, err) {
 		assert.Equal(t, etcd.OpTxn(
 			// If
-			[]etcd.Cmp{},
+			nil,
 			// Then
-			[]etcd.Op{},
+			nil,
 			// Else
-			[]etcd.Op{},
+			nil,
 		), lowLevel.Op)
 	}
 
@@ -424,37 +424,37 @@ func TestTxnOp_Then_Simple(t *testing.T) {
 		// ----- Txn - Level 1 ------
 		assert.Equal(t, etcd.OpTxn(
 			// If
-			[]etcd.Cmp{},
+			nil,
 			// Then
 			[]etcd.Op{
 				etcd.OpPut("key1", "value1"),
 				// ----- Txn - Level 2 ------
 				etcd.OpTxn(
 					// If
-					[]etcd.Cmp{},
+					nil,
 					// Then
 					[]etcd.Op{
 						etcd.OpPut("key2", "value2"),
 						// ----- Txn - Level 3 ------
 						etcd.OpTxn(
 							// If
-							[]etcd.Cmp{},
+							nil,
 							// Then
 							[]etcd.Op{
 								etcd.OpPut("key3", "value3"),
 							},
 							// Else
-							[]etcd.Op{},
+							nil,
 						),
 					},
 					// Else
-					[]etcd.Op{},
+					nil,
 				),
 				// -----
 				etcd.OpPut("key4", "value4"),
 			},
 			// Else
-			[]etcd.Op{},
+			nil,
 		), lowLevel.Op)
 	}
 
@@ -510,7 +510,7 @@ func TestTxnOp_Merge_Simple(t *testing.T) {
 	if lowLevel, err := txn.Op(ctx); assert.NoError(t, err) {
 		assert.Equal(t, etcd.OpTxn(
 			// If
-			[]etcd.Cmp{},
+			nil,
 			// Then
 			[]etcd.Op{
 				etcd.OpPut("key1", "value1"),
@@ -519,7 +519,7 @@ func TestTxnOp_Merge_Simple(t *testing.T) {
 				etcd.OpPut("key4", "value4"),
 			},
 			// Else
-			[]etcd.Op{},
+			nil,
 		), lowLevel.Op)
 	}
 
@@ -619,17 +619,17 @@ func TestTxnOp_Then_Simple_Ifs(t *testing.T) {
 								etcd.OpPut("key3", "value3"),
 							},
 							// Else
-							[]etcd.Op{},
+							nil,
 						),
 					},
 					// Else
-					[]etcd.Op{},
+					nil,
 				),
 				// -----
 				etcd.OpPut("key4", "value4"),
 			},
 			// Else
-			[]etcd.Op{},
+			nil,
 		), lowLevel.Op)
 	}
 
@@ -738,11 +738,11 @@ func TestTxnOp_Merge_Simple_Ifs(t *testing.T) {
 						etcd.Compare(etcd.Version("key3"), "=", 0),
 					},
 					// Then
-					[]etcd.Op{},
+					nil,
 					// Else
 					[]etcd.Op{
 						// Check conditions of the nested transaction - 2, for processors
-						etcd.OpTxn([]etcd.Cmp{etcd.Compare(etcd.Version("key3"), "=", 0)}, []etcd.Op{}, []etcd.Op{}),
+						etcd.OpTxn([]etcd.Cmp{etcd.Compare(etcd.Version("key3"), "=", 0)}, nil, nil),
 					},
 				),
 			},
@@ -830,16 +830,8 @@ func TestTxnOp_Merge_RealExample(t *testing.T) {
 			},
 			// Else
 			[]etcd.Op{
-				etcd.OpTxn(
-					[]etcd.Cmp{etcd.Compare(etcd.Version("key/put"), "=", 0)}, // If
-					[]etcd.Op{}, // Then
-					[]etcd.Op{}, // Else
-				),
-				etcd.OpTxn(
-					[]etcd.Cmp{etcd.Compare(etcd.Version("key/delete"), "!=", 0)}, // If
-					[]etcd.Op{}, // Then
-					[]etcd.Op{}, // Else
-				),
+				etcd.OpTxn([]etcd.Cmp{etcd.Compare(etcd.Version("key/put"), "=", 0)}, nil, nil),
+				etcd.OpTxn([]etcd.Cmp{etcd.Compare(etcd.Version("key/delete"), "!=", 0)}, nil, nil),
 				etcd.OpPut("key/txn/succeeded", "false"),
 			},
 		), lowLevel.Op)
@@ -1075,7 +1067,7 @@ func TestTxnOp_Merge_Complex(t *testing.T) {
 						etcd.Compare(etcd.Value("txn1/if"), "=", "ok"),
 					},
 					// Then
-					[]etcd.Op{},
+					nil,
 					// Else
 					[]etcd.Op{
 						etcd.OpPut("txn1/else/put", "ok"),
@@ -1088,7 +1080,7 @@ func TestTxnOp_Merge_Complex(t *testing.T) {
 						etcd.Compare(etcd.Value("txn2/if"), "=", "ok"),
 					},
 					// Then
-					[]etcd.Op{},
+					nil,
 					// Else
 					[]etcd.Op{
 						etcd.OpPut("txn2/else/put", "ok"),


### PR DESCRIPTION
Jira: https://keboola.atlassian.net/browse/PSGO-596

All tests will pass in the final [PR](https://github.com/keboola/keboola-as-code/pull/1770).

[Large set of fixes and E2e tests](https://github.com/keboola/keboola-as-code/pull/1759) is divided into smaller PRs to do a review.

--------------

**Changes:**
- Fixed order of  callback invocations, if `TxnOp.Merge` is used.
- Aded method `TxnOp.FirstErrorOnly`.

-----------

Commend per commits.

-----------

![image](https://github.com/keboola/keboola-as-code/assets/19371734/a7cb8601-f565-4cb3-9dda-8cface2571cc)

---------

At first, please read `TxnOp` docs:

https://github.com/keboola/keboola-as-code/blob/1d5dffdda7b8375ab05800820be1b8860168b497/internal/pkg/service/common/etcdop/op/txn.go#L19-L34