### PR TITLE
feat: Move graceful shutdown code to pkgs, where it is missing

### DIFF
--- a/internal/pkg/service/stream/source/httpsource/httpsource_test.go
+++ b/internal/pkg/service/stream/source/httpsource/httpsource_test.go
@@ -58,7 +58,7 @@ func TestStart(t *testing.T) {
 	require.NoError(t, stream.StartComponents(ctx, d, mock.TestConfig(), stream.ComponentHTTPSource))
 
 	// Wait for the HTTP server
-	require.NoError(t, netutils.WaitForTCP(listenAddr, time.Second))
+	require.NoError(t, netutils.WaitForHTTP(url, 10*time.Second))
 	logger.AssertJSONMessages(t, `
 {"level":"info","message":"starting HTTP source node","component":"http-source"}
 {"level":"info","message":"started HTTP source on \"0.0.0.0:%d\"","component":"http-source"}

--- a/internal/pkg/service/stream/storage/level/local/reader/volume/volumes.go
+++ b/internal/pkg/service/stream/storage/level/local/reader/volume/volumes.go
@@ -6,19 +6,19 @@ import (
 	"github.com/benbjohnson/clock"
 
 	"github.com/keboola/keboola-as-code/internal/pkg/log"
+	"github.com/keboola/keboola-as-code/internal/pkg/service/common/servicectx"
 	volume "github.com/keboola/keboola-as-code/internal/pkg/service/stream/storage/level/local/volume/model"
 	"github.com/keboola/keboola-as-code/internal/pkg/service/stream/storage/level/local/volume/opener"
+	"github.com/keboola/keboola-as-code/internal/pkg/utils/errors"
 )
 
-type collection = volume.Collection[*Volume]
-
 type Volumes struct {
-	*collection
-	logger log.Logger
+	logger     log.Logger
+	collection *volume.Collection[*Volume]
 }
 
 // OpenVolumes function detects and opens all volumes in the path.
-func OpenVolumes(ctx context.Context, logger log.Logger, clock clock.Clock, nodeID, volumesPath string, opts ...Option) (out *Volumes, err error) {
+func OpenVolumes(ctx context.Context, logger log.Logger, clock clock.Clock, process *servicectx.Process, nodeID, volumesPath string, opts ...Option) (out *Volumes, err error) {
 	out = &Volumes{logger: logger}
 	out.collection, err = opener.OpenVolumes(ctx, logger, nodeID, volumesPath, func(spec volume.Spec) (*Volume, error) {
 		return Open(ctx, logger, clock, spec, opts...)
@@ -27,10 +27,19 @@ func OpenVolumes(ctx context.Context, logger log.Logger, clock clock.Clock, node
 		return nil, err
 	}
 
+	// Graceful shutdown
+	process.OnShutdown(func(ctx context.Context) {
+		logger.Info(ctx, "closing volumes")
+		if err := out.collection.Close(ctx); err != nil {
+			err := errors.PrefixError(err, "cannot close volumes")
+			logger.Error(ctx, err.Error())
+		}
+		logger.Info(ctx, "closed volumes")
+	})
+
 	return out, nil
 }
 
-func (v *Volumes) Close(ctx context.Context) error {
-	v.logger.Info(ctx, "closing volumes")
-	return v.collection.Close(ctx)
+func (v *Volumes) Collection() *volume.Collection[*Volume] {
+	return v.collection
 }

--- a/internal/pkg/service/stream/storage/level/local/volume/registration/registration.go
+++ b/internal/pkg/service/stream/storage/level/local/volume/registration/registration.go
@@ -33,10 +33,10 @@ func RegisterVolumes[V volume.Volume](cfg Config, d dependencies, volumes *volum
 	ctx, cancel := context.WithCancel(context.Background())
 	wg := &sync.WaitGroup{}
 	d.Process().OnShutdown(func(ctx context.Context) {
-		logger.Info(ctx, "received shutdown request")
+		logger.Info(ctx, "stopping volumes registration")
 		cancel()
 		wg.Wait()
-		logger.Info(ctx, "shutdown done")
+		logger.Info(ctx, "stopped volumes registration")
 	})
 
 	// Register volumes

--- a/internal/pkg/service/stream/storage/node/readernode/readernode.go
+++ b/internal/pkg/service/stream/storage/node/readernode/readernode.go
@@ -12,7 +12,6 @@ import (
 	"github.com/keboola/keboola-as-code/internal/pkg/service/common/servicectx"
 	"github.com/keboola/keboola-as-code/internal/pkg/service/stream/config"
 	"github.com/keboola/keboola-as-code/internal/pkg/service/stream/storage/level/local/reader/volume"
-	"github.com/keboola/keboola-as-code/internal/pkg/utils/errors"
 )
 
 type dependencies interface {
@@ -27,18 +26,10 @@ func Start(ctx context.Context, d dependencies, cfg config.Config) error {
 	logger.Info(ctx, `starting storage reader node`)
 
 	// Open volumes
-	volumes, err := volume.OpenVolumes(ctx, logger, d.Clock(), cfg.NodeID, cfg.Storage.VolumesPath)
+	_, err := volume.OpenVolumes(ctx, logger, d.Clock(), d.Process(), cfg.NodeID, cfg.Storage.VolumesPath)
 	if err != nil {
 		return err
 	}
-
-	// Graceful shutdown
-	d.Process().OnShutdown(func(ctx context.Context) {
-		if err := volumes.Close(ctx); err != nil {
-			err := errors.PrefixError(err, "`cannot close reader volumes")
-			logger.Error(ctx, err.Error())
-		}
-	})
 
 	return nil
 }

--- a/internal/pkg/service/stream/storage/node/writernode/writernode.go
+++ b/internal/pkg/service/stream/storage/node/writernode/writernode.go
@@ -48,7 +48,7 @@ func Start(ctx context.Context, d dependencies, cfg config.Config) error {
 
 	// Setup statistics collector
 	syncCfg := cfg.Storage.Statistics.Collector
-	collector.New(logger, clk, d.StatisticsRepository(), volumes.Events(), syncCfg)
+	collector.Start(d, volumes.Events(), syncCfg)
 
 	// Graceful shutdown
 	d.Process().OnShutdown(func(ctx context.Context) {

--- a/internal/pkg/service/stream/storage/node/writernode/writernode.go
+++ b/internal/pkg/service/stream/storage/node/writernode/writernode.go
@@ -16,7 +16,6 @@ import (
 	storageRepo "github.com/keboola/keboola-as-code/internal/pkg/service/stream/storage/repository"
 	"github.com/keboola/keboola-as-code/internal/pkg/service/stream/storage/statistics/collector"
 	statsRepo "github.com/keboola/keboola-as-code/internal/pkg/service/stream/storage/statistics/repository"
-	"github.com/keboola/keboola-as-code/internal/pkg/utils/errors"
 )
 
 type dependencies interface {
@@ -29,12 +28,11 @@ type dependencies interface {
 }
 
 func Start(ctx context.Context, d dependencies, cfg config.Config) error {
-	clk := d.Clock()
 	logger := d.Logger().WithComponent("storage.node.writer")
 	logger.Info(ctx, `starting storage writer node`)
 
 	// Open volumes
-	volumes, err := volume.OpenVolumes(ctx, logger, clk, cfg.NodeID, cfg.Storage.VolumesPath, cfg.Storage.Level.Local.Writer)
+	volumes, err := volume.OpenVolumes(ctx, logger, d.Clock(), d.Process(), cfg.NodeID, cfg.Storage.VolumesPath, cfg.Storage.Level.Local.Writer)
 	if err != nil {
 		return err
 	}
@@ -49,14 +47,6 @@ func Start(ctx context.Context, d dependencies, cfg config.Config) error {
 	// Setup statistics collector
 	syncCfg := cfg.Storage.Statistics.Collector
 	collector.Start(d, volumes.Events(), syncCfg)
-
-	// Graceful shutdown
-	d.Process().OnShutdown(func(ctx context.Context) {
-		if err := volumes.Close(ctx); err != nil {
-			err := errors.PrefixError(err, "`cannot close writer volumes")
-			logger.Error(ctx, err.Error())
-		}
-	})
 
 	return nil
 }

--- a/internal/pkg/service/stream/storage/node/writernode/writernode_test.go
+++ b/internal/pkg/service/stream/storage/node/writernode/writernode_test.go
@@ -70,17 +70,22 @@ func TestStart_Ok(t *testing.T) {
 	// Logs
 	mock.DebugLogger().AssertJSONMessages(t, `
 {"level":"info","message":"starting storage writer node","component":"storage.node.writer"}
-{"level":"info","message":"searching for volumes in volumes path","volumes.path":"%s","component":"storage.node.writer"}
+{"level":"info","message":"searching for volumes in volumes path","component":"storage.node.writer"}
 {"level":"info","message":"found \"2\" volumes","component":"storage.node.writer"}
 {"level":"info","message":"creating etcd session","component":"volumes.registry.etcd.session"}
 {"level":"info","message":"created etcd session","component":"volumes.registry.etcd.session"}
 {"level":"info","message":"exiting (bye bye)"}
-{"level":"info","message":"closing volumes","component":"storage.node.writer"}
-{"level":"info","message":"received shutdown request","component":"volumes.registry"}
+{"level":"info","message":"stopping storage statistics collector","component":"statistics.collector"}
+{"level":"debug","message":"sync done","component":"statistics.collector"}
+{"level":"info","message":"storage statistics stopped","component":"statistics.collector"}
+{"level":"info","message":"stopping volumes registration","component":"volumes.registry"}
 {"level":"info","message":"closing etcd session: context canceled","component":"volumes.registry.etcd.session"}
 {"level":"info","message":"closed etcd session","component":"volumes.registry.etcd.session"}
-{"level":"info","message":"shutdown done","component":"volumes.registry"}
+{"level":"info","message":"stopped volumes registration","component":"volumes.registry"}
+{"level":"info","message":"closing volumes","component":"storage.node.writer"}
+{"level":"info","message":"closed volumes","component":"storage.node.writer"}
 {"level":"info","message":"closing volumes stream","component":"volume.repository"}
+{"level":"info","message":"consumer closed: context canceled","component":"volume.repository"}
 {"level":"info","message":"closed volumes stream","component":"volume.repository"}
 {"level":"info","message":"received shutdown request","component":"distribution.mutex.provider"}
 {"level":"info","message":"closing etcd session: context canceled","component":"distribution.mutex.provider.etcd.session"}

--- a/test/stream/api/base/api-startup/expected-server-stdout
+++ b/test/stream/api/base/api-startup/expected-server-stdout
@@ -23,13 +23,13 @@
 {"level":"info","message":"exiting (terminated)"}
 {"level":"info","message":"shutting down HTTP server at \"%s\"","component":"api"}
 {"level":"info","message":"HTTP server shutdown finished","component":"api"}
+{"level":"info","message":"stopping volumes registration","component":"volumes.registry"}
+{"level":"info","message":"closing etcd session: context canceled","component":"volumes.registry.etcd.session"}
+{"level":"info","message":"closed etcd session","component":"volumes.registry.etcd.session"}
+{"level":"info","message":"stopped volumes registration","component":"volumes.registry"}
 {"level":"info","message":"closing volumes","component":"storage.node.writer"}
 {"level":"info","message":"closing volume","volume.path":"%s/hdd/my-volume","volume.id":"my-volume","component":"storage.node.writer.volume"}
 {"level":"info","message":"closed volume","volume.path":"%s/hdd/my-volume","volume.id":"my-volume","component":"storage.node.writer.volume"}
-{"level":"info","message":"received shutdown request","component":"volumes.registry"}
-{"level":"info","message":"closing etcd session: context canceled","component":"volumes.registry.etcd.session"}
-{"level":"info","message":"closed etcd session","component":"volumes.registry.etcd.session"}
-{"level":"info","message":"shutdown done","component":"volumes.registry"}
 {"level":"info","message":"closing volumes stream","component":"volume.repository"}
 {"level":"info","message":"closed volumes stream","component":"volume.repository"}
 {"level":"info","message":"received shutdown request","node":"test-node","component":"task"}


### PR DESCRIPTION
Jira: https://keboola.atlassian.net/browse/PSGO-597

**Changes:**
- Some componets had graceful shutdown solved externally (eg. `Stop` method).
- It's easier to test it, but it's easy to forget to call the method, that's why I moved graceful shutdown directly to components.

-----------
