### PR TITLE
fix: Minor fixes in/from benchmarks (3)

### DIFF
--- a/internal/pkg/service/stream/config/config_test.go
+++ b/internal/pkg/service/stream/config/config_test.go
@@ -167,7 +167,7 @@ storage:
                     # Concurrency of the format writer for the specified file type. 0 = auto = num of CPU cores. Validation rules: min=0,max=256
                     concurrency: 0
                 # Max size of the buffer before compression, if compression is enabled. 0 = disabled. Validation rules: maxBytes=16MB
-                inputBuffer: 1MB
+                inputBuffer: 2MB
                 # Max size of a chunk sent over the network to a disk writer node. Validation rules: required,minBytes=64kB,maxBytes=1MB
                 maxChunkSize: 512KB
                 # If the defined number of chunks cannot be sent, the pipeline is marked as not ready. Validation rules: required,min=1,max=100
@@ -396,8 +396,8 @@ func TestTableSinkConfigPatch_ToKVs(t *testing.T) {
     "key": "storage.level.local.encoding.inputBuffer",
     "type": "string",
     "description": "Max size of the buffer before compression, if compression is enabled. 0 = disabled",
-    "value": "1MB",
-    "defaultValue": "1MB",
+    "value": "2MB",
+    "defaultValue": "2MB",
     "overwritten": false,
     "protected": true,
     "validation": "maxBytes=16MB"

--- a/internal/pkg/service/stream/sink/type/tablesink/keboola/bridge/fixtures/create_sink_snapshot.txt
+++ b/internal/pkg/service/stream/sink/type/tablesink/keboola/bridge/fixtures/create_sink_snapshot.txt
@@ -47,7 +47,7 @@ storage/file/level/local/123/456/my-source/my-sink/2000-01-01T01:00:00.000Z
       "type": "csv",
       "concurrency": 0
     },
-    "inputBuffer": "1MB",
+    "inputBuffer": "2MB",
     "maxChunkSize": "512KB",
     "failedChunksThreshold": 3,
     "compression": {
@@ -152,7 +152,7 @@ storage/slice/level/local/123/456/my-source/my-sink/2000-01-01T01:00:00.000Z/my-
       "type": "csv",
       "concurrency": 0
     },
-    "inputBuffer": "1MB",
+    "inputBuffer": "2MB",
     "maxChunkSize": "512KB",
     "failedChunksThreshold": 3,
     "compression": {

--- a/internal/pkg/service/stream/storage/level/local/encoding/config/config.go
+++ b/internal/pkg/service/stream/storage/level/local/encoding/config/config.go
@@ -32,7 +32,7 @@ type ConfigPatch struct {
 func NewConfig() Config {
 	return Config{
 		Encoder:               encoder.NewConfig(),
-		InputBuffer:           1 * datasize.MB,
+		InputBuffer:           2 * datasize.MB,
 		Compression:           compression.NewConfig(),
 		Sync:                  writesync.NewConfig(),
 		MaxChunkSize:          512 * datasize.KB,

--- a/internal/pkg/telemetry/pprof/http.go
+++ b/internal/pkg/telemetry/pprof/http.go
@@ -3,10 +3,13 @@ package pprof
 import (
 	"net/http"
 	"net/http/pprof"
+	"runtime"
 	"time"
 )
 
 func NewHTTPServer(addr string) *http.Server {
+	runtime.SetBlockProfileRate(20)     // 5%
+	runtime.SetMutexProfileFraction(20) // 5%
 	mux := http.NewServeMux()
 	mux.HandleFunc("/debug/pprof/", pprof.Index)
 	mux.HandleFunc("/debug/pprof/cmdline", pprof.Cmdline)

--- a/provisioning/stream/kubernetes/templates/benchmark/job.yaml
+++ b/provisioning/stream/kubernetes/templates/benchmark/job.yaml
@@ -51,14 +51,24 @@ spec:
               value: $(DD_AGENT_HOST):$(DD_STATSD_PORT)
             - name: K6_STATSD_ENABLE_TAGS
               value: "true"
-            - name: K6_MAX_VIRTUAL_USERS
-              value: "1000"
             - name: K6_PARALLEL_REQS_PER_USER
               value: "10"
-            - name: K6_RAMPING_DURATION
+            - name: K6_SCENARIO
+              value: "ramping"
+            - name: K6_CONST_VIRTUAL_USERS
+              value: "1000"
+            - name: K6_CONST_TOTAL_REQUESTS
+              value: "1000000"
+            - name: K6_CONST_TIMEOUT
+              value: "20m"
+            - name: K6_RAMPING_MAX_VIRTUAL_USERS
+              value: "1000"
+            - name: K6_RAMPING_UP_DURATION
               value: "2m"
-            - name: K6_STABLE_RATE_DURATION
+            - name: K6_RAMPING_STABLE_DURATION
               value: "10m"
+            - name: K6_RAMPING_DOWN_DURATION
+              value: "2m"
       tolerations:
         - key: app
           operator: Exists

--- a/provisioning/stream/kubernetes/templates/config/config-map.yaml
+++ b/provisioning/stream/kubernetes/templates/config/config-map.yaml
@@ -148,7 +148,7 @@ data:
               # Concurrency of the format writer for the specified file type. 0 = auto = num of CPU cores. Validation rules: min=0,max=256
               concurrency: 0
             # Max size of the buffer before compression, if compression is enabled. 0 = disabled. Validation rules: maxBytes=16MB
-            inputBuffer: 1MB
+            inputBuffer: 2MB
             # Max size of a chunk sent over the network to a disk writer node. Validation rules: required,minBytes=64kB,maxBytes=1MB
             maxChunkSize: 512KB
             # If the defined number of chunks cannot be sent, the pipeline is marked as not ready. Validation rules: required,min=1,max=100

--- a/scripts/k6/stream-api/common.js
+++ b/scripts/k6/stream-api/common.js
@@ -38,7 +38,7 @@ const scenarios = {
   constant: {
     executor: "shared-iterations",
     vus: CONST_VIRTUAL_USERS,
-    iterations: CONST_TOTAL_REQUESTS/PARALLEL_REQS_PER_USER,
+    iterations: CONST_TOTAL_REQUESTS / PARALLEL_REQS_PER_USER,
     maxDuration: CONST_TIMEOUT,
   },
   ramping: {

--- a/scripts/k6/stream-api/static.js
+++ b/scripts/k6/stream-api/static.js
@@ -3,7 +3,7 @@ import * as common from "./common.js";
 export const options = common.options;
 
 export function setup() {
-  let strings = common.randomStrings()
+  let payloads = common.randomPayloads()
 
   let source = common.setupSource();
 
@@ -33,7 +33,7 @@ export function setup() {
     "My-Custom-Header": "custom header value abcd",
   };
 
-  return { source, sink, strings, headers };
+  return { source, sink, payloads, headers };
 }
 
 export function teardown(data) {
@@ -41,12 +41,10 @@ export function teardown(data) {
 }
 
 export default function(data) {
-  const payload = { a: "b", c: { d: "e", f: { g: common.randomElement(data.strings) } } };
-
   common.batchWithCheckResponse({
     method: 'POST',
     url: data.source.url,
-    body: payload,
+    body: common.randomElement(data.payloads),
     params: {headers: data.headers,},
   });
 }

--- a/scripts/k6/stream-api/template.js
+++ b/scripts/k6/stream-api/template.js
@@ -3,7 +3,7 @@ import * as common from "./common.js";
 export const options = common.options;
 
 export function setup() {
-  let strings = common.randomStrings()
+  let payloads = common.randomPayloads()
 
   let source = common.setupSource();
 
@@ -38,7 +38,7 @@ export function setup() {
     "My-Custom-Header": "custom header value abcd",
   };
 
-  return { source, sink, strings, headers };
+  return { source, sink, payloads, headers };
 }
 
 export function teardown(data) {
@@ -46,12 +46,10 @@ export function teardown(data) {
 }
 
 export default function(data) {
-  const payload = { a: "b", c: { d: "e", f: { g: common.randomElement(data.strings) } } };
-
   common.batchWithCheckResponse({
     method: 'POST',
     url: data.source.url,
-    body: payload,
+    body: common.randomElement(data.payloads),
     params: {headers: data.headers,},
   })
 }

--- a/test/stream/api/sink/settings-001-all/005-get-settings/expected-response.json
+++ b/test/stream/api/sink/settings-001-all/005-get-settings/expected-response.json
@@ -83,8 +83,8 @@
       "key": "storage.level.local.encoding.inputBuffer",
       "type": "string",
       "description": "Max size of the buffer before compression, if compression is enabled. 0 = disabled",
-      "value": "1MB",
-      "defaultValue": "1MB",
+      "value": "2MB",
+      "defaultValue": "2MB",
       "overwritten": false,
       "protected": true,
       "validation": "maxBytes=16MB"

--- a/test/stream/api/sink/settings-001-all/012-get-settings/expected-response.json
+++ b/test/stream/api/sink/settings-001-all/012-get-settings/expected-response.json
@@ -83,8 +83,8 @@
       "key": "storage.level.local.encoding.inputBuffer",
       "type": "string",
       "description": "Max size of the buffer before compression, if compression is enabled. 0 = disabled",
-      "value": "1MB",
-      "defaultValue": "1MB",
+      "value": "2MB",
+      "defaultValue": "2MB",
       "overwritten": false,
       "protected": true,
       "validation": "maxBytes=16MB"

--- a/test/stream/api/source/settings-001-all/003-get-settings/expected-response.json
+++ b/test/stream/api/source/settings-001-all/003-get-settings/expected-response.json
@@ -83,8 +83,8 @@
       "key": "storage.level.local.encoding.inputBuffer",
       "type": "string",
       "description": "Max size of the buffer before compression, if compression is enabled. 0 = disabled",
-      "value": "1MB",
-      "defaultValue": "1MB",
+      "value": "2MB",
+      "defaultValue": "2MB",
       "overwritten": false,
       "protected": true,
       "validation": "maxBytes=16MB"

--- a/test/stream/api/source/settings-001-all/010-get-settings/expected-response.json
+++ b/test/stream/api/source/settings-001-all/010-get-settings/expected-response.json
@@ -83,8 +83,8 @@
       "key": "storage.level.local.encoding.inputBuffer",
       "type": "string",
       "description": "Max size of the buffer before compression, if compression is enabled. 0 = disabled",
-      "value": "1MB",
-      "defaultValue": "1MB",
+      "value": "2MB",
+      "defaultValue": "2MB",
       "overwritten": false,
       "protected": true,
       "validation": "maxBytes=16MB"


### PR DESCRIPTION
**Changes:**
- Increased buffer size before the compression.
- Fixed empty block/mutex profile.
- Improved benchmark scripts.

-----------

Local results:

![image](https://github.com/user-attachments/assets/8f17064c-c58e-409b-9fb4-2f1e9161fdd1)

