### PR TITLE
lint: Add usestdlibvars linter to prevent unnecessary constants

### DIFF
--- a/build/ci/golangci.yml
+++ b/build/ci/golangci.yml
@@ -150,6 +150,7 @@ linters:
     - thelper
     - tparallel
     - paralleltest
+    - usestdlibvars
     - unconvert
     - unparam
     - unused

--- a/internal/pkg/service/appsproxy/proxy/server_test.go
+++ b/internal/pkg/service/appsproxy/proxy/server_test.go
@@ -71,20 +71,20 @@ func TestAppProxyHandler(t *testing.T) {
 
 	// Get robots.txt
 	rec := httptest.NewRecorder()
-	req := httptest.NewRequest("GET", "https://hub.keboola.local/robots.txt", nil)
+	req := httptest.NewRequest(http.MethodGet, "https://hub.keboola.local/robots.txt", nil)
 	handler.ServeHTTP(rec, req)
 	require.Equal(t, http.StatusOK, rec.Code)
 	assert.Contains(t, rec.Body.String(), "Disallow: /")
 
 	// Get missing asset
 	rec = httptest.NewRecorder()
-	req = httptest.NewRequest("GET", "https://hub.keboola.local/_proxy/assets/foo.bar", nil)
+	req = httptest.NewRequest(http.MethodGet, "https://hub.keboola.local/_proxy/assets/foo.bar", nil)
 	handler.ServeHTTP(rec, req)
 	require.Equal(t, http.StatusNotFound, rec.Code)
 
 	// Invalid host
 	rec = httptest.NewRecorder()
-	req = httptest.NewRequest("GET", "https://public-123.foo.bar.local/path", nil)
+	req = httptest.NewRequest(http.MethodGet, "https://public-123.foo.bar.local/path", nil)
 	req.Header.Set("User-Agent", "my-user-agent")
 	handler.ServeHTTP(rec, req)
 	require.Equal(t, http.StatusBadRequest, rec.Code)
@@ -92,7 +92,7 @@ func TestAppProxyHandler(t *testing.T) {
 
 	// Send logged request
 	rec = httptest.NewRecorder()
-	req = httptest.NewRequest("GET", "https://public-123.hub.keboola.local/path", nil)
+	req = httptest.NewRequest(http.MethodGet, "https://public-123.hub.keboola.local/path", nil)
 	req.Header.Set("User-Agent", "my-user-agent")
 	handler.ServeHTTP(rec, req)
 	require.Equal(t, http.StatusOK, rec.Code)
@@ -100,7 +100,7 @@ func TestAppProxyHandler(t *testing.T) {
 
 	// Send ignored request
 	rec = httptest.NewRecorder()
-	req = httptest.NewRequest("GET", "https://hub.keboola.local/health-check", nil)
+	req = httptest.NewRequest(http.MethodGet, "https://hub.keboola.local/health-check", nil)
 	req.Header.Set("User-Agent", "my-user-agent")
 	handler.ServeHTTP(rec, req)
 	require.Equal(t, http.StatusOK, rec.Code)

--- a/internal/pkg/service/common/httpserver/middleware/logger_test.go
+++ b/internal/pkg/service/common/httpserver/middleware/logger_test.go
@@ -47,7 +47,7 @@ func TestLoggerMiddleware(t *testing.T) {
 
 	// Send logged request
 	rec := httptest.NewRecorder()
-	req := httptest.NewRequest("GET", "/api/action", nil)
+	req := httptest.NewRequest(http.MethodGet, "/api/action", nil)
 	req.Header.Set("User-Agent", "my-user-agent")
 	handler.ServeHTTP(rec, req)
 	assert.Equal(t, http.StatusOK, rec.Code)
@@ -55,13 +55,13 @@ func TestLoggerMiddleware(t *testing.T) {
 
 	// Send ignored requests
 	rec = httptest.NewRecorder()
-	req = httptest.NewRequest("GET", "/api/ignored-1", nil)
+	req = httptest.NewRequest(http.MethodGet, "/api/ignored-1", nil)
 	req.Header.Set("User-Agent", "my-user-agent")
 	handler.ServeHTTP(rec, req)
 	assert.Equal(t, http.StatusOK, rec.Code)
 	assert.Equal(t, "OK", rec.Body.String())
 	rec = httptest.NewRecorder()
-	req = httptest.NewRequest("GET", "/api/ignored-2", nil)
+	req = httptest.NewRequest(http.MethodGet, "/api/ignored-2", nil)
 	req.Header.Set("User-Agent", "my-user-agent")
 	handler.ServeHTTP(rec, req)
 	assert.Equal(t, http.StatusOK, rec.Code)

--- a/internal/pkg/service/common/httpserver/middleware/otel_test.go
+++ b/internal/pkg/service/common/httpserver/middleware/otel_test.go
@@ -35,7 +35,7 @@ type MiddlewareTest struct {
 
 func middlewareTests() []MiddlewareTest {
 	req1Attrs := attribute.NewSet(
-		attribute.String("http.method", "GET"),
+		attribute.String("http.method", http.MethodGet),
 		attribute.String("http.scheme", "http"),
 		attribute.String("net.host.name", "example.com"),
 		attribute.String("http.route", "/api/ignored-tracing"),
@@ -261,7 +261,7 @@ func TestOpenTelemetryMiddleware(t *testing.T) {
 		// Create request
 		rec := httptest.NewRecorder()
 		body := io.NopCloser(strings.NewReader("some body"))
-		req := httptest.NewRequest("POST", "/api/item/123/my-secret-1?foo=bar&secret2=my-secret-2", body)
+		req := httptest.NewRequest(http.MethodPost, "/api/item/123/my-secret-1?foo=bar&secret2=my-secret-2", body)
 		req.Header.Set("User-Agent", "my-user-agent")
 		req.Header.Set("X-StorageAPI-Token", "my-token")
 
@@ -275,11 +275,11 @@ func TestOpenTelemetryMiddleware(t *testing.T) {
 
 		// Send ignored requests
 		rec = httptest.NewRecorder()
-		handler.ServeHTTP(rec, httptest.NewRequest("GET", "/api/ignored-all", nil))
+		handler.ServeHTTP(rec, httptest.NewRequest(http.MethodGet, "/api/ignored-all", nil))
 		assert.Equal(t, http.StatusOK, rec.Code)
 		assert.Equal(t, responseContent, rec.Body.String())
 		rec = httptest.NewRecorder()
-		handler.ServeHTTP(rec, httptest.NewRequest("GET", "/api/ignored-tracing", nil))
+		handler.ServeHTTP(rec, httptest.NewRequest(http.MethodGet, "/api/ignored-tracing", nil))
 		assert.Equal(t, http.StatusOK, rec.Code)
 		assert.Equal(t, responseContent, rec.Body.String())
 

--- a/internal/pkg/service/common/httpserver/middleware/requestinfo_test.go
+++ b/internal/pkg/service/common/httpserver/middleware/requestinfo_test.go
@@ -29,7 +29,7 @@ func TestMetaMiddleware(t *testing.T) {
 
 	// Send request
 	rec := httptest.NewRecorder()
-	req := httptest.NewRequest("GET", "/", nil)
+	req := httptest.NewRequest(http.MethodGet, "/", nil)
 	handler.ServeHTTP(rec, req)
 
 	// Assert

--- a/internal/pkg/service/templates/dependencies/reqproject_test.go
+++ b/internal/pkg/service/templates/dependencies/reqproject_test.go
@@ -4,6 +4,7 @@ import (
 	"bytes"
 	"context"
 	"fmt"
+	"net/http"
 	"net/http/httptest"
 	"os"
 	"os/exec"
@@ -45,7 +46,7 @@ func TestProjectRequestScope_TemplateRepository_Cached(t *testing.T) {
 
 	// Mocked request scope
 	reqScpFactory := func() ProjectRequestScope {
-		req := httptest.NewRequest("GET", "/req1", nil)
+		req := httptest.NewRequest(http.MethodGet, "/req1", nil)
 		return newProjectRequestScope(NewPublicRequestScope(apiScp, req), mock)
 	}
 	// Get repository for request 1
@@ -164,7 +165,7 @@ func TestProjectRequestScope_Template_Cached(t *testing.T) {
 
 	// Mocked request scope
 	reqScopeFactory := func() ProjectRequestScope {
-		req := httptest.NewRequest("GET", "/req1", nil)
+		req := httptest.NewRequest(http.MethodGet, "/req1", nil)
 		return newProjectRequestScope(NewPublicRequestScope(apiScp, req), mock)
 	}
 

--- a/internal/pkg/service/templates/dependencies/reqpublic_test.go
+++ b/internal/pkg/service/templates/dependencies/reqpublic_test.go
@@ -33,7 +33,7 @@ func TestPublicRequestScope_Components_Cached(t *testing.T) {
 	apiScp, mock := NewMockedAPIScope(t, ctx, config.New(), dependencies.WithMockedComponents(components1))
 
 	// Request 1 gets "components1"
-	req1Scp := NewPublicRequestScope(apiScp, httptest.NewRequest("GET", "/req1", nil))
+	req1Scp := NewPublicRequestScope(apiScp, httptest.NewRequest(http.MethodGet, "/req1", nil))
 	assert.Equal(t, components1, req1Scp.Components().All())
 	assert.Equal(t, components1, req1Scp.Components().All())
 
@@ -52,7 +52,7 @@ func TestPublicRequestScope_Components_Cached(t *testing.T) {
 	assert.Equal(t, components1, req1Scp.Components().All())
 
 	// But request2 gets "components2"
-	req2Scp := NewPublicRequestScope(apiScp, httptest.NewRequest("GET", "/req2", nil))
+	req2Scp := NewPublicRequestScope(apiScp, httptest.NewRequest(http.MethodGet, "/req2", nil))
 	assert.Equal(t, components2, req2Scp.Components().All())
 	assert.Equal(t, components2, req2Scp.Components().All())
 }

--- a/test/stream/bridge/keboola/setup_test.go
+++ b/test/stream/bridge/keboola/setup_test.go
@@ -324,7 +324,7 @@ func (ts *testState) setupSourceThroughAPI(t *testing.T, ctx context.Context, ex
 
 	url := ts.apiScp.APIPublicURL()
 	url.Path = fmt.Sprintf("/v1/branches/%s/sources", ts.branchID.String())
-	req, err := http.NewRequestWithContext(ctx, "POST", url.String(), bytes.NewBuffer(out))
+	req, err := http.NewRequestWithContext(ctx, http.MethodPost, url.String(), bytes.NewBuffer(out))
 	require.NoError(t, err)
 	req.Header.Add("X-StorageAPI-Token", ts.project.StorageAPIToken().Token)
 	req.Header.Add("Content-Type", "application/json")
@@ -350,7 +350,7 @@ func (ts *testState) setupSourceThroughAPI(t *testing.T, ctx context.Context, ex
 	require.NoError(t, err)
 
 	urlString := task["url"].(string)
-	req, err = http.NewRequestWithContext(ctx, "GET", urlString, nil)
+	req, err = http.NewRequestWithContext(ctx, http.MethodGet, urlString, nil)
 	require.NoError(t, err)
 	req.Header.Add("X-StorageAPI-Token", ts.project.StorageAPIToken().Token)
 	resp, err = http.DefaultClient.Do(req)
@@ -377,7 +377,7 @@ func (ts *testState) setupSinkThroughAPI(t *testing.T, ctx context.Context, expe
 
 	url := ts.apiScp.APIPublicURL()
 	url.Path = fmt.Sprintf("/v1/branches/%s/sources/%s/sinks", ts.branchID.String(), sourceKey.SourceID.String())
-	req, err := http.NewRequestWithContext(ctx, "POST", url.String(), bytes.NewBuffer(out))
+	req, err := http.NewRequestWithContext(ctx, http.MethodPost, url.String(), bytes.NewBuffer(out))
 	require.NoError(t, err)
 	req.Header.Add("X-StorageAPI-Token", ts.project.StorageAPIToken().Token)
 	req.Header.Add("Content-Type", "application/json")
@@ -403,7 +403,7 @@ func (ts *testState) setupSinkThroughAPI(t *testing.T, ctx context.Context, expe
 	require.NoError(t, err)
 
 	urlString := task["url"].(string)
-	req, err = http.NewRequestWithContext(ctx, "GET", urlString, nil)
+	req, err = http.NewRequestWithContext(ctx, http.MethodGet, urlString, nil)
 	require.NoError(t, err)
 	req.Header.Add("X-StorageAPI-Token", ts.project.StorageAPIToken().Token)
 	resp, err = http.DefaultClient.Do(req)


### PR DESCRIPTION
Jira: [PSGO-682](https://keboola.atlassian.net/browse/PSGO-682)

**Changes:**
- Add usestdlib vars linter to prevent unnecessary duplication of constants

-----------


[PSGO-682]: https://keboola.atlassian.net/browse/PSGO-682?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ