### PR TITLE
fix: Increase timeout of proxy concurrency test

### DIFF
--- a/internal/pkg/service/appsproxy/proxy/proxy_test.go
+++ b/internal/pkg/service/appsproxy/proxy/proxy_test.go
@@ -1677,7 +1677,7 @@ func TestAppProxyRouter(t *testing.T) {
 		{
 			name: "concurrency-test",
 			run: func(t *testing.T, client *http.Client, m []*mockoidc.MockOIDC, appServer *testutil.AppServer, service *testutil.DataAppsAPI, dnsServer *dnsmock.Server) {
-				ctx, cancel := context.WithTimeout(context.Background(), 10*time.Second)
+				ctx, cancel := context.WithTimeout(context.Background(), 30*time.Second)
 				defer cancel()
 
 				wg := sync.WaitGroup{}


### PR DESCRIPTION
**Changes:**
- Change behaviour of single context per test case -> context of single go routine

-----------
