### PR TITLE
fix: Two small fixes in background tasks

### DIFF
--- a/internal/pkg/service/common/task/cleanup.go
+++ b/internal/pkg/service/common/task/cleanup.go
@@ -24,8 +24,8 @@ const (
 )
 
 // Cleanup deletes old tasks to free space in etcd.
-func (n *Node) Cleanup() (err error) {
-	return n.RunTaskOrErr(Config{
+func (n *Node) Cleanup(ctx context.Context) (err error) {
+	return n.RunTaskOrErr(ctx, Config{
 		Type: cleanupTaskType,
 		Key:  Key{SystemTask: true, TaskID: cleanupTaskType},
 		Lock: cleanupTaskType,

--- a/internal/pkg/service/common/task/cleanup_test.go
+++ b/internal/pkg/service/common/task/cleanup_test.go
@@ -94,7 +94,7 @@ func TestCleanup(t *testing.T) {
 
 	// Run the cleanup
 	tel.Reset()
-	assert.NoError(t, node.Cleanup())
+	assert.NoError(t, node.Cleanup(ctx))
 
 	// Shutdown - wait for cleanup
 	d.Process().Shutdown(ctx, errors.New("bye bye"))

--- a/internal/pkg/service/templates/api/service/cleanup.go
+++ b/internal/pkg/service/templates/api/service/cleanup.go
@@ -26,7 +26,7 @@ func (s *service) cleanup(ctx context.Context, wg *sync.WaitGroup) <-chan error 
 			case <-ctx.Done():
 				return
 			case <-ticker.C:
-				if err := s.tasks.Cleanup(); err != nil && !errors.Is(err, context.Canceled) {
+				if err := s.tasks.Cleanup(ctx); err != nil && !errors.Is(err, context.Canceled) {
 					logger.Error(ctx, err.Error())
 				}
 			}


### PR DESCRIPTION
Jira: https://keboola.atlassian.net/browse/PSGO-596

All tests will pass in the final [PR](https://github.com/keboola/keboola-as-code/pull/1770).

[Large set of fixes and E2e tests](https://github.com/keboola/keboola-as-code/pull/1759) is divided into smaller PRs to do a review.

--------------

**Changes:**
- Task prepare phase is now connected to the caller context - fixed telemetry.
- The Stream API is using `StartTask`, instead of `RunTask`.
  - There was a bug, tasks were running in the foreground and were blocking the completion of the request.

-----------

Commend per commits. Please, explore [the final version](https://github.com/keboola/keboola-as-code/pull/1759) in the IDE.

-------------
