### PR TITLE
style: Remove x := x assignments, it is no more required in Go 1.22+

### DIFF
--- a/internal/pkg/service/common/etcdop/mutex_test.go
+++ b/internal/pkg/service/common/etcdop/mutex_test.go
@@ -194,8 +194,6 @@ func TestMutex_ParallelWork(t *testing.T) {
 					// Create N unique locks in the session
 					locksWg := &sync.WaitGroup{}
 					for _, lockTester := range lockTesters {
-						lockTester := lockTester
-
 						// Use each lock N times in parallel
 						for k := 0; k < tc.Parallel; k++ {
 							workWg.Add(1)

--- a/internal/pkg/service/stream/definition/repository/sink/sink_delete.go
+++ b/internal/pkg/service/stream/definition/repository/sink/sink_delete.go
@@ -53,8 +53,6 @@ func (r *Repository) softDeleteAllFrom(parentKey fmt.Stringer, now time.Time, by
 	atomicOp.Write(func(ctx context.Context) op.Op {
 		txn := op.Txn(r.client)
 		for _, old := range allOriginal {
-			old := old
-
 			// Mark deleted
 			deleted := deepcopy.Copy(old).(definition.Sink)
 			deleted.Delete(now, by, directly)

--- a/internal/pkg/service/stream/definition/repository/sink/sink_disable.go
+++ b/internal/pkg/service/stream/definition/repository/sink/sink_disable.go
@@ -56,8 +56,6 @@ func (r *Repository) disableAllFrom(parentKey fmt.Stringer, now time.Time, by de
 	atomicOp.Write(func(ctx context.Context) op.Op {
 		txn := op.Txn(r.client)
 		for _, original := range allOriginal {
-			original := original
-
 			if original.IsDisabled() {
 				continue
 			}

--- a/internal/pkg/service/stream/definition/repository/source/source_delete.go
+++ b/internal/pkg/service/stream/definition/repository/source/source_delete.go
@@ -52,8 +52,6 @@ func (r *Repository) softDeleteAllFrom(parentKey fmt.Stringer, now time.Time, by
 	atomicOp.Write(func(ctx context.Context) op.Op {
 		txn := op.Txn(r.client)
 		for _, old := range allOriginal {
-			old := old
-
 			// Mark deleted
 			deleted := deepcopy.Copy(old).(definition.Source)
 			deleted.Delete(now, by, directly)

--- a/internal/pkg/service/stream/definition/repository/source/source_disable.go
+++ b/internal/pkg/service/stream/definition/repository/source/source_disable.go
@@ -56,8 +56,6 @@ func (r *Repository) disableAllFrom(parentKey fmt.Stringer, now time.Time, by de
 	atomicOp.Write(func(ctx context.Context) op.Op {
 		txn := op.Txn(r.client)
 		for _, original := range allOriginal {
-			original := original
-
 			if original.IsDisabled() {
 				continue
 			}

--- a/internal/pkg/service/stream/definition/repository/source/source_enable.go
+++ b/internal/pkg/service/stream/definition/repository/source/source_enable.go
@@ -56,8 +56,6 @@ func (r *Repository) enableAllFrom(parentKey fmt.Stringer, now time.Time, by def
 	atomicOp.Write(func(ctx context.Context) op.Op {
 		txn := op.Txn(r.client)
 		for _, original := range allOriginal {
-			original := original
-
 			if original.IsDisabledDirectly() != directly {
 				continue
 			}

--- a/internal/pkg/service/stream/definition/repository/source/source_undelete.go
+++ b/internal/pkg/service/stream/definition/repository/source/source_undelete.go
@@ -63,8 +63,6 @@ func (r *Repository) undeleteAllFrom(parentKey fmt.Stringer, now time.Time, by d
 	atomicOp.Write(func(ctx context.Context) op.Op {
 		txn := op.Txn(r.client)
 		for _, old := range allOld {
-			old := old
-
 			if old.Deleted.Directly != directly {
 				continue
 			}

--- a/internal/pkg/service/stream/mapping/table/column/columns.go
+++ b/internal/pkg/service/stream/mapping/table/column/columns.go
@@ -28,8 +28,6 @@ func (v Columns) MarshalJSON() ([]byte, error) {
 	var items []json.RawMessage
 
 	for _, column := range v {
-		column := column
-
 		typ := column.ColumnType()
 
 		typeJSON, err := json.Marshal(typ)

--- a/internal/pkg/utils/testproject/project.go
+++ b/internal/pkg/utils/testproject/project.go
@@ -365,8 +365,6 @@ func (p *Project) createFiles(files []*fixtures.File) error {
 	errs := errors.NewMultiError()
 
 	for _, fixture := range files {
-		fixture := fixture
-
 		wg.Add(1)
 		go func() {
 			defer wg.Done()
@@ -429,8 +427,6 @@ func (p *Project) createSandboxes(defaultBranchID keboola.BranchID, sandboxes []
 	errs := errors.NewMultiError()
 
 	for _, fixture := range sandboxes {
-		fixture := fixture
-
 		wg.Add(1)
 		go func() {
 			defer wg.Done()


### PR DESCRIPTION
Jira: https://keboola.atlassian.net/browse/PSGO-596

All tests will pass in the final [PR](https://github.com/keboola/keboola-as-code/pull/1770).

[Large set of fixes and E2e tests](https://github.com/keboola/keboola-as-code/pull/1759) is divided into smaller PRs to do a review.

--------------

See:  https://github.com/keboola/keboola-as-code/pull/1781#discussion_r1608129321

Regexp: `^\s+([a-zA-Z0-9_\-]+) := \1\n$`

Changes: 
- Removed old assignments in for loops, which are no longer required in Go 1.22+.

-----------
