### PR TITLE
feat: Difference slice statistics by the source node ID

### DIFF
--- a/internal/pkg/service/common/utctime/utctime.go
+++ b/internal/pkg/service/common/utctime/utctime.go
@@ -40,6 +40,9 @@ func (v UTCTime) After(target UTCTime) bool {
 }
 
 func (v UTCTime) MarshalJSON() ([]byte, error) {
+	if v.IsZero() {
+		return jsonLib.Marshal("")
+	}
 	return jsonLib.Marshal(v.String())
 }
 
@@ -47,6 +50,10 @@ func (v *UTCTime) UnmarshalJSON(b []byte) error {
 	var str string
 	if err := jsonLib.Unmarshal(b, &str); err != nil {
 		return err
+	}
+	if str == "" {
+		*v = UTCTime{}
+		return nil
 	}
 	out, err := time.Parse(TimeFormat, str)
 	if err != nil {

--- a/internal/pkg/service/stream/keboolasink/bridge/fixtures/enable_sink_ops.txt
+++ b/internal/pkg/service/stream/keboolasink/bridge/fixtures/enable_sink_ops.txt
@@ -14,11 +14,11 @@
 ➡️  GET "storage/keboola/secret/token/123/456/my-source/my-sink"
 ✔️  GET "storage/keboola/secret/token/123/456/my-source/my-sink" | count: 0
 
-// READ: statistics to calculate pre-allocated space for new slices
+// READ: sink slices and their statistics to calculate pre-allocated disk space - there is no previous slice
 ➡️  TXN
   ➡️  THEN:
-  001 ➡️  GET ["storage/stats/staging/123/456/my-source/my-sink/", "storage/stats/staging/123/456/my-source/my-sink0")
-  002 ➡️  GET ["storage/stats/target/123/456/my-source/my-sink/", "storage/stats/target/123/456/my-source/my-sink0")
+  001 ➡️  GET ["storage/slice/level/staging/123/456/my-source/my-sink/", "storage/slice/level/staging/123/456/my-source/my-sink0")
+  002 ➡️  GET ["storage/slice/level/target/123/456/my-source/my-sink/", "storage/slice/level/target/123/456/my-source/my-sink0")
 ✔️  TXN | succeeded: true
 
 // WRITE:

--- a/internal/pkg/service/stream/storage/node/writernode/writernode.go
+++ b/internal/pkg/service/stream/storage/node/writernode/writernode.go
@@ -46,7 +46,7 @@ func Start(ctx context.Context, d dependencies, cfg config.Config) error {
 
 	// Setup statistics collector
 	syncCfg := cfg.Storage.Statistics.Collector
-	collector.Start(d, volumes.Events(), syncCfg)
+	collector.Start(d, volumes.Events(), syncCfg, cfg.NodeID)
 
 	return nil
 }

--- a/internal/pkg/service/stream/storage/quota/quota_test.go
+++ b/internal/pkg/service/stream/storage/quota/quota_test.go
@@ -48,14 +48,11 @@ func TestQuota_Check(t *testing.T) {
 	quoteChecker := quota.New(d)
 	updateStats := func(sliceKey model.SliceKey, size datasize.ByteSize) {
 		header := etcdhelper.ExpectModificationInPrefix(t, client, "storage/stats/", func() {
-			require.NoError(t, repo.Put(ctx, []statistics.PerSlice{
+			require.NoError(t, repo.Put(ctx, "test-node", []statistics.PerSlice{
 				{
-					SliceKey: sliceKey,
-					Value: statistics.Value{
-						SlicesCount:    1,
-						RecordsCount:   123,
-						CompressedSize: size,
-					},
+					SliceKey:       sliceKey,
+					RecordsCount:   123,
+					CompressedSize: size,
 				},
 			}))
 		})

--- a/internal/pkg/service/stream/storage/repository/file/fixtures/file_open_ops_001.txt
+++ b/internal/pkg/service/stream/storage/repository/file/fixtures/file_open_ops_001.txt
@@ -10,18 +10,18 @@
   001 ➡️  GET ["definition/sink/active/123/456/my-source/", "definition/sink/active/123/456/my-source0")
 ✔️  TXN | succeeded: true
 
-// READ - get statistics of the sink1 - to calculate pre-allocated disk space
+// READ - get previous slices from the sink 1 and their statistics to calculate pre-allocated disk space - there is no slice
 ➡️  TXN
   ➡️  THEN:
-  001 ➡️  GET ["storage/stats/staging/123/456/my-source/my-sink-1/", "storage/stats/staging/123/456/my-source/my-sink-10")
-  002 ➡️  GET ["storage/stats/target/123/456/my-source/my-sink-1/", "storage/stats/target/123/456/my-source/my-sink-10")
+  001 ➡️  GET ["storage/slice/level/staging/123/456/my-source/my-sink-1/", "storage/slice/level/staging/123/456/my-source/my-sink-10")
+  002 ➡️  GET ["storage/slice/level/target/123/456/my-source/my-sink-1/", "storage/slice/level/target/123/456/my-source/my-sink-10")
 ✔️  TXN | succeeded: true
 
-// READ - get statistics of the sink2 - to calculate pre-allocated disk space
+// READ - get previous slices from the sink 2 and their statistics to calculate pre-allocated disk space - there is no slice
 ➡️  TXN
   ➡️  THEN:
-  001 ➡️  GET ["storage/stats/staging/123/456/my-source/my-sink-2/", "storage/stats/staging/123/456/my-source/my-sink-20")
-  002 ➡️  GET ["storage/stats/target/123/456/my-source/my-sink-2/", "storage/stats/target/123/456/my-source/my-sink-20")
+  001 ➡️  GET ["storage/slice/level/staging/123/456/my-source/my-sink-2/", "storage/slice/level/staging/123/456/my-source/my-sink-20")
+  002 ➡️  GET ["storage/slice/level/target/123/456/my-source/my-sink-2/", "storage/slice/level/target/123/456/my-source/my-sink-20")
 ✔️  TXN | succeeded: true
 
 // WRITE

--- a/internal/pkg/service/stream/storage/repository/file/fixtures/file_rotate_ops_001.txt
+++ b/internal/pkg/service/stream/storage/repository/file/fixtures/file_rotate_ops_001.txt
@@ -12,11 +12,11 @@
   001 ➡️  GET ["storage/slice/level/local/123/456/my-source/my-sink/2000-01-01T01:00:00.000Z/", "storage/slice/level/local/123/456/my-source/my-sink/2000-01-01T01:00:00.000Z0")
 ✔️  TXN | succeeded: true
 
-// READ - statistics for aggregation
+// READ - previous slices for statistics for aggregation - there is no previous slice in the sink
 ➡️  TXN
   ➡️  THEN:
-  001 ➡️  GET ["storage/stats/staging/123/456/my-source/my-sink/", "storage/stats/staging/123/456/my-source/my-sink0")
-  002 ➡️  GET ["storage/stats/target/123/456/my-source/my-sink/", "storage/stats/target/123/456/my-source/my-sink0")
+  001 ➡️  GET ["storage/slice/level/staging/123/456/my-source/my-sink/", "storage/slice/level/staging/123/456/my-source/my-sink0")
+  002 ➡️  GET ["storage/slice/level/target/123/456/my-source/my-sink/", "storage/slice/level/target/123/456/my-source/my-sink0")
 ✔️  TXN | succeeded: true
 
 // WRITE

--- a/internal/pkg/service/stream/storage/repository/file/fixtures/file_state_ops_001.txt
+++ b/internal/pkg/service/stream/storage/repository/file/fixtures/file_state_ops_001.txt
@@ -15,7 +15,7 @@
 // READ - get statistics to be moved
 ➡️  TXN
   ➡️  THEN:
-  001 ➡️  GET "storage/stats/staging/123/456/my-source/my-sink/2000-01-01T01:00:00.000Z/my-volume-1/2000-01-01T01:00:00.000Z/value"
+  001 ➡️  GET ["storage/stats/staging/123/456/my-source/my-sink/2000-01-01T01:00:00.000Z/my-volume-1/2000-01-01T01:00:00.000Z/", "storage/stats/staging/123/456/my-source/my-sink/2000-01-01T01:00:00.000Z/my-volume-1/2000-01-01T01:00:00.000Z0")
 
 ✔️  TXN | succeeded: true
 
@@ -29,7 +29,7 @@
   005 ["storage/slice/all/123/456/my-source/my-sink/2000-01-01T01:00:00.000Z/", "storage/slice/all/123/456/my-source/my-sink/2000-01-01T01:00:00.000Z0") MOD GREATER 0
   006 ["storage/slice/all/123/456/my-source/my-sink/2000-01-01T01:00:00.000Z/", "storage/slice/all/123/456/my-source/my-sink/2000-01-01T01:00:00.000Z0") MOD LESS %d
   007 "storage/slice/all/123/456/my-source/my-sink/2000-01-01T01:00:00.000Z/my-volume-1/2000-01-01T01:00:00.000Z" MOD GREATER 0
-  008 "storage/stats/staging/123/456/my-source/my-sink/2000-01-01T01:00:00.000Z/my-volume-1/2000-01-01T01:00:00.000Z/value" MOD EQUAL 0
+  008 ["storage/stats/staging/123/456/my-source/my-sink/2000-01-01T01:00:00.000Z/my-volume-1/2000-01-01T01:00:00.000Z/", "storage/stats/staging/123/456/my-source/my-sink/2000-01-01T01:00:00.000Z/my-volume-1/2000-01-01T01:00:00.000Z0") MOD EQUAL 0
   ➡️  THEN:
   // Mark file and slice as imported, move stats
   001 ➡️  PUT "storage/file/all/123/456/my-source/my-sink/2000-01-01T01:00:00.000Z"

--- a/internal/pkg/service/stream/storage/repository/slice/fixtures/slice_open_ops_001.txt
+++ b/internal/pkg/service/stream/storage/repository/slice/fixtures/slice_open_ops_001.txt
@@ -10,18 +10,16 @@
   001 ➡️  GET ["definition/sink/active/123/456/my-source/", "definition/sink/active/123/456/my-source0")
 ✔️  TXN | succeeded: true
 
-// READ - sinks from the source
+// READ - get previous slices in the sink and their statistics to calculate pre-allocated disk space
 ➡️  TXN
   ➡️  THEN:
-  001 ➡️  GET ["storage/stats/staging/123/456/my-source/my-sink/", "storage/stats/staging/123/456/my-source/my-sink0")
-  002 ➡️  GET ["storage/stats/target/123/456/my-source/my-sink/", "storage/stats/target/123/456/my-source/my-sink0")
+  001 ➡️  GET ["storage/slice/level/staging/123/456/my-source/my-sink/", "storage/slice/level/staging/123/456/my-source/my-sink0")
+  002 ➡️  GET ["storage/slice/level/target/123/456/my-source/my-sink/", "storage/slice/level/target/123/456/my-source/my-sink0")
 ✔️  TXN | succeeded: true
-
-// READ - get statistics of the sink - to calculate pre-allocated disk space
 ➡️  TXN
   ➡️  THEN:
-  001 ➡️  GET ["storage/stats/staging/123/456/my-source/my-sink/", "storage/stats/staging/123/456/my-source/my-sink0")
-  002 ➡️  GET ["storage/stats/target/123/456/my-source/my-sink/", "storage/stats/target/123/456/my-source/my-sink0")
+  001 ➡️  GET ["storage/slice/level/staging/123/456/my-source/my-sink/", "storage/slice/level/staging/123/456/my-source/my-sink0")
+  002 ➡️  GET ["storage/slice/level/target/123/456/my-source/my-sink/", "storage/slice/level/target/123/456/my-source/my-sink0")
 ✔️  TXN | succeeded: true
 
 // WRITE

--- a/internal/pkg/service/stream/storage/repository/slice/fixtures/slice_rotate_ops_001.txt
+++ b/internal/pkg/service/stream/storage/repository/slice/fixtures/slice_rotate_ops_001.txt
@@ -5,11 +5,11 @@
   002 ➡️  GET ["storage/slice/level/local/123/456/my-source/my-sink-1/2000-01-01T01:00:00.000Z/my-volume-1/", "storage/slice/level/local/123/456/my-source/my-sink-1/2000-01-01T01:00:00.000Z/my-volume-10")
 ✔️  TXN | succeeded: true
 
-// READ - statistics to be moved
+// READ - get previous slice and their statistics to calculate size of the new slice - there are no previous slices
 ➡️  TXN
   ➡️  THEN:
-  001 ➡️  GET ["storage/stats/staging/123/456/my-source/my-sink-1/", "storage/stats/staging/123/456/my-source/my-sink-10")
-  002 ➡️  GET ["storage/stats/target/123/456/my-source/my-sink-1/", "storage/stats/target/123/456/my-source/my-sink-10")
+  001 ➡️  GET ["storage/slice/level/staging/123/456/my-source/my-sink-1/", "storage/slice/level/staging/123/456/my-source/my-sink-10")
+  002 ➡️  GET ["storage/slice/level/target/123/456/my-source/my-sink-1/", "storage/slice/level/target/123/456/my-source/my-sink-10")
 ✔️  TXN | succeeded: true
 
 // WRITE

--- a/internal/pkg/service/stream/storage/repository/slice/fixtures/slice_state_ops_001.txt
+++ b/internal/pkg/service/stream/storage/repository/slice/fixtures/slice_state_ops_001.txt
@@ -8,7 +8,7 @@
 // READ - statistics - to be moved
 ➡️  TXN
   ➡️  THEN:
-  001 ➡️  GET "storage/stats/local/123/456/my-source/my-sink-1/2000-01-01T01:00:00.000Z/my-volume-1/2000-01-01T01:00:00.000Z/value"
+  001 ➡️  GET ["storage/stats/local/123/456/my-source/my-sink-1/2000-01-01T01:00:00.000Z/my-volume-1/2000-01-01T01:00:00.000Z/", "storage/stats/local/123/456/my-source/my-sink-1/2000-01-01T01:00:00.000Z/my-volume-1/2000-01-01T01:00:00.000Z0")
 ✔️  TXN | succeeded: true
 
 // WRITE
@@ -20,7 +20,7 @@
   003 "storage/file/all/123/456/my-source/my-sink-1/2000-01-01T01:00:00.000Z" MOD LESS %d
   004 "storage/slice/all/123/456/my-source/my-sink-1/2000-01-01T01:00:00.000Z/my-volume-1/2000-01-01T01:00:00.000Z" MOD GREATER 0
   005 "storage/slice/all/123/456/my-source/my-sink-1/2000-01-01T01:00:00.000Z/my-volume-1/2000-01-01T01:00:00.000Z" MOD LESS %d
-  006 "storage/stats/local/123/456/my-source/my-sink-1/2000-01-01T01:00:00.000Z/my-volume-1/2000-01-01T01:00:00.000Z/value" MOD EQUAL 0
+  006 ["storage/stats/local/123/456/my-source/my-sink-1/2000-01-01T01:00:00.000Z/my-volume-1/2000-01-01T01:00:00.000Z/", "storage/stats/local/123/456/my-source/my-sink-1/2000-01-01T01:00:00.000Z/my-volume-1/2000-01-01T01:00:00.000Z0") MOD EQUAL 0
   ➡️  THEN:
   // Mark the slices as uploaded, move it to the staging level
   001 ➡️  PUT "storage/slice/all/123/456/my-source/my-sink-1/2000-01-01T01:00:00.000Z/my-volume-1/2000-01-01T01:00:00.000Z"

--- a/internal/pkg/service/stream/storage/repository/slice/slice_list.go
+++ b/internal/pkg/service/stream/storage/repository/slice/slice_list.go
@@ -8,13 +8,13 @@ import (
 )
 
 // ListIn lists slices in the parent, in all storage levels.
-func (r *Repository) ListIn(parentKey fmt.Stringer) iterator.DefinitionT[model.Slice] {
-	return r.schema.AllLevels().InObject(parentKey).GetAll(r.client)
+func (r *Repository) ListIn(parentKey fmt.Stringer, opts ...iterator.Option) iterator.DefinitionT[model.Slice] {
+	return r.schema.AllLevels().InObject(parentKey).GetAll(r.client, opts...)
 }
 
 // ListInLevel lists slices in the specified storage level.
-func (r *Repository) ListInLevel(parentKey fmt.Stringer, level model.Level) iterator.DefinitionT[model.Slice] {
-	return r.schema.InLevel(level).InObject(parentKey).GetAll(r.client)
+func (r *Repository) ListInLevel(parentKey fmt.Stringer, level model.Level, opts ...iterator.Option) iterator.DefinitionT[model.Slice] {
+	return r.schema.InLevel(level).InObject(parentKey).GetAll(r.client, opts...)
 }
 
 // ListInState lists slices in the specified state.

--- a/internal/pkg/service/stream/storage/statistics/collector/collector.go
+++ b/internal/pkg/service/stream/storage/statistics/collector/collector.go
@@ -39,8 +39,10 @@ type WriterEvents interface {
 // writerSnapshot contains collected statistics from a writer.Writer.
 // It is used to determine whether the statistics have changed and should be saved to the database or not.
 type writerSnapshot struct {
-	stats  statistics.PerSlice
-	writer writer.Writer
+	writer       writer.Writer
+	sliceKey     model.SliceKey
+	initialValue statistics.Value
+	value        statistics.Value
 }
 
 type dependencies interface {
@@ -76,13 +78,17 @@ func Start(d dependencies, events WriterEvents, config statistics.SyncConfig, no
 		// Register the writer for the periodical sync, see bellow
 		k := w.SliceKey()
 
+		initialValue, err := c.repository.OpenSlice(k, c.nodeID).Do(ctx).ResultOrErr()
+		if err != nil {
+			return err
+		}
+
 		c.writersLock.Lock()
 		c.writers[k] = &writerSnapshot{
-			writer: w,
-			stats: statistics.PerSlice{
-				SliceKey: k,
-				Value:    statistics.Value{SlicesCount: 1},
-			},
+			writer:       w,
+			sliceKey:     k,
+			initialValue: initialValue,
+			value:        statistics.Value{},
 		}
 		c.writersLock.Unlock()
 
@@ -142,16 +148,30 @@ func (c *Collector) sync(filter *model.SliceKey) error {
 	if filter == nil {
 		// Collect all writers
 		for _, s := range c.writers {
-			if changed := c.collect(s.writer, &s.stats); changed {
-				forSync = append(forSync, s.stats)
+			if changed := c.collect(s.writer, &s.value); changed {
+				value := s.initialValue.Add(s.value)
+				forSync = append(forSync, statistics.PerSlice{
+					SliceKey:         s.sliceKey,
+					FirstRecordAt:    value.FirstRecordAt,
+					LastRecordAt:     value.LastRecordAt,
+					RecordsCount:     value.RecordsCount,
+					UncompressedSize: value.UncompressedSize,
+					CompressedSize:   value.CompressedSize,
+				})
 			}
 		}
-	} else {
+	} else if s, found := c.writers[*filter]; found {
 		// Collect one writer
-		if s, found := c.writers[*filter]; found {
-			if changed := c.collect(s.writer, &s.stats); changed {
-				forSync = append(forSync, s.stats)
-			}
+		if changed := c.collect(s.writer, &s.value); changed {
+			value := s.initialValue.Add(s.value)
+			forSync = append(forSync, statistics.PerSlice{
+				SliceKey:         s.sliceKey,
+				FirstRecordAt:    value.FirstRecordAt,
+				LastRecordAt:     value.LastRecordAt,
+				RecordsCount:     value.RecordsCount,
+				UncompressedSize: value.UncompressedSize,
+				CompressedSize:   value.CompressedSize,
+			})
 		}
 	}
 	c.writersLock.Unlock()
@@ -175,7 +195,7 @@ func (c *Collector) sync(filter *model.SliceKey) error {
 }
 
 // collect statistics from the writer to the PerSlice struct.
-func (c *Collector) collect(w writer.Writer, out *statistics.PerSlice) (changed bool) {
+func (c *Collector) collect(w writer.Writer, out *statistics.Value) (changed bool) {
 	// Get values
 	firstRowAt := w.FirstRecordAt()
 	lastRowAt := w.LastRecordAt()
@@ -184,18 +204,18 @@ func (c *Collector) collect(w writer.Writer, out *statistics.PerSlice) (changed 
 	uncompressedSize := w.UncompressedSize()
 
 	// Are statistics changed?
-	changed = out.Value.FirstRecordAt != firstRowAt ||
-		out.Value.LastRecordAt != lastRowAt ||
-		out.Value.RecordsCount != rowsCount ||
-		out.Value.CompressedSize != compressedSize ||
-		out.Value.UncompressedSize != uncompressedSize
+	changed = out.FirstRecordAt != firstRowAt ||
+		out.LastRecordAt != lastRowAt ||
+		out.RecordsCount != rowsCount ||
+		out.CompressedSize != compressedSize ||
+		out.UncompressedSize != uncompressedSize
 
 	// Update values
-	out.Value.FirstRecordAt = firstRowAt
-	out.Value.LastRecordAt = lastRowAt
-	out.Value.RecordsCount = rowsCount
-	out.Value.CompressedSize = compressedSize
-	out.Value.UncompressedSize = uncompressedSize
+	out.FirstRecordAt = firstRowAt
+	out.LastRecordAt = lastRowAt
+	out.RecordsCount = rowsCount
+	out.CompressedSize = compressedSize
+	out.UncompressedSize = uncompressedSize
 
 	return changed
 }

--- a/internal/pkg/service/stream/storage/statistics/collector/fixtures/stats_collector_snapshot_001.txt
+++ b/internal/pkg/service/stream/storage/statistics/collector/fixtures/stats_collector_snapshot_001.txt
@@ -1,0 +1,19 @@
+<<<<<
+storage/stats/local/123/456/my-source/my-sink/2000-01-01T19:00:00.000Z/my-volume/2000-01-01T01:00:00.000Z/_open
+-----
+{
+  "slicesCount": 1,
+  "firstRecordAt": "",
+  "lastRecordAt": ""
+}
+>>>>>
+
+<<<<<
+storage/stats/local/123/456/my-source/my-sink/2000-01-01T19:00:00.000Z/my-volume/2000-01-01T02:00:00.000Z/_open
+-----
+{
+  "slicesCount": 1,
+  "firstRecordAt": "",
+  "lastRecordAt": ""
+}
+>>>>>

--- a/internal/pkg/service/stream/storage/statistics/collector/fixtures/stats_collector_snapshot_002.txt
+++ b/internal/pkg/service/stream/storage/statistics/collector/fixtures/stats_collector_snapshot_002.txt
@@ -1,0 +1,31 @@
+<<<<<
+storage/stats/local/123/456/my-source/my-sink/2000-01-01T19:00:00.000Z/my-volume/2000-01-01T01:00:00.000Z/_open
+-----
+{
+  "slicesCount": 1,
+  "firstRecordAt": "",
+  "lastRecordAt": ""
+}
+>>>>>
+
+<<<<<
+storage/stats/local/123/456/my-source/my-sink/2000-01-01T19:00:00.000Z/my-volume/2000-01-01T02:00:00.000Z/_open
+-----
+{
+  "slicesCount": 1,
+  "firstRecordAt": "",
+  "lastRecordAt": ""
+}
+>>>>>
+
+<<<<<
+storage/stats/local/123/456/my-source/my-sink/2000-01-01T19:00:00.000Z/my-volume/2000-01-01T01:00:00.000Z/test-node
+-----
+{
+  "firstRecordAt": "2000-01-01T01:10:00.000Z",
+  "lastRecordAt": "2000-01-01T01:10:00.000Z",
+  "recordsCount": 1,
+  "uncompressedSize": "100B",
+  "compressedSize": "10B"
+}
+>>>>>

--- a/internal/pkg/service/stream/storage/statistics/collector/fixtures/stats_collector_snapshot_003.txt
+++ b/internal/pkg/service/stream/storage/statistics/collector/fixtures/stats_collector_snapshot_003.txt
@@ -1,0 +1,43 @@
+<<<<<
+storage/stats/local/123/456/my-source/my-sink/2000-01-01T19:00:00.000Z/my-volume/2000-01-01T01:00:00.000Z/_open
+-----
+{
+  "slicesCount": 1,
+  "firstRecordAt": "",
+  "lastRecordAt": ""
+}
+>>>>>
+
+<<<<<
+storage/stats/local/123/456/my-source/my-sink/2000-01-01T19:00:00.000Z/my-volume/2000-01-01T02:00:00.000Z/_open
+-----
+{
+  "slicesCount": 1,
+  "firstRecordAt": "",
+  "lastRecordAt": ""
+}
+>>>>>
+
+<<<<<
+storage/stats/local/123/456/my-source/my-sink/2000-01-01T19:00:00.000Z/my-volume/2000-01-01T01:00:00.000Z/test-node
+-----
+{
+  "firstRecordAt": "2000-01-01T01:10:00.000Z",
+  "lastRecordAt": "2000-01-01T01:30:00.000Z",
+  "recordsCount": 5,
+  "uncompressedSize": "500B",
+  "compressedSize": "50B"
+}
+>>>>>
+
+<<<<<
+storage/stats/local/123/456/my-source/my-sink/2000-01-01T19:00:00.000Z/my-volume/2000-01-01T02:00:00.000Z/test-node
+-----
+{
+  "firstRecordAt": "2000-01-01T01:25:00.000Z",
+  "lastRecordAt": "2000-01-01T01:25:00.000Z",
+  "recordsCount": 1,
+  "uncompressedSize": "100B",
+  "compressedSize": "10B"
+}
+>>>>>

--- a/internal/pkg/service/stream/storage/statistics/collector/fixtures/stats_collector_snapshot_004.txt
+++ b/internal/pkg/service/stream/storage/statistics/collector/fixtures/stats_collector_snapshot_004.txt
@@ -1,0 +1,44 @@
+<<<<<
+storage/stats/local/123/456/my-source/my-sink/2000-01-01T19:00:00.000Z/my-volume/2000-01-01T01:00:00.000Z/_open
+-----
+{
+  "slicesCount": 1,
+  "firstRecordAt": "",
+  "lastRecordAt": ""
+}
+>>>>>
+
+<<<<<
+storage/stats/local/123/456/my-source/my-sink/2000-01-01T19:00:00.000Z/my-volume/2000-01-01T02:00:00.000Z/_open
+-----
+{
+  "slicesCount": 1,
+  "firstRecordAt": "",
+  "lastRecordAt": ""
+}
+>>>>>
+
+
+<<<<<
+storage/stats/local/123/456/my-source/my-sink/2000-01-01T19:00:00.000Z/my-volume/2000-01-01T01:00:00.000Z/test-node
+-----
+{
+  "firstRecordAt": "2000-01-01T01:10:00.000Z",
+  "lastRecordAt": "2000-01-01T01:40:00.000Z",
+  "recordsCount": 6,
+  "uncompressedSize": "600B",
+  "compressedSize": "60B"
+}
+>>>>>
+
+<<<<<
+storage/stats/local/123/456/my-source/my-sink/2000-01-01T19:00:00.000Z/my-volume/2000-01-01T02:00:00.000Z/test-node
+-----
+{
+  "firstRecordAt": "2000-01-01T01:25:00.000Z",
+  "lastRecordAt": "2000-01-01T01:25:00.000Z",
+  "recordsCount": 1,
+  "uncompressedSize": "100B",
+  "compressedSize": "10B"
+}
+>>>>>

--- a/internal/pkg/service/stream/storage/statistics/collector/fixtures/stats_collector_snapshot_005.txt
+++ b/internal/pkg/service/stream/storage/statistics/collector/fixtures/stats_collector_snapshot_005.txt
@@ -1,0 +1,43 @@
+<<<<<
+storage/stats/local/123/456/my-source/my-sink/2000-01-01T19:00:00.000Z/my-volume/2000-01-01T01:00:00.000Z/_open
+-----
+{
+  "slicesCount": 1,
+  "firstRecordAt": "",
+  "lastRecordAt": ""
+}
+>>>>>
+
+<<<<<
+storage/stats/local/123/456/my-source/my-sink/2000-01-01T19:00:00.000Z/my-volume/2000-01-01T02:00:00.000Z/_open
+-----
+{
+  "slicesCount": 1,
+  "firstRecordAt": "",
+  "lastRecordAt": ""
+}
+>>>>>
+
+<<<<<
+storage/stats/local/123/456/my-source/my-sink/2000-01-01T19:00:00.000Z/my-volume/2000-01-01T01:00:00.000Z/test-node
+-----
+{
+  "firstRecordAt": "2000-01-01T01:10:00.000Z",
+  "lastRecordAt": "2000-01-01T01:40:00.000Z",
+  "recordsCount": 6,
+  "uncompressedSize": "600B",
+  "compressedSize": "60B"
+}
+>>>>>
+
+<<<<<
+storage/stats/local/123/456/my-source/my-sink/2000-01-01T19:00:00.000Z/my-volume/2000-01-01T02:00:00.000Z/test-node
+-----
+{
+  "firstRecordAt": "2000-01-01T01:25:00.000Z",
+  "lastRecordAt": "2000-01-01T01:35:00.000Z",
+  "recordsCount": 3,
+  "uncompressedSize": "300B",
+  "compressedSize": "30B"
+}
+>>>>>

--- a/internal/pkg/service/stream/storage/statistics/provider_test.go
+++ b/internal/pkg/service/stream/storage/statistics/provider_test.go
@@ -102,6 +102,7 @@ func TestStatisticsProviders(t *testing.T) {
 	}
 
 	// Define test cases
+	nodeID := "test-node"
 	cases := []providerTestCase{
 		{
 			Description: "Empty",
@@ -112,19 +113,34 @@ func TestStatisticsProviders(t *testing.T) {
 			},
 		},
 		{
+			Description: "Open slice statistics (1)",
+			Prepare: func() {
+				require.NoError(t, statsRepo.OpenSlice(sliceKey1, nodeID).Do(ctx).Err())
+			},
+			Assert: func(provider repository.Provider) {
+				stats, err := provider.SinkStats(ctx, sinkKey)
+				require.NoError(t, err)
+				assert.Equal(t, statistics.Aggregated{
+					Local: statistics.Value{
+						SlicesCount: 1,
+					},
+					Total: statistics.Value{
+						SlicesCount: 1,
+					},
+				}, stats)
+			},
+		},
+		{
 			Description: "Add record (1)",
 			Prepare: func() {
-				require.NoError(t, statsRepo.Put(ctx, []statistics.PerSlice{
+				require.NoError(t, statsRepo.Put(ctx, nodeID, []statistics.PerSlice{
 					{
-						SliceKey: sliceKey1,
-						Value: statistics.Value{
-							SlicesCount:      1,
-							FirstRecordAt:    utctime.MustParse("2000-01-01T01:00:00.000Z"),
-							LastRecordAt:     utctime.MustParse("2000-01-01T02:00:00.000Z"),
-							RecordsCount:     1,
-							UncompressedSize: 1,
-							CompressedSize:   1,
-						},
+						SliceKey:         sliceKey1,
+						FirstRecordAt:    utctime.MustParse("2000-01-01T01:00:00.000Z"),
+						LastRecordAt:     utctime.MustParse("2000-01-01T02:00:00.000Z"),
+						RecordsCount:     1,
+						UncompressedSize: 1,
+						CompressedSize:   1,
 					},
 				}))
 			},
@@ -152,19 +168,44 @@ func TestStatisticsProviders(t *testing.T) {
 			},
 		},
 		{
+			Description: "Open slice statistics (2)",
+			Prepare: func() {
+				require.NoError(t, statsRepo.OpenSlice(sliceKey2, nodeID).Do(ctx).Err())
+			},
+			Assert: func(provider repository.Provider) {
+				stats, err := provider.SinkStats(ctx, sinkKey)
+				require.NoError(t, err)
+				assert.Equal(t, statistics.Aggregated{
+					Local: statistics.Value{
+						SlicesCount:      2,
+						FirstRecordAt:    utctime.MustParse("2000-01-01T01:00:00.000Z"),
+						LastRecordAt:     utctime.MustParse("2000-01-01T02:00:00.000Z"),
+						RecordsCount:     1,
+						UncompressedSize: 1,
+						CompressedSize:   1,
+					},
+					Total: statistics.Value{
+						SlicesCount:      2,
+						FirstRecordAt:    utctime.MustParse("2000-01-01T01:00:00.000Z"),
+						LastRecordAt:     utctime.MustParse("2000-01-01T02:00:00.000Z"),
+						RecordsCount:     1,
+						UncompressedSize: 1,
+						CompressedSize:   1,
+					},
+				}, stats)
+			},
+		},
+		{
 			Description: "Add record (2)",
 			Prepare: func() {
-				require.NoError(t, statsRepo.Put(ctx, []statistics.PerSlice{
+				require.NoError(t, statsRepo.Put(ctx, nodeID, []statistics.PerSlice{
 					{
-						SliceKey: sliceKey2,
-						Value: statistics.Value{
-							SlicesCount:      1,
-							FirstRecordAt:    utctime.MustParse("2000-01-01T02:00:00.000Z"),
-							LastRecordAt:     utctime.MustParse("2000-01-01T03:00:00.000Z"),
-							RecordsCount:     10,
-							UncompressedSize: 10,
-							CompressedSize:   10,
-						},
+						SliceKey:         sliceKey2,
+						FirstRecordAt:    utctime.MustParse("2000-01-01T02:00:00.000Z"),
+						LastRecordAt:     utctime.MustParse("2000-01-01T03:00:00.000Z"),
+						RecordsCount:     10,
+						UncompressedSize: 10,
+						CompressedSize:   10,
 					},
 				}))
 			},
@@ -233,19 +274,54 @@ func TestStatisticsProviders(t *testing.T) {
 			},
 		},
 		{
+			Description: "Open slice statistics (3)",
+			Prepare: func() {
+				require.NoError(t, statsRepo.OpenSlice(sliceKey3, nodeID).Do(ctx).Err())
+			},
+			Assert: func(provider repository.Provider) {
+				stats, err := provider.SinkStats(ctx, sinkKey)
+				require.NoError(t, err)
+				assert.Equal(t, statistics.Aggregated{
+					Local: statistics.Value{
+						SlicesCount:      2,
+						FirstRecordAt:    utctime.MustParse("2000-01-01T01:00:00.000Z"),
+						LastRecordAt:     utctime.MustParse("2000-01-01T02:00:00.000Z"),
+						RecordsCount:     1,
+						UncompressedSize: 1,
+						CompressedSize:   1,
+					},
+					Staging: statistics.Value{
+						SlicesCount:      1,
+						FirstRecordAt:    utctime.MustParse("2000-01-01T02:00:00.000Z"),
+						LastRecordAt:     utctime.MustParse("2000-01-01T03:00:00.000Z"),
+						RecordsCount:     10,
+						UncompressedSize: 10,
+						CompressedSize:   10,
+						StagingSize:      10,
+					},
+					Total: statistics.Value{
+						SlicesCount:      3,
+						FirstRecordAt:    utctime.MustParse("2000-01-01T01:00:00.000Z"),
+						LastRecordAt:     utctime.MustParse("2000-01-01T03:00:00.000Z"),
+						RecordsCount:     11,
+						UncompressedSize: 11,
+						CompressedSize:   11,
+						StagingSize:      10,
+					},
+				}, stats)
+			},
+		},
+		{
 			Description: "Add record (3)",
 			Prepare: func() {
-				require.NoError(t, statsRepo.Put(ctx, []statistics.PerSlice{
+				require.NoError(t, statsRepo.Put(ctx, nodeID, []statistics.PerSlice{
 					{
-						SliceKey: sliceKey3,
-						Value: statistics.Value{
-							SlicesCount:      1,
-							FirstRecordAt:    utctime.MustParse("2000-01-01T03:00:00.000Z"),
-							LastRecordAt:     utctime.MustParse("2000-01-01T04:00:00.000Z"),
-							RecordsCount:     100,
-							UncompressedSize: 100,
-							CompressedSize:   100,
-						},
+						SliceKey:         sliceKey3,
+						FirstRecordAt:    utctime.MustParse("2000-01-01T03:00:00.000Z"),
+						LastRecordAt:     utctime.MustParse("2000-01-01T04:00:00.000Z"),
+						RecordsCount:     100,
+						UncompressedSize: 100,
+						CompressedSize:   100,
 					},
 				}))
 			},

--- a/internal/pkg/service/stream/storage/statistics/repository/fixtures/stats_alloc_on_rotate_ops.txt
+++ b/internal/pkg/service/stream/storage/statistics/repository/fixtures/stats_alloc_on_rotate_ops.txt
@@ -12,11 +12,16 @@
   001 ➡️  GET ["storage/slice/level/local/123/456/my-source/my-sink/2000-01-01T03:00:00.000Z/", "storage/slice/level/local/123/456/my-source/my-sink/2000-01-01T03:00:00.000Z0")
 ✔️  TXN | succeeded: true
 
-// READ: to calculate pre-allocated space for new slices, statistics of previous slices are loaded.
+// READ: to calculate pre-allocated space for new slices, previous slices and their statistics are loaded.
 ➡️  TXN
   ➡️  THEN:
-  001 ➡️  GET ["storage/stats/staging/123/456/my-source/my-sink/", "storage/stats/staging/123/456/my-source/my-sink0")
-  002 ➡️  GET ["storage/stats/target/123/456/my-source/my-sink/", "storage/stats/target/123/456/my-source/my-sink0")
+  001 ➡️  GET ["storage/slice/level/staging/123/456/my-source/my-sink/", "storage/slice/level/staging/123/456/my-source/my-sink0")
+  002 ➡️  GET ["storage/slice/level/target/123/456/my-source/my-sink/", "storage/slice/level/target/123/456/my-source/my-sink0")
+✔️  TXN | succeeded: true
+➡️  TXN
+  ➡️  THEN:
+  001 ➡️  GET ["storage/stats/staging/123/456/my-source/my-sink/2000-01-01T01:00:00.000Z/my-volume-1/2000-01-01T01:00:00.000Z/", "storage/stats/staging/123/456/my-source/my-sink/2000-01-01T01:00:00.000Z/my-volume-1/2000-01-01T01:00:00.000Z0")
+  002 ➡️  GET ["storage/stats/target/123/456/my-source/my-sink/2000-01-01T02:00:00.000Z/my-volume-1/2000-01-01T02:00:00.000Z/", "storage/stats/target/123/456/my-source/my-sink/2000-01-01T02:00:00.000Z/my-volume-1/2000-01-01T02:00:00.000Z0")
 ✔️  TXN | succeeded: true
 
 ➡️  TXN

--- a/internal/pkg/service/stream/storage/statistics/repository/fixtures/stats_delete_snapshot_001.txt
+++ b/internal/pkg/service/stream/storage/statistics/repository/fixtures/stats_delete_snapshot_001.txt
@@ -1,40 +1,67 @@
 <<<<<
-storage/stats/staging/123/456/my-source/my-sink/2000-01-01T01:00:00.000Z/my-volume-1/2000-01-01T01:00:00.000Z/value
+storage/stats/local/123/456/my-source/my-sink/2000-01-01T03:00:00.000Z/my-volume-1/2000-01-01T03:00:00.000Z/_open
 -----
 {
   "slicesCount": 1,
-  "firstRecordAt": "2000-01-01T01:00:00.000Z",
-  "lastRecordAt": "2000-01-01T02:00:00.000Z",
-  "recordsCount": 1,
-  "uncompressedSize": "1B",
-  "compressedSize": "1B",
-  "stagingSize": "1B"
+  "firstRecordAt": "",
+  "lastRecordAt": ""
 }
 >>>>>
 
 <<<<<
-storage/stats/staging/123/456/my-source/my-sink/2000-01-01T02:00:00.000Z/my-volume-1/2000-01-01T02:00:00.000Z/value
+storage/stats/local/123/456/my-source/my-sink/2000-01-01T03:00:00.000Z/my-volume-1/2000-01-01T03:00:00.000Z/test-node
 -----
 {
-  "slicesCount": 1,
-  "firstRecordAt": "2000-01-01T01:00:00.000Z",
-  "lastRecordAt": "2000-01-01T02:00:00.000Z",
-  "recordsCount": 1,
-  "uncompressedSize": "1B",
-  "compressedSize": "1B",
-  "stagingSize": "1B"
-}
->>>>>
-
-<<<<<
-storage/stats/local/123/456/my-source/my-sink/2000-01-01T03:00:00.000Z/my-volume-1/2000-01-01T03:00:00.000Z/value
------
-{
-  "slicesCount": 1,
   "firstRecordAt": "2000-01-01T01:00:00.000Z",
   "lastRecordAt": "2000-01-01T02:00:00.000Z",
   "recordsCount": 1,
   "uncompressedSize": "1B",
   "compressedSize": "1B"
+}
+>>>>>
+
+<<<<<
+storage/stats/staging/123/456/my-source/my-sink/2000-01-01T01:00:00.000Z/my-volume-1/2000-01-01T01:00:00.000Z/_open
+-----
+{
+  "slicesCount": 1,
+  "firstRecordAt": "",
+  "lastRecordAt": ""
+}
+>>>>>
+
+<<<<<
+storage/stats/staging/123/456/my-source/my-sink/2000-01-01T01:00:00.000Z/my-volume-1/2000-01-01T01:00:00.000Z/test-node
+-----
+{
+  "firstRecordAt": "2000-01-01T01:00:00.000Z",
+  "lastRecordAt": "2000-01-01T02:00:00.000Z",
+  "recordsCount": 1,
+  "uncompressedSize": "1B",
+  "compressedSize": "1B",
+  "stagingSize": "1B"
+}
+>>>>>
+
+<<<<<
+storage/stats/staging/123/456/my-source/my-sink/2000-01-01T02:00:00.000Z/my-volume-1/2000-01-01T02:00:00.000Z/_open
+-----
+{
+  "slicesCount": 1,
+  "firstRecordAt": "",
+  "lastRecordAt": ""
+}
+>>>>>
+
+<<<<<
+storage/stats/staging/123/456/my-source/my-sink/2000-01-01T02:00:00.000Z/my-volume-1/2000-01-01T02:00:00.000Z/test-node
+-----
+{
+  "firstRecordAt": "2000-01-01T01:00:00.000Z",
+  "lastRecordAt": "2000-01-01T02:00:00.000Z",
+  "recordsCount": 1,
+  "uncompressedSize": "1B",
+  "compressedSize": "1B",
+  "stagingSize": "1B"
 }
 >>>>>

--- a/internal/pkg/service/stream/storage/statistics/repository/fixtures/stats_delete_snapshot_002.txt
+++ b/internal/pkg/service/stream/storage/statistics/repository/fixtures/stats_delete_snapshot_002.txt
@@ -1,8 +1,17 @@
 <<<<<
-storage/stats/target/123/456/my-source/my-sink/2000-01-01T01:00:00.000Z/my-volume-1/2000-01-01T01:00:00.000Z/value
+storage/stats/target/123/456/my-source/my-sink/2000-01-01T01:00:00.000Z/my-volume-1/2000-01-01T01:00:00.000Z/_open
 -----
 {
   "slicesCount": 1,
+  "firstRecordAt": "",
+  "lastRecordAt": ""
+}
+>>>>>
+
+<<<<<
+storage/stats/target/123/456/my-source/my-sink/2000-01-01T01:00:00.000Z/my-volume-1/2000-01-01T01:00:00.000Z/test-node
+-----
+{
   "firstRecordAt": "2000-01-01T01:00:00.000Z",
   "lastRecordAt": "2000-01-01T02:00:00.000Z",
   "recordsCount": 1,
@@ -13,10 +22,19 @@ storage/stats/target/123/456/my-source/my-sink/2000-01-01T01:00:00.000Z/my-volum
 >>>>>
 
 <<<<<
-storage/stats/target/123/456/my-source/my-sink/2000-01-01T02:00:00.000Z/my-volume-1/2000-01-01T02:00:00.000Z/value
+storage/stats/target/123/456/my-source/my-sink/2000-01-01T02:00:00.000Z/my-volume-1/2000-01-01T02:00:00.000Z/_open
 -----
 {
   "slicesCount": 1,
+  "firstRecordAt": "",
+  "lastRecordAt": ""
+}
+>>>>>
+
+<<<<<
+storage/stats/target/123/456/my-source/my-sink/2000-01-01T02:00:00.000Z/my-volume-1/2000-01-01T02:00:00.000Z/test-node
+-----
+{
   "firstRecordAt": "2000-01-01T02:00:00.000Z",
   "lastRecordAt": "2000-01-01T03:00:00.000Z",
   "recordsCount": 10,
@@ -27,10 +45,19 @@ storage/stats/target/123/456/my-source/my-sink/2000-01-01T02:00:00.000Z/my-volum
 >>>>>
 
 <<<<<
-storage/stats/target/123/456/my-source/my-sink/2000-01-01T03:00:00.000Z/my-volume-1/2000-01-01T03:00:00.000Z/value
+storage/stats/target/123/456/my-source/my-sink/2000-01-01T03:00:00.000Z/my-volume-1/2000-01-01T03:00:00.000Z/_open
 -----
 {
   "slicesCount": 1,
+  "firstRecordAt": "",
+  "lastRecordAt": ""
+}
+>>>>>
+
+<<<<<
+storage/stats/target/123/456/my-source/my-sink/2000-01-01T03:00:00.000Z/my-volume-1/2000-01-01T03:00:00.000Z/test-node
+-----
+{
   "firstRecordAt": "2000-01-01T03:00:00.000Z",
   "lastRecordAt": "2000-01-01T04:00:00.000Z",
   "recordsCount": 100,

--- a/internal/pkg/service/stream/storage/statistics/repository/fixtures/stats_move_snapshot_001.txt
+++ b/internal/pkg/service/stream/storage/statistics/repository/fixtures/stats_move_snapshot_001.txt
@@ -1,8 +1,17 @@
 <<<<<
-storage/stats/local/123/456/my-source/my-sink/2000-01-01T01:00:00.000Z/my-volume-1/2000-01-01T01:00:00.000Z/value
+storage/stats/local/123/456/my-source/my-sink/2000-01-01T01:00:00.000Z/my-volume-1/2000-01-01T01:00:00.000Z/_open
 -----
 {
   "slicesCount": 1,
+  "firstRecordAt": "",
+  "lastRecordAt": ""
+}
+>>>>>
+
+<<<<<
+storage/stats/local/123/456/my-source/my-sink/2000-01-01T01:00:00.000Z/my-volume-1/2000-01-01T01:00:00.000Z/test-node
+-----
+{
   "firstRecordAt": "2000-01-01T01:00:00.000Z",
   "lastRecordAt": "2000-01-01T02:00:00.000Z",
   "recordsCount": 1,
@@ -12,10 +21,19 @@ storage/stats/local/123/456/my-source/my-sink/2000-01-01T01:00:00.000Z/my-volume
 >>>>>
 
 <<<<<
-storage/stats/local/123/456/my-source/my-sink/2000-01-01T02:00:00.000Z/my-volume-1/2000-01-01T02:00:00.000Z/value
+storage/stats/local/123/456/my-source/my-sink/2000-01-01T02:00:00.000Z/my-volume-1/2000-01-01T02:00:00.000Z/_open
 -----
 {
   "slicesCount": 1,
+  "firstRecordAt": "",
+  "lastRecordAt": ""
+}
+>>>>>
+
+<<<<<
+storage/stats/local/123/456/my-source/my-sink/2000-01-01T02:00:00.000Z/my-volume-1/2000-01-01T02:00:00.000Z/test-node
+-----
+{
   "firstRecordAt": "2000-01-01T01:00:00.000Z",
   "lastRecordAt": "2000-01-01T02:00:00.000Z",
   "recordsCount": 1,
@@ -25,10 +43,19 @@ storage/stats/local/123/456/my-source/my-sink/2000-01-01T02:00:00.000Z/my-volume
 >>>>>
 
 <<<<<
-storage/stats/local/123/456/my-source/my-sink/2000-01-01T03:00:00.000Z/my-volume-1/2000-01-01T03:00:00.000Z/value
+storage/stats/local/123/456/my-source/my-sink/2000-01-01T03:00:00.000Z/my-volume-1/2000-01-01T03:00:00.000Z/_open
 -----
 {
   "slicesCount": 1,
+  "firstRecordAt": "",
+  "lastRecordAt": ""
+}
+>>>>>
+
+<<<<<
+storage/stats/local/123/456/my-source/my-sink/2000-01-01T03:00:00.000Z/my-volume-1/2000-01-01T03:00:00.000Z/test-node
+-----
+{
   "firstRecordAt": "2000-01-01T01:00:00.000Z",
   "lastRecordAt": "2000-01-01T02:00:00.000Z",
   "recordsCount": 1,

--- a/internal/pkg/service/stream/storage/statistics/repository/fixtures/stats_move_snapshot_002.txt
+++ b/internal/pkg/service/stream/storage/statistics/repository/fixtures/stats_move_snapshot_002.txt
@@ -1,8 +1,17 @@
 <<<<<
-storage/stats/local/123/456/my-source/my-sink/2000-01-01T01:00:00.000Z/my-volume-1/2000-01-01T01:00:00.000Z/value
+storage/stats/local/123/456/my-source/my-sink/2000-01-01T01:00:00.000Z/my-volume-1/2000-01-01T01:00:00.000Z/_open
 -----
 {
   "slicesCount": 1,
+  "firstRecordAt": "",
+  "lastRecordAt": ""
+}
+>>>>>
+
+<<<<<
+storage/stats/local/123/456/my-source/my-sink/2000-01-01T01:00:00.000Z/my-volume-1/2000-01-01T01:00:00.000Z/test-node
+-----
+{
   "firstRecordAt": "2000-01-01T01:00:00.000Z",
   "lastRecordAt": "2000-01-01T02:00:00.000Z",
   "recordsCount": 1,
@@ -12,10 +21,19 @@ storage/stats/local/123/456/my-source/my-sink/2000-01-01T01:00:00.000Z/my-volume
 >>>>>
 
 <<<<<
-storage/stats/staging/123/456/my-source/my-sink/2000-01-01T02:00:00.000Z/my-volume-1/2000-01-01T02:00:00.000Z/value
+storage/stats/staging/123/456/my-source/my-sink/2000-01-01T02:00:00.000Z/my-volume-1/2000-01-01T02:00:00.000Z/_open
 -----
 {
   "slicesCount": 1,
+  "firstRecordAt": "",
+  "lastRecordAt": ""
+}
+>>>>>
+
+<<<<<
+storage/stats/staging/123/456/my-source/my-sink/2000-01-01T02:00:00.000Z/my-volume-1/2000-01-01T02:00:00.000Z/test-node
+-----
+{
   "firstRecordAt": "2000-01-01T01:00:00.000Z",
   "lastRecordAt": "2000-01-01T02:00:00.000Z",
   "recordsCount": 1,
@@ -26,10 +44,19 @@ storage/stats/staging/123/456/my-source/my-sink/2000-01-01T02:00:00.000Z/my-volu
 >>>>>
 
 <<<<<
-storage/stats/target/123/456/my-source/my-sink/2000-01-01T03:00:00.000Z/my-volume-1/2000-01-01T03:00:00.000Z/value
+storage/stats/target/123/456/my-source/my-sink/2000-01-01T03:00:00.000Z/my-volume-1/2000-01-01T03:00:00.000Z/_open
 -----
 {
   "slicesCount": 1,
+  "firstRecordAt": "",
+  "lastRecordAt": ""
+}
+>>>>>
+
+<<<<<
+storage/stats/target/123/456/my-source/my-sink/2000-01-01T03:00:00.000Z/my-volume-1/2000-01-01T03:00:00.000Z/test-node
+-----
+{
   "firstRecordAt": "2000-01-01T01:00:00.000Z",
   "lastRecordAt": "2000-01-01T02:00:00.000Z",
   "recordsCount": 1,

--- a/internal/pkg/service/stream/storage/statistics/repository/fixtures/stats_open_snapshot_001.txt
+++ b/internal/pkg/service/stream/storage/statistics/repository/fixtures/stats_open_snapshot_001.txt
@@ -1,0 +1,9 @@
+<<<<<
+storage/stats/local/123/456/my-source/my-sink/2000-01-01T19:00:00.000Z/my-volume/2000-01-01T20:00:00.000Z/_open
+-----
+{
+  "slicesCount": 1,
+  "firstRecordAt": "",
+  "lastRecordAt": ""
+}
+>>>>>

--- a/internal/pkg/service/stream/storage/statistics/repository/fixtures/stats_open_snapshot_002.txt
+++ b/internal/pkg/service/stream/storage/statistics/repository/fixtures/stats_open_snapshot_002.txt
@@ -1,0 +1,21 @@
+<<<<<
+storage/stats/local/123/456/my-source/my-sink/2000-01-01T19:00:00.000Z/my-volume/2000-01-01T20:00:00.000Z/_open
+-----
+{
+  "slicesCount": 1,
+  "firstRecordAt": "",
+  "lastRecordAt": ""
+}
+>>>>>
+
+<<<<<
+storage/stats/local/123/456/my-source/my-sink/2000-01-01T19:00:00.000Z/my-volume/2000-01-01T20:00:00.000Z/test-node
+-----
+{
+  "firstRecordAt": "2000-01-01T00:00:00.000Z",
+  "lastRecordAt": "2000-01-02T00:00:00.000Z",
+  "recordsCount": 1,
+  "uncompressedSize": "1B",
+  "compressedSize": "1B"
+}
+>>>>>

--- a/internal/pkg/service/stream/storage/statistics/repository/fixtures/stats_put_snapshot_001.txt
+++ b/internal/pkg/service/stream/storage/statistics/repository/fixtures/stats_put_snapshot_001.txt
@@ -1,0 +1,21 @@
+<<<<<
+storage/stats/local/123/456/my-source/my-sink/2000-01-01T19:00:00.000Z/my-volume/2000-01-20T00:00:00.000Z/_open
+-----
+{
+  "slicesCount": 1,
+  "firstRecordAt": "",
+  "lastRecordAt": ""
+}
+>>>>>
+
+<<<<<
+storage/stats/local/123/456/my-source/my-sink/2000-01-01T19:00:00.000Z/my-volume/2000-01-20T00:00:00.000Z/test-node-1
+-----
+{
+  "firstRecordAt": "2000-01-20T00:00:00.000Z",
+  "lastRecordAt": "2000-01-21T00:00:00.000Z",
+  "recordsCount": 1,
+  "uncompressedSize": "1B",
+  "compressedSize": "1B"
+}
+>>>>>

--- a/internal/pkg/service/stream/storage/statistics/repository/fixtures/stats_put_snapshot_002.txt
+++ b/internal/pkg/service/stream/storage/statistics/repository/fixtures/stats_put_snapshot_002.txt
@@ -1,0 +1,33 @@
+<<<<<
+storage/stats/local/123/456/my-source/my-sink/2000-01-01T19:00:00.000Z/my-volume/2000-01-20T00:00:00.000Z/_open
+-----
+{
+  "slicesCount": 1,
+  "firstRecordAt": "",
+  "lastRecordAt": ""
+}
+>>>>>
+
+<<<<<
+storage/stats/local/123/456/my-source/my-sink/2000-01-01T19:00:00.000Z/my-volume/2000-01-20T00:00:00.000Z/test-node-1
+-----
+{
+  "firstRecordAt": "2000-01-20T00:00:00.000Z",
+  "lastRecordAt": "2000-01-21T00:00:00.000Z",
+  "recordsCount": 1,
+  "uncompressedSize": "1B",
+  "compressedSize": "1B"
+}
+>>>>>
+
+<<<<<
+storage/stats/local/123/456/my-source/my-sink/2000-01-01T19:00:00.000Z/my-volume/2000-01-20T00:00:00.000Z/test-node-2
+-----
+{
+  "firstRecordAt": "2000-01-21T00:00:00.000Z",
+  "lastRecordAt": "2000-01-22T00:00:00.000Z",
+  "recordsCount": 2,
+  "uncompressedSize": "2B",
+  "compressedSize": "2B"
+}
+>>>>>

--- a/internal/pkg/service/stream/storage/statistics/repository/stats_allocation_test.go
+++ b/internal/pkg/service/stream/storage/statistics/repository/stats_allocation_test.go
@@ -112,23 +112,23 @@ func TestRepository_EstimateSliceSizeOnSliceCreate(t *testing.T) {
 	// Create stats records
 	// -----------------------------------------------------------------------------------------------------------------
 	{
-		assert.NoError(t, statsRepo.Put(ctx, []statistics.PerSlice{
-			{SliceKey: sliceKey1, Value: statistics.Value{
-				SlicesCount:      1,
+		assert.NoError(t, statsRepo.Put(ctx, "test-node", []statistics.PerSlice{
+			{
+				SliceKey:         sliceKey1,
 				FirstRecordAt:    utctime.MustParse("2000-01-01T01:00:00.000Z"),
 				LastRecordAt:     utctime.MustParse("2000-01-01T02:00:00.000Z"),
 				RecordsCount:     123,
 				UncompressedSize: 20000,
 				CompressedSize:   1000, // <<<<<<<<<<<
-			}},
-			{SliceKey: sliceKey2, Value: statistics.Value{
-				SlicesCount:      1,
+			},
+			{
+				SliceKey:         sliceKey2,
 				FirstRecordAt:    utctime.MustParse("2000-01-01T02:00:00.000Z"),
 				LastRecordAt:     utctime.MustParse("2000-01-01T03:00:00.000Z"),
 				RecordsCount:     345,
 				UncompressedSize: 10000,
 				CompressedSize:   500,
-			}},
+			},
 		}))
 	}
 

--- a/internal/pkg/service/stream/storage/statistics/repository/stats_delete_test.go
+++ b/internal/pkg/service/stream/storage/statistics/repository/stats_delete_test.go
@@ -108,18 +108,35 @@ func TestRepository_RollupStatisticsOnFileDelete_LevelLocalStaging(t *testing.T)
 	// Create stats records
 	// -----------------------------------------------------------------------------------------------------------------
 	{
-		value := statistics.Value{
-			SlicesCount:      1,
-			FirstRecordAt:    utctime.MustParse("2000-01-01T01:00:00.000Z"),
-			LastRecordAt:     utctime.MustParse("2000-01-01T02:00:00.000Z"),
-			RecordsCount:     1,
-			UncompressedSize: 1,
-			CompressedSize:   1,
-		}
-		assert.NoError(t, statsRepo.Put(ctx, []statistics.PerSlice{
-			{SliceKey: sliceKey1, Value: value},
-			{SliceKey: sliceKey2, Value: value},
-			{SliceKey: sliceKey3, Value: value},
+		nodeID := "test-node"
+		assert.NoError(t, statsRepo.OpenSlice(sliceKey1, nodeID).Do(ctx).Err())
+		assert.NoError(t, statsRepo.OpenSlice(sliceKey2, nodeID).Do(ctx).Err())
+		assert.NoError(t, statsRepo.OpenSlice(sliceKey3, nodeID).Do(ctx).Err())
+		assert.NoError(t, statsRepo.Put(ctx, nodeID, []statistics.PerSlice{
+			{
+				SliceKey:         sliceKey1,
+				FirstRecordAt:    utctime.MustParse("2000-01-01T01:00:00.000Z"),
+				LastRecordAt:     utctime.MustParse("2000-01-01T02:00:00.000Z"),
+				RecordsCount:     1,
+				UncompressedSize: 1,
+				CompressedSize:   1,
+			},
+			{
+				SliceKey:         sliceKey2,
+				FirstRecordAt:    utctime.MustParse("2000-01-01T01:00:00.000Z"),
+				LastRecordAt:     utctime.MustParse("2000-01-01T02:00:00.000Z"),
+				RecordsCount:     1,
+				UncompressedSize: 1,
+				CompressedSize:   1,
+			},
+			{
+				SliceKey:         sliceKey3,
+				FirstRecordAt:    utctime.MustParse("2000-01-01T01:00:00.000Z"),
+				LastRecordAt:     utctime.MustParse("2000-01-01T02:00:00.000Z"),
+				RecordsCount:     1,
+				UncompressedSize: 1,
+				CompressedSize:   1,
+			},
 		}))
 	}
 
@@ -234,39 +251,34 @@ func TestRepository_RollupStatisticsOnFileDelete_LevelTarget(t *testing.T) {
 	}
 
 	// Create records
-	assert.NoError(t, statsRepo.Put(ctx, []statistics.PerSlice{
+	nodeID := "test-node"
+	assert.NoError(t, statsRepo.OpenSlice(sliceKey1, nodeID).Do(ctx).Err())
+	assert.NoError(t, statsRepo.OpenSlice(sliceKey2, nodeID).Do(ctx).Err())
+	assert.NoError(t, statsRepo.OpenSlice(sliceKey3, nodeID).Do(ctx).Err())
+	assert.NoError(t, statsRepo.Put(ctx, nodeID, []statistics.PerSlice{
 		{
-			SliceKey: sliceKey1,
-			Value: statistics.Value{
-				SlicesCount:      1,
-				FirstRecordAt:    utctime.MustParse("2000-01-01T01:00:00.000Z"),
-				LastRecordAt:     utctime.MustParse("2000-01-01T02:00:00.000Z"),
-				RecordsCount:     1,
-				UncompressedSize: 1,
-				CompressedSize:   1,
-			},
+			SliceKey:         sliceKey1,
+			FirstRecordAt:    utctime.MustParse("2000-01-01T01:00:00.000Z"),
+			LastRecordAt:     utctime.MustParse("2000-01-01T02:00:00.000Z"),
+			RecordsCount:     1,
+			UncompressedSize: 1,
+			CompressedSize:   1,
 		},
 		{
-			SliceKey: sliceKey2,
-			Value: statistics.Value{
-				SlicesCount:      1,
-				FirstRecordAt:    utctime.MustParse("2000-01-01T02:00:00.000Z"),
-				LastRecordAt:     utctime.MustParse("2000-01-01T03:00:00.000Z"),
-				RecordsCount:     10,
-				UncompressedSize: 10,
-				CompressedSize:   10,
-			},
+			SliceKey:         sliceKey2,
+			FirstRecordAt:    utctime.MustParse("2000-01-01T02:00:00.000Z"),
+			LastRecordAt:     utctime.MustParse("2000-01-01T03:00:00.000Z"),
+			RecordsCount:     10,
+			UncompressedSize: 10,
+			CompressedSize:   10,
 		},
 		{
-			SliceKey: sliceKey3,
-			Value: statistics.Value{
-				SlicesCount:      1,
-				FirstRecordAt:    utctime.MustParse("2000-01-01T03:00:00.000Z"),
-				LastRecordAt:     utctime.MustParse("2000-01-01T04:00:00.000Z"),
-				RecordsCount:     100,
-				UncompressedSize: 100,
-				CompressedSize:   100,
-			},
+			SliceKey:         sliceKey3,
+			FirstRecordAt:    utctime.MustParse("2000-01-01T03:00:00.000Z"),
+			LastRecordAt:     utctime.MustParse("2000-01-01T04:00:00.000Z"),
+			RecordsCount:     100,
+			UncompressedSize: 100,
+			CompressedSize:   100,
 		},
 	}))
 

--- a/internal/pkg/service/stream/storage/statistics/repository/stats_files_test.go
+++ b/internal/pkg/service/stream/storage/statistics/repository/stats_files_test.go
@@ -90,50 +90,43 @@ func TestRepository_FilesStats(t *testing.T) {
 	// Add some statistics
 	// -----------------------------------------------------------------------------------------------------------------
 	{
-		assert.NoError(t, statsRepo.Put(ctx, []statistics.PerSlice{
+		nodeID := "test-node"
+		assert.NoError(t, statsRepo.OpenSlice(sliceKey1, nodeID).Do(ctx).Err())
+		assert.NoError(t, statsRepo.OpenSlice(sliceKey2, nodeID).Do(ctx).Err())
+		assert.NoError(t, statsRepo.OpenSlice(sliceKey3, nodeID).Do(ctx).Err())
+		assert.NoError(t, statsRepo.OpenSlice(sliceKey4, nodeID).Do(ctx).Err())
+		assert.NoError(t, statsRepo.Put(ctx, nodeID, []statistics.PerSlice{
 			{
-				SliceKey: sliceKey1,
-				Value: statistics.Value{
-					SlicesCount:      1,
-					FirstRecordAt:    utctime.MustParse("2000-01-01T01:00:00.000Z"),
-					LastRecordAt:     utctime.MustParse("2000-01-01T02:00:00.000Z"),
-					RecordsCount:     1,
-					UncompressedSize: 1,
-					CompressedSize:   1,
-				},
+				SliceKey:         sliceKey1,
+				FirstRecordAt:    utctime.MustParse("2000-01-01T01:00:00.000Z"),
+				LastRecordAt:     utctime.MustParse("2000-01-01T02:00:00.000Z"),
+				RecordsCount:     1,
+				UncompressedSize: 1,
+				CompressedSize:   1,
 			},
 			{
-				SliceKey: sliceKey2,
-				Value: statistics.Value{
-					SlicesCount:      1,
-					FirstRecordAt:    utctime.MustParse("2000-01-01T02:00:00.000Z"),
-					LastRecordAt:     utctime.MustParse("2000-01-01T03:00:00.000Z"),
-					RecordsCount:     10,
-					UncompressedSize: 10,
-					CompressedSize:   10,
-				},
+				SliceKey:         sliceKey2,
+				FirstRecordAt:    utctime.MustParse("2000-01-01T02:00:00.000Z"),
+				LastRecordAt:     utctime.MustParse("2000-01-01T03:00:00.000Z"),
+				RecordsCount:     10,
+				UncompressedSize: 10,
+				CompressedSize:   10,
 			},
 			{
-				SliceKey: sliceKey3,
-				Value: statistics.Value{
-					SlicesCount:      1,
-					FirstRecordAt:    utctime.MustParse("2000-01-01T03:00:00.000Z"),
-					LastRecordAt:     utctime.MustParse("2000-01-01T04:00:00.000Z"),
-					RecordsCount:     100,
-					UncompressedSize: 100,
-					CompressedSize:   100,
-				},
+				SliceKey:         sliceKey3,
+				FirstRecordAt:    utctime.MustParse("2000-01-01T03:00:00.000Z"),
+				LastRecordAt:     utctime.MustParse("2000-01-01T04:00:00.000Z"),
+				RecordsCount:     100,
+				UncompressedSize: 100,
+				CompressedSize:   100,
 			},
 			{
-				SliceKey: sliceKey4,
-				Value: statistics.Value{
-					SlicesCount:      1,
-					FirstRecordAt:    utctime.MustParse("2000-01-02T01:00:00.000Z"),
-					LastRecordAt:     utctime.MustParse("2000-01-02T04:00:00.000Z"),
-					RecordsCount:     1,
-					UncompressedSize: 1,
-					CompressedSize:   1,
-				},
+				SliceKey:         sliceKey4,
+				FirstRecordAt:    utctime.MustParse("2000-01-02T01:00:00.000Z"),
+				LastRecordAt:     utctime.MustParse("2000-01-02T04:00:00.000Z"),
+				RecordsCount:     1,
+				UncompressedSize: 1,
+				CompressedSize:   1,
 			},
 		}))
 	}

--- a/internal/pkg/service/stream/storage/statistics/repository/stats_get_test.go
+++ b/internal/pkg/service/stream/storage/statistics/repository/stats_get_test.go
@@ -115,42 +115,58 @@ func TestProvider(t *testing.T) {
 	// Add some statistics
 	// -----------------------------------------------------------------------------------------------------------------
 	{
-		assert.NoError(t, statsRepo.Put(ctx, []statistics.PerSlice{
+		nodeID1 := "test-node-1"
+		assert.NoError(t, statsRepo.OpenSlice(sliceKey1, nodeID1).Do(ctx).Err())
+		assert.NoError(t, statsRepo.OpenSlice(sliceKey2, nodeID1).Do(ctx).Err())
+		assert.NoError(t, statsRepo.OpenSlice(sliceKey3, nodeID1).Do(ctx).Err())
+		assert.NoError(t, statsRepo.Put(ctx, nodeID1, []statistics.PerSlice{
 			{
-				SliceKey: sliceKey1,
-				Value: statistics.Value{
-					SlicesCount:      1,
-					FirstRecordAt:    utctime.MustParse("2000-01-01T01:00:00.000Z"),
-					LastRecordAt:     utctime.MustParse("2000-01-01T02:00:00.000Z"),
-					RecordsCount:     1,
-					UncompressedSize: 1,
-					CompressedSize:   1,
-				},
+				SliceKey:         sliceKey1,
+				FirstRecordAt:    utctime.MustParse("2000-01-01T01:00:00.000Z"),
+				LastRecordAt:     utctime.MustParse("2000-01-01T02:00:00.000Z"),
+				RecordsCount:     1,
+				UncompressedSize: 1,
+				CompressedSize:   1,
 			},
 			{
-				SliceKey: sliceKey2,
-				Value: statistics.Value{
-					SlicesCount:      1,
-					FirstRecordAt:    utctime.MustParse("2000-01-01T02:00:00.000Z"),
-					LastRecordAt:     utctime.MustParse("2000-01-01T03:00:00.000Z"),
-					RecordsCount:     10,
-					UncompressedSize: 10,
-					CompressedSize:   10,
-				},
+				SliceKey:         sliceKey2,
+				FirstRecordAt:    utctime.MustParse("2000-01-01T02:00:00.000Z"),
+				LastRecordAt:     utctime.MustParse("2000-01-01T02:10:00.000Z"),
+				RecordsCount:     1,
+				UncompressedSize: 1,
+				CompressedSize:   1,
 			},
 			{
-				SliceKey: sliceKey3,
-				Value: statistics.Value{
-					SlicesCount:      1,
-					FirstRecordAt:    utctime.MustParse("2000-01-01T03:00:00.000Z"),
-					LastRecordAt:     utctime.MustParse("2000-01-01T04:00:00.000Z"),
-					RecordsCount:     100,
-					UncompressedSize: 100,
-					CompressedSize:   100,
-				},
+				SliceKey:         sliceKey3,
+				FirstRecordAt:    utctime.MustParse("2000-01-01T03:00:00.000Z"),
+				LastRecordAt:     utctime.MustParse("2000-01-01T03:10:00.000Z"),
+				RecordsCount:     1,
+				UncompressedSize: 1,
+				CompressedSize:   1,
 			},
 		}))
 	}
+	nodeID2 := "test-node-2"
+	assert.NoError(t, statsRepo.OpenSlice(sliceKey2, nodeID2).Do(ctx).Err())
+	assert.NoError(t, statsRepo.OpenSlice(sliceKey3, nodeID2).Do(ctx).Err())
+	assert.NoError(t, statsRepo.Put(ctx, nodeID2, []statistics.PerSlice{
+		{
+			SliceKey:         sliceKey2,
+			FirstRecordAt:    utctime.MustParse("2000-01-01T02:10:00.000Z"),
+			LastRecordAt:     utctime.MustParse("2000-01-01T03:00:00.000Z"),
+			RecordsCount:     9,
+			UncompressedSize: 9,
+			CompressedSize:   9,
+		},
+		{
+			SliceKey:         sliceKey3,
+			FirstRecordAt:    utctime.MustParse("2000-01-01T03:10:00.000Z"),
+			LastRecordAt:     utctime.MustParse("2000-01-01T04:00:00.000Z"),
+			RecordsCount:     99,
+			UncompressedSize: 99,
+			CompressedSize:   99,
+		},
+	}))
 
 	// Move statistics file2 to the staging, and file3 to the target level
 	// -----------------------------------------------------------------------------------------------------------------

--- a/internal/pkg/service/stream/storage/statistics/repository/stats_move.go
+++ b/internal/pkg/service/stream/storage/statistics/repository/stats_move.go
@@ -64,10 +64,8 @@ func (r *Repository) moveAll(parentKey fmt.Stringer, from, to model.Level, trans
 				oldKey := etcdop.NewTypedKey[statistics.Value](kv.Key(), r.schema.Serde())
 
 				// Save value to the new destination
-				if kv.Value.RecordsCount > 0 {
-					newKey := oldKey.ReplacePrefix(r.schema.InLevel(from).Prefix(), r.schema.InLevel(to).Prefix())
-					txn.Then(newKey.Put(r.client, kv.Value))
-				}
+				newKey := oldKey.ReplacePrefix(r.schema.InLevel(from).Prefix(), r.schema.InLevel(to).Prefix())
+				txn.Then(newKey.Put(r.client, kv.Value))
 
 				// Delete old record
 				txn.Then(oldKey.Delete(r.client))

--- a/internal/pkg/service/stream/storage/statistics/repository/stats_move_test.go
+++ b/internal/pkg/service/stream/storage/statistics/repository/stats_move_test.go
@@ -95,18 +95,35 @@ func TestRepository_MoveStatisticsOnSliceUpdate(t *testing.T) {
 	// Create stats records
 	// -----------------------------------------------------------------------------------------------------------------
 	{
-		value := statistics.Value{
-			SlicesCount:      1,
-			FirstRecordAt:    utctime.MustParse("2000-01-01T01:00:00.000Z"),
-			LastRecordAt:     utctime.MustParse("2000-01-01T02:00:00.000Z"),
-			RecordsCount:     1,
-			UncompressedSize: 1,
-			CompressedSize:   1,
-		}
-		assert.NoError(t, statsRepo.Put(ctx, []statistics.PerSlice{
-			{SliceKey: sliceKey1, Value: value},
-			{SliceKey: sliceKey2, Value: value},
-			{SliceKey: sliceKey3, Value: value},
+		nodeID := "test-node"
+		assert.NoError(t, statsRepo.OpenSlice(sliceKey1, nodeID).Do(ctx).Err())
+		assert.NoError(t, statsRepo.OpenSlice(sliceKey2, nodeID).Do(ctx).Err())
+		assert.NoError(t, statsRepo.OpenSlice(sliceKey3, nodeID).Do(ctx).Err())
+		assert.NoError(t, statsRepo.Put(ctx, nodeID, []statistics.PerSlice{
+			{
+				SliceKey:         sliceKey1,
+				FirstRecordAt:    utctime.MustParse("2000-01-01T01:00:00.000Z"),
+				LastRecordAt:     utctime.MustParse("2000-01-01T02:00:00.000Z"),
+				RecordsCount:     1,
+				UncompressedSize: 1,
+				CompressedSize:   1,
+			},
+			{
+				SliceKey:         sliceKey2,
+				FirstRecordAt:    utctime.MustParse("2000-01-01T01:00:00.000Z"),
+				LastRecordAt:     utctime.MustParse("2000-01-01T02:00:00.000Z"),
+				RecordsCount:     1,
+				UncompressedSize: 1,
+				CompressedSize:   1,
+			},
+			{
+				SliceKey:         sliceKey3,
+				FirstRecordAt:    utctime.MustParse("2000-01-01T01:00:00.000Z"),
+				LastRecordAt:     utctime.MustParse("2000-01-01T02:00:00.000Z"),
+				RecordsCount:     1,
+				UncompressedSize: 1,
+				CompressedSize:   1,
+			},
 		}))
 	}
 

--- a/internal/pkg/service/stream/storage/statistics/repository/stats_open.go
+++ b/internal/pkg/service/stream/storage/statistics/repository/stats_open.go
@@ -1,0 +1,30 @@
+package repository
+
+import (
+	"github.com/keboola/keboola-as-code/internal/pkg/service/common/etcdop/op"
+	"github.com/keboola/keboola-as-code/internal/pkg/service/stream/storage/model"
+	"github.com/keboola/keboola-as-code/internal/pkg/service/stream/storage/statistics"
+)
+
+const (
+	sliceOpenKey = "_open"
+)
+
+// OpenSlice is called by the statistics Collector when a slice writer is opened by a source node.
+//
+// The method writes SlicesCount=1 value to the Slice statistics prefix, if the key not exists.
+// This is required for the statistics calculation mechanism to work correctly
+// and returns the correct number of slices on all levels.
+// Individual source nodes later put partial slice statistics without the SlicesCount value, see the Put method.
+//
+// The result of the TXN is a snapshot of the statistics for the source node and slice,
+// so the Collector can continue where it left off.
+// A non-empty value is returned only if the source node was already writing to the slice, but there was a crash/restart.
+func (r *Repository) OpenSlice(k model.SliceKey, nodeID string) *op.TxnOp[statistics.Value] {
+	openKey := r.schema.InLevel(model.LevelLocal).InSlice(k).Key(sliceOpenKey)
+	nodeKey := r.schema.InLevel(model.LevelLocal).InSliceSourceNode(k, nodeID)
+	var statsValue statistics.Value
+	return op.TxnWithResult(r.client, &statsValue).
+		ThenTxn(openKey.PutIfNotExists(r.client, statistics.Value{SlicesCount: 1})).
+		Then(nodeKey.GetOrEmpty(r.client).WithResultTo(&statsValue))
+}

--- a/internal/pkg/service/stream/storage/statistics/repository/stats_open_test.go
+++ b/internal/pkg/service/stream/storage/statistics/repository/stats_open_test.go
@@ -1,0 +1,60 @@
+package repository_test
+
+import (
+	"context"
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+
+	"github.com/keboola/keboola-as-code/internal/pkg/service/common/utctime"
+	"github.com/keboola/keboola-as-code/internal/pkg/service/stream/dependencies"
+	"github.com/keboola/keboola-as-code/internal/pkg/service/stream/storage/statistics"
+	"github.com/keboola/keboola-as-code/internal/pkg/service/stream/storage/test"
+	"github.com/keboola/keboola-as-code/internal/pkg/utils/etcdhelper"
+)
+
+func TestRepository_OpenSlice(t *testing.T) {
+	t.Parallel()
+
+	ctx, cancel := context.WithTimeout(context.Background(), 10*time.Second)
+	defer cancel()
+
+	d, mock := dependencies.NewMockedLocalStorageScope(t)
+	client := mock.TestEtcdClient()
+	repo := d.StatisticsRepository()
+
+	sliceKey := test.NewSliceKey()
+	nodeID := "test-node"
+
+	// Open first time
+	initialValue, err := repo.OpenSlice(sliceKey, nodeID).Do(ctx).ResultOrErr()
+	require.NoError(t, err)
+	assert.Empty(t, initialValue)
+	etcdhelper.AssertKVsFromFile(t, client, "fixtures/stats_open_snapshot_001.txt")
+
+	// Put some values
+	require.NoError(t, repo.Put(ctx, nodeID, []statistics.PerSlice{
+		{
+			SliceKey:         sliceKey,
+			FirstRecordAt:    utctime.MustParse("2000-01-01T00:00:00.000Z"),
+			LastRecordAt:     utctime.MustParse("2000-01-02T00:00:00.000Z"),
+			RecordsCount:     1,
+			UncompressedSize: 1,
+			CompressedSize:   1,
+		},
+	}))
+
+	// Open second time
+	initialValue, err = repo.OpenSlice(sliceKey, nodeID).Do(ctx).ResultOrErr()
+	require.NoError(t, err)
+	assert.Equal(t, statistics.Value{
+		FirstRecordAt:    utctime.MustParse("2000-01-01T00:00:00.000Z"),
+		LastRecordAt:     utctime.MustParse("2000-01-02T00:00:00.000Z"),
+		RecordsCount:     1,
+		UncompressedSize: 1,
+		CompressedSize:   1,
+	}, initialValue)
+	etcdhelper.AssertKVsFromFile(t, client, "fixtures/stats_open_snapshot_002.txt")
+}

--- a/internal/pkg/service/stream/storage/statistics/repository/stats_put.go
+++ b/internal/pkg/service/stream/storage/statistics/repository/stats_put.go
@@ -13,7 +13,7 @@ import (
 )
 
 // Put creates or updates slices statistics records in the level.LevelLocal.
-func (r *Repository) Put(ctx context.Context, stats []statistics.PerSlice) (err error) {
+func (r *Repository) Put(ctx context.Context, nodeID string, stats []statistics.PerSlice) (err error) {
 	ctx, span := r.telemetry.Tracer().Start(ctx, "keboola.go.buffer.storage.statistics.Repository.Put")
 	defer span.End(&err)
 
@@ -31,7 +31,7 @@ func (r *Repository) Put(ctx context.Context, stats []statistics.PerSlice) (err 
 			i = 0
 			addTxn()
 		}
-		currentTxn.Then(r.schema.InLevel(model.LevelLocal).InSlice(v.SliceKey).Put(r.client, v.Value))
+		currentTxn.Then(r.schema.InLevel(model.LevelLocal).InSourceNodeSlice(v.SliceKey, nodeID).Put(r.client, v.Value))
 		i++
 	}
 

--- a/internal/pkg/service/stream/storage/statistics/repository/stats_repo.go
+++ b/internal/pkg/service/stream/storage/statistics/repository/stats_repo.go
@@ -35,6 +35,7 @@ import (
 	"github.com/keboola/keboola-as-code/internal/pkg/service/common/etcdop/serde"
 	"github.com/keboola/keboola-as-code/internal/pkg/service/stream/plugin"
 	"github.com/keboola/keboola-as-code/internal/pkg/service/stream/storage/model"
+	storageRepo "github.com/keboola/keboola-as-code/internal/pkg/service/stream/storage/repository"
 	"github.com/keboola/keboola-as-code/internal/pkg/telemetry"
 )
 
@@ -55,6 +56,7 @@ type Repository struct {
 	telemetry telemetry.Telemetry
 	client    *etcd.Client
 	plugins   *plugin.Plugins
+	storage   *storageRepo.Repository
 	schema    schema
 }
 
@@ -64,6 +66,7 @@ type dependencies interface {
 	EtcdClient() *etcd.Client
 	EtcdSerde() *serde.Serde
 	Plugins() *plugin.Plugins
+	StorageRepository() *storageRepo.Repository
 }
 
 func New(d dependencies) *Repository {
@@ -72,6 +75,7 @@ func New(d dependencies) *Repository {
 		telemetry: d.Telemetry(),
 		client:    d.EtcdClient(),
 		plugins:   d.Plugins(),
+		storage:   d.StorageRepository(),
 		schema:    newSchema(d.EtcdSerde()),
 	}
 

--- a/internal/pkg/service/stream/storage/statistics/repository/stats_repo.go
+++ b/internal/pkg/service/stream/storage/statistics/repository/stats_repo.go
@@ -4,7 +4,7 @@
 //
 // Statistics are stored in the etcd database as [statistics.Value] under the following key format:
 //
-//	storage/stats/<LEVEL:local>/<SLICE_KEY:PROJECT_ID/SOURCE_ID/SINK_ID/FILE_ID/VOLUME_ID/SLICE_ID>/value
+//	storage/stats/<LEVEL:local>/<SLICE_KEY:PROJECT_ID/SOURCE_ID/SINK_ID/FILE_ID/VOLUME_ID/SLICE_ID>/<NODE_ID>
 //
 // Statistics are stored at the slice level, which represents the smallest unit.
 //
@@ -54,8 +54,8 @@ type Repository struct {
 	logger    log.Logger
 	telemetry telemetry.Telemetry
 	client    *etcd.Client
-	schema    schema
 	plugins   *plugin.Plugins
+	schema    schema
 }
 
 type dependencies interface {
@@ -71,8 +71,8 @@ func New(d dependencies) *Repository {
 		logger:    d.Logger().WithComponent("storage.statistics.repository"),
 		telemetry: d.Telemetry(),
 		client:    d.EtcdClient(),
-		schema:    newSchema(d.EtcdSerde()),
 		plugins:   d.Plugins(),
+		schema:    newSchema(d.EtcdSerde()),
 	}
 
 	// Setup Provider interface

--- a/internal/pkg/service/stream/storage/statistics/repository/stats_schema.go
+++ b/internal/pkg/service/stream/storage/statistics/repository/stats_schema.go
@@ -14,8 +14,6 @@ import (
 )
 
 const (
-	// sliceValueKey contains a slice statistics, it is the lowest level.
-	sliceValueKey = "value"
 	// rollupSumKey contains the sum of all statistics from the object children that were deleted.
 	rollupSumKey = "_sum"
 )
@@ -86,8 +84,12 @@ func (v schemaInLevel) InFile(k FileKey) schemaInObject {
 	return v.inObject(k)
 }
 
-func (v schemaInLevel) InSlice(k SliceKey) KeyT[statistics.Value] {
-	return v.inObject(k).Key(sliceValueKey)
+func (v schemaInLevel) InSlice(k SliceKey) schemaInObject {
+	return v.inObject(k)
+}
+
+func (v schemaInLevel) InSliceSourceNode(k SliceKey, nodeID string) KeyT[statistics.Value] {
+	return v.inObject(k).Key(nodeID)
 }
 
 func (v schemaInLevel) inObject(objectKey fmt.Stringer) schemaInObject {

--- a/internal/pkg/service/stream/storage/statistics/repository/stats_schema_test.go
+++ b/internal/pkg/service/stream/storage/statistics/repository/stats_schema_test.go
@@ -68,8 +68,12 @@ func TestSchema(t *testing.T) {
 			"storage/stats/local/123/456/my-source/my-sink/2000-01-01T19:00:00.000Z/",
 		},
 		{
-			s.InLevel(model.LevelLocal).InSlice(sliceKey).Key(),
-			"storage/stats/local/123/456/my-source/my-sink/2000-01-01T19:00:00.000Z/my-volume/2000-01-01T20:00:00.000Z/value",
+			s.InLevel(model.LevelLocal).InSlice(sliceKey).Prefix(),
+			"storage/stats/local/123/456/my-source/my-sink/2000-01-01T19:00:00.000Z/my-volume/2000-01-01T20:00:00.000Z/",
+		},
+		{
+			s.InLevel(model.LevelLocal).InSliceSourceNode(sliceKey, "my-node").Key(),
+			"storage/stats/local/123/456/my-source/my-sink/2000-01-01T19:00:00.000Z/my-volume/2000-01-01T20:00:00.000Z/my-node",
 		},
 		{
 			s.InLevel(model.LevelLocal).InParentOf(sliceKey.BranchKey).Prefix(),

--- a/internal/pkg/service/stream/storage/statistics/repository/stats_watch_test.go
+++ b/internal/pkg/service/stream/storage/statistics/repository/stats_watch_test.go
@@ -26,28 +26,22 @@ func TestRepository_GetAllAndWatch(t *testing.T) {
 	// Add 2 records
 	sliceKey1 := test.NewSliceKeyOpenedAt("2000-01-01T01:00:00.000Z")
 	sliceKey2 := test.NewSliceKeyOpenedAt("2000-01-01T02:00:00.000Z")
-	assert.NoError(t, repo.Put(ctx, []statistics.PerSlice{
+	assert.NoError(t, repo.Put(ctx, "test-node", []statistics.PerSlice{
 		{
-			SliceKey: sliceKey1,
-			Value: statistics.Value{
-				SlicesCount:      1,
-				FirstRecordAt:    utctime.MustParse("2000-01-01T01:00:00.000Z"),
-				LastRecordAt:     utctime.MustParse("2000-01-01T02:00:00.000Z"),
-				RecordsCount:     1,
-				UncompressedSize: 1,
-				CompressedSize:   1,
-			},
+			SliceKey:         sliceKey1,
+			FirstRecordAt:    utctime.MustParse("2000-01-01T01:00:00.000Z"),
+			LastRecordAt:     utctime.MustParse("2000-01-01T02:00:00.000Z"),
+			RecordsCount:     1,
+			UncompressedSize: 1,
+			CompressedSize:   1,
 		},
 		{
-			SliceKey: sliceKey2,
-			Value: statistics.Value{
-				SlicesCount:      1,
-				FirstRecordAt:    utctime.MustParse("2000-01-01T02:00:00.000Z"),
-				LastRecordAt:     utctime.MustParse("2000-01-01T03:00:00.000Z"),
-				RecordsCount:     10,
-				UncompressedSize: 10,
-				CompressedSize:   10,
-			},
+			SliceKey:         sliceKey2,
+			FirstRecordAt:    utctime.MustParse("2000-01-01T02:00:00.000Z"),
+			LastRecordAt:     utctime.MustParse("2000-01-01T03:00:00.000Z"),
+			RecordsCount:     10,
+			UncompressedSize: 10,
+			CompressedSize:   10,
 		},
 	}))
 
@@ -57,7 +51,6 @@ func TestRepository_GetAllAndWatch(t *testing.T) {
 	assert.True(t, ok)
 	assert.Equal(t, []statistics.Value{
 		{
-			SlicesCount:      1,
 			FirstRecordAt:    utctime.MustParse("2000-01-01T01:00:00.000Z"),
 			LastRecordAt:     utctime.MustParse("2000-01-01T02:00:00.000Z"),
 			RecordsCount:     1,
@@ -65,7 +58,6 @@ func TestRepository_GetAllAndWatch(t *testing.T) {
 			CompressedSize:   1,
 		},
 		{
-			SlicesCount:      1,
 			FirstRecordAt:    utctime.MustParse("2000-01-01T02:00:00.000Z"),
 			LastRecordAt:     utctime.MustParse("2000-01-01T03:00:00.000Z"),
 			RecordsCount:     10,
@@ -76,17 +68,14 @@ func TestRepository_GetAllAndWatch(t *testing.T) {
 
 	// Add record
 	sliceKey3 := test.NewSliceKeyOpenedAt("2000-01-01T03:00:00.000Z")
-	assert.NoError(t, repo.Put(ctx, []statistics.PerSlice{
+	assert.NoError(t, repo.Put(ctx, "test-node", []statistics.PerSlice{
 		{
-			SliceKey: sliceKey3,
-			Value: statistics.Value{
-				SlicesCount:      1,
-				FirstRecordAt:    utctime.MustParse("2000-01-01T03:00:00.000Z"),
-				LastRecordAt:     utctime.MustParse("2000-01-01T04:00:00.000Z"),
-				RecordsCount:     100,
-				UncompressedSize: 100,
-				CompressedSize:   100,
-			},
+			SliceKey:         sliceKey3,
+			FirstRecordAt:    utctime.MustParse("2000-01-01T03:00:00.000Z"),
+			LastRecordAt:     utctime.MustParse("2000-01-01T04:00:00.000Z"),
+			RecordsCount:     100,
+			UncompressedSize: 100,
+			CompressedSize:   100,
 		},
 	}))
 
@@ -101,7 +90,6 @@ func TestRepository_GetAllAndWatch(t *testing.T) {
 	assert.True(t, ok)
 	assert.Equal(t, []statistics.Value{
 		{
-			SlicesCount:      1,
 			FirstRecordAt:    utctime.MustParse("2000-01-01T03:00:00.000Z"),
 			LastRecordAt:     utctime.MustParse("2000-01-01T04:00:00.000Z"),
 			RecordsCount:     100,

--- a/internal/pkg/service/stream/storage/statistics/statistics.go
+++ b/internal/pkg/service/stream/storage/statistics/statistics.go
@@ -21,7 +21,7 @@ import (
 
 // Value contains statistics for a slice or summarized statistics for a parent object.
 type Value struct {
-	SlicesCount int `json:"slicesCount,omitempty" validate:"required_with=RecordsCount"`
+	SlicesCount int `json:"slicesCount,omitempty"`
 	// FirstRecordAt contains the timestamp of the first received record.
 	FirstRecordAt utctime.UTCTime `json:"firstRecordAt"`
 	// LastRecordAt contains the timestamp of the last received record.

--- a/internal/pkg/service/stream/storage/statistics/statistics.go
+++ b/internal/pkg/service/stream/storage/statistics/statistics.go
@@ -40,7 +40,14 @@ type Value struct {
 
 type PerSlice struct {
 	SliceKey model.SliceKey
-	Value    Value
+
+	// The following fields are part of the Value structure, which are applicable when collecting statistics.
+
+	FirstRecordAt    utctime.UTCTime
+	LastRecordAt     utctime.UTCTime
+	RecordsCount     uint64
+	UncompressedSize datasize.ByteSize
+	CompressedSize   datasize.ByteSize
 }
 
 // Aggregated contains aggregated statistics for an object, such as file or export.

--- a/internal/pkg/service/stream/storage/statistics/statistics.go
+++ b/internal/pkg/service/stream/storage/statistics/statistics.go
@@ -3,7 +3,13 @@
 // These statistics are primarily used to evaluate upload and import conditions,
 // but users can also access them through the API.
 //
-// Statistics are collected and stored per definition.Sink, one definition.Source can have multiple sinks.
+// Statistics are collected and stored per definition.Sink, one definition.Source can have multiple sinks,
+// so one message, received by a source, is counted several times, according to the number of sinks.
+//
+// The statistics Collector collects statistics from each active slice writer on each source node.
+//
+// Statistics are saved per the slice and the source node, see OpenSlice and Put method in the repository.
+// Later, the rollup operation is performed, see deleteOrRollup method.
 package statistics
 
 import (

--- a/internal/pkg/service/stream/storage/statistics/statistics.go
+++ b/internal/pkg/service/stream/storage/statistics/statistics.go
@@ -27,11 +27,11 @@ type Value struct {
 	// LastRecordAt contains the timestamp of the last received record.
 	LastRecordAt utctime.UTCTime `json:"lastRecordAt"`
 	// RecordsCount is count of received records.
-	RecordsCount uint64 `json:"recordsCount"`
+	RecordsCount uint64 `json:"recordsCount,omitempty"`
 	// UncompressedSize is data size before compression in the local storage.
-	UncompressedSize datasize.ByteSize `json:"uncompressedSize"`
+	UncompressedSize datasize.ByteSize `json:"uncompressedSize,omitempty"`
 	// CompressedSize is data size after compression in the local storage.
-	CompressedSize datasize.ByteSize `json:"compressedSize"`
+	CompressedSize datasize.ByteSize `json:"compressedSize,omitempty"`
 	// StagingSize is data size in the staging storage.
 	// The value is usually same as the CompressedSize,
 	// if the type of compression did not change during the upload.


### PR DESCRIPTION
Jira: https://keboola.atlassian.net/browse/PSGO-597

**Changes:**
- Statistics are collected by `<sliceID>/<sourceNodeID>`, not by `<sliceID>`.

-----------

### HTTP Source PRs Intro

We are now solving communication between a source node (HTTP source) and a writer node.
- Reason: The HTTP source could be scaled independently of the storage.
- Originally, these parts were connected directly, it was one pod.
- So we can have `M` source nodes and `N` writer nodes.


![image](https://github.com/keboola/keboola-as-code/assets/19371734/e79f2717-8624-4384-b293-eb7fbdfe9b3f)

---------------------

#### Architectural decisions

- **Compression** is the responsibility of the source node, not the writer node.
  - The source node typically performs CPU intensive tasks (generation of CSV lines).
  - Compression is also CPU intensive task, so it makes sense to group these jobs, for scaling purposes.
  - The write node is limited by disk I/O, if we had to scale it for the CPU, we would have to unnecessarily scale the number of disks (stateful set).
  - It reduces the size of bytes transferred over the local network.
- **Sink statistics** are collected by the source node.
  - Writer node receives compressed data, so there would be a problem with 1. count and 2. uncompressed size metrics.
    - They have to be sent via a network side channel, so we can rather store them directly in the DB.
- So in the end there are 2 changes:
  - In the source node/writers chain, we don't write to a physical OS file, but to a network file abstraction.
  - There is `M:N` - `source nodes:writer nodes` situation:
    - We need to modify statistics `Collector` (this PR).
    - Source node is stateless, so statistcs cannot be backed up to a file - but only directly to the DB (next PR).
    - We need a routing algorithm `source -> writer` node with retries.

##### WIP diagram

![image](https://github.com/keboola/keboola-as-code/assets/19371734/3f060979-0645-4c6a-961a-d6dd2772beff)


