### PR TITLE
tests: Fix Stream API E2E tests, register an empty volume

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -35,6 +35,8 @@ build-stream-service:
 	CGO_ENABLED=0 go build -v -mod mod -ldflags "-s -w" -o "$(or $(BUILD_TARGET_PATH), ./target/stream/service)" ./cmd/stream
 
 run-stream-service:
+	rm -rf /tmp/stream-volumes && \
+    mkdir -p /tmp/stream-volumes/hdd/my-volume && \
 	air -c ./provisioning/stream/dev/.air.toml
 
 run-stream-service-once: build-stream-service

--- a/internal/pkg/service/stream/api/start.go
+++ b/internal/pkg/service/stream/api/start.go
@@ -9,7 +9,7 @@ import (
 	"github.com/keboola/keboola-as-code/internal/pkg/service/common/httpserver"
 	"github.com/keboola/keboola-as-code/internal/pkg/service/common/httpserver/middleware"
 	apiServer "github.com/keboola/keboola-as-code/internal/pkg/service/stream/api/gen/http/stream/server"
-	bufferGen "github.com/keboola/keboola-as-code/internal/pkg/service/stream/api/gen/stream"
+	streamGen "github.com/keboola/keboola-as-code/internal/pkg/service/stream/api/gen/stream"
 	"github.com/keboola/keboola-as-code/internal/pkg/service/stream/api/openapi"
 	"github.com/keboola/keboola-as-code/internal/pkg/service/stream/api/service"
 	"github.com/keboola/keboola-as-code/internal/pkg/service/stream/config"
@@ -60,7 +60,7 @@ func Start(ctx context.Context, d dependencies.ServiceScope, cfg config.Config) 
 			// Create server with endpoints
 			docsFs := http.FS(openapi.Fs)
 			swaggerFs := http.FS(swaggerui.SwaggerFS)
-			endpoints := bufferGen.NewEndpoints(svc)
+			endpoints := streamGen.NewEndpoints(svc)
 			endpoints.Use(middleware.OpenTelemetryExtractEndpoint())
 			server := apiServer.New(endpoints, c.Muxer, c.Decoder, c.Encoder, c.ErrorHandler, c.ErrorFormatter, docsFs, docsFs, docsFs, docsFs, swaggerFs)
 

--- a/internal/pkg/service/stream/config/config_test.go
+++ b/internal/pkg/service/stream/config/config_test.go
@@ -89,6 +89,8 @@ source:
         # Public URL of the HTTP source for link generation.
         publicUrl: null
 storage:
+    # Mounted volumes path, each volume is in "{type}/{label}" subdir. Validation rules: required
+    volumesPath: ""
     statistics:
         sync:
             # Statistics synchronization interval, from memory to the etcd. Validation rules: required,minDuration=100ms,maxDuration=5s
@@ -206,6 +208,7 @@ storage:
 	// Add missing values, and validate it
 	cfg.NodeID = "test-node"
 	cfg.StorageAPIHost = "connection.keboola.local"
+	cfg.Storage.VolumesPath = "/tmp/stream-volumes"
 	cfg.Source.HTTP.PublicURL, _ = url.Parse("https://stream-in.keboola.local")
 	cfg.Etcd.Endpoint = "test-etcd"
 	cfg.Etcd.Namespace = "test-namespace"

--- a/internal/pkg/service/stream/storage/config.go
+++ b/internal/pkg/service/stream/storage/config.go
@@ -8,9 +8,10 @@ import (
 
 // Config contains global configuration for the storage.
 type Config struct {
-	Statistics statistics.Config `configKey:"statistics"`
-	Cleanup    cleanup.Config    `configKey:"cleanup"`
-	Level      level.Config      `configKey:"level"`
+	VolumesPath string            `configKey:"volumesPath" configUsage:"Mounted volumes path, each volume is in \"{type}/{label}\" subdir." validate:"required"`
+	Statistics  statistics.Config `configKey:"statistics"`
+	Cleanup     cleanup.Config    `configKey:"cleanup"`
+	Level       level.Config      `configKey:"level"`
 }
 
 type ConfigPatch struct {

--- a/internal/pkg/service/stream/storage/node/writernode/writernode.go
+++ b/internal/pkg/service/stream/storage/node/writernode/writernode.go
@@ -1,0 +1,51 @@
+package writernode
+
+import (
+	"context"
+
+	"github.com/benbjohnson/clock"
+	etcd "go.etcd.io/etcd/client/v3"
+
+	"github.com/keboola/keboola-as-code/internal/pkg/log"
+	"github.com/keboola/keboola-as-code/internal/pkg/service/common/servicectx"
+	"github.com/keboola/keboola-as-code/internal/pkg/service/stream/config"
+	"github.com/keboola/keboola-as-code/internal/pkg/service/stream/storage/level/local/volume/registration"
+	"github.com/keboola/keboola-as-code/internal/pkg/service/stream/storage/level/local/writer/volume"
+	storageRepo "github.com/keboola/keboola-as-code/internal/pkg/service/stream/storage/repository"
+	"github.com/keboola/keboola-as-code/internal/pkg/service/stream/storage/statistics/collector"
+	statsRepo "github.com/keboola/keboola-as-code/internal/pkg/service/stream/storage/statistics/repository"
+)
+
+type dependencies interface {
+	Clock() clock.Clock
+	Logger() log.Logger
+	Process() *servicectx.Process
+	EtcdClient() *etcd.Client
+	StorageRepository() *storageRepo.Repository
+	StatisticsRepository() *statsRepo.Repository
+}
+
+func Start(ctx context.Context, d dependencies, cfg config.Config) error {
+	clk := d.Clock()
+	logger := d.Logger().WithComponent("storage.node.writer")
+	logger.Info(ctx, `starting storage writer node`)
+
+	// Open volumes
+	volumes, err := volume.OpenVolumes(ctx, logger, clk, cfg.NodeID, cfg.Storage.VolumesPath, cfg.Storage.Level.Local.Writer)
+	if err != nil {
+		return err
+	}
+
+	// Register volumes to database
+	regCfg := cfg.Storage.Level.Local.Volume.Registration
+	err = registration.RegisterVolumes(regCfg, d, volumes.Collection(), d.StorageRepository().Volume().RegisterWriterVolume)
+	if err != nil {
+		return err
+	}
+
+	// Setup statistics collector
+	syncCfg := cfg.Storage.Statistics.Collector
+	collector.New(logger, clk, d.StatisticsRepository(), volumes.Events(), syncCfg)
+
+	return nil
+}

--- a/provisioning/stream/dev/.air.toml
+++ b/provisioning/stream/dev/.air.toml
@@ -3,7 +3,7 @@ tmp_dir = "target/.watcher"
 
 [build]
   bin = "./target/stream/service"
-  args_bin = ["--node-id","my-node","--source-http-public-url","http://localhost:1234","--storage-volumes-path", "/tmp/stream-volumes", "api", "disk-writer"]
+  args_bin = ["--node-id", "my-node", "--source-http-public-url", "http://localhost:1234", "--storage-volumes-path", "/tmp/stream-volumes", "api", "disk-writer"]
   cmd = "make build-stream-service"
   delay = 2000
   exclude_dir = ["internal/pkg/service/stream/api/gen"]

--- a/provisioning/stream/dev/.air.toml
+++ b/provisioning/stream/dev/.air.toml
@@ -3,7 +3,7 @@ tmp_dir = "target/.watcher"
 
 [build]
   bin = "./target/stream/service"
-  args_bin = ["--node-id","my-node","--source-http-public-url","http://localhost:1234","api"]
+  args_bin = ["--node-id","my-node","--source-http-public-url","http://localhost:1234","--storage-volumes-path", "/tmp/stream-volumes", "api", "disk-writer"]
   cmd = "make build-stream-service"
   delay = 2000
   exclude_dir = ["internal/pkg/service/stream/api/gen"]

--- a/test/stream/api/api_test.go
+++ b/test/stream/api/api_test.go
@@ -3,6 +3,8 @@ package api
 
 import (
 	"context"
+	"os"
+	"path/filepath"
 	"runtime"
 	"testing"
 
@@ -11,6 +13,7 @@ import (
 
 	"github.com/keboola/keboola-as-code/internal/pkg/env"
 	"github.com/keboola/keboola-as-code/internal/pkg/filesystem"
+	volume "github.com/keboola/keboola-as-code/internal/pkg/service/stream/storage/level/local/volume/model"
 	"github.com/keboola/keboola-as-code/internal/pkg/utils/etcdhelper"
 	"github.com/keboola/keboola-as-code/internal/pkg/utils/testhelper"
 	"github.com/keboola/keboola-as-code/internal/pkg/utils/testhelper/runner"
@@ -47,10 +50,17 @@ func TestStreamApiE2E(t *testing.T) {
 				assert.NoError(test.T(), err)
 			}
 
+			// Simulate an empty volume with fixed volumeID
+			volumesPath := t.TempDir()
+			volumePath := filepath.Join(volumesPath, "hdd", "my-volume")
+			require.NoError(t, os.MkdirAll(volumePath, 0o700))
+			require.NoError(t, os.WriteFile(filepath.Join(volumePath, volume.IDFile), []byte("my-volume"), 0o600))
+
 			addEnvs := env.FromMap(map[string]string{
 				"STREAM_DATADOG_ENABLED":        "false",
 				"STREAM_NODE_ID":                "test-node",
 				"STREAM_STORAGE_API_HOST":       test.TestProject().StorageAPIHost(),
+				"STREAM_STORAGE_VOLUMES_PATH":   volumesPath,
 				"STREAM_API_PUBLIC_URL":         "https://stream.keboola.local",
 				"STREAM_SOURCE_HTTP_PUBLIC_URL": "https://stream-in.keboola.local",
 				"STREAM_ETCD_NAMESPACE":         etcdCfg.Namespace,
@@ -64,7 +74,7 @@ func TestStreamApiE2E(t *testing.T) {
 				runner.WithInitProjectState(),
 				runner.WithRunAPIServerAndRequests(
 					binaryPath,
-					[]string{"api"}, // start only the API component
+					[]string{"api", "disk-writer"}, // start api component and disk-writer to detect the volume
 					addEnvs,
 					nil,
 				),


### PR DESCRIPTION
Jira: https://keboola.atlassian.net/browse/PSGO-596

All tests will pass in the final [PR](https://github.com/keboola/keboola-as-code/pull/1770).

[Large set of fixes and E2e tests](https://github.com/keboola/keboola-as-code/pull/1759) is divided into smaller PRs to do a review.

--------------

**Changes:**
- An dummy disk writer component is started in API E2E test, so an empty volume is registered, and sink create/update API calls work.

-----------

Commend per commits. Please, explore [the final version](https://github.com/keboola/keboola-as-code/pull/1759) in the IDE.

-------------
