### PR TITLE
refactor: Separate Value Sub method

### DIFF
--- a/internal/pkg/service/stream/storage/statistics/aggregate/aggregate.go
+++ b/internal/pkg/service/stream/storage/statistics/aggregate/aggregate.go
@@ -23,3 +23,12 @@ func Aggregate(l model.Level, partial statistics.Value, out *statistics.Aggregat
 		panic(errors.Errorf(`unexpected statistics level "%v"`, l))
 	}
 }
+
+func AggregateSub(l model.Level, partial statistics.Value, out *statistics.Aggregated) {
+	if l != model.LevelTarget {
+		panic("AggregateSub only makes sense for level target")
+	}
+
+	out.Target = out.Target.Sub(partial)
+	out.Total = out.Total.Sub(partial)
+}

--- a/internal/pkg/service/stream/storage/statistics/aggregate/aggregate_test.go
+++ b/internal/pkg/service/stream/storage/statistics/aggregate/aggregate_test.go
@@ -5,6 +5,7 @@ import (
 
 	"github.com/stretchr/testify/assert"
 
+	"github.com/keboola/keboola-as-code/internal/pkg/service/common/ptr"
 	"github.com/keboola/keboola-as-code/internal/pkg/service/common/utctime"
 	"github.com/keboola/keboola-as-code/internal/pkg/service/stream/storage/model"
 	"github.com/keboola/keboola-as-code/internal/pkg/service/stream/storage/statistics"
@@ -249,4 +250,92 @@ func TestAggregate(t *testing.T) {
 	assert.Panics(t, func() {
 		Aggregate("foo", statistics.Value{}, &result)
 	})
+
+	// Negative value
+	assert.Panics(t, func() {
+		Aggregate("foo", statistics.Value{ResetAt: ptr.Ptr(utctime.MustParse("2000-01-10T00:00:00.000Z"))}, &result)
+	})
+}
+
+func TestAggregateSub(t *testing.T) {
+	t.Parallel()
+
+	result := statistics.Aggregated{
+		Local: statistics.Value{
+			SlicesCount:      10,
+			FirstRecordAt:    utctime.MustParse("2000-01-10T00:00:00.000Z"),
+			LastRecordAt:     utctime.MustParse("2000-01-20T00:00:00.000Z"),
+			RecordsCount:     10,
+			UncompressedSize: 10,
+			CompressedSize:   10,
+		},
+		Staging: statistics.Value{
+			SlicesCount:      10,
+			FirstRecordAt:    utctime.MustParse("2000-01-10T00:00:00.000Z"),
+			LastRecordAt:     utctime.MustParse("2000-01-20T00:00:00.000Z"),
+			RecordsCount:     10,
+			UncompressedSize: 10,
+			CompressedSize:   10,
+		},
+		Target: statistics.Value{
+			SlicesCount:      10,
+			FirstRecordAt:    utctime.MustParse("2000-01-10T00:00:00.000Z"),
+			LastRecordAt:     utctime.MustParse("2000-01-20T00:00:00.000Z"),
+			RecordsCount:     10,
+			UncompressedSize: 10,
+			CompressedSize:   10,
+		},
+		Total: statistics.Value{
+			SlicesCount:      10,
+			FirstRecordAt:    utctime.MustParse("2000-01-10T00:00:00.000Z"),
+			LastRecordAt:     utctime.MustParse("2000-01-20T00:00:00.000Z"),
+			RecordsCount:     10,
+			UncompressedSize: 10,
+			CompressedSize:   10,
+		},
+	}
+
+	AggregateSub(model.LevelTarget, statistics.Value{
+		ResetAt:          ptr.Ptr(utctime.MustParse("2001-01-10T00:00:00.000Z")),
+		SlicesCount:      1,
+		FirstRecordAt:    utctime.MustParse("2000-01-10T00:00:00.000Z"),
+		LastRecordAt:     utctime.MustParse("2000-01-20T00:00:00.000Z"),
+		RecordsCount:     1,
+		UncompressedSize: 1,
+		CompressedSize:   1,
+	}, &result)
+	assert.Equal(t, &statistics.Aggregated{
+		Local: statistics.Value{
+			SlicesCount:      10,
+			FirstRecordAt:    utctime.MustParse("2000-01-10T00:00:00.000Z"),
+			LastRecordAt:     utctime.MustParse("2000-01-20T00:00:00.000Z"),
+			RecordsCount:     10,
+			UncompressedSize: 10,
+			CompressedSize:   10,
+		},
+		Staging: statistics.Value{
+			SlicesCount:      10,
+			FirstRecordAt:    utctime.MustParse("2000-01-10T00:00:00.000Z"),
+			LastRecordAt:     utctime.MustParse("2000-01-20T00:00:00.000Z"),
+			RecordsCount:     10,
+			UncompressedSize: 10,
+			CompressedSize:   10,
+		},
+		Target: statistics.Value{
+			SlicesCount:      9,
+			FirstRecordAt:    utctime.MustParse("2000-01-10T00:00:00.000Z"),
+			LastRecordAt:     utctime.MustParse("2000-01-20T00:00:00.000Z"),
+			RecordsCount:     9,
+			UncompressedSize: 9,
+			CompressedSize:   9,
+		},
+		Total: statistics.Value{
+			SlicesCount:      9,
+			FirstRecordAt:    utctime.MustParse("2000-01-10T00:00:00.000Z"),
+			LastRecordAt:     utctime.MustParse("2000-01-20T00:00:00.000Z"),
+			RecordsCount:     9,
+			UncompressedSize: 9,
+			CompressedSize:   9,
+		},
+	}, &result)
 }

--- a/internal/pkg/service/stream/storage/statistics/repository/stats_get.go
+++ b/internal/pkg/service/stream/storage/statistics/repository/stats_get.go
@@ -85,7 +85,7 @@ func (r *Repository) AggregateIn(objectKey fmt.Stringer) *op.TxnOp[statistics.Ag
 
 	txn.Then(pfx.GetOrNil(r.client).WithOnResult(func(v *statistics.Value) {
 		if v != nil && v.ResetAt != nil {
-			aggregate.Aggregate(model.LevelTarget, *v, &result)
+			aggregate.AggregateSub(model.LevelTarget, *v, &result)
 		}
 	}))
 

--- a/internal/pkg/service/stream/storage/statistics/repository/stats_sum.go
+++ b/internal/pkg/service/stream/storage/statistics/repository/stats_sum.go
@@ -16,7 +16,7 @@ func SumStats(ctx context.Context, now time.Time, prefix iterator.DefinitionT[st
 	if err := sumStatsOp(now, prefix, &out, &outReset).Do(ctx).Err(); err != nil {
 		return out, err
 	}
-	return out.Add(outReset), nil
+	return out.Sub(outReset), nil
 }
 
 // sumStatsOp sums all stats from the iterator.


### PR DESCRIPTION
Changes:

- `statistics.Value.Add` now panics if one (but not both) of the values has `ResetAt != nil`
- Relevant places where reset values can occur have been changed to use the new `statistics.Value.Sub` instead
	- In general this means places where statistics from level target are involves and the key is sink or higher.