### PR TITLE
feat: Azure deployment k8s StorageClass for stream-api

### DIFF
--- a/provisioning/stream/azure.sh
+++ b/provisioning/stream/azure.sh
@@ -28,6 +28,7 @@ export ETCD_STORAGE_CLASS_NAME=
 # Azure specific part of the deploy
 kubectl apply -f ./kubernetes/deploy/cloud/azure/service-api.yaml
 kubectl apply -f ./kubernetes/deploy/cloud/azure/service-http-source.yaml
+kubectl apply -f ./kubernetes/deploy/cloud/azure/sc-stream-api.yaml
 
 # Wait for the rollout
 . ./wait.sh

--- a/provisioning/stream/kubernetes/build.sh
+++ b/provisioning/stream/kubernetes/build.sh
@@ -75,6 +75,7 @@ elif [[ "$CLOUD_PROVIDER" == "azure" ]]; then
   mkdir deploy/cloud/azure
   envsubst < templates/cloud/azure/service-api.yaml > deploy/cloud/azure/service-api.yaml
    envsubst < templates/cloud/azure/service-http-source.yaml > deploy/cloud/azure/service-http-source.yaml
+   envsubst < templates/cloud/azure/sc-stream-api.yaml > deploy/cloud/azure/sc-stream-api.yaml
 elif [[ "$CLOUD_PROVIDER" == "local" ]]; then
   mkdir deploy/cloud/local
   envsubst < templates/cloud/local/service-api.yaml > deploy/cloud/local/service-api.yaml

--- a/provisioning/stream/kubernetes/templates/cloud/azure/sc-stream-api.yaml
+++ b/provisioning/stream/kubernetes/templates/cloud/azure/sc-stream-api.yaml
@@ -1,0 +1,13 @@
+apiVersion: storage.k8s.io/v1
+kind: StorageClass
+metadata:
+  name: stream-api
+provisioner: kubernetes.io/azure-disk
+volumeBindingMode: WaitForFirstConsumer
+allowVolumeExpansion: true
+parameters:
+  skuName: Premium_LRS
+  storageaccounttype: Premium_LRS
+  kind: Managed
+  cachingmode: None
+  fsType: ext4


### PR DESCRIPTION
Jira :https://keboola.atlassian.net/browse/ST-1962

please see:
https://keboola.atlassian.net/wiki/spaces/ENGG/pages/3514040374/Cloud+storage+benchmarks#Azure--(VM-node:-Standard_F4s_v2)

I got up to about 173 MB/s. But we don't have a better instance than Standard_F4s_v2 for testing. We have a larger VM size in production, so we can always tune the speed there.

Changes:
new Kubernetes storage class for Azure dedicated to stream-api service
Plan:

- [x]  [set ENV to VG for Azure testing](https://dev.azure.com/keboola-prod/Keboola%20Connection%20Azure/_library?itemType=VariableGroups&view=VariableGroupView&variableGroupId=3&path=Parameters%20-%20kbc-testing-azure-east-us-2)
- [x]  review & merge this
- [x]  deploy to testing Azure stack
- [ ]  run benchmarks
- [ ]  compare benchmarks with GCP
- [ ]  decide if we need some changes based on benchmark results
