### PR TITLE
feat: Set limit for too big row encoded

### DIFF
--- a/internal/pkg/service/stream/config/config_test.go
+++ b/internal/pkg/service/stream/config/config_test.go
@@ -180,6 +180,8 @@ storage:
                     type: csv
                     # Concurrency of the format writer for the specified file type. 0 = auto = num of CPU cores. Validation rules: min=0,max=256
                     concurrency: 0
+                    # Set's the limit of single row to be encoded. Limit should be bigger than accepted request on source otherwise received message will never be encoded. Validation rules: minBytes=1kB,maxBytes=2MB
+                    limit: 1536KB
                 # Max size of the buffer before compression, if compression is enabled. 0 = disabled. Validation rules: maxBytes=16MB
                 inputBuffer: 2MB
                 # Max size of a chunk sent over the network to a disk writer node. Validation rules: required,minBytes=64kB,maxBytes=1MB

--- a/internal/pkg/service/stream/config/config_test.go
+++ b/internal/pkg/service/stream/config/config_test.go
@@ -181,7 +181,7 @@ storage:
                     # Concurrency of the format writer for the specified file type. 0 = auto = num of CPU cores. Validation rules: min=0,max=256
                     concurrency: 0
                     # Set's the limit of single row to be encoded. Limit should be bigger than accepted request on source otherwise received message will never be encoded. Validation rules: minBytes=1kB,maxBytes=2MB
-                    limit: 1536KB
+                    rowSizeLimit: 1536KB
                 # Max size of the buffer before compression, if compression is enabled. 0 = disabled. Validation rules: maxBytes=16MB
                 inputBuffer: 2MB
                 # Max size of a chunk sent over the network to a disk writer node. Validation rules: required,minBytes=64kB,maxBytes=1MB

--- a/internal/pkg/service/stream/sink/type/tablesink/keboola/bridge/fixtures/create_sink_snapshot.txt
+++ b/internal/pkg/service/stream/sink/type/tablesink/keboola/bridge/fixtures/create_sink_snapshot.txt
@@ -45,7 +45,8 @@ storage/file/level/local/123/456/my-source/my-sink/2000-01-01T01:00:00.000Z
   "encoding": {
     "encoder": {
       "type": "csv",
-      "concurrency": 0
+      "concurrency": 0,
+      "rowSizeLimit": "1536KB"
     },
     "inputBuffer": "2MB",
     "maxChunkSize": "512KB",
@@ -152,7 +153,8 @@ storage/slice/level/local/123/456/my-source/my-sink/2000-01-01T01:00:00.000Z/my-
   "encoding": {
     "encoder": {
       "type": "csv",
-      "concurrency": 0
+      "concurrency": 0,
+      "rowSizeLimit": "1536KB"
     },
     "inputBuffer": "2MB",
     "maxChunkSize": "512KB",

--- a/internal/pkg/service/stream/storage/level/local/config/config_test.go
+++ b/internal/pkg/service/stream/storage/level/local/config/config_test.go
@@ -19,6 +19,7 @@ func TestConfig_Validation(t *testing.T) {
 - "volume.assignment.preferredTypes" is a required field
 - "volume.registration.ttlSeconds" is a required field
 - "encoding.encoder.type" is a required field
+- "encoding.encoder.rowSizeLimit" must be 1KB or greater
 - "encoding.maxChunkSize" is a required field
 - "encoding.failedChunksThreshold" is a required field
 - "encoding.compression.type" is a required field

--- a/internal/pkg/service/stream/storage/level/local/encoding/encoder/config.go
+++ b/internal/pkg/service/stream/storage/level/local/encoding/encoder/config.go
@@ -10,9 +10,9 @@ type Type string
 
 // Config configures the local writer.
 type Config struct {
-	Type        Type              `json:"type" configKey:"type" configUsage:"Encoder type." validate:"required,oneof=csv"`
-	Concurrency int               `json:"concurrency" configKey:"concurrency" configUsage:"Concurrency of the format writer for the specified file type. 0 = auto = num of CPU cores" validate:"min=0,max=256"`
-	Limit       datasize.ByteSize `json:"limit" configKey:"limit" configUsage:"Set's the limit of single row to be encoded. Limit should be bigger than accepted request on source otherwise received message will never be encoded" validate:"minBytes=1kB,maxBytes=2MB"`
+	Type         Type              `json:"type" configKey:"type" configUsage:"Encoder type." validate:"required,oneof=csv"`
+	Concurrency  int               `json:"concurrency" configKey:"concurrency" configUsage:"Concurrency of the format writer for the specified file type. 0 = auto = num of CPU cores" validate:"min=0,max=256"`
+	RowSizeLimit datasize.ByteSize `json:"rowSizeLimit" configKey:"rowSizeLimit" configUsage:"Set's the limit of single row to be encoded. Limit should be bigger than accepted request on source otherwise received message will never be encoded" validate:"minBytes=1kB,maxBytes=2MB"`
 	// OverrideEncoderFactory overrides encoder factory.
 	// A custom implementation can be useful for tests.
 	OverrideEncoderFactory Factory `json:"-"`
@@ -25,8 +25,8 @@ type ConfigPatch struct {
 
 func NewConfig() Config {
 	return Config{
-		Type:        TypeCSV,
-		Concurrency: 0,                  // 0 = auto = CPU cores
-		Limit:       1536 * datasize.KB, // ~1.5 MB
+		Type:         TypeCSV,
+		Concurrency:  0,                  // 0 = auto = CPU cores
+		RowSizeLimit: 1536 * datasize.KB, // ~1.5 MB
 	}
 }

--- a/internal/pkg/service/stream/storage/level/local/encoding/encoder/config.go
+++ b/internal/pkg/service/stream/storage/level/local/encoding/encoder/config.go
@@ -1,5 +1,7 @@
 package encoder
 
+import "github.com/c2h5oh/datasize"
+
 const (
 	TypeCSV = Type("csv")
 )
@@ -8,8 +10,9 @@ type Type string
 
 // Config configures the local writer.
 type Config struct {
-	Type        Type `json:"type" configKey:"type" configUsage:"Encoder type." validate:"required,oneof=csv"`
-	Concurrency int  `json:"concurrency" configKey:"concurrency" configUsage:"Concurrency of the format writer for the specified file type. 0 = auto = num of CPU cores" validate:"min=0,max=256"`
+	Type        Type              `json:"type" configKey:"type" configUsage:"Encoder type." validate:"required,oneof=csv"`
+	Concurrency int               `json:"concurrency" configKey:"concurrency" configUsage:"Concurrency of the format writer for the specified file type. 0 = auto = num of CPU cores" validate:"min=0,max=256"`
+	Limit       datasize.ByteSize `json:"limit" configKey:"limit" configUsage:"Set's the limit of single row to be encoded. Limit should be bigger than accepted request on source otherwise received message will never be encoded" validate:"minBytes=1kB,maxBytes=2MB"`
 	// OverrideEncoderFactory overrides encoder factory.
 	// A custom implementation can be useful for tests.
 	OverrideEncoderFactory Factory `json:"-"`
@@ -23,6 +26,7 @@ type ConfigPatch struct {
 func NewConfig() Config {
 	return Config{
 		Type:        TypeCSV,
-		Concurrency: 0, // 0 = auto = CPU cores
+		Concurrency: 0,                  // 0 = auto = CPU cores
+		Limit:       1536 * datasize.KB, // ~1.5 MB
 	}
 }

--- a/internal/pkg/service/stream/storage/level/local/encoding/encoder/csv/csv.go
+++ b/internal/pkg/service/stream/storage/level/local/encoding/encoder/csv/csv.go
@@ -22,7 +22,8 @@ var columnRenderer = column.NewRenderer() //nolint:gochecknoglobals // contains 
 // NewEncoder creates CSV writers pool and implements encoder.Encoder
 // The order of the lines is not preserved, because we use the writers pool,
 // but also because there are several source nodes with a load balancer in front of them.
-func NewEncoder(concurrency int, mapping any, out io.Writer) (*Encoder, error) {
+// In case of encoder accepts too big csv row, it returns error.
+func NewEncoder(concurrency int, limit uint64, mapping any, out io.Writer) (*Encoder, error) {
 	tableMapping, ok := mapping.(table.Mapping)
 	if !ok {
 		return nil, errors.Errorf("csv encoder supports only table mapping, given %v", mapping)
@@ -30,7 +31,7 @@ func NewEncoder(concurrency int, mapping any, out io.Writer) (*Encoder, error) {
 
 	return &Encoder{
 		columns:     tableMapping.Columns,
-		writersPool: fastcsv.NewWritersPool(out, concurrency),
+		writersPool: fastcsv.NewWritersPool(out, limit, concurrency),
 		valuesPool: &sync.Pool{
 			New: func() any {
 				v := make([]any, len(tableMapping.Columns))

--- a/internal/pkg/service/stream/storage/level/local/encoding/encoder/csv/csv.go
+++ b/internal/pkg/service/stream/storage/level/local/encoding/encoder/csv/csv.go
@@ -1,7 +1,6 @@
 package csv
 
 import (
-	"fmt"
 	"io"
 	"sync"
 
@@ -70,7 +69,7 @@ func (w *Encoder) WriteRecord(record recordctx.Context) (int, error) {
 		var limitErr fastcsv.LimitError
 		if errors.As(err, &limitErr) {
 			columnName := w.columns[limitErr.ColumnIndex].ColumnName()
-			return n, svcerrors.NewPayloadTooLargeError(fmt.Errorf(`too big CSV row, column: "%s", row limit: %s`, columnName, limitErr.Limit.HumanReadable()))
+			return n, svcerrors.NewPayloadTooLargeError(errors.Errorf(`too big CSV row, column: "%s", row limit: %s`, columnName, limitErr.Limit.HumanReadable()))
 		}
 		return n, err
 	}

--- a/internal/pkg/service/stream/storage/level/local/encoding/encoder/csv/csv_test.go
+++ b/internal/pkg/service/stream/storage/level/local/encoding/encoder/csv/csv_test.go
@@ -96,7 +96,7 @@ func TestCSVWriterAboveLimit(t *testing.T) {
 			column.Body{Name: "body"},
 		},
 	}
-	csvEncoder, err := csv.NewEncoder(0, uint64(40*datasize.B), columns, io.Discard)
+	csvEncoder, err := csv.NewEncoder(0, 40*datasize.B, columns, io.Discard)
 	require.NoError(t, err)
 	record := recordctx.FromHTTP(
 		utctime.MustParse("2000-01-01T03:00:00.000Z").Time(),
@@ -110,7 +110,7 @@ func TestCSVWriterAboveLimit(t *testing.T) {
 		&http.Request{Body: io.NopCloser(strings.NewReader("foobartoomuch"))},
 	)
 	_, err = csvEncoder.WriteRecord(record)
-	assert.Equal(t, "too big csv row to be written", err.Error())
+	assert.Equal(t, "too big CSV row, column: \"body\", row limit: 40 B", err.Error())
 }
 
 func newTestCase(comp fileCompression, syncMode writesync.Mode, syncWait bool, parallelWrite bool) *testcase.WriterTestCase {

--- a/internal/pkg/service/stream/storage/level/local/encoding/encoder/csv/fastcsv/error.go
+++ b/internal/pkg/service/stream/storage/level/local/encoding/encoder/csv/fastcsv/error.go
@@ -1,7 +1,15 @@
 package fastcsv
 
+import "github.com/c2h5oh/datasize"
+
 type ValueError struct {
 	ColumnIndex int
+	err         error
+}
+
+type LimitError struct {
+	ColumnIndex int
+	Limit       datasize.ByteSize
 	err         error
 }
 
@@ -10,5 +18,13 @@ func (e ValueError) Error() string {
 }
 
 func (e ValueError) Unwrap() error {
+	return e.err
+}
+
+func (e LimitError) Error() string {
+	return e.err.Error()
+}
+
+func (e LimitError) Unwrap() error {
 	return e.err
 }

--- a/internal/pkg/service/stream/storage/level/local/encoding/encoder/csv/fastcsv/fastcsv.go
+++ b/internal/pkg/service/stream/storage/level/local/encoding/encoder/csv/fastcsv/fastcsv.go
@@ -19,7 +19,7 @@ type WritersPool struct {
 	pool *sync.Pool
 }
 
-func NewWritersPool(out io.Writer, writers int) *WritersPool {
+func NewWritersPool(out io.Writer, limit uint64, writers int) *WritersPool {
 	if writers <= 0 {
 		writers = runtime.GOMAXPROCS(0)
 	}
@@ -27,7 +27,7 @@ func NewWritersPool(out io.Writer, writers int) *WritersPool {
 	p := &WritersPool{}
 	p.pool = &sync.Pool{
 		New: func() any {
-			return newWriter(out)
+			return newWriter(out, limit)
 		},
 	}
 

--- a/internal/pkg/service/stream/storage/level/local/encoding/encoder/csv/fastcsv/fastcsv.go
+++ b/internal/pkg/service/stream/storage/level/local/encoding/encoder/csv/fastcsv/fastcsv.go
@@ -10,6 +10,8 @@ import (
 	"io"
 	"runtime"
 	"sync"
+
+	"github.com/c2h5oh/datasize"
 )
 
 type WritersPool struct {
@@ -19,7 +21,7 @@ type WritersPool struct {
 	pool *sync.Pool
 }
 
-func NewWritersPool(out io.Writer, limit uint64, writers int) *WritersPool {
+func NewWritersPool(out io.Writer, rowSizeLimit datasize.ByteSize, writers int) *WritersPool {
 	if writers <= 0 {
 		writers = runtime.GOMAXPROCS(0)
 	}
@@ -27,7 +29,7 @@ func NewWritersPool(out io.Writer, limit uint64, writers int) *WritersPool {
 	p := &WritersPool{}
 	p.pool = &sync.Pool{
 		New: func() any {
-			return newWriter(out, limit)
+			return newWriter(out, rowSizeLimit)
 		},
 	}
 

--- a/internal/pkg/service/stream/storage/level/local/encoding/encoder/factory.go
+++ b/internal/pkg/service/stream/storage/level/local/encoding/encoder/factory.go
@@ -16,7 +16,7 @@ type DefaultFactory struct{}
 func (DefaultFactory) NewEncoder(cfg Config, mapping any, out io.Writer) (Encoder, error) {
 	switch cfg.Type {
 	case TypeCSV:
-		return csv.NewEncoder(cfg.Concurrency, uint64(cfg.RowSizeLimit), mapping, out)
+		return csv.NewEncoder(cfg.Concurrency, cfg.RowSizeLimit, mapping, out)
 	default:
 		return nil, errors.Errorf(`unexpected encoder type "%s"`, cfg.Type)
 	}

--- a/internal/pkg/service/stream/storage/level/local/encoding/encoder/factory.go
+++ b/internal/pkg/service/stream/storage/level/local/encoding/encoder/factory.go
@@ -16,7 +16,7 @@ type DefaultFactory struct{}
 func (DefaultFactory) NewEncoder(cfg Config, mapping any, out io.Writer) (Encoder, error) {
 	switch cfg.Type {
 	case TypeCSV:
-		return csv.NewEncoder(cfg.Concurrency, uint64(cfg.Limit), mapping, out)
+		return csv.NewEncoder(cfg.Concurrency, uint64(cfg.RowSizeLimit), mapping, out)
 	default:
 		return nil, errors.Errorf(`unexpected encoder type "%s"`, cfg.Type)
 	}

--- a/internal/pkg/service/stream/storage/level/local/encoding/encoder/factory.go
+++ b/internal/pkg/service/stream/storage/level/local/encoding/encoder/factory.go
@@ -16,7 +16,7 @@ type DefaultFactory struct{}
 func (DefaultFactory) NewEncoder(cfg Config, mapping any, out io.Writer) (Encoder, error) {
 	switch cfg.Type {
 	case TypeCSV:
-		return csv.NewEncoder(cfg.Concurrency, mapping, out)
+		return csv.NewEncoder(cfg.Concurrency, uint64(cfg.Limit), mapping, out)
 	default:
 		return nil, errors.Errorf(`unexpected encoder type "%s"`, cfg.Type)
 	}

--- a/internal/pkg/service/stream/storage/model/file_test.go
+++ b/internal/pkg/service/stream/storage/model/file_test.go
@@ -133,6 +133,7 @@ func TestFile_Validation(t *testing.T) {
 - "state" is a required field
 - "mapping.columns" is a required field
 - "encoding.encoder.type" is a required field
+- "encoding.encoder.rowSizeLimit" must be 1KB or greater
 - "encoding.maxChunkSize" is a required field
 - "encoding.failedChunksThreshold" is a required field
 - "encoding.compression.type" is a required field

--- a/internal/pkg/service/stream/storage/model/slice_test.go
+++ b/internal/pkg/service/stream/storage/model/slice_test.go
@@ -182,6 +182,7 @@ func TestSlice_Validation(t *testing.T) {
 - "state" is a required field
 - "mapping.columns" is a required field
 - "encoding.encoder.type" is a required field
+- "encoding.encoder.rowSizeLimit" must be 1KB or greater
 - "encoding.maxChunkSize" is a required field
 - "encoding.failedChunksThreshold" is a required field
 - "encoding.compression.type" is a required field

--- a/provisioning/stream/kubernetes/templates/config/config-map.yaml
+++ b/provisioning/stream/kubernetes/templates/config/config-map.yaml
@@ -166,6 +166,8 @@ data:
               type: csv
               # Concurrency of the format writer for the specified file type. 0 = auto = num of CPU cores. Validation rules: min=0,max=256
               concurrency: 1
+              # Set's the limit of single row to be encoded. Limit should be bigger than accepted request on source otherwise received message will never be encoded. Validation rules: minBytes=1kB,maxBytes=2MB
+              rowSizeLimit: 1536KB
             # Max size of the buffer before compression, if compression is enabled. 0 = disabled. Validation rules: maxBytes=16MB
             inputBuffer: 1MB
             # Max size of a chunk sent over the network to a disk writer node. Validation rules: required,minBytes=64kB,maxBytes=1MB


### PR DESCRIPTION
We need to make sure that the request of clients does not make buffer/memory overflow per single column encoded

