### PR TITLE
fix: Telemetry events compatibility

### DIFF
--- a/internal/pkg/service/stream/storage/event/sender.go
+++ b/internal/pkg/service/stream/storage/event/sender.go
@@ -17,7 +17,8 @@ import (
 	"github.com/keboola/keboola-as-code/internal/pkg/utils/errors"
 )
 
-const componentID = keboola.ComponentID("keboola.keboola-stream")
+// Schema: https://github.com/keboola/event-schema/blob/main/schema/ext.keboola.keboola-buffer..json
+const componentID = keboola.ComponentID("keboola.keboola-buffer")
 
 type Sender struct {
 	logger log.Logger
@@ -114,11 +115,16 @@ func (s *Sender) sendEvent(ctx context.Context, api *keboola.AuthorizedAPI, dura
 		Duration:    client.DurationSeconds(duration),
 		Params: map[string]any{
 			"eventName": eventName,
+			// legacy fields for compatibility with buffer events
+			"task": eventName,
 		},
 		Results: map[string]any{
 			"projectId": params.ProjectID,
 			"sourceId":  params.SourceID,
 			"sinkId":    params.SinkID,
+			// legacy fields for compatibility with buffer events
+			"receiverId": params.SourceID,
+			"exportId":   params.SinkID,
 		},
 	}
 	if err != nil {
@@ -133,6 +139,11 @@ func (s *Sender) sendEvent(ctx context.Context, api *keboola.AuthorizedAPI, dura
 			"uncompressedSize": params.Stats.UncompressedSize.Bytes(),
 			"compressedSize":   params.Stats.CompressedSize.Bytes(),
 			"stagingSize":      params.Stats.StagingSize.Bytes(),
+			// legacy fields for compatibility with buffer events
+			"recordsSize":  params.Stats.CompressedSize.Bytes(),
+			"bodySize":     params.Stats.UncompressedSize.Bytes(),
+			"fileSize":     params.Stats.UncompressedSize.Bytes(),
+			"fileGZipSize": params.Stats.CompressedSize.Bytes(),
 		}
 	}
 

--- a/internal/pkg/service/stream/storage/event/sender_test.go
+++ b/internal/pkg/service/stream/storage/event/sender_test.go
@@ -46,11 +46,11 @@ func TestSender_SendSliceUploadEvent_OkEvent(t *testing.T) {
 	mock.DebugLogger().AssertJSONMessages(t, `{"level":"debug","message":"Sent \"slice-upload\" event id: \"12345\""}`)
 	wildcards.Assert(t, `
 {
-  "component": "keboola.keboola-stream",
+  "component": "keboola.keboola-buffer",
   "duration": 3,
   "message": "Slice upload done.",
-  "params": "{\"eventName\":\"slice-upload\"}",
-  "results": "{\"projectId\":123,\"sinkId\":\"my-sink\",\"sourceId\":\"my-source\",\"statistics\":{\"compressedSize\":52428800,\"firstRecordAt\":\"2000-01-01T20:00:00.000Z\",\"lastRecordAt\":\"2000-01-02T01:00:00.000Z\",\"recordsCount\":123,\"slicesCount\":1,\"stagingSize\":26214400,\"uncompressedSize\":104857600}}",
+  "params": "{\"eventName\":\"slice-upload\",\"task\":\"slice-upload\"}",
+  "results": "{\"exportId\":\"my-sink\",\"projectId\":123,\"receiverId\":\"my-source\",\"sinkId\":\"my-sink\",\"sourceId\":\"my-source\",\"statistics\":{\"bodySize\":104857600,\"compressedSize\":52428800,\"fileGZipSize\":52428800,\"fileSize\":104857600,\"firstRecordAt\":\"2000-01-01T20:00:00.000Z\",\"lastRecordAt\":\"2000-01-02T01:00:00.000Z\",\"recordsCount\":123,\"recordsSize\":52428800,\"slicesCount\":1,\"stagingSize\":26214400,\"uncompressedSize\":104857600}}",
   "type": "info"
 }`, body)
 }
@@ -78,11 +78,11 @@ func TestSender_SendSliceUploadEvent_ErrorEvent(t *testing.T) {
 	mock.DebugLogger().AssertJSONMessages(t, `{"level":"debug","message":"Sent \"slice-upload\" event id: \"12345\""}`)
 	wildcards.Assert(t, `
 {
-  "component": "keboola.keboola-stream",
+  "component": "keboola.keboola-buffer",
   "duration": 3,
   "message": "Slice upload failed.",
-  "params": "{\"eventName\":\"slice-upload\"}",
-  "results": "{\"error\":\"some error\",\"projectId\":123,\"sinkId\":\"my-sink\",\"sourceId\":\"my-source\"}",
+  "params": "{\"eventName\":\"slice-upload\",\"task\":\"slice-upload\"}",
+  "results": "{\"error\":\"some error\",\"exportId\":\"my-sink\",\"projectId\":123,\"receiverId\":\"my-source\",\"sinkId\":\"my-sink\",\"sourceId\":\"my-source\"}",
   "type": "error"
 }`, body)
 }
@@ -132,11 +132,11 @@ func TestSender_SendFileImportEvent_OkEvent(t *testing.T) {
 	mock.DebugLogger().AssertJSONMessages(t, `{"level":"debug","message":"Sent \"file-import\" event id: \"12345\""}`)
 	wildcards.Assert(t, `
 {
-  "component": "keboola.keboola-stream",
+  "component": "keboola.keboola-buffer",
   "duration": 3,
   "message": "File import done.",
-  "params": "{\"eventName\":\"file-import\"}",
-  "results": "{\"projectId\":123,\"sinkId\":\"my-sink\",\"sourceId\":\"my-source\",\"statistics\":{\"compressedSize\":52428800,\"firstRecordAt\":\"2000-01-01T01:00:00.000Z\",\"lastRecordAt\":\"2000-01-02T01:00:00.000Z\",\"recordsCount\":123,\"slicesCount\":10,\"stagingSize\":26214400,\"uncompressedSize\":104857600}}",
+  "params": "{\"eventName\":\"file-import\",\"task\":\"file-import\"}",
+  "results": "{\"exportId\":\"my-sink\",\"projectId\":123,\"receiverId\":\"my-source\",\"sinkId\":\"my-sink\",\"sourceId\":\"my-source\",\"statistics\":{\"bodySize\":104857600,\"compressedSize\":52428800,\"fileGZipSize\":52428800,\"fileSize\":104857600,\"firstRecordAt\":\"2000-01-01T01:00:00.000Z\",\"lastRecordAt\":\"2000-01-02T01:00:00.000Z\",\"recordsCount\":123,\"recordsSize\":52428800,\"slicesCount\":10,\"stagingSize\":26214400,\"uncompressedSize\":104857600}}",
   "type": "info"
 }`, body)
 }
@@ -164,11 +164,11 @@ func TestSender_SendFileImportEvent_ErrorEvent(t *testing.T) {
 	mock.DebugLogger().AssertJSONMessages(t, `{"level":"debug","message":"Sent \"file-import\" event id: \"12345\""}`)
 	wildcards.Assert(t, `
 {
-  "component": "keboola.keboola-stream",
+  "component": "keboola.keboola-buffer",
   "duration": 3,
   "message": "File import failed.",
-  "params": "{\"eventName\":\"file-import\"}",
-  "results": "{\"error\":\"some error\",\"projectId\":123,\"sinkId\":\"my-sink\",\"sourceId\":\"my-source\"}",
+  "params": "{\"eventName\":\"file-import\",\"task\":\"file-import\"}",
+  "results": "{\"error\":\"some error\",\"exportId\":\"my-sink\",\"projectId\":123,\"receiverId\":\"my-source\",\"sinkId\":\"my-sink\",\"sourceId\":\"my-source\"}",
   "type": "error"
 }`, body)
 }


### PR DESCRIPTION
Jira: https://keboola.atlassian.net/browse/PSGO-687

**Changes:**
- Telemetry events of streams are now backwards compatible with buffer events.

-----------
