### PR TITLE
feat: local storage writer: remove stats backup file

### DIFF
--- a/internal/pkg/service/stream/storage/level/local/writer/volume/writer.go
+++ b/internal/pkg/service/stream/storage/level/local/writer/volume/writer.go
@@ -99,7 +99,7 @@ func (v *Volume) OpenWriter(slice *model.Slice) (w writer.Writer, err error) {
 	}
 
 	// Create writer
-	w, err = writer.New(v.ctx, logger, v.clock, v.config.writerConfig, slice, file, dirPath, filePath, v.config.syncerFactory, v.config.formatWriterFactory, v.events)
+	w, err = writer.New(v.ctx, logger, v.clock, v.config.writerConfig, slice, file, v.config.syncerFactory, v.config.formatWriterFactory, v.events)
 	if err != nil {
 		return nil, err
 	}

--- a/internal/pkg/service/stream/storage/level/local/writer/volume/writer_linux_test.go
+++ b/internal/pkg/service/stream/storage/level/local/writer/volume/writer_linux_test.go
@@ -29,7 +29,7 @@ func TestVolume_Writer_AllocateSpace_Enabled(t *testing.T) {
 	// Check file size after allocation
 	// The size is rounded to whole blocks, so we check:
 	// EXPECTED <= ACTUAL SIZE < 2*EXPECTED
-	allocated, err := diskalloc.Allocated(w.FilePath())
+	allocated, err := diskalloc.Allocated(tc.FilePath())
 	require.NoError(t, err)
 	assert.GreaterOrEqual(t, allocated, expectedSize)
 	assert.Less(t, allocated, 2*expectedSize)

--- a/internal/pkg/service/stream/storage/level/local/writer/volume/writer_test.go
+++ b/internal/pkg/service/stream/storage/level/local/writer/volume/writer_test.go
@@ -73,10 +73,10 @@ func TestVolume_Writer_OpenFile_Ok(t *testing.T) {
 
 	w, err := tc.NewWriter()
 	assert.NoError(t, err)
-	assert.FileExists(t, w.FilePath())
+	assert.FileExists(t, tc.FilePath())
 
 	assert.NoError(t, w.Close(context.Background()))
-	assert.FileExists(t, w.FilePath())
+	assert.FileExists(t, tc.FilePath())
 }
 
 func TestVolume_Writer_OpenFile_MkdirError(t *testing.T) {
@@ -180,7 +180,7 @@ func TestVolume_Writer_Sync_Enabled_Wait_ToDisk(t *testing.T) {
 	wg.Wait()
 
 	// Check file content
-	AssertFileContent(t, w.FilePath(), `
+	AssertFileContent(t, tc.FilePath(), `
 foo,bar,123
 foo,bar,123
 abc,def,456
@@ -282,7 +282,7 @@ func TestVolume_Writer_Sync_Enabled_Wait_ToDiskCache(t *testing.T) {
 	wg.Wait()
 
 	// Check file content
-	AssertFileContent(t, w.FilePath(), `
+	AssertFileContent(t, tc.FilePath(), `
 foo,bar,123
 foo,bar,123
 abc,def,456
@@ -353,7 +353,7 @@ func TestVolume_Writer_Sync_Enabled_NoWait_ToDisk(t *testing.T) {
 	assert.NoError(t, w.Close(ctx))
 
 	// Check file content
-	AssertFileContent(t, w.FilePath(), `
+	AssertFileContent(t, tc.FilePath(), `
 foo,bar,123
 foo,bar,123
 abc,def,456
@@ -430,7 +430,7 @@ func TestVolume_Writer_Sync_Enabled_NoWait_ToDiskCache(t *testing.T) {
 	assert.NoError(t, w.Close(ctx))
 
 	// Check file content
-	AssertFileContent(t, w.FilePath(), `
+	AssertFileContent(t, tc.FilePath(), `
 foo,bar,123
 foo,bar,123
 abc,def,456
@@ -495,7 +495,7 @@ func TestVolume_Writer_Sync_Disabled(t *testing.T) {
 	assert.NoError(t, w.Close(ctx))
 
 	// Check file content
-	AssertFileContent(t, w.FilePath(), `
+	AssertFileContent(t, tc.FilePath(), `
 foo,bar,123
 foo,bar,123
 abc,def,456
@@ -529,11 +529,11 @@ func TestVolume_Writer_AllocateSpace_Error(t *testing.T) {
 
 	w, err := tc.NewWriter()
 	assert.NoError(t, err)
-	assert.FileExists(t, w.FilePath())
+	assert.FileExists(t, tc.FilePath())
 
 	// Close writer
 	assert.NoError(t, w.Close(ctx))
-	assert.FileExists(t, w.FilePath())
+	assert.FileExists(t, tc.FilePath())
 
 	// Check logs
 	tc.AssertLogs(`
@@ -555,11 +555,11 @@ func TestVolume_Writer_AllocateSpace_NotSupported(t *testing.T) {
 
 	w, err := tc.NewWriter()
 	assert.NoError(t, err)
-	assert.FileExists(t, w.FilePath())
+	assert.FileExists(t, tc.FilePath())
 
 	// Close writer
 	assert.NoError(t, w.Close(ctx))
-	assert.FileExists(t, w.FilePath())
+	assert.FileExists(t, tc.FilePath())
 
 	// Check logs
 	tc.AssertLogs(`
@@ -582,7 +582,7 @@ func TestVolume_Writer_AllocateSpace_Disabled(t *testing.T) {
 	assert.NoError(t, err)
 
 	// Check file - no allocation
-	allocated, err := diskalloc.Allocated(w.FilePath())
+	allocated, err := diskalloc.Allocated(tc.FilePath())
 	require.NoError(t, err)
 	assert.Less(t, allocated, datasize.KB)
 
@@ -643,6 +643,10 @@ func (tc *writerTestCase) NewWriter(opts ...Option) (writer.Writer, error) {
 	}
 
 	return w, nil
+}
+
+func (tc *writerTestCase) FilePath() string {
+	return filepath.Join(tc.VolumePath, tc.Slice.LocalStorage.Dir, tc.Slice.LocalStorage.Filename)
 }
 
 type testAllocator struct {

--- a/internal/pkg/service/stream/storage/level/local/writer/writer_test.go
+++ b/internal/pkg/service/stream/storage/level/local/writer/writer_test.go
@@ -33,13 +33,11 @@ func TestWriter(t *testing.T) {
 	file, err := os.OpenFile(filePath, os.O_WRONLY|os.O_CREATE|os.O_APPEND, 0o644)
 	assert.NoError(t, err)
 
-	w, err := writer.New(ctx, logger, clk, cfg, slice, file, dirPath, filePath, disksync.NewSyncer, test.DummyWriterFactory, writer.NewEvents())
+	w, err := writer.New(ctx, logger, clk, cfg, slice, file, disksync.NewSyncer, test.DummyWriterFactory, writer.NewEvents())
 	require.NoError(t, err)
 
 	// Test getters
 	assert.Equal(t, slice.SliceKey, w.SliceKey())
-	assert.Equal(t, dirPath, w.DirPath())
-	assert.Equal(t, filePath, w.FilePath())
 
 	// Test write methods
 	assert.NoError(t, w.WriteRecord(clk.Now(), []any{"123", "456", "789"}))
@@ -79,7 +77,7 @@ func TestWriter_FlushError(t *testing.T) {
 		return w, nil
 	}
 
-	w, err := writer.New(ctx, logger, clk, cfg, slice, file, dirPath, filePath, disksync.NewSyncer, writerFactory, writer.NewEvents())
+	w, err := writer.New(ctx, logger, clk, cfg, slice, file, disksync.NewSyncer, writerFactory, writer.NewEvents())
 	require.NoError(t, err)
 
 	// Test Close method
@@ -108,7 +106,7 @@ func TestWriter_CloseError(t *testing.T) {
 		return w, nil
 	}
 
-	w, err := writer.New(ctx, logger, clk, cfg, slice, file, dirPath, filePath, disksync.NewSyncer, writerFactory, writer.NewEvents())
+	w, err := writer.New(ctx, logger, clk, cfg, slice, file, disksync.NewSyncer, writerFactory, writer.NewEvents())
 	require.NoError(t, err)
 
 	// Test Close method


### PR DESCRIPTION
Jira: https://keboola.atlassian.net/browse/PSGO-597

**See [HTTP Source PRs Intro](https://github.com/keboola/keboola-as-code/pull/1875) at first.**

**Changes:**
- Statistics are no more backed up  to a filesystem file, only the etcd database is used.

-----------
