### PR TITLE
fix: Add missing CORS headers to http source

### DIFF
--- a/internal/pkg/service/stream/source/httpsource/httpsource.go
+++ b/internal/pkg/service/stream/source/httpsource/httpsource.go
@@ -4,6 +4,7 @@ package httpsource
 import (
 	"context"
 	"net"
+	"net/http"
 	"strconv"
 	"time"
 
@@ -74,6 +75,15 @@ func Start(ctx context.Context, d dependencies, cfg Config) error {
 	}
 
 	// Route import requests to the dispatcher
+	router.Options("/stream/<projectID>/<sourceID>/<secret>", func(c *routing.Context) error {
+		c.Response.Header.Set("Allow", "OPTIONS, POST")
+		c.Response.Header.Set("Access-Control-Allow-Methods", "OPTIONS, POST")
+		c.Response.Header.Set("Access-Control-Allow-Headers", "*")
+		c.Response.Header.Set("Access-Control-Expose-Headers", "*")
+		c.Response.Header.Set("Access-Control-Allow-Origin", "*")
+		c.Response.SetStatusCode(http.StatusOK)
+		return nil
+	})
 	router.Post("/stream/<projectID>/<sourceID>/<secret>", func(c *routing.Context) error {
 		// Get parameters
 		projectIDStr := c.Param("projectID")

--- a/internal/pkg/service/stream/source/httpsource/httpsource_test.go
+++ b/internal/pkg/service/stream/source/httpsource/httpsource_test.go
@@ -190,9 +190,13 @@ func testCases(t *testing.T, ts *testState) []TestCase {
 			Path:               "/stream/1234/my-source/my-secret",
 			ExpectedStatusCode: http.StatusOK,
 			ExpectedHeaders: map[string]string{
-				"Allow":          "OPTIONS, POST",
-				"Content-Length": "0",
-				"Server":         httpsource.ServerHeader,
+				"Allow":                         "OPTIONS, POST",
+				"Access-Control-Allow-Methods":  "OPTIONS, POST",
+				"Access-Control-Allow-Headers":  "*",
+				"Access-Control-Expose-Headers": "*",
+				"Access-Control-Allow-Origin":   "*",
+				"Content-Length":                "0",
+				"Server":                        httpsource.ServerHeader,
 			},
 		},
 		{


### PR DESCRIPTION
Slack: https://keboolaglobal.slack.com/archives/C054DF6DZ1B/p1726492019295029?thread_ts=1725965177.093219&cid=C054DF6DZ1B
