### PR TITLE
fix: Wrong split of encoded chunk.

### DIFF
--- a/internal/pkg/service/stream/storage/level/local/encoding/chunk/writer.go
+++ b/internal/pkg/service/stream/storage/level/local/encoding/chunk/writer.go
@@ -83,7 +83,7 @@ func (w *Writer) Write(p []byte) (total int, err error) {
 		// Write
 		n, err := chunk.write(toActual)
 		if err != nil {
-			return total, err
+			return 0, err
 		}
 		total += n
 

--- a/internal/pkg/service/stream/storage/level/local/encoding/chunk/writer_test.go
+++ b/internal/pkg/service/stream/storage/level/local/encoding/chunk/writer_test.go
@@ -53,7 +53,7 @@ func TestWriter_Ok(t *testing.T) {
 	n, err = w.Write([]byte("67890"))
 	assert.Equal(t, 5, n)
 	assert.NoError(t, err)
-	assert.Equal(t, 0, w.CompletedChunks())
+	assert.Equal(t, 1, w.CompletedChunks())
 	expectedChunks = append(expectedChunks, "aligned = false, data = 1234567890")
 
 	// Write over the maximum
@@ -75,13 +75,13 @@ func TestWriter_Ok(t *testing.T) {
 	expectedChunks = append(expectedChunks, "aligned = true, data = kl")
 
 	// Write long message, which requires more than 2 chunks
-	n, err = w.Write([]byte("012345678901234567890123456789abc"))
+	n, err = w.Write([]byte("111111111122222222223333333333abc"))
 	assert.Equal(t, 33, n)
 	assert.NoError(t, err)
 	assert.Equal(t, 6, w.CompletedChunks())
-	expectedChunks = append(expectedChunks, "aligned = false, data = 0123456789")
-	expectedChunks = append(expectedChunks, "aligned = false, data = 0123456789")
-	expectedChunks = append(expectedChunks, "aligned = false, data = 0123456789")
+	expectedChunks = append(expectedChunks, "aligned = false, data = 1111111111")
+	expectedChunks = append(expectedChunks, "aligned = false, data = 2222222222")
+	expectedChunks = append(expectedChunks, "aligned = false, data = 3333333333")
 
 	// Flush
 	assert.NoError(t, w.Flush())

--- a/internal/pkg/service/stream/storage/level/local/encoding/chunk/writer_test.go
+++ b/internal/pkg/service/stream/storage/level/local/encoding/chunk/writer_test.go
@@ -74,16 +74,30 @@ func TestWriter_Ok(t *testing.T) {
 	assert.Equal(t, 3, w.CompletedChunks())
 	expectedChunks = append(expectedChunks, "aligned = true, data = kl")
 
+	// Write long message, which requires more than 2 chunks
+	n, err = w.Write([]byte("012345678901234567890123456789abc"))
+	assert.Equal(t, 33, n)
+	assert.NoError(t, err)
+	assert.Equal(t, 6, w.CompletedChunks())
+	expectedChunks = append(expectedChunks, "aligned = false, data = 0123456789")
+	expectedChunks = append(expectedChunks, "aligned = false, data = 0123456789")
+	expectedChunks = append(expectedChunks, "aligned = false, data = 0123456789")
+
+	// Flush
+	assert.NoError(t, w.Flush())
+	assert.Equal(t, 7, w.CompletedChunks())
+	expectedChunks = append(expectedChunks, "aligned = true, data = abc")
+
 	// Empty flush
 	assert.NoError(t, w.Flush())
-	assert.Equal(t, 3, w.CompletedChunks())
+	assert.Equal(t, 7, w.CompletedChunks())
 
 	// Close
 	n, err = w.Write([]byte("xyz"))
 	assert.Equal(t, 3, n)
 	assert.NoError(t, err)
 	assert.NoError(t, w.Close())
-	assert.Equal(t, 4, w.CompletedChunks())
+	assert.Equal(t, 8, w.CompletedChunks())
 	expectedChunks = append(expectedChunks, "aligned = true, data = xyz")
 
 	// Compare


### PR DESCRIPTION
**Changes:**
- Fixed bug, missing `for` loop.
  - It the payload was bigger than `2xmaxChunkSize`, it was always written only to the 2 chunks.
  - Size of the second chunk then was over the `maxChunkSiz`e, and the next write failed on negative slice index.
- Improved variables naming

-----------
