### PR TITLE
fix: Tasks cannot be enabled/disabled via CLI

### DIFF
--- a/internal/pkg/model/orchestrator.go
+++ b/internal/pkg/model/orchestrator.go
@@ -62,12 +62,17 @@ func (t Task) String() string {
 	if len(targetConfigDesc) == 0 {
 		targetConfigDesc = fmt.Sprintf(`branch:%d/componentId:%s/configId:%s`, t.BranchID, t.ComponentID, t.ConfigID)
 	}
+
+	// Add field enabled to task.Content
+	content := t.Content.Clone()
+	content.Set("enabled", t.Enabled)
+
 	return fmt.Sprintf(
 		"## %03d %s\n>> %s\n%s",
 		t.Index+1,
 		t.Name,
 		targetConfigDesc,
-		json.MustEncodeString(t.Content, true),
+		json.MustEncodeString(content, true),
 	)
 }
 


### PR DESCRIPTION
Jira: [PSGO-752](https://keboola.atlassian.net/browse/PSGO-752)

**Changes:**
- added field to task content

-----------

We couldn't enable/disabled tasks via CLI. The `enabled` field was missing in the output.

[PSGO-752]: https://keboola.atlassian.net/browse/PSGO-752?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ