### PR TITLE
fix: RPC now checks context.Done to prevent go routine exhaustion

### DIFF
--- a/internal/pkg/service/stream/storage/level/local/diskwriter/network/rpc/client.go
+++ b/internal/pkg/service/stream/storage/level/local/diskwriter/network/rpc/client.go
@@ -2,6 +2,7 @@ package rpc
 
 import (
 	"context"
+	"io"
 	"net"
 
 	"google.golang.org/grpc"
@@ -111,16 +112,26 @@ func OpenNetworkFile(ctx context.Context, logger log.Logger, sourceNodeID string
 		return nil, err
 	}
 	go func() {
-		if _, err := termStream.Recv(); err != nil {
-			if s, ok := status.FromError(err); !ok || s.Code() != codes.Canceled {
-				logger.Errorf(ctx, "error when waiting for network file server termination: %s", err)
+		for {
+			if _, err := termStream.Recv(); err != nil {
+				if err == io.EOF {
+					continue
+				}
+
+				if s, ok := status.FromError(err); !ok || s.Code() != codes.Canceled {
+					logger.Errorf(ctx, "error when waiting for network file server termination: %s", err)
+				}
 			}
+
+			break
 		}
+
 		if err := termStream.CloseSend(); err != nil {
 			if s, ok := status.FromError(err); !ok || s.Code() != codes.Canceled {
 				logger.Errorf(ctx, "rpc close send error: %s", err)
 			}
 		}
+
 		onServerTermination(ctx, "remote server shutdown")
 	}()
 

--- a/internal/pkg/service/stream/storage/level/local/diskwriter/network/rpc/server.go
+++ b/internal/pkg/service/stream/storage/level/local/diskwriter/network/rpc/server.go
@@ -143,8 +143,13 @@ func (s *NetworkFileServer) Open(ctx context.Context, req *pb.OpenRequest) (*pb.
 }
 
 func (s *NetworkFileServer) WaitForServerTermination(_ *pb.WaitForServerTerminationRequest, stream pb.NetworkFile_WaitForServerTerminationServer) error {
-	<-s.terminating
-	return stream.Send(&pb.ServerIsTerminatingResponse{})
+	select {
+	case <-s.terminating:
+		return stream.Send(&pb.ServerIsTerminatingResponse{})
+
+	case <-stream.Context().Done():
+		return nil
+	}
 }
 
 func (s *NetworkFileServer) Write(ctx context.Context, req *pb.WriteRequest) (*pb.WriteResponse, error) {


### PR DESCRIPTION
**Changes:**
- Update client receiver to listen on `io.EOF`

-----------
