### PR TITLE
feat: Network transport (2) - TCP/KCP protocol can be switched by cfg

### DIFF
--- a/.github/actions/go-setup/action.yml
+++ b/.github/actions/go-setup/action.yml
@@ -66,12 +66,14 @@ runs:
         mkdir -p $GODIRS/modcache
         mkdir -p $GODIRS/lintcache
         mkdir -p $GODIRS/bin
+        mkdir -p $GODIRS/tmp
         
         go env -w \
         GOPATH=$GODIRS/path \
         GOCACHE=$GODIRS/cache \
         GOMODCACHE=$GODIRS/modcache \
         GOBIN=$GODIRS/bin \
+        GOTMPDIR=$GODIRS/tmp
         
         echo "GODIRS=$GODIRS" >> $GITHUB_ENV
         echo "GOLANGCI_LINT_CACHE=$GODIRS/lintcache" >> $GITHUB_ENV 

--- a/.github/workflows/test-lint.yml
+++ b/.github/workflows/test-lint.yml
@@ -16,6 +16,16 @@ jobs:
       - name: Checkout
         uses: actions/checkout@v4
 
+      - name: Free Disk Space (Ubuntu)
+        uses: jlumbroso/free-disk-space@main
+        with:
+          android: true
+          dotnet: true
+          haskell: true
+          large-packages: false
+          docker-images: false
+          swap-storage: false
+
       - name: Setup Go, tools and caching
         uses: ./.github/actions/go-setup
         with:

--- a/internal/pkg/service/stream/config/config_test.go
+++ b/internal/pkg/service/stream/config/config_test.go
@@ -184,24 +184,26 @@ storage:
                 network:
                     # Listen address of the configuration HTTP API. Validation rules: required,hostname_port
                     listen: 0.0.0.0:6000
+                    # Transport protocol. Validation rules: required,oneof=tcp kcp
+                    transport: tcp
                     # Keep alive interval. Validation rules: required,minDuration=1s,maxDuration=60s
                     keepAliveInterval: 5s
-                    # Buffer size for transferring data between source and writer nodes. Validation rules: required,minBytes=16kB,maxBytes=100MB
-                    inputBuffer: 10MB
-                    # Buffer size for transferring responses between writer and source node. Validation rules: required,minBytes=16kB,maxBytes=1MB
-                    responseBuffer: 32KB
                     # How many streams may be waiting an accept per connection. Validation rules: required,min=10,max=100000
                     maxWaitingStreamsPerConn: 1024
                     # Validation rules: required,minBytes=256kB,maxBytes=10MB
-                    streamMaxWindow: 512KB
+                    streamMaxWindow: 8MB
                     # Stream ACK timeout. Validation rules: required,minDuration=1s,maxDuration=30s
-                    streamOpenTimeout: 5s
+                    streamOpenTimeout: 10s
                     # Stream close timeout. Validation rules: required,minDuration=1s,maxDuration=30s
-                    streamCloseTimeout: 5s
+                    streamCloseTimeout: 10s
                     # Stream write timeout. Validation rules: required,minDuration=1s,maxDuration=60s
-                    streamWriteTimeout: 5s
+                    streamWriteTimeout: 10s
                     # How long the server waits for streams closing. Validation rules: required,minDuration=1s,max=600s
-                    shutdownTimeout: 5s
+                    shutdownTimeout: 30s
+                    # Buffer size for transferring data between source and writer nodes (kcp). Validation rules: required,minBytes=16kB,maxBytes=100MB
+                    kcpInputBuffer: 8MB
+                    # Buffer size for transferring responses between writer and source node (kcp). Validation rules: required,minBytes=16kB,maxBytes=100MB
+                    kcpResponseBuffer: 512KB
         staging:
             # Maximum number of slices in a file, a new file is created after reaching it. Validation rules: required,min=1,max=50000
             maxSlicesPerFile: 100

--- a/internal/pkg/service/stream/storage/level/local/config_test.go
+++ b/internal/pkg/service/stream/storage/level/local/config_test.go
@@ -23,15 +23,16 @@ func TestConfig_Validation(t *testing.T) {
 - "volume.allocation.relative" must be 100 or greater
 - "encoding.compression.type" is a required field
 - "writer.network.listen" is a required field
+- "writer.network.transport" is a required field
 - "writer.network.keepAliveInterval" is a required field
-- "writer.network.inputBuffer" is a required field
-- "writer.network.responseBuffer" is a required field
 - "writer.network.maxWaitingStreamsPerConn" is a required field
 - "writer.network.streamMaxWindow" is a required field
 - "writer.network.streamOpenTimeout" is a required field
 - "writer.network.streamCloseTimeout" is a required field
 - "writer.network.streamWriteTimeout" is a required field
 - "writer.network.shutdownTimeout" is a required field
+- "writer.network.kcpInputBuffer" is a required field
+- "writer.network.kcpResponseBuffer" is a required field
 `,
 			Value: local.Config{},
 		},

--- a/internal/pkg/service/stream/storage/level/local/diskwriter/network/config.go
+++ b/internal/pkg/service/stream/storage/level/local/diskwriter/network/config.go
@@ -6,30 +6,39 @@ import (
 	"github.com/c2h5oh/datasize"
 )
 
+const (
+	TransportProtocolKCP = TransportProtocol("kcp")
+	TransportProtocolTCP = TransportProtocol("tcp")
+)
+
+type TransportProtocol string
+
 type Config struct {
 	Listen             string            `configKey:"listen" configUsage:"Listen address of the configuration HTTP API." validate:"required,hostname_port"`
+	Transport          TransportProtocol `configKey:"transport" configUsage:"Transport protocol." validate:"required,oneof=tcp kcp"`
 	KeepAliveInterval  time.Duration     `configKey:"keepAliveInterval" configUsage:"Keep alive interval." validate:"required,minDuration=1s,maxDuration=60s"`
-	InputBuffer        datasize.ByteSize `configKey:"inputBuffer" configUsage:"Buffer size for transferring data between source and writer nodes." validate:"required,minBytes=16kB,maxBytes=100MB"`
-	ResponseBuffer     datasize.ByteSize `configKey:"responseBuffer" configUsage:"Buffer size for transferring responses between writer and source node." validate:"required,minBytes=16kB,maxBytes=1MB"`
 	MaxWaitingStreams  int               `configKey:"maxWaitingStreamsPerConn" configUsage:"How many streams may be waiting an accept per connection." validate:"required,min=10,max=100000"`
 	StreamMaxWindow    datasize.ByteSize `configKey:"streamMaxWindow" configUsage:"" validate:"required,minBytes=256kB,maxBytes=10MB"`
 	StreamOpenTimeout  time.Duration     `configKey:"streamOpenTimeout" configUsage:"Stream ACK timeout." validate:"required,minDuration=1s,maxDuration=30s"`
 	StreamCloseTimeout time.Duration     `configKey:"streamCloseTimeout" configUsage:"Stream close timeout." validate:"required,minDuration=1s,maxDuration=30s"`
 	StreamWriteTimeout time.Duration     `configKey:"streamWriteTimeout" configUsage:"Stream write timeout." validate:"required,minDuration=1s,maxDuration=60s"`
 	ShutdownTimeout    time.Duration     `configKey:"shutdownTimeout" configUsage:"How long the server waits for streams closing." validate:"required,minDuration=1s,max=600s"`
+	KCPInputBuffer     datasize.ByteSize `configKey:"kcpInputBuffer" configUsage:"Buffer size for transferring data between source and writer nodes (kcp)." validate:"required,minBytes=16kB,maxBytes=100MB"`
+	KCPResponseBuffer  datasize.ByteSize `configKey:"kcpResponseBuffer" configUsage:"Buffer size for transferring responses between writer and source node (kcp)." validate:"required,minBytes=16kB,maxBytes=100MB"`
 }
 
 func NewConfig() Config {
 	return Config{
 		Listen:             "0.0.0.0:6000",
+		Transport:          TransportProtocolTCP,
 		KeepAliveInterval:  5 * time.Second,
-		InputBuffer:        10 * datasize.MB,
-		ResponseBuffer:     32 * datasize.KB,
 		MaxWaitingStreams:  1024,
-		StreamMaxWindow:    512 * datasize.KB,
-		StreamOpenTimeout:  5 * time.Second,
-		StreamCloseTimeout: 5 * time.Second,
-		StreamWriteTimeout: 5 * time.Second,
-		ShutdownTimeout:    5 * time.Second,
+		StreamMaxWindow:    8 * datasize.MB,
+		StreamOpenTimeout:  10 * time.Second,
+		StreamCloseTimeout: 10 * time.Second,
+		StreamWriteTimeout: 10 * time.Second,
+		ShutdownTimeout:    30 * time.Second,
+		KCPInputBuffer:     8 * datasize.MB,
+		KCPResponseBuffer:  512 * datasize.KB,
 	}
 }

--- a/internal/pkg/service/stream/storage/level/local/diskwriter/network/transport/transport_kcp.go
+++ b/internal/pkg/service/stream/storage/level/local/diskwriter/network/transport/transport_kcp.go
@@ -1,0 +1,73 @@
+package transport
+
+import (
+	"github.com/keboola/keboola-as-code/internal/pkg/service/stream/storage/level/local/diskwriter/network"
+	"github.com/keboola/keboola-as-code/internal/pkg/utils/errors"
+	"github.com/xtaci/kcp-go/v5"
+	"net"
+)
+
+type Transport interface {
+	// Listen for connections by the server.
+	Listen(config network.Config) (net.Listener, error)
+	// Accept new connection by the server.
+	Accept(listener net.Listener) (net.Conn, error)
+	// Dial a new connection from the client.
+	Dial(addr string, config network.Config) (net.Conn, error)
+}
+
+type kcpTransport struct{}
+
+func (*kcpTransport) Listen(config network.Config) (net.Listener, error) {
+	listener, err := kcp.ListenWithOptions(config.Listen, nil, 0, 0)
+	if err != nil {
+		return nil, errors.PrefixError(err, "cannot create listener")
+	}
+
+	// Setup buffer sizes (reversed as on the client side)
+	if err := listener.SetReadBuffer(int(config.InputBuffer.Bytes())); err != nil {
+		return nil, errors.PrefixError(err, "cannot set read buffer size")
+	}
+	if err := listener.SetWriteBuffer(int(config.ResponseBuffer.Bytes())); err != nil {
+		return nil, errors.PrefixError(err, "cannot set write buffer size")
+	}
+
+	return listener, nil
+}
+
+func (t *kcpTransport) Accept(listener net.Listener) (net.Conn, error) {
+	conn, err := listener.Accept()
+	if err != nil {
+		return nil, err
+	}
+
+	if conn, ok := conn.(*kcp.UDPSession); ok {
+		t.setupKCPConnection(conn)
+	}
+
+	return conn, nil
+}
+
+func (t *kcpTransport) Dial(addr string, config network.Config) (net.Conn, error) {
+	conn, err := kcp.DialWithOptions(addr, nil, 0, 0)
+	if err != nil {
+		return nil, err
+	}
+
+	// Setup buffer sizes (reversed as on the server side)
+	if err := conn.SetReadBuffer(int(config.ResponseBuffer.Bytes())); err != nil {
+		return nil, errors.PrefixError(err, "cannot set read buffer size")
+	}
+	if err := conn.SetWriteBuffer(int(config.InputBuffer.Bytes())); err != nil {
+		return nil, errors.PrefixError(err, "cannot set write buffer size")
+	}
+
+	t.setupKCPConnection(conn)
+
+	return conn, nil
+}
+
+func (*kcpTransport) setupKCPConnection(conn *kcp.UDPSession) {
+	conn.SetStreamMode(true)
+	conn.SetNoDelay(1, 5, 2, 1)
+}

--- a/internal/pkg/service/stream/storage/level/local/diskwriter/network/transport/transport_tcp.go
+++ b/internal/pkg/service/stream/storage/level/local/diskwriter/network/transport/transport_tcp.go
@@ -1,0 +1,70 @@
+package transport
+
+import (
+	"github.com/keboola/keboola-as-code/internal/pkg/service/stream/storage/level/local/diskwriter/network"
+	"github.com/keboola/keboola-as-code/internal/pkg/utils/errors"
+	"github.com/xtaci/kcp-go/v5"
+	"net"
+)
+
+type kcpTransport struct {
+	config network.Config
+}
+
+func newKcpTransport(config network.Config) Transport {
+	return &kcpTransport{config: config}
+}
+
+func (t *kcpTransport) Listen() (net.Listener, error) {
+	listener, err := kcp.ListenWithOptions(t.config.Listen, nil, 0, 0)
+	if err != nil {
+		return nil, errors.PrefixError(err, "cannot create listener")
+	}
+
+	// Setup buffer sizes (reversed as on the client side)
+	if err := listener.SetReadBuffer(int(t.config.InputBuffer.Bytes())); err != nil {
+		return nil, errors.PrefixError(err, "cannot set read buffer size")
+	}
+	if err := listener.SetWriteBuffer(int(t.config.ResponseBuffer.Bytes())); err != nil {
+		return nil, errors.PrefixError(err, "cannot set write buffer size")
+	}
+
+	return listener, nil
+}
+
+func (t *kcpTransport) Accept(listener net.Listener) (net.Conn, error) {
+	conn, err := listener.Accept()
+	if err != nil {
+		return nil, err
+	}
+
+	if conn, ok := conn.(*kcp.UDPSession); ok {
+		t.setupConnection(conn)
+	}
+
+	return conn, nil
+}
+
+func (t *kcpTransport) Dial(addr string) (net.Conn, error) {
+	conn, err := kcp.DialWithOptions(addr, nil, 0, 0)
+	if err != nil {
+		return nil, err
+	}
+
+	// Setup buffer sizes (reversed as on the server side)
+	if err := conn.SetReadBuffer(int(t.config.ResponseBuffer.Bytes())); err != nil {
+		return nil, errors.PrefixError(err, "cannot set read buffer size")
+	}
+	if err := conn.SetWriteBuffer(int(t.config.InputBuffer.Bytes())); err != nil {
+		return nil, errors.PrefixError(err, "cannot set write buffer size")
+	}
+
+	t.setupConnection(conn)
+
+	return conn, nil
+}
+
+func (*kcpTransport) setupConnection(conn *kcp.UDPSession) {
+	conn.SetStreamMode(true)
+	conn.SetNoDelay(1, 5, 2, 1)
+}

--- a/internal/pkg/service/stream/storage/level/local/diskwriter/network/transport/util.go
+++ b/internal/pkg/service/stream/storage/level/local/diskwriter/network/transport/util.go
@@ -1,0 +1,33 @@
+package transport
+
+import (
+	"fmt"
+	"io"
+
+	"github.com/hashicorp/yamux"
+
+	"github.com/keboola/keboola-as-code/internal/pkg/log"
+	"github.com/keboola/keboola-as-code/internal/pkg/service/stream/storage/level/local/diskwriter/network"
+)
+
+func sessionKey(session *yamux.Session) string {
+	return session.RemoteAddr().String()
+}
+
+func streamKey(stream *yamux.Stream) string {
+	return fmt.Sprintf(`%s-%d`, stream.RemoteAddr(), stream.StreamID())
+}
+
+func multiplexerConfig(_ log.Logger, config network.Config) *yamux.Config {
+	return &yamux.Config{
+		AcceptBacklog:          config.MaxWaitingStreams,
+		EnableKeepAlive:        true,
+		KeepAliveInterval:      config.KeepAliveInterval,
+		ConnectionWriteTimeout: config.StreamWriteTimeout,
+		MaxStreamWindowSize:    uint32(config.StreamMaxWindow.Bytes()),
+		StreamOpenTimeout:      config.StreamOpenTimeout,
+		StreamCloseTimeout:     config.StreamCloseTimeout,
+		// Logger: log.NewStdErrorLogger(logger.WithComponent("mux")),
+		LogOutput: io.Discard,
+	}
+}

--- a/internal/pkg/service/stream/storage/level/local/diskwriter/network/transport/util.go
+++ b/internal/pkg/service/stream/storage/level/local/diskwriter/network/transport/util.go
@@ -27,6 +27,7 @@ func multiplexerConfig(_ log.Logger, config network.Config) *yamux.Config {
 		MaxStreamWindowSize:    uint32(config.StreamMaxWindow.Bytes()),
 		StreamOpenTimeout:      config.StreamOpenTimeout,
 		StreamCloseTimeout:     config.StreamCloseTimeout,
+		// Disable logs, prevent duplicate error logs.
 		// Logger: log.NewStdErrorLogger(logger.WithComponent("mux")),
 		LogOutput: io.Discard,
 	}

--- a/provisioning/stream/kubernetes/templates/config/config-map.yaml
+++ b/provisioning/stream/kubernetes/templates/config/config-map.yaml
@@ -169,24 +169,26 @@ data:
               network:
                 # Listen address of the configuration HTTP API. Validation rules: required,hostname_port
                 #listen: 0.0.0.0:6000
+                # Transport protocol. Validation rules: required,oneof=tcp kcp
+                transport: tcp
                 # Keep alive interval. Validation rules: required,minDuration=1s,maxDuration=60s
                 keepAliveInterval: 5s
-                # Buffer size for transferring data between source and writer nodes. Validation rules: required,minBytes=16kB,maxBytes=100MB
-                inputBuffer: 10MB
-                # Buffer size for transferring responses between writer and source node. Validation rules: required,minBytes=16kB,maxBytes=1MB
-                responseBuffer: 32KB
                 # How many streams may be waiting an accept per connection. Validation rules: required,min=10,max=100000
                 maxWaitingStreamsPerConn: 1024
                 # Validation rules: required,minBytes=256kB,maxBytes=10MB
-                streamMaxWindow: 512KB
+                streamMaxWindow: 8MB
                 # Stream ACK timeout. Validation rules: required,minDuration=1s,maxDuration=30s
-                streamOpenTimeout: 5s
+                streamOpenTimeout: 10s
                 # Stream close timeout. Validation rules: required,minDuration=1s,maxDuration=30s
-                streamCloseTimeout: 5s
+                streamCloseTimeout: 10s
                 # Stream write timeout. Validation rules: required,minDuration=1s,maxDuration=60s
-                streamWriteTimeout: 5s
+                streamWriteTimeout: 10s
                 # How long the server waits for streams closing. Validation rules: required,minDuration=1s,max=600s
-                shutdownTimeout: 5s
+                shutdownTimeout: 30s
+                # Buffer size for transferring data between source and writer nodes (kcp). Validation rules: required,minBytes=16kB,maxBytes=100MB
+                kcpInputBuffer: 8MB
+                # Buffer size for transferring responses between writer and source node (kcp). Validation rules: required,minBytes=16kB,maxBytes=100MB
+                kcpResponseBuffer: 512KB
         staging:
           # Maximum number of slices in a file, a new file is created after reaching it. Validation rules: required,min=1,max=50000
           maxSlicesPerFile: 100

--- a/provisioning/stream/kubernetes/templates/storage-writer-reader/statefulset.yaml
+++ b/provisioning/stream/kubernetes/templates/storage-writer-reader/statefulset.yaml
@@ -67,7 +67,7 @@ spec:
             limits:
               memory: "$STREAM_STORAGE_WRITER_MEMORY_HARD_LIMIT"
           ports:
-            - containerPort: 6000 # R-UDP disk writer listener
+            - containerPort: 6000 # disk writer listener
             - containerPort: 9001 # metrics
           volumeMounts:
             - name: config


### PR DESCRIPTION
Jira: https://keboola.atlassian.net/browse/PSGO-597

See https://github.com/keboola/keboola-as-code/pull/1894

**Changes:**
- `TCP/KCP` protocol can be switched by configuration.
  - Default value is `TCP`.
  - It will be good enough for start and save time.
  - [UPD Buffer Size](https://github.com/quic-go/quic-go/wiki/UDP-Buffer-Sizes) is necessary to achieve high performance, but it is not easy to set up in Kubernetes (I don't know which defaults value are in our stacks).
- Improved tests.
- Related to:
  - https://github.com/keboola/keboola-as-code/pull/1894#discussion_r1670096248
  - https://github.com/keboola/keboola-as-code/pull/1894#discussion_r1669818027
-----------

KCP is on `localhost` 2-3x slower than TCP, but it is expected.
- TCP runs in kernel space and has various optimalization for localhost.
- KCP runs in user space and its benefits can be seen on real networks (see projects like: [kcptun](https://github.com/xtaci/kcptun), [frp](https://github.com/fatedier/frp), [syncthing](https://github.com/syncthing/syncthing), ...)

`dataSize = 100MB` - both protocols are fast enough up to `500MB/s` on localhost.

![image](https://github.com/keboola/keboola-as-code/assets/19371734/060ce0ca-e6ea-4094-ac67-ee0d8678404d)

Read more (`quic` is another R-UDP protocol, the principle is the same):
- https://github.com/quic-go/quic-go/issues/2586#issuecomment-642312892
- https://github.com/quic-go/quic-go/issues/2586#issuecomment-876488346

