### PR TITLE
fix: Remove panic to error on templates shared code helper.

### DIFF
--- a/internal/pkg/mapper/sharedcode/helper/helper.go
+++ b/internal/pkg/mapper/sharedcode/helper/helper.go
@@ -65,7 +65,7 @@ func (h *SharedCodeHelper) IsTransformation(key model.Key) (bool, error) {
 
 func (h *SharedCodeHelper) CheckTargetComponent(sharedCodeConfig *model.Config, transformation model.ConfigKey) error {
 	if sharedCodeConfig.SharedCode == nil {
-		panic(errors.New(`shared code value is not set`))
+		return errors.New("shared code value is not set")
 	}
 	if sharedCodeConfig.SharedCode.Target != transformation.ComponentID {
 		return errors.NewNestedError(


### PR DESCRIPTION
Jira: [PSGO-725](https://keboola.atlassian.net/browse/PSGO-725)

**Changes:**
- Spans are created accordingly and we are able to investigate template remote_load issues.

-----------


[PSGO-725]: https://keboola.atlassian.net/browse/PSGO-725?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ