### PR TITLE
fix: Reduce number of tags reported by k6

### DIFF
--- a/scripts/k6/stream-api/main.js
+++ b/scripts/k6/stream-api/main.js
@@ -78,6 +78,7 @@ const mappings = {
 
 // K6 options
 export const options = {
+  systemTags: ['status', 'group'],
   discardResponseBodies: true, // we are checking only status codes
   teardownTimeout: '120s',
   batch: PARALLEL_REQS_PER_USER,


### PR DESCRIPTION
**Changes:**
- Only `status` and `group` tags are reported by k6 metrics.

-----------
