### PR TITLE
feat: Remove recordctx.BodyString(), skip []byte -> string conv

### DIFF
--- a/internal/pkg/encoding/jsonnet/utils.go
+++ b/internal/pkg/encoding/jsonnet/utils.go
@@ -1,10 +1,11 @@
 package jsonnet
 
 import (
+	"unsafe"
+
 	"github.com/google/go-jsonnet/ast"
 	"github.com/keboola/go-utils/pkg/orderedmap"
 	"github.com/spf13/cast"
-	"unsafe"
 )
 
 // ValueToLiteral converts Go value to jsonnet.Ast literal.

--- a/internal/pkg/encoding/jsonnet/utils.go
+++ b/internal/pkg/encoding/jsonnet/utils.go
@@ -4,6 +4,7 @@ import (
 	"github.com/google/go-jsonnet/ast"
 	"github.com/keboola/go-utils/pkg/orderedmap"
 	"github.com/spf13/cast"
+	"unsafe"
 )
 
 // ValueToLiteral converts Go value to jsonnet.Ast literal.
@@ -48,19 +49,29 @@ func ValueToLiteral(v any) ast.Node {
 
 // ValueToJSONType converts Go value to a Json value for the Jsonnet VM.
 func ValueToJSONType(in any) any {
-	if v, ok := in.(*orderedmap.OrderedMap); ok {
+	switch v := in.(type) {
+	case []byte:
+		return bytesToStr(v)
+	case *orderedmap.OrderedMap:
 		m := make(map[string]any)
 		for _, k := range v.Keys() {
 			m[k], _ = v.Get(k)
 			m[k] = ValueToJSONType(m[k])
 		}
 		return m
-	}
-	if v, ok := in.([]any); ok {
+	case []any:
 		for i, arrVal := range v {
 			v[i] = ValueToJSONType(arrVal)
 		}
 		return v
 	}
+
 	return in
+}
+
+func bytesToStr(b []byte) string {
+	if len(b) == 0 {
+		return ""
+	}
+	return unsafe.String(unsafe.SliceData(b), len(b))
 }

--- a/internal/pkg/service/stream/api/mapper/source_response.go
+++ b/internal/pkg/service/stream/api/mapper/source_response.go
@@ -10,6 +10,7 @@ import (
 	api "github.com/keboola/keboola-as-code/internal/pkg/service/stream/api/gen/stream"
 	"github.com/keboola/keboola-as-code/internal/pkg/service/stream/definition"
 	"github.com/keboola/keboola-as-code/internal/pkg/service/stream/definition/key"
+	"github.com/keboola/keboola-as-code/internal/pkg/service/stream/mapping/csvfmt"
 	"github.com/keboola/keboola-as-code/internal/pkg/service/stream/mapping/recordctx"
 	"github.com/keboola/keboola-as-code/internal/pkg/service/stream/mapping/table/column"
 	"github.com/keboola/keboola-as-code/internal/pkg/utils/errors"
@@ -79,9 +80,14 @@ func (m *Mapper) NewTestResultResponse(sourceKey key.SourceKey, sinks []definiti
 				return nil, err
 			}
 
+			csvValueBytes, err := csvfmt.Format(csvValue)
+			if err != nil {
+				return nil, err
+			}
+
 			row.Columns = append(row.Columns, &api.TestResultColumn{
 				Name:  c.ColumnName(),
-				Value: csvValue,
+				Value: string(csvValueBytes),
 			})
 		}
 

--- a/internal/pkg/service/stream/mapping/csvfmt/csvfmt.go
+++ b/internal/pkg/service/stream/mapping/csvfmt/csvfmt.go
@@ -1,0 +1,52 @@
+package csvfmt
+
+import (
+	"strconv"
+	"unsafe"
+
+	"github.com/keboola/keboola-as-code/internal/pkg/utils/errors"
+)
+
+func Format(v any) ([]byte, error) {
+	// Inspired by cast.ToStringE(), but without slow reflection
+	switch s := v.(type) {
+	case []byte:
+		return s, nil
+	case string:
+		return []byte(s), nil
+	case bool:
+		return strToBytes(strconv.FormatBool(s)), nil
+	case float64:
+		return strToBytes(strconv.FormatFloat(s, 'f', -1, 64)), nil
+	case float32:
+		return strToBytes(strconv.FormatFloat(float64(s), 'f', -1, 32)), nil
+	case int:
+		return strToBytes(strconv.FormatInt(int64(s), 10)), nil
+	case int64:
+		return strToBytes(strconv.FormatInt(s, 10)), nil
+	case int32:
+		return strToBytes(strconv.FormatInt(int64(s), 10)), nil
+	case int16:
+		return strToBytes(strconv.FormatInt(int64(s), 10)), nil
+	case int8:
+		return strToBytes(strconv.FormatInt(int64(s), 10)), nil
+	case uint:
+		return strToBytes(strconv.FormatUint(uint64(s), 10)), nil
+	case uint64:
+		return strToBytes(strconv.FormatUint(s, 10)), nil
+	case uint32:
+		return strToBytes(strconv.FormatUint(uint64(s), 10)), nil
+	case uint16:
+		return strToBytes(strconv.FormatUint(uint64(s), 10)), nil
+	case uint8:
+		return strToBytes(strconv.FormatUint(uint64(s), 10)), nil
+	case nil:
+		return nil, nil
+	default:
+		return nil, errors.Errorf("unable to cast %#v of type %T to string", v, v)
+	}
+}
+
+func strToBytes(s string) []byte {
+	return unsafe.Slice(unsafe.StringData(s), len(s))
+}

--- a/internal/pkg/service/stream/mapping/jsonnet/jsonnet.go
+++ b/internal/pkg/service/stream/mapping/jsonnet/jsonnet.go
@@ -120,7 +120,7 @@ func bodyStrFn(fnName string, vm *jsonnet.VM[recordctx.Context]) *jsonnet.Native
 				return nil, errors.Errorf("no parameter expected, found %d", len(params))
 			}
 
-			body, err := vm.Payload().BodyString()
+			body, err := vm.Payload().BodyBytes()
 			if err != nil {
 				return nil, err
 			}

--- a/internal/pkg/service/stream/mapping/recordctx/fasthttp.go
+++ b/internal/pkg/service/stream/mapping/recordctx/fasthttp.go
@@ -23,8 +23,6 @@ type fastHTTPContext struct {
 	clientIP      net.IP
 	headersMap    *orderedmap.OrderedMap
 	headersString *string
-	bodyString    *string
-	bodyStringErr error
 	bodyMap       *orderedmap.OrderedMap
 	bodyMapErr    error
 }
@@ -79,26 +77,6 @@ func (c *fastHTTPContext) HeadersMap() *orderedmap.OrderedMap {
 		c.headersMap = c.headersToMap()
 	}
 	return c.headersMap
-}
-
-func (c *fastHTTPContext) BodyString() (string, error) {
-	c.lock.Lock()
-	defer c.lock.Unlock()
-
-	if c.bodyString == nil && c.bodyStringErr == nil {
-		if bytes, err := c.BodyBytes(); err == nil {
-			v := string(bytes)
-			c.bodyString = &v
-		} else {
-			c.bodyStringErr = err
-		}
-	}
-
-	if c.bodyStringErr != nil {
-		return "", c.bodyStringErr
-	}
-
-	return *c.bodyString, nil
 }
 
 func (c *fastHTTPContext) BodyBytes() ([]byte, error) {

--- a/internal/pkg/service/stream/mapping/recordctx/http.go
+++ b/internal/pkg/service/stream/mapping/recordctx/http.go
@@ -23,8 +23,6 @@ type httpContext struct {
 	clientIP      net.IP
 	headersMap    *orderedmap.OrderedMap
 	headersString *string
-	bodyString    *string
-	bodyStringErr error
 	bodyBytes     []byte
 	bodyBytesErr  error
 	bodyMap       *orderedmap.OrderedMap
@@ -79,26 +77,6 @@ func (c *httpContext) HeadersMap() *orderedmap.OrderedMap {
 		c.headersMap = c.headersToMap()
 	}
 	return c.headersMap
-}
-
-func (c *httpContext) BodyString() (string, error) {
-	c.lock.Lock()
-	defer c.lock.Unlock()
-
-	if c.bodyString == nil && c.bodyStringErr == nil {
-		if bytes, err := c.bodyBytesWithoutLock(); err == nil {
-			v := string(bytes)
-			c.bodyString = &v
-		} else {
-			c.bodyStringErr = err
-		}
-	}
-
-	if c.bodyStringErr != nil {
-		return "", c.bodyStringErr
-	}
-
-	return *c.bodyString, nil
 }
 
 func (c *httpContext) BodyBytes() ([]byte, error) {

--- a/internal/pkg/service/stream/mapping/recordctx/recordctx.go
+++ b/internal/pkg/service/stream/mapping/recordctx/recordctx.go
@@ -15,7 +15,6 @@ type Context interface {
 	ClientIP() net.IP
 	HeadersString() string
 	HeadersMap() *orderedmap.OrderedMap
-	BodyString() (string, error)
 	BodyBytes() ([]byte, error)
 	BodyMap() (*orderedmap.OrderedMap, error)
 }

--- a/internal/pkg/service/stream/mapping/table/column/renderer.go
+++ b/internal/pkg/service/stream/mapping/table/column/renderer.go
@@ -22,10 +22,10 @@ func NewRenderer() *Renderer {
 	}
 }
 
-func (r *Renderer) CSVValue(c Column, ctx recordctx.Context) (string, error) {
+func (r *Renderer) CSVValue(c Column, ctx recordctx.Context) (any, error) {
 	switch c := c.(type) {
 	case Body:
-		return ctx.BodyString()
+		return ctx.BodyBytes()
 	case Datetime:
 		// Time is always in UTC, time format has fixed length
 		return ctx.Timestamp().UTC().Format(TimeFormat), nil

--- a/internal/pkg/service/stream/mapping/table/column/renderer_test.go
+++ b/internal/pkg/service/stream/mapping/table/column/renderer_test.go
@@ -9,6 +9,7 @@ import (
 
 	"github.com/gofrs/uuid/v5"
 	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
 
 	"github.com/keboola/keboola-as-code/internal/pkg/service/common/ptr"
 	"github.com/keboola/keboola-as-code/internal/pkg/service/stream/mapping/recordctx"
@@ -23,7 +24,9 @@ func TestRenderer_UUID(t *testing.T) {
 
 	val, err := renderer.CSVValue(c, recordctx.FromHTTP(time.Now(), &http.Request{}))
 	assert.NoError(t, err)
-	id, err := uuid.FromString(val)
+	valStr, ok := val.(string)
+	require.True(t, ok)
+	id, err := uuid.FromString(valStr)
 	assert.NoError(t, err)
 	assert.Equal(t, uuid.V7, id.Version())
 }
@@ -60,7 +63,7 @@ func TestRenderer_Body(t *testing.T) {
 	body := "a,b,c"
 	val, err := renderer.CSVValue(c, recordctx.FromHTTP(time.Now(), &http.Request{Body: io.NopCloser(strings.NewReader(body))}))
 	assert.NoError(t, err)
-	assert.Equal(t, "a,b,c", val)
+	assert.Equal(t, []byte("a,b,c"), val)
 }
 
 func TestRenderer_Headers(t *testing.T) {

--- a/internal/pkg/service/stream/storage/level/local/encoding/encoder/csv/csv.go
+++ b/internal/pkg/service/stream/storage/level/local/encoding/encoder/csv/csv.go
@@ -47,11 +47,11 @@ func (w *Encoder) WriteRecord(record recordctx.Context) error {
 
 	// Map the record to tabular data
 	for i, col := range w.columns {
-		str, err := columnRenderer.CSVValue(col, record)
+		value, err := columnRenderer.CSVValue(col, record)
 		if err != nil {
 			return errors.PrefixErrorf(err, "cannot convert column %q to CSV value", col)
 		}
-		(*values)[i] = str
+		(*values)[i] = value
 	}
 
 	// Encode the values to CSV format

--- a/internal/pkg/service/stream/storage/level/local/encoding/pipeline.go
+++ b/internal/pkg/service/stream/storage/level/local/encoding/pipeline.go
@@ -281,12 +281,8 @@ func (p *pipeline) WriteRecord(record recordctx.Context) error {
 	// Increments number of high-level writes in progress
 	p.acceptedWrites.Add(timestamp, 1)
 
-	// Set sync timeout
-	ctx, cancel := context.WithTimeout(record.Ctx(), 20*time.Second)
-	defer cancel()
-
 	// Wait for sync and return sync error, if any
-	if err := notifier.Wait(ctx); err != nil {
+	if err := notifier.Wait(record.Ctx()); err != nil {
 		return errors.PrefixError(err, "error when waiting for sync")
 	}
 

--- a/internal/pkg/service/stream/storage/level/local/encoding/pipeline_test.go
+++ b/internal/pkg/service/stream/storage/level/local/encoding/pipeline_test.go
@@ -598,12 +598,14 @@ func newDummyEncoder(out io.Writer, writeDone chan struct{}) *dummyEncoder {
 }
 
 func (w *dummyEncoder) WriteRecord(record recordctx.Context) error {
-	body, err := record.BodyString()
+	body, err := record.BodyBytes()
 	if err != nil {
 		return err
 	}
 
-	_, err = w.out.Write([]byte(body + "\n"))
+	body = append(body, '\n')
+
+	_, err = w.out.Write(body)
 	if err == nil && w.writeDone != nil {
 		w.writeDone <- struct{}{}
 	}


### PR DESCRIPTION
**Changes:**
- Reduced memory allocations:
 - There is no more conversion of the request body `[]byte -> string`.
 - Removed `context.WithTimeout` from the hot path.

-----------
