### PR TITLE
feat: Add column.Renderer to csv.Encoder, modify the interface

### DIFF
--- a/internal/pkg/service/stream/dependencies/mocked.go
+++ b/internal/pkg/service/stream/dependencies/mocked.go
@@ -2,6 +2,7 @@ package dependencies
 
 import (
 	"context"
+	"fmt"
 	"net/url"
 	"strings"
 	"testing"
@@ -20,6 +21,7 @@ import (
 	"github.com/keboola/keboola-as-code/internal/pkg/service/stream/sink/pipeline"
 	"github.com/keboola/keboola-as-code/internal/pkg/service/stream/storage/model"
 	"github.com/keboola/keboola-as-code/internal/pkg/service/stream/storage/test"
+	"github.com/keboola/keboola-as-code/internal/pkg/utils/netutils"
 )
 
 // mocked implements Mocked interface.
@@ -205,6 +207,7 @@ func testConfig(t *testing.T, d dependencies.Mocked) config.Config {
 	cfg.API.PublicURL, _ = url.Parse("https://stream.keboola.local")
 	cfg.Source.HTTP.PublicURL, _ = url.Parse("https://stream-in.keboola.local")
 	cfg.Etcd = d.TestEtcdConfig()
+	cfg.Storage.Level.Local.Writer.Network.Listen = fmt.Sprintf("0.0.0.0:%d", netutils.FreePortForTest(t))
 
 	// There are some timers with a few seconds interval.
 	// It causes problems when mocked clock is used.

--- a/internal/pkg/service/stream/storage/level/local/diskwriter/network/transport/client.go
+++ b/internal/pkg/service/stream/storage/level/local/diskwriter/network/transport/client.go
@@ -90,6 +90,8 @@ func NewClient(d clientDependencies, config network.Config, nodeID string) (*Cli
 		}
 		sessWg.Wait()
 
+		// Wait for remaining goroutines
+		c.logger.Info(ctx, "waiting for goroutines")
 		c.wg.Wait()
 		c.logger.Info(ctx, "closed disk writer client")
 	})

--- a/internal/pkg/service/stream/storage/level/local/encoding/encoder/csv/csv.go
+++ b/internal/pkg/service/stream/storage/level/local/encoding/encoder/csv/csv.go
@@ -2,7 +2,9 @@ package csv
 
 import (
 	"io"
+	"sync"
 
+	"github.com/keboola/keboola-as-code/internal/pkg/service/stream/mapping/recordctx"
 	"github.com/keboola/keboola-as-code/internal/pkg/service/stream/mapping/table/column"
 	"github.com/keboola/keboola-as-code/internal/pkg/service/stream/storage/level/local/encoding/encoder/csv/fastcsv"
 	"github.com/keboola/keboola-as-code/internal/pkg/service/stream/storage/model"
@@ -10,22 +12,45 @@ import (
 )
 
 type Encoder struct {
-	columns column.Columns
-	pool    *fastcsv.WritersPool
+	columns     column.Columns
+	writersPool *fastcsv.WritersPool
+	valuesPool  *sync.Pool
 }
+
+var columnRenderer = column.NewRenderer() //nolint:gochecknoglobals // contains Jsonnet VMs sync.Pool
 
 // NewEncoder creates CSV writers pool and implements encoder.Encoder
 // The order of the lines is not preserved, because we use the writers pool,
 // but also because there are several source nodes with a load balancer in front of them.
 func NewEncoder(concurrency int, out io.Writer, slice *model.Slice) (*Encoder, error) {
 	return &Encoder{
-		columns: slice.Columns,
-		pool:    fastcsv.NewWritersPool(out, concurrency),
+		columns:     slice.Columns,
+		writersPool: fastcsv.NewWritersPool(out, concurrency),
+		valuesPool: &sync.Pool{
+			New: func() any {
+				v := make([]any, len(slice.Columns))
+				return &v
+			},
+		},
 	}, nil
 }
 
-func (w *Encoder) WriteRecord(values []any) error {
-	err := w.pool.WriteRow(&values)
+func (w *Encoder) WriteRecord(record recordctx.Context) error {
+	// Reduce memory allocations
+	values := w.valuesPool.Get().(*[]any)
+	defer w.valuesPool.Put(values)
+
+	// Map the record to tabular data
+	for i, col := range w.columns {
+		str, err := columnRenderer.CSVValue(col, record)
+		if err != nil {
+			return errors.PrefixErrorf(err, "cannot convert column %q to CSV value", col)
+		}
+		(*values)[i] = str
+	}
+
+	// Encode the values to CSV format
+	err := w.writersPool.WriteRow(values)
 	if err != nil {
 		var valErr fastcsv.ValueError
 		if errors.As(err, &valErr) {

--- a/internal/pkg/service/stream/storage/level/local/encoding/encoder/encoder.go
+++ b/internal/pkg/service/stream/storage/level/local/encoding/encoder/encoder.go
@@ -1,9 +1,11 @@
 package encoder
 
+import "github.com/keboola/keboola-as-code/internal/pkg/service/stream/mapping/recordctx"
+
 // Encoder writers record values as bytes to the underlying writer.
 // It is used inside the Writer pipeline, at the beginning, before the compression.
 type Encoder interface {
-	WriteRecord(values []any) error
+	WriteRecord(record recordctx.Context) error
 	Flush() error
 	Close() error
 }

--- a/internal/pkg/service/stream/storage/statistics/collector/collector_test.go
+++ b/internal/pkg/service/stream/storage/statistics/collector/collector_test.go
@@ -14,6 +14,7 @@ import (
 	commonDeps "github.com/keboola/keboola-as-code/internal/pkg/service/common/dependencies"
 	"github.com/keboola/keboola-as-code/internal/pkg/service/common/utctime"
 	"github.com/keboola/keboola-as-code/internal/pkg/service/stream/dependencies"
+	"github.com/keboola/keboola-as-code/internal/pkg/service/stream/mapping/recordctx"
 	"github.com/keboola/keboola-as-code/internal/pkg/service/stream/storage/level/local/encoding"
 	"github.com/keboola/keboola-as-code/internal/pkg/service/stream/storage/level/local/events"
 	"github.com/keboola/keboola-as-code/internal/pkg/service/stream/storage/model"
@@ -156,7 +157,7 @@ func (w *testWriter) UncompressedSize() datasize.ByteSize {
 	return w.UncompressedSizeValue
 }
 
-func (w *testWriter) WriteRecord(_ time.Time, _ []any) error {
+func (w *testWriter) WriteRecord(recordctx.Context) error {
 	panic(errors.New("method should not be called"))
 }
 

--- a/internal/pkg/service/stream/storage/test/slice.go
+++ b/internal/pkg/service/stream/storage/test/slice.go
@@ -43,8 +43,7 @@ func NewSliceOpenedAt(openedAt string) *model.Slice {
 		Type:     model.FileTypeCSV,
 		State:    model.SliceWriting,
 		Columns: column.Columns{
-			column.UUID{},
-			column.Headers{},
+			column.Datetime{},
 			column.Body{},
 		},
 		LocalStorage: localModel.Slice{


### PR DESCRIPTION
Jira: https://keboola.atlassian.net/browse/PSGO-597

**Changes:**
- `column.Renderer` is now part of the `csv.Encoder`.
- Modified the pipeline interface:
  - From: `WriteRecord(values []any) error`
  - To: `WriteRecord(record recordctx.Context) error`
- Why:
  - It simplifies other parts of the service.
  - CSV encoding is no more divided to two parts, the encoder gets record context and produces CSV rows.
  - Other formats will be implemented more easily if needed.

![image](https://github.com/user-attachments/assets/ac161385-e7c7-48d2-a572-9dae5c5191cd)

