### PR TITLE
fix: Data apps timeouts

### DIFF
--- a/internal/pkg/service/appsproxy/config/config.go
+++ b/internal/pkg/service/appsproxy/config/config.go
@@ -2,6 +2,7 @@ package config
 
 import (
 	"net/url"
+	"time"
 
 	"github.com/keboola/keboola-as-code/internal/pkg/telemetry/datadog"
 	"github.com/keboola/keboola-as-code/internal/pkg/telemetry/metric/prometheus"
@@ -20,6 +21,7 @@ type Config struct {
 	DNSServer        string            `configKey:"dnsServer" configUsage:"DNS server for proxy. If empty, the /etc/resolv.conf is used."`
 	API              API               `configKey:"api"`
 	CookieSecretSalt string            `configKey:"cookieSecretSalt" configUsage:"Cookie secret needed by OAuth 2 Proxy." validate:"required" sensitive:"true"`
+	AppTimeouts      Timeouts          `configKey:"appTimeouts" configUsage:"Timeouts set for application interactions"`
 	SandboxesAPI     SandboxesAPI      `configKey:"sandboxesAPI"`
 }
 
@@ -33,6 +35,11 @@ type SandboxesAPI struct {
 	Token string `configKey:"token" configUsage:"Sandboxes API token." validate:"required" sensitive:"true"`
 }
 
+type Timeouts struct {
+	HttpUpstreamTimeout      time.Duration `configKey:"httpUpstreamTimeout" configUsage:"Timeout for HTTP request on upstream"`
+	WebsocketUpstreamTimeout time.Duration `configKey:"wessocketUpstreamTimeout" configUsage:"Timeout for websocket request on upstream"`
+}
+
 func New() Config {
 	return Config{
 		DebugLog:        false,
@@ -40,6 +47,10 @@ func New() Config {
 		CPUProfFilePath: "",
 		Datadog:         datadog.NewConfig(),
 		Metrics:         prometheus.NewConfig(),
+		AppTimeouts: Timeouts{
+			HttpUpstreamTimeout:      30 * time.Second,
+			WebsocketUpstreamTimeout: 6 * time.Hour,
+		},
 		API: API{
 			Listen: "0.0.0.0:8000",
 			PublicURL: &url.URL{

--- a/internal/pkg/service/appsproxy/config/config.go
+++ b/internal/pkg/service/appsproxy/config/config.go
@@ -36,7 +36,7 @@ type SandboxesAPI struct {
 }
 
 type Timeouts struct {
-	HttpUpstreamTimeout      time.Duration `configKey:"httpUpstreamTimeout" configUsage:"Timeout for HTTP request on upstream"`
+	HTTPUpstreamTimeout      time.Duration `configKey:"httpUpstreamTimeout" configUsage:"Timeout for HTTP request on upstream"`
 	WebsocketUpstreamTimeout time.Duration `configKey:"wessocketUpstreamTimeout" configUsage:"Timeout for websocket request on upstream"`
 }
 
@@ -48,7 +48,7 @@ func New() Config {
 		Datadog:         datadog.NewConfig(),
 		Metrics:         prometheus.NewConfig(),
 		AppTimeouts: Timeouts{
-			HttpUpstreamTimeout:      30 * time.Second,
+			HTTPUpstreamTimeout:      30 * time.Second,
 			WebsocketUpstreamTimeout: 6 * time.Hour,
 		},
 		API: API{

--- a/internal/pkg/service/appsproxy/config/config.go
+++ b/internal/pkg/service/appsproxy/config/config.go
@@ -21,7 +21,7 @@ type Config struct {
 	DNSServer        string            `configKey:"dnsServer" configUsage:"DNS server for proxy. If empty, the /etc/resolv.conf is used."`
 	API              API               `configKey:"api"`
 	CookieSecretSalt string            `configKey:"cookieSecretSalt" configUsage:"Cookie secret needed by OAuth 2 Proxy." validate:"required" sensitive:"true"`
-	AppTimeouts      Timeouts          `configKey:"appTimeouts" configUsage:"Timeouts set for application interactions"`
+	Upstream         Upstream          `configKey:"-" configUsage:"Configuration options for upstream"`
 	SandboxesAPI     SandboxesAPI      `configKey:"sandboxesAPI"`
 }
 
@@ -35,9 +35,9 @@ type SandboxesAPI struct {
 	Token string `configKey:"token" configUsage:"Sandboxes API token." validate:"required" sensitive:"true"`
 }
 
-type Timeouts struct {
-	HTTPUpstreamTimeout      time.Duration `configKey:"httpUpstreamTimeout" configUsage:"Timeout for HTTP request on upstream"`
-	WebsocketUpstreamTimeout time.Duration `configKey:"wessocketUpstreamTimeout" configUsage:"Timeout for websocket request on upstream"`
+type Upstream struct {
+	HTTPTimeout time.Duration `configKey:"httpTimeout" configUsage:"Timeout for HTTP request on upstream"`
+	WsTimeout   time.Duration `configKey:"wsTimeout" configUsage:"Timeout for websocket request on upstream"`
 }
 
 func New() Config {
@@ -47,9 +47,9 @@ func New() Config {
 		CPUProfFilePath: "",
 		Datadog:         datadog.NewConfig(),
 		Metrics:         prometheus.NewConfig(),
-		AppTimeouts: Timeouts{
-			HTTPUpstreamTimeout:      30 * time.Second,
-			WebsocketUpstreamTimeout: 6 * time.Hour,
+		Upstream: Upstream{
+			HTTPTimeout: 30 * time.Second,
+			WsTimeout:   6 * time.Hour,
 		},
 		API: API{
 			Listen: "0.0.0.0:8000",

--- a/internal/pkg/service/appsproxy/proxy/apphandler/apphandler.go
+++ b/internal/pkg/service/appsproxy/proxy/apphandler/apphandler.go
@@ -108,6 +108,12 @@ func (h *appHandler) ServeHTTP(w http.ResponseWriter, req *http.Request) {
 func (h *appHandler) serveHTTPOrError(w http.ResponseWriter, req *http.Request) (err error) {
 	ctx := req.Context()
 
+	// Enrich root span with attributes
+	reqSpan, ok := middleware.RequestSpan(ctx)
+	if ok {
+		reqSpan.SetAttributes(h.attrs...)
+	}
+
 	// Enrich context with attributes
 	ctx = ctxattr.ContextWith(ctx, h.attrs...)
 

--- a/internal/pkg/service/appsproxy/proxy/apphandler/upstream/upstream.go
+++ b/internal/pkg/service/appsproxy/proxy/apphandler/upstream/upstream.go
@@ -106,8 +106,8 @@ func (m *Manager) NewUpstream(ctx context.Context, app api.AppConfig) (upstream 
 
 	// Create reverse proxy
 	upstream = &AppUpstream{manager: m, app: app, target: target}
-	upstream.handler = upstream.newProxy(m.config.AppTimeouts.HTTPUpstreamTimeout)
-	upstream.wsHandler = upstream.newWebsocketProxy(m.config.AppTimeouts.WebsocketUpstreamTimeout)
+	upstream.handler = upstream.newProxy(m.config.Upstream.HTTPTimeout)
+	upstream.wsHandler = upstream.newWebsocketProxy(m.config.Upstream.WsTimeout)
 	return upstream, nil
 }
 

--- a/internal/pkg/service/appsproxy/proxy/apphandler/upstream/upstream.go
+++ b/internal/pkg/service/appsproxy/proxy/apphandler/upstream/upstream.go
@@ -14,6 +14,7 @@ import (
 	"go.opentelemetry.io/otel/attribute"
 
 	"github.com/keboola/keboola-as-code/internal/pkg/log"
+	"github.com/keboola/keboola-as-code/internal/pkg/service/appsproxy/config"
 	"github.com/keboola/keboola-as-code/internal/pkg/service/appsproxy/dataapps/api"
 	"github.com/keboola/keboola-as-code/internal/pkg/service/appsproxy/dataapps/appconfig"
 	"github.com/keboola/keboola-as-code/internal/pkg/service/appsproxy/dataapps/notify"
@@ -43,6 +44,7 @@ type Manager struct {
 	configLoader *appconfig.Loader
 	notify       *notify.Manager
 	wakeup       *wakeup.Manager
+	config       config.Config
 }
 
 type AppUpstream struct {
@@ -62,6 +64,7 @@ type dependencies interface {
 	AppConfigLoader() *appconfig.Loader
 	NotifyManager() *notify.Manager
 	WakeupManager() *wakeup.Manager
+	Config() config.Config
 }
 
 func NewManager(d dependencies) *Manager {
@@ -74,6 +77,7 @@ func NewManager(d dependencies) *Manager {
 		configLoader: d.AppConfigLoader(),
 		notify:       d.NotifyManager(),
 		wakeup:       d.WakeupManager(),
+		config:       d.Config(),
 	}
 
 	d.Process().OnShutdown(func(ctx context.Context) {
@@ -102,8 +106,8 @@ func (m *Manager) NewUpstream(ctx context.Context, app api.AppConfig) (upstream 
 
 	// Create reverse proxy
 	upstream = &AppUpstream{manager: m, app: app, target: target}
-	upstream.handler = upstream.newProxy()
-	upstream.wsHandler = upstream.newWebsocketProxy()
+	upstream.handler = upstream.newProxy(m.config.AppTimeouts.HTTPUpstreamTimeout)
+	upstream.wsHandler = upstream.newWebsocketProxy(m.config.AppTimeouts.WebsocketUpstreamTimeout)
 	return upstream, nil
 }
 
@@ -115,7 +119,7 @@ func (u *AppUpstream) ServeHTTPOrError(rw http.ResponseWriter, req *http.Request
 	return u.handler.ServeHTTPOrError(rw, req)
 }
 
-func (u *AppUpstream) newProxy() *chain.Chain {
+func (u *AppUpstream) newProxy(timeout time.Duration) *chain.Chain {
 	proxy := httputil.NewSingleHostReverseProxy(u.target)
 	proxy.Transport = u.manager.transport
 	proxy.ErrorHandler = u.manager.pageWriter.ProxyErrorHandlerFor(u.app)
@@ -123,6 +127,8 @@ func (u *AppUpstream) newProxy() *chain.Chain {
 	return chain.
 		New(chain.HandlerFunc(func(w http.ResponseWriter, req *http.Request) error {
 			ctx := ctxattr.ContextWith(req.Context(), attribute.Bool(attrWebsocket, false))
+			ctx, cancel := context.WithTimeout(ctx, timeout)
+			defer cancel()
 			proxy.ServeHTTP(w, req.WithContext(ctx))
 			return nil
 		})).
@@ -132,7 +138,7 @@ func (u *AppUpstream) newProxy() *chain.Chain {
 		)
 }
 
-func (u *AppUpstream) newWebsocketProxy() *chain.Chain {
+func (u *AppUpstream) newWebsocketProxy(timeout time.Duration) *chain.Chain {
 	proxy := httputil.NewSingleHostReverseProxy(u.target)
 	proxy.Transport = u.manager.transport
 	proxy.ErrorHandler = u.manager.pageWriter.ProxyErrorHandlerFor(u.app)
@@ -140,6 +146,8 @@ func (u *AppUpstream) newWebsocketProxy() *chain.Chain {
 	return chain.
 		New(chain.HandlerFunc(func(w http.ResponseWriter, req *http.Request) error {
 			ctx := ctxattr.ContextWith(req.Context(), attribute.Bool(attrWebsocket, true))
+			ctx, cancel := context.WithTimeout(ctx, timeout)
+			defer cancel()
 			proxy.ServeHTTP(w, req.WithContext(ctx))
 			return nil
 		})).

--- a/internal/pkg/service/appsproxy/proxy/server.go
+++ b/internal/pkg/service/appsproxy/proxy/server.go
@@ -21,7 +21,6 @@ import (
 )
 
 const (
-	requestTimeout          = 30 * time.Second
 	readHeaderTimeout       = 10 * time.Second
 	gracefulShutdownTimeout = 30 * time.Second
 )
@@ -131,7 +130,6 @@ func NewHandler(d dependencies.ServiceScope) http.Handler {
 	)
 	return middleware.Wrap(
 		mux,
-		middleware.ContextTimout(requestTimeout),
 		// Mandatory middleware when used in combination with newTracerProviderWrapper
 		middleware.RequestInfo(),
 		middleware.Filter(middlewareCfg),

--- a/internal/pkg/service/appsproxy/proxy/testutil/app.go
+++ b/internal/pkg/service/appsproxy/proxy/testutil/app.go
@@ -39,6 +39,7 @@ func StartAppServer(t *testing.T) *AppServer {
 
 		assert.NoError(t, c.Close(websocket.StatusNormalClosure, ""))
 	})
+
 	mux.HandleFunc("/", func(w http.ResponseWriter, r *http.Request) {
 		lock.Lock()
 		defer lock.Unlock()


### PR DESCRIPTION
Jira: [PSGO-686](https://keboola.atlassian.net/browse/PSGO-686)

**Changes:**
- Set data apps timeout for websocket differently than for HTTP upstream handler.
- HTTP root span contains attributes.

-----------


[PSGO-686]: https://keboola.atlassian.net/browse/PSGO-686?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ