### PR TITLE
Apps Proxy - Increase max upload size for AWS, GCP

### DIFF
--- a/provisioning/apps-proxy/kubernetes/templates/cloud/aws/ingress.yaml
+++ b/provisioning/apps-proxy/kubernetes/templates/cloud/aws/ingress.yaml
@@ -8,6 +8,7 @@ metadata:
     app: apps-proxy
   annotations:
     kubernetes.io/ingress.class: "nginx"
+    nginx.ingress.kubernetes.io/proxy-body-size: "4096m"
 spec:
   rules:
     - host: "hub.${HOSTNAME_SUFFIX}"

--- a/provisioning/apps-proxy/kubernetes/templates/cloud/gcp/ingress.yaml
+++ b/provisioning/apps-proxy/kubernetes/templates/cloud/gcp/ingress.yaml
@@ -8,6 +8,7 @@ metadata:
     app: apps-proxy
   annotations:
     kubernetes.io/ingress.class: "nginx"
+    nginx.ingress.kubernetes.io/proxy-body-size: "4096m"
 spec:
   rules:
     - host: "hub.${HOSTNAME_SUFFIX}"


### PR DESCRIPTION
Jira: https://keboola.atlassian.net/browse/SUPPORT-6651

**Changes:**
- Increase max upload size for Apps proxy

-----------

- Increased max upload size for Apps proxy for AWS and GCP
- Azure does not use K8S ingress. Application Gateway is used for Azure, I will test it there later.
- Tests after change https://my-data-app-3141611.hub.us-central1.gcp.keboola.dev/ 
<img width="641" alt="image" src="https://github.com/keboola/keboola-as-code/assets/903531/6d9fe782-33a9-4f69-b5af-0520a246ebbb">
