### PR TITLE
fix: Prevent no disk space left on device by removing usused SDKs

### DIFF
--- a/.github/workflows/test-unit.yml
+++ b/.github/workflows/test-unit.yml
@@ -59,14 +59,7 @@ jobs:
         run: |
           echo "BEFORE CLEAN-UP:"
           df -hI /dev/disk3s1s1
-          sudo rm -rf /Applications/Xcode_14.3.1.app
-          sudo rm -rf /Applications/Xcode_15.0.1.app
-          sudo rm -rf /Applications/Xcode_15.1.app
-          sudo rm -rf /Applications/Xcode_15.2.app
-          sudo rm -rf /Applications/Xcode_15.3.app
-          #sudo rm -rf ~/.dotnet
-          #sudo rm -rf /Library/Android
-          #sudo rm -rf /Library/Developer/CoreSimulator
+          sudo rm -rf /Applications/Xcode_*.app
           echo "AFTER CLEAN-UP:"
           df -hI /dev/disk3s1s1
         continue-on-error: true

--- a/.github/workflows/test-unit.yml
+++ b/.github/workflows/test-unit.yml
@@ -53,6 +53,24 @@ jobs:
           docker-images: false
           swap-storage: false
 
+        # To free up disk space to not run out during the run
+      - name: Delete unused SDKs MacOS
+        if: matrix.name == 'mac-os'
+        run: |
+          echo "BEFORE CLEAN-UP:"
+          df -hI /dev/disk3s1s1
+          sudo rm -rf /Applications/Xcode_14.3.1.app
+          sudo rm -rf /Applications/Xcode_15.0.1.app
+          sudo rm -rf /Applications/Xcode_15.1.app
+          sudo rm -rf /Applications/Xcode_15.2.app
+          sudo rm -rf /Applications/Xcode_15.3.app
+          #sudo rm -rf ~/.dotnet
+          #sudo rm -rf /Library/Android
+          #sudo rm -rf /Library/Developer/CoreSimulator
+          echo "AFTER CLEAN-UP:"
+          df -hI /dev/disk3s1s1
+        continue-on-error: true
+
       - name: Setup Go, tools and caching
         uses: ./.github/actions/go-setup
         with:


### PR DESCRIPTION
Issue found here: https://github.com/actions/runner-images/issues/10511

Some workarounds:
- https://github.com/XrXr/ruby/commit/5b5853c17fe46ef0bb13f8b9c83e6c1d249f3086
- https://github.com/actions/runner-images/issues/10511#issuecomment-2325830665 <- This i went for.

Results:
```
BEFORE CLEAN-UP:
Filesystem        Size    Used   Avail Capacity  Mounted on
/dev/disk3s1s1   295Gi   9.6Gi    18Gi    35%    /
AFTER CLEAN-UP:
Filesystem        Size    Used   Avail Capacity  Mounted on
/dev/disk3s1s1   295Gi   9.6Gi    49Gi    17%    /
```