### PR TITLE
ci: add caching of e2e tests locally.

### DIFF
--- a/.github/actions/go-cache/action.yml
+++ b/.github/actions/go-cache/action.yml
@@ -20,6 +20,7 @@ runs:
           ~/.cache/go-build
           ~/Library/Caches/go-build
           ~\AppData\Local\go-build
+          ${{ github.workspace }}/test/cli/.out
         key: ${{ runner.os }}-go-${{ env.GO_VERSION }}-v6-${{ inputs.key }}-${{ hashFiles('**/go.sum') }}
         restore-keys: |
           ${{ runner.os }}-go-${{ env.GO_VERSION }}-v6-${{ inputs.key }}-

--- a/internal/pkg/utils/testhelper/runner/test.go
+++ b/internal/pkg/utils/testhelper/runner/test.go
@@ -640,6 +640,10 @@ func (t *Test) assertProjectState() {
 		err = t.workingDirFS.WriteFile(t.ctx, filesystem.NewRawFile("actual-state.json", json.MustEncodeString(actualState, true)))
 		assert.NoError(t.t, err)
 
+		tm := time.Unix(1, 0).Local()
+		// this prevents file too new check when go caching, updates modtime of actual-state.json
+		err = os.Chtimes(t.workingDirFS.BasePath()+"/actual-state.json", tm, tm) // nolint:forbidigo
+		assert.NoError(t.t, err)
 		// Compare expected and actual state
 		wildcards.Assert(
 			t.t,

--- a/test/cli/cli_test.go
+++ b/test/cli/cli_test.go
@@ -2,8 +2,11 @@
 package cli
 
 import (
+	"os"
 	"testing"
 
+	// enables caching of binary.
+	_ "github.com/keboola/keboola-as-code/internal/pkg/service/cli/cmd"
 	"github.com/keboola/keboola-as-code/internal/pkg/utils/testhelper"
 	"github.com/keboola/keboola-as-code/internal/pkg/utils/testhelper/runner"
 )
@@ -12,7 +15,10 @@ import (
 func TestCliE2E(t *testing.T) {
 	t.Parallel()
 
-	binaryPath := testhelper.CompileBinary(t, "cli", "build-local")
+	binaryPath := os.Getenv("TEST_BINARY_PATH")
+	if binaryPath == "" {
+		binaryPath = testhelper.CompileBinary(t, "cli", "build-local")
+	}
 
 	runner.
 		NewRunner(t).

--- a/test/stream/api/api_test.go
+++ b/test/stream/api/api_test.go
@@ -11,6 +11,8 @@ import (
 
 	"github.com/keboola/keboola-as-code/internal/pkg/env"
 	"github.com/keboola/keboola-as-code/internal/pkg/filesystem"
+	_ "github.com/keboola/keboola-as-code/internal/pkg/service/common/entrypoint"
+	_ "github.com/keboola/keboola-as-code/internal/pkg/service/stream"
 	"github.com/keboola/keboola-as-code/internal/pkg/utils/etcdhelper"
 	"github.com/keboola/keboola-as-code/internal/pkg/utils/testhelper"
 	"github.com/keboola/keboola-as-code/internal/pkg/utils/testhelper/runner"

--- a/test/templates/api/api_test.go
+++ b/test/templates/api/api_test.go
@@ -13,6 +13,8 @@ import (
 
 	"github.com/keboola/keboola-as-code/internal/pkg/env"
 	"github.com/keboola/keboola-as-code/internal/pkg/filesystem"
+	_ "github.com/keboola/keboola-as-code/internal/pkg/service/common/entrypoint"
+	_ "github.com/keboola/keboola-as-code/internal/pkg/service/templates/api/service"
 	"github.com/keboola/keboola-as-code/internal/pkg/utils/etcdhelper"
 	"github.com/keboola/keboola-as-code/internal/pkg/utils/testhelper"
 	"github.com/keboola/keboola-as-code/internal/pkg/utils/testhelper/runner"


### PR DESCRIPTION
Jira: [PSGO-565](https://keboola.atlassian.net/browse/PSGO-565)

**Changes:**
- Works only locally. CI not functioning, see document.
- Add dependencies to files that compiles into binary so the changes are checked for caching purposes.
- Change modtime of actual-state.json to prevent cache not being generated due to file too new issue (new file has to be at least 2 seconds created and compared with stat to generate cache entry for tests)

-----------


[PSGO-565]: https://keboola.atlassian.net/browse/PSGO-565?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ