### PR TITLE
fix: Improve etcd logging

### DIFF
--- a/internal/pkg/log/log.go
+++ b/internal/pkg/log/log.go
@@ -22,9 +22,9 @@ type Logger interface {
 	withAttributes
 }
 
-type loggerWithZapCore interface {
+type LoggerWithZapCore interface {
 	Logger
-	zapCore() zapcore.Core
+	ZapCore() zapcore.Core
 }
 
 // DebugLogger returns logs as string in tests.

--- a/internal/pkg/log/logger.go
+++ b/internal/pkg/log/logger.go
@@ -118,7 +118,7 @@ func (l *zapLogger) Sync() error {
 	return l.logger.Sync()
 }
 
-func (l *zapLogger) zapCore() zapcore.Core {
+func (l *zapLogger) ZapCore() zapcore.Core {
 	return l.core
 }
 

--- a/internal/pkg/log/memory.go
+++ b/internal/pkg/log/memory.go
@@ -23,8 +23,8 @@ type MemoryLogger struct {
 }
 
 func (l *MemoryLogger) CopyLogsTo(target Logger) {
-	if zap, ok := target.(loggerWithZapCore); ok {
-		targetCore := zap.zapCore()
+	if zap, ok := target.(LoggerWithZapCore); ok {
+		targetCore := zap.ZapCore()
 		for _, entry := range *l.core.entries {
 			if ce := targetCore.Check(entry.entry, nil); ce != nil {
 				ce.Write(entry.fields...)


### PR DESCRIPTION
With the old implementation our logger gets the entire json as message:

```json
{
  "level":"warn",
  "time":"2024-06-20T10:09:28.823Z",
  "message":"{\"level\":\"warn\",\"ts\":1718878168.8237646,\"msg\":\"retrying of unary invoker failed\",\"target\":\"etcd-endpoints://0xc00065e780/etcd:2379\",\"attempt\":0,\"error\":\"rpc error: code = Canceled desc = grpc: the client connection is closing\",\"component\":\"etcd.client\"}",
  "component":"etcd.client"
}
```

The new implementation solves it better:

```json
{
  "level":"warn",
  "time":"2024-06-20T12:36:14.912Z",
  "message":"retrying of unary invoker failed",
  "target":"etcd-endpoints://0xc0016fcb40/etcd:2379",
  "attempt":0,
  "error":"rpc error: code = Canceled desc = grpc: the client connection is closing",
  "component":"etcd.client"
}
```