### PR TITLE
Create new tracer wrapper to not propagate data apps errors into DD

### DIFF
--- a/internal/pkg/service/appsproxy/proxy/server.go
+++ b/internal/pkg/service/appsproxy/proxy/server.go
@@ -3,12 +3,16 @@ package proxy
 import (
 	"context"
 	"net/http"
+	"strings"
 	"time"
 
 	oautproxylogger "github.com/oauth2-proxy/oauth2-proxy/v7/pkg/logger"
+	"go.opentelemetry.io/otel/codes"
 	"go.opentelemetry.io/otel/propagation"
+	"go.opentelemetry.io/otel/trace"
 
 	"github.com/keboola/keboola-as-code/internal/pkg/log"
+	"github.com/keboola/keboola-as-code/internal/pkg/service/appsproxy/config"
 	"github.com/keboola/keboola-as-code/internal/pkg/service/appsproxy/dependencies"
 	"github.com/keboola/keboola-as-code/internal/pkg/service/appsproxy/proxy/apphandler/authproxy/logging"
 	"github.com/keboola/keboola-as-code/internal/pkg/service/appsproxy/proxy/approuter"
@@ -21,6 +25,51 @@ const (
 	readHeaderTimeout       = 10 * time.Second
 	gracefulShutdownTimeout = 30 * time.Second
 )
+
+// tracerProviderWrapper wraps the TraceProvider to manipulate with all spans within tracing.
+type tracerProviderWrapper struct {
+	trace.TracerProvider
+}
+
+// tracerWrapper wraps the Tracer to manipulate with spans within tracing.
+type tracerWrapper struct {
+	trace.Tracer
+}
+
+// spanWrapper wraps the Span that is received through Tracer.
+type spanWrapper struct {
+	trace.Span
+	req *http.Request
+}
+
+func newTracerProviderWrapper(tp trace.TracerProvider) trace.TracerProvider {
+	return &tracerProviderWrapper{TracerProvider: tp}
+}
+
+func (tpw *tracerProviderWrapper) Tracer(name string, options ...trace.TracerOption) trace.Tracer {
+	return &tracerWrapper{Tracer: tpw.TracerProvider.Tracer(name, options...)}
+}
+
+func (t *tracerWrapper) Start(ctx context.Context, spanName string, opts ...trace.SpanStartOption) (context.Context, trace.Span) {
+	req, ok := middleware.RequestValue(ctx)
+	if !ok {
+		panic("context does not have http request set")
+	}
+
+	ctx, span := t.Tracer.Start(ctx, spanName, opts...)
+	span = &spanWrapper{Span: span, req: req}
+	ctx = trace.ContextWithSpan(ctx, span)
+	return ctx, span
+}
+
+func (w *spanWrapper) End(options ...trace.SpanEndOption) {
+	if !strings.HasPrefix(w.req.URL.Path, config.InternalPrefix) {
+		// Proxied requests of Data App are always OK, regardless of the status code
+		w.Span.SetStatus(codes.Ok, "proxied request")
+	}
+
+	w.Span.End(options...)
+}
 
 func StartServer(ctx context.Context, d dependencies.ServiceScope) error {
 	logger := d.Logger()
@@ -83,11 +132,12 @@ func NewHandler(d dependencies.ServiceScope) http.Handler {
 	return middleware.Wrap(
 		mux,
 		middleware.ContextTimout(requestTimeout),
+		// Mandatory middleware when used in combination with newTracerProviderWrapper
 		middleware.RequestInfo(),
 		middleware.Filter(middlewareCfg),
 		middleware.Logger(d.Logger()),
 		middleware.OpenTelemetry(
-			d.Telemetry().TracerProvider(),
+			newTracerProviderWrapper(d.Telemetry().TracerProvider()),
 			d.Telemetry().MeterProvider(),
 			middlewareCfg,
 		),

--- a/internal/pkg/service/common/httpserver/middleware/otel.go
+++ b/internal/pkg/service/common/httpserver/middleware/otel.go
@@ -39,6 +39,7 @@ func OpenTelemetry(tp trace.TracerProvider, mp metric.MeterProvider, cfg Config)
 
 			// Set additional request attributes
 			span.SetAttributes(spanRequestAttrs(&cfg, req)...)
+			ctx = context.WithValue(ctx, RequestCtxKey, req)
 			ctx = context.WithValue(ctx, RequestSpanCtxKey, span)
 
 			// Route and route params must be obtained by the OpenTelemetryRoute middleware registered to httptreemux.Muxer.

--- a/internal/pkg/service/common/httpserver/middleware/requestinfo.go
+++ b/internal/pkg/service/common/httpserver/middleware/requestinfo.go
@@ -13,6 +13,7 @@ import (
 
 const (
 	RequestIDHeader  = "X-Request-Id"
+	RequestCtxKey    = ctxKey("request")
 	RequestIDCtxKey  = ctxKey("request-id")
 	RequestURLCtxKey = ctxKey("request-url")
 )
@@ -26,6 +27,7 @@ func RequestInfo() Middleware {
 
 			// Update context
 			ctx := req.Context()
+			ctx = context.WithValue(ctx, RequestCtxKey, req)
 			ctx = context.WithValue(ctx, goaMiddleware.RequestIDKey, requestID) // nolint:staticcheck // intentionally used the ctx key from external package
 			ctx = context.WithValue(ctx, RequestIDCtxKey, requestID)
 			ctx = context.WithValue(ctx, RequestURLCtxKey, req.URL)
@@ -43,4 +45,9 @@ func RequestInfo() Middleware {
 
 func RequestIDFromContext(ctx context.Context) string {
 	return ctx.Value(RequestIDCtxKey).(string)
+}
+
+func RequestValue(ctx context.Context) (*http.Request, bool) {
+	v, ok := ctx.Value(RequestCtxKey).(*http.Request)
+	return v, ok
 }


### PR DESCRIPTION
Jira: [PSGO-637](https://keboola.atlassian.net/browse/PSGO-637)

**Changes:**
- Modify request info middleware to contain request. 
- Spans of proxied requests should be always set to Ok instead of error when app is broken (waked up).
- Create tests for checking the `Status` of Spans.

-----------


[PSGO-637]: https://keboola.atlassian.net/browse/PSGO-637?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ