### PR TITLE
feat: AWS deployment k8s StorageClass for stream-api

### DIFF
--- a/provisioning/stream/aws.sh
+++ b/provisioning/stream/aws.sh
@@ -24,6 +24,7 @@ kubectl apply -f ./kubernetes/deploy/cloud/aws/service-api.yaml
 kubectl apply -f ./kubernetes/deploy/cloud/aws/ingress-api.yaml
 kubectl apply -f ./kubernetes/deploy/cloud/aws/service-http-source.yaml
 kubectl apply -f ./kubernetes/deploy/cloud/aws/ingress-http-source.yaml
+kubectl apply -f ./kubernetes/deploy/cloud/aws/sc-stream-api.yaml
 
 # Wait for the rollout
 . ./wait.sh

--- a/provisioning/stream/kubernetes/build.sh
+++ b/provisioning/stream/kubernetes/build.sh
@@ -64,6 +64,7 @@ if [[ "$CLOUD_PROVIDER" == "aws" ]]; then
   envsubst < templates/cloud/aws/ingress-api.yaml > deploy/cloud/aws/ingress-api.yaml
     envsubst < templates/cloud/aws/service-http-source.yaml > deploy/cloud/aws/service-http-source.yaml
     envsubst < templates/cloud/aws/ingress-http-source.yaml > deploy/cloud/aws/ingress-http-source.yaml
+  envsubst < templates/cloud/aws/sc-stream-api.yaml > deploy/cloud/aws/sc-stream-api.yaml
 elif [[ "$CLOUD_PROVIDER" == "gcp" ]]; then
   mkdir deploy/cloud/gcp
   envsubst < templates/cloud/gcp/service-api.yaml > deploy/cloud/gcp/service-api.yaml

--- a/provisioning/stream/kubernetes/templates/cloud/aws/sc-stream-api.yaml
+++ b/provisioning/stream/kubernetes/templates/cloud/aws/sc-stream-api.yaml
@@ -1,0 +1,14 @@
+apiVersion: storage.k8s.io/v1
+kind: StorageClass
+metadata:
+  name: stream-api
+provisioner: kubernetes.io/aws-ebs
+volumeBindingMode: WaitForFirstConsumer
+allowVolumeExpansion: true
+parameters:
+  type: gp3
+  fsType: ext4
+  throughput: "270"
+  encrypted: "true"
+  allowAutoIOPSPerGBIncrease: "true"
+


### PR DESCRIPTION
Jira: [ST-1962](https://keboola.atlassian.net/browse/ST-1962)

please see:
https://keboola.atlassian.net/wiki/spaces/ENGG/pages/3514040374/Cloud+storage+benchmarks

**Changes:**
- new Kubernetes storage class for AWS dedicated to stream-api service

**Plan:**
- [ ] review & merge this
- [ ] merge https://github.com/keboola/kbc-stacks/pull/1099/files
- [ ] deploy to testing AWS stack
- [ ] run benchmarks
- [ ] compare benchmarks with GCP
- [ ] decide if we need some changes based on benchmark results


[ST-1962]: https://keboola.atlassian.net/browse/ST-1962?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ