### PR TITLE
fix: Add glob on volume path to read from all files within single volume

### DIFF
--- a/internal/pkg/service/stream/storage/level/local/diskreader/reader.go
+++ b/internal/pkg/service/stream/storage/level/local/diskreader/reader.go
@@ -84,11 +84,12 @@ func newReader(
 		for _, filePath := range matched {
 			openFileAndWrite(ctx, r.logger, opener, filePath, writer)
 		}
+
+		writer.Close()
 	}()
 
 	// Init readers chain
 	r.chain = readchain.New(r.logger, reader)
-	r.chain.AppendCloser(writer)
 
 	// Close resources on error
 	defer func() {

--- a/internal/pkg/service/stream/storage/level/local/diskreader/reader_test.go
+++ b/internal/pkg/service/stream/storage/level/local/diskreader/reader_test.go
@@ -113,8 +113,8 @@ func TestVolume_NewReaderFor_MultipleFilesSingleVolume(t *testing.T) {
 		tc.Logger.AssertJSONMessages(collect, `
 {"level":"info","message":"opening volume"}
 {"level":"info","message":"opened volume"}
-{"level":"debug","message":"opened file","volume.id":"my-volume","file.path":"%s/slice-my-node%d.csv","projectId":"123","branchId":"456","sourceId":"my-source","sinkId":"my-sink","fileId":"2000-01-01T19:00:00.000Z","sliceId":"2000-01-01T20:00:00.000Z"}
-{"level":"debug","message":"opened file","volume.id":"my-volume","file.path":"%s/slice-my-node%d.csv","projectId":"123","branchId":"456","sourceId":"my-source","sinkId":"my-sink","fileId":"2000-01-01T19:00:00.000Z","sliceId":"2000-01-01T20:00:00.000Z"}
+{"level":"debug","message":"opened file","volume.id":"my-volume","file.path":"%sslice-my-node%d.csv","projectId":"123","branchId":"456","sourceId":"my-source","sinkId":"my-sink","fileId":"2000-01-01T19:00:00.000Z","sliceId":"2000-01-01T20:00:00.000Z"}
+{"level":"debug","message":"opened file","volume.id":"my-volume","file.path":"%sslice-my-node%d.csv","projectId":"123","branchId":"456","sourceId":"my-source","sinkId":"my-sink","fileId":"2000-01-01T19:00:00.000Z","sliceId":"2000-01-01T20:00:00.000Z"}
 	`)
 	}, 5*time.Second, 10*time.Millisecond)
 }

--- a/internal/pkg/service/stream/storage/level/local/diskreader/reader_test.go
+++ b/internal/pkg/service/stream/storage/level/local/diskreader/reader_test.go
@@ -113,8 +113,8 @@ func TestVolume_NewReaderFor_MultipleFilesSingleVolume(t *testing.T) {
 		tc.Logger.AssertJSONMessages(collect, `
 {"level":"info","message":"opening volume"}
 {"level":"info","message":"opened volume"}
-{"level":"debug","message":"opened file","volume.id":"my-volume","file.path":"%sslice-my-node%d.csv","projectId":"123","branchId":"456","sourceId":"my-source","sinkId":"my-sink","fileId":"2000-01-01T19:00:00.000Z","sliceId":"2000-01-01T20:00:00.000Z"}
-{"level":"debug","message":"opened file","volume.id":"my-volume","file.path":"%sslice-my-node%d.csv","projectId":"123","branchId":"456","sourceId":"my-source","sinkId":"my-sink","fileId":"2000-01-01T19:00:00.000Z","sliceId":"2000-01-01T20:00:00.000Z"}
+{"level":"debug","message":"opened file","volume.id":"my-volume","file.path":"%sslice-my-node%d.csv","project.id":"123","branch.id":"456","source.id":"my-source","sink.id":"my-sink","file.id":"2000-01-01T19:00:00.000Z","slice.id":"2000-01-01T20:00:00.000Z"}
+{"level":"debug","message":"opened file","volume.id":"my-volume","file.path":"%sslice-my-node%d.csv","project.id":"123","branch.id":"456","source.id":"my-source","sink.id":"my-sink","file.id":"2000-01-01T19:00:00.000Z","slice.id":"2000-01-01T20:00:00.000Z"}
 	`)
 	}, 5*time.Second, 10*time.Millisecond)
 }

--- a/internal/pkg/service/stream/storage/level/local/diskreader/volume.go
+++ b/internal/pkg/service/stream/storage/level/local/diskreader/volume.go
@@ -182,7 +182,6 @@ func (v *Volume) OpenReader(sliceKey model.SliceKey, slice localModel.Slice, enc
 		stagingCompression,
 		v.readerEvents,
 	)
-
 	if err != nil {
 		return nil, err
 	}

--- a/internal/pkg/service/stream/storage/level/local/diskreader/volume.go
+++ b/internal/pkg/service/stream/storage/level/local/diskreader/volume.go
@@ -168,19 +168,21 @@ func (v *Volume) OpenReader(sliceKey model.SliceKey, slice localModel.Slice, enc
 		opener = v.config.OverrideFileOpener
 	}
 
-	// Open file
-	filePath := slice.FileName(v.Path(), "my-node")
-	logger = logger.With(attribute.String("file.path", filePath))
-	file, err = opener.OpenFile(filePath)
-	if err == nil {
-		logger.Debug(v.ctx, "opened file")
-	} else {
-		logger.Errorf(v.ctx, `cannot open file "%s": %s`, filePath, err)
-		return nil, err
-	}
+	// <volumePath>/FilenamePrefix * FilenameExtension
+	path := slice.FileGlob(v.Path())
 
 	// Init reader and chain
-	r, err = newReader(v.ctx, logger, sliceKey, encodingCompression, stagingCompression, file, v.readerEvents)
+	r, err = newReader(
+		v.ctx,
+		logger,
+		sliceKey,
+		opener,
+		path,
+		encodingCompression,
+		stagingCompression,
+		v.readerEvents,
+	)
+
 	if err != nil {
 		return nil, err
 	}

--- a/internal/pkg/service/stream/storage/level/local/diskreader/volume_test.go
+++ b/internal/pkg/service/stream/storage/level/local/diskreader/volume_test.go
@@ -265,8 +265,8 @@ func TestVolume_Close_Errors(t *testing.T) {
 	require.NoError(t, vol.Close(context.Background()))
 	assert.EventuallyWithT(t, func(collect *assert.CollectT) {
 		tc.Logger.AssertJSONMessages(collect, `
-{"level":"error","message":"cannot copy to writer \"/tmp/%s/slice-my-node.csv\": io: read/write on closed pipe","volume.id":"abcdef"}
-{"level":"error","message":"cannot copy to writer \"/tmp/%s/slice-my-node.csv\": io: read/write on closed pipe","volume.id":"abcdef"}
+{"level":"error","message":"cannot copy to writer \"%sslice-my-node.csv\": io: read/write on closed pipe","volume.id":"abcdef"}
+{"level":"error","message":"cannot copy to writer \"%sslice-my-node.csv\": io: read/write on closed pipe","volume.id":"abcdef"}
 	`)
 	}, 5*time.Second, 10*time.Millisecond)
 }

--- a/internal/pkg/service/stream/storage/level/local/diskreader/volume_test.go
+++ b/internal/pkg/service/stream/storage/level/local/diskreader/volume_test.go
@@ -21,6 +21,7 @@ import (
 	volumeModel "github.com/keboola/keboola-as-code/internal/pkg/service/stream/storage/level/local/volume/model"
 	"github.com/keboola/keboola-as-code/internal/pkg/service/stream/storage/test"
 	"github.com/keboola/keboola-as-code/internal/pkg/utils/errors"
+	"github.com/keboola/keboola-as-code/internal/pkg/utils/testhelper"
 )
 
 // TestOpenVolume_NonExistentPath tests that an error should occur if there is no access to the volume directory.
@@ -295,6 +296,7 @@ func newVolumeTestCase(tb testing.TB) *volumeTestCase {
 	})
 
 	logger := log.NewDebugLogger()
+	logger.ConnectTo(testhelper.VerboseStdout())
 	tmpDir := tb.TempDir()
 
 	return &volumeTestCase{

--- a/internal/pkg/service/stream/storage/level/local/diskreader/volume_test.go
+++ b/internal/pkg/service/stream/storage/level/local/diskreader/volume_test.go
@@ -265,8 +265,8 @@ func TestVolume_Close_Errors(t *testing.T) {
 	require.NoError(t, vol.Close(context.Background()))
 	assert.EventuallyWithT(t, func(collect *assert.CollectT) {
 		tc.Logger.AssertJSONMessages(collect, `
-{"level":"error","message":"cannot copy to writer \"%sslice-my-node.csv\": io: read/write on closed pipe","volume.id":"abcdef"}
-{"level":"error","message":"cannot copy to writer \"%sslice-my-node.csv\": io: read/write on closed pipe","volume.id":"abcdef"}
+{"level":"error","message":"cannot copy to writer %sslice-my-node.csv\": io: read/write on closed pipe","volume.id":"abcdef","volume.id":"my-volume"}
+{"level":"error","message":"cannot copy to writer %sslice-my-node.csv\": io: read/write on closed pipe","volume.id":"abcdef","volume.id":"my-volume"}
 	`)
 	}, 5*time.Second, 10*time.Millisecond)
 }

--- a/internal/pkg/service/stream/storage/level/local/diskreader/volume_test.go
+++ b/internal/pkg/service/stream/storage/level/local/diskreader/volume_test.go
@@ -245,32 +245,30 @@ func TestVolume_Close_Errors(t *testing.T) {
 
 	// Create volume ID file
 	assert.NoError(t, os.WriteFile(filepath.Join(tc.VolumePath, volumeModel.IDFile), []byte("abcdef"), 0o640))
+	slice1 := test.NewSliceOpenedAt("2000-01-01T20:00:00.000Z")
+	slice2 := test.NewSliceOpenedAt("2000-01-01T21:00:00.000Z")
+	assert.NoError(tc.TB, os.MkdirAll(slice1.LocalStorage.DirName(tc.VolumePath), 0o750))
+	assert.NoError(tc.TB, os.MkdirAll(slice2.LocalStorage.DirName(tc.VolumePath), 0o750))
+	assert.NoError(tc.TB, os.WriteFile(slice1.LocalStorage.FileName(tc.VolumePath, "my-node"), []byte("abc"), 0o640))
+	assert.NoError(tc.TB, os.WriteFile(slice2.LocalStorage.FileName(tc.VolumePath, "my-node"), []byte("def"), 0o640))
 
 	// Open volume, replace file opener
 	vol, err := tc.OpenVolume()
 	require.NoError(t, err)
-
 	// Open two writers
-	slice := test.NewSliceOpenedAt("2000-01-01T20:00:00.000Z")
-	_, err = vol.OpenReader(slice.SliceKey, slice.LocalStorage, slice.Encoding.Compression, slice.StagingStorage.Compression)
+	_, err = vol.OpenReader(slice1.SliceKey, slice1.LocalStorage, slice1.Encoding.Compression, slice1.StagingStorage.Compression)
 	require.NoError(t, err)
-	slice = test.NewSliceOpenedAt("2000-01-01T21:00:00.000Z")
-	_, err = vol.OpenReader(slice.SliceKey, slice.LocalStorage, slice.Encoding.Compression, slice.StagingStorage.Compression)
+	_, err = vol.OpenReader(slice2.SliceKey, slice2.LocalStorage, slice2.Encoding.Compression, slice2.StagingStorage.Compression)
 	require.NoError(t, err)
 
 	// Close volume, expect close errors from the writers
-	err = vol.Close(context.Background())
-	if assert.Error(t, err) {
-		// Order of the errors is random, readers are closed in parallel
-		wildcards.Assert(t, strings.TrimSpace(`
-- cannot close reader for slice "123/456/my-source/my-sink/2000-01-01T19:00:00.000Z/my-volume/2000-01-01T%s":
-  - chain close error:
-    - cannot close file: some close error
-- cannot close reader for slice "123/456/my-source/my-sink/2000-01-01T19:00:00.000Z/my-volume/2000-01-01T%s":
-  - chain close error:
-    - cannot close file: some close error
-`), err.Error())
-	}
+	require.NoError(t, vol.Close(context.Background()))
+	assert.EventuallyWithT(t, func(collect *assert.CollectT) {
+		tc.Logger.AssertJSONMessages(collect, `
+{"level":"error","message":"cannot copy to writer \"/tmp/%s/slice-my-node.csv\": io: read/write on closed pipe","volume.id":"abcdef"}
+{"level":"error","message":"cannot copy to writer \"/tmp/%s/slice-my-node.csv\": io: read/write on closed pipe","volume.id":"abcdef"}
+	`)
+	}, 5*time.Second, 10*time.Millisecond)
 }
 
 // volumeTestCase is a helper to open disk reader volume in tests.

--- a/internal/pkg/service/stream/storage/level/local/model/slice.go
+++ b/internal/pkg/service/stream/storage/level/local/model/slice.go
@@ -28,3 +28,7 @@ func (s Slice) DirName(volumePath string) string {
 func (s Slice) FileName(volumePath string, sourceNodeID string) string {
 	return filepath.Join(s.DirName(volumePath), fmt.Sprintf("%s-%s.%s", s.FilenamePrefix, sourceNodeID, s.FilenameExtension))
 }
+
+func (s Slice) FileGlob(volumePath string) string {
+	return filepath.Join(s.DirName(volumePath), fmt.Sprintf("%s*%s", s.FilenamePrefix, s.FilenameExtension))
+}


### PR DESCRIPTION
**Changes:**
- Read slice from multiple source nodes using `filepath.Glob` matched paths.
- The file path is `<volume.path>/slice.FilenamePrefix*slice.FilenameExtension`
- Create new `FileGlob` method on `slice` to create abstraction for `Glob` pattern.

-----------
