### PR TITLE
feat: Add aligned writes for diskwriter.

### DIFF
--- a/internal/pkg/service/stream/storage/level/local/diskreader/reader_test.go
+++ b/internal/pkg/service/stream/storage/level/local/diskreader/reader_test.go
@@ -37,7 +37,7 @@ func TestVolume_NewReaderFor_Ok(t *testing.T) {
 
 	// Wait for file open
 	assert.EventuallyWithT(t, func(collect *assert.CollectT) {
-		tc.AssertLogs(`
+		tc.Logger.AssertJSONMessages(collect, `
 {"level":"debug","message":"opened file","volume.id":"my-volume","file.path":"%s","project.id":"123","branch.id":"456","source.id":"my-source","sink.id":"my-sink","file.id":"2000-01-01T19:00:00.000Z","slice.id":"2000-01-01T20:00:00.000Z"}
 `)
 	}, 5*time.Second, 10*time.Millisecond)

--- a/internal/pkg/service/stream/storage/level/local/diskreader/volume_test.go
+++ b/internal/pkg/service/stream/storage/level/local/diskreader/volume_test.go
@@ -91,7 +91,7 @@ func TestOpenVolume_Ok(t *testing.T) {
 	assert.NoError(t, lock.Unlock())
 
 	// Check logs
-	tc.AssertLogs(`
+	tc.Logger.AssertJSONMessages(tc.TB, `
 {"level":"info","message":"opening volume","volume.path":"%s"}
 {"level":"info","message":"opened volume","volume.id":"abcdef","volume.path":"%s","volume.type":"hdd","volume.label":"1"}
 {"level":"info","message":"closing volume"}
@@ -153,7 +153,7 @@ func TestOpenVolume_WaitForVolumeIDFile_Ok(t *testing.T) {
 	assert.NoError(t, lock.Unlock())
 
 	// Check logs
-	tc.AssertLogs(`
+	tc.Logger.AssertJSONMessages(tc.TB, `
 {"level":"info","message":"opening volume"}
 {"level":"info","message":"waiting for volume ID file"}
 {"level":"info","message":"waiting for volume ID file"}
@@ -200,7 +200,7 @@ func TestOpenVolume_WaitForVolumeIDFile_Timeout(t *testing.T) {
 	}
 
 	// Check logs
-	tc.AssertLogs(`
+	tc.Logger.AssertJSONMessages(tc.TB, `
 {"level":"info","message":"opening volume"}
 {"level":"info","message":"waiting for volume ID file"}
 {"level":"info","message":"waiting for volume ID file"}
@@ -320,8 +320,4 @@ func (tc *volumeTestCase) OpenVolume() (*diskreader.Volume, error) {
 		Label:       tc.VolumeLabel,
 	}
 	return diskreader.OpenVolume(tc.Ctx, tc.Logger, tc.Clock, tc.Config, events.New[diskreader.Reader](), info)
-}
-
-func (tc *volumeTestCase) AssertLogs(expected string) bool {
-	return tc.Logger.AssertJSONMessages(tc.TB, expected)
 }

--- a/internal/pkg/service/stream/storage/level/local/diskwriter/file.go
+++ b/internal/pkg/service/stream/storage/level/local/diskwriter/file.go
@@ -15,6 +15,8 @@ const (
 type File interface {
 	io.Writer
 	Fd() uintptr
+	Seek(offset int64, whence int) (ret int64, err error)
+	Truncate(size int64) error
 	Stat() (os.FileInfo, error)
 	Sync() error
 	Close() error

--- a/internal/pkg/service/stream/storage/level/local/diskwriter/file.go
+++ b/internal/pkg/service/stream/storage/level/local/diskwriter/file.go
@@ -6,7 +6,7 @@ import (
 )
 
 const (
-	sliceFileFlags = os.O_CREATE | os.O_WRONLY | os.O_APPEND
+	sliceFileFlags = os.O_CREATE | os.O_WRONLY
 	sliceFilePerm  = 0o640
 )
 
@@ -34,7 +34,18 @@ func FileOpenerFn(fn func(filePath string) (File, error)) FileOpener {
 type DefaultFileOpener struct{}
 
 func (DefaultFileOpener) OpenFile(filePath string) (File, error) {
-	return os.OpenFile(filePath, sliceFileFlags, sliceFilePerm)
+	f, err := os.OpenFile(filePath, sliceFileFlags, sliceFilePerm)
+	if err != nil {
+		return nil, err
+	}
+
+	// Windows does not support truncate of file in `os.O_APPEND` file mode
+	_, err = f.Seek(0, io.SeekEnd)
+	if err != nil {
+		return nil, err
+	}
+
+	return f, nil
 }
 
 type fileOpenerFn struct {

--- a/internal/pkg/service/stream/storage/level/local/diskwriter/network/router/router_test.go
+++ b/internal/pkg/service/stream/storage/level/local/diskwriter/network/router/router_test.go
@@ -209,7 +209,6 @@ func TestRouter_ShutdownDiskWriterNodeFirst(t *testing.T) {
 {"level":"info","message":"closing sink router","nodeId":"source","component":"sink.router"}
 {"level":"info","message":"closed sink router","nodeId":"source","component":"sink.router"}
 {"level":"info","message":"stopping storage statistics collector","nodeId":"source","component":"statistics.collector"}
-{"level":"debug","message":"sync done","nodeId":"source","component":"statistics.collector"}                                                                
 {"level":"info","message":"storage statistics stopped","nodeId":"source","component":"statistics.collector"}
 {"level":"info","message":"closing connections","nodeId":"source","component":"storage.router.connections"}
 {"level":"info","message":"closing disk writer client","nodeId":"source","component":"storage.router.connections.client.transport"}

--- a/internal/pkg/service/stream/storage/level/local/diskwriter/network/rpc/server.go
+++ b/internal/pkg/service/stream/storage/level/local/diskwriter/network/rpc/server.go
@@ -179,7 +179,7 @@ func (s *NetworkFileServer) Write(ctx context.Context, req *pb.WriteRequest) (*p
 		return nil, err
 	}
 
-	n, err := w.Write(ctx, req.Data)
+	n, err := w.Write(ctx, req.Aligned, req.Data)
 	if err != nil {
 		return nil, err
 	}

--- a/internal/pkg/service/stream/storage/level/local/encoding/pipeline.go
+++ b/internal/pkg/service/stream/storage/level/local/encoding/pipeline.go
@@ -66,6 +66,7 @@ type NetworkOutput interface {
 	// IsReady returns true if the underlying network is working.
 	IsReady() bool
 	// Write bytes to a file in disk writer node.
+	// When write is aligned, it commits that already writen bytes are safely stored.
 	// The operation is used on Flush of the encoding pipeline.
 	Write(ctx context.Context, aligned bool, p []byte) (n int, err error)
 	// Sync OS disk cache to the physical disk.

--- a/internal/pkg/service/stream/storage/node/writernode/diskcleanup/diskcleanup_test.go
+++ b/internal/pkg/service/stream/storage/node/writernode/diskcleanup/diskcleanup_test.go
@@ -126,7 +126,7 @@ func TestDiskCleanup(t *testing.T) {
 	{
 		writer, err := vol.OpenWriter("my-source", slice.SliceKey, slice.LocalStorage)
 		require.NoError(t, err)
-		_, err = writer.Write(ctx, []byte("foo\n"))
+		_, err = writer.Write(ctx, true, []byte("foo\n"))
 		require.NoError(t, err)
 		require.NoError(t, writer.Close(ctx))
 		require.DirExists(t, filepath.Join(vol.Path(), slice.LocalStorage.Dir))

--- a/internal/pkg/service/stream/storage/test/writer_file.go
+++ b/internal/pkg/service/stream/storage/test/writer_file.go
@@ -13,10 +13,10 @@ type WriterTestFile struct {
 	CloseError error
 }
 
-func NewWriterTestFile(t *testing.T, filePath string) *WriterTestFile {
-	t.Helper()
+func NewWriterTestFile(tb testing.TB, filePath string) *WriterTestFile {
+	tb.Helper()
 	file, err := os.OpenFile(filePath, os.O_CREATE|os.O_WRONLY|os.O_APPEND, 0o640)
-	require.NoError(t, err)
+	require.NoError(tb, err)
 	return &WriterTestFile{file: file}
 }
 
@@ -30,6 +30,14 @@ func (f *WriterTestFile) WriteString(s string) (int, error) {
 
 func (f *WriterTestFile) Fd() uintptr {
 	return f.file.Fd()
+}
+
+func (f *WriterTestFile) Seek(offset int64, whence int) (ret int64, err error) {
+	return f.file.Seek(offset, whence)
+}
+
+func (f *WriterTestFile) Truncate(size int64) error {
+	return f.file.Truncate(size)
 }
 
 func (f *WriterTestFile) Stat() (os.FileInfo, error) {


### PR DESCRIPTION
We need to ensure by aligned write to properly truncate file if there is some newly written bytes that we do not want due to graceful/non graceful shutdown.

