### PR TITLE
feat: setup of temporary dataapps URL redirector for CSAS migration

### DIFF
--- a/provisioning/apps-proxy/common.sh
+++ b/provisioning/apps-proxy/common.sh
@@ -45,3 +45,10 @@ kubectl apply -f ./kubernetes/deploy/proxy/config-map.yaml
 kubectl apply -f ./kubernetes/deploy/proxy/pdb.yaml
 kubectl apply -f ./kubernetes/deploy/proxy/network-policy.yaml
 kubectl apply -f ./kubernetes/deploy/proxy/deployment.yaml
+
+# CSAS migration dataaps users redirector
+export CSAS_MIGRATION_APPS_PROXY_REDIRECT_REPLICAS="${CSAS_MIGRATION_APPS_PROXY_REDIRECT_REPLICAS:=0}"
+if [ "$CSAS_MIGRATION_APPS_PROXY_REDIRECT_REPLICAS" -gt 0 ]; then
+  kubectl apply -f ./kubernetes/deploy/nginx-redir/config-map.yaml
+  kubectl apply -f ./kubernetes/deploy/nginx-redir/deployment.yaml
+fi

--- a/provisioning/apps-proxy/kubernetes/build.sh
+++ b/provisioning/apps-proxy/kubernetes/build.sh
@@ -14,6 +14,11 @@ envsubst < templates/proxy/pdb.yaml            > deploy/proxy/pdb.yaml
 envsubst < templates/proxy/network-policy.yaml > deploy/proxy/network-policy.yaml
 envsubst < templates/proxy/deployment.yaml     > deploy/proxy/deployment.yaml
 
+# CSAS migration, without condition because it's trashed after build
+envsubst < templates/nginx-redir/deployment.yaml > deploy/nginx-redir/deployment.yaml
+# required NGINX configuration breaks ideal templating so skipping it
+cat templates/nginx-redir/config-map.yaml        > deploy/nginx-redir/config-map.yaml
+
 # Remove resources requests/limits to fit all pods to the CI environment
 REMOVE_RESOURCES_LIMITS="${REMOVE_RESOURCES_LIMITS:=false}"
 if [[ "$REMOVE_RESOURCES_LIMITS" == "true" ]]; then

--- a/provisioning/apps-proxy/kubernetes/templates/nginx-redir/config-map.yaml
+++ b/provisioning/apps-proxy/kubernetes/templates/nginx-redir/config-map.yaml
@@ -1,0 +1,20 @@
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: nginx-config
+  namespace: apps-proxy
+data:
+  nginx.conf: |
+    events {
+      # Events block is needed
+    }
+    http {
+        server {
+            listen 8000;
+            server_name ~^(?<subdomain>.+)\.hub\.csas\.keboola\.cloud$;
+
+            location / {
+                return 302 https://$subdomain.hub.cs.keboola.cloud$request_uri;
+            }
+        }
+    }

--- a/provisioning/apps-proxy/kubernetes/templates/nginx-redir/deployment.yaml
+++ b/provisioning/apps-proxy/kubernetes/templates/nginx-redir/deployment.yaml
@@ -1,0 +1,30 @@
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: nginx-csas-redirector
+  namespace: $NAMESPACE
+  labels:
+    app: apps-proxy
+spec:
+  replicas: $CSAS_MIGRATION_APPS_PROXY_REDIRECT_REPLICAS
+  selector:
+    matchLabels:
+      app: apps-proxy
+  template:
+    metadata:
+      labels:
+        app: apps-proxy
+    spec:
+      containers:
+      - name: nginx
+        image: nginx:latest
+        volumeMounts:
+        - name: nginx-config-volume
+          mountPath: /etc/nginx/nginx.conf
+          subPath: nginx.conf
+        ports:
+        - containerPort: 8000
+      volumes:
+      - name: nginx-config-volume
+        configMap:
+          name: nginx-config


### PR DESCRIPTION
temporary feature required by CSAS migration scenario. redirection of dataapps URLs between old and new stacks. 

Jira: https://keboola.atlassian.net/browse/ST-2246


**Changes:**
- adds conditional deployment of  NGINX
- adds clusters specific NGINX configuration for sending http redirects
- changes template for k8s Service to match different deployments using labels based on non-mandatory value of CSAS_MIGRATION_APPS_PROXY_REDIRECT_REPLICAS

-----------
test skrze [pipeline](https://dev.azure.com/keboola-prod/Keboola%20Connection%20Azure/_releaseProgress?_a=release-environment-logs&releaseId=51836&environmentId=179241)