### PR TITLE
refactor: Convert lowercase to uppercase for secrets in user input

### DIFF
--- a/internal/pkg/service/cli/dialog/use_template.go
+++ b/internal/pkg/service/cli/dialog/use_template.go
@@ -240,7 +240,7 @@ func (d *useTmplInputsDialog) askInput(ctx context.Context, inputDef *input.Inpu
 					return err
 				}
 
-				strValue := cast.ToString(value)
+				strValue := strings.ToUpper(cast.ToString(value))
 				if !regexpcache.MustCompile(`^[A-Z0-9\_]+$`).MatchString(strValue) {
 					return errors.Errorf(`the variable name "%s" is invalid, it can contain only uppercase letters, numbers and underscores`, strValue)
 				}
@@ -254,7 +254,7 @@ func (d *useTmplInputsDialog) askInput(ctx context.Context, inputDef *input.Inpu
 		}
 
 		value, _ := d.Ask(question)
-		envVar := fmt.Sprintf("KBC_SECRET_%s", value)
+		envVar := strings.ToUpper(fmt.Sprintf("KBC_SECRET_%s", value))
 		// Add the env var to the input as placeholder, that's the reason for the surrounding '##'
 		err := d.addInputValue(ctx, fmt.Sprintf("##%s##", envVar), inputDef, true)
 		if err != nil {


### PR DESCRIPTION
Jira: [PSGO-838](https://keboola.atlassian.net/browse/PSGO-838)

**Changes:**
- convert lowercase to uppercase

-----------
if the token is lowercase, the secret name will be converted to uppercase in the output.

<img width="1016" alt="image" src="https://github.com/user-attachments/assets/562a1b41-5521-4e1b-adbb-1b0daeb31c02">


<img width="694" alt="image" src="https://github.com/user-attachments/assets/91d7a89a-f3e1-4eaf-98b5-42ccaba70660">


[PSGO-838]: https://keboola.atlassian.net/browse/PSGO-838?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ