### PR TITLE
feat: Format afterID for source/sink version endpoints

### DIFF
--- a/internal/pkg/service/stream/api/service/sink.go
+++ b/internal/pkg/service/stream/api/service/sink.go
@@ -384,20 +384,15 @@ func (s *service) ListSinkVersions(ctx context.Context, scope dependencies.SinkR
 		return nil, err
 	}
 
-	afterID, err := formatAfterID(payload.AfterID)
-	if err != nil {
-		return nil, err
-	}
-
 	list := func(opts ...iterator.Option) iterator.DefinitionT[definition.Sink] {
 		opts = append(opts,
 			iterator.WithLimit(payload.Limit),
-			iterator.WithStartOffset(afterID, false),
+			iterator.WithStartOffset(formatAfterID(payload.AfterID), false),
 		)
 		return s.definition.Sink().ListVersions(scope.SinkKey(), opts...)
 	}
 
-	return s.mapper.NewSinkVersions(ctx, afterID, payload.Limit, list)
+	return s.mapper.NewSinkVersions(ctx, formatAfterID(payload.AfterID), payload.Limit, list)
 }
 
 func (s *service) sinkMustNotExist(ctx context.Context, k key.SinkKey) error {

--- a/internal/pkg/service/stream/api/service/sink.go
+++ b/internal/pkg/service/stream/api/service/sink.go
@@ -384,15 +384,20 @@ func (s *service) ListSinkVersions(ctx context.Context, scope dependencies.SinkR
 		return nil, err
 	}
 
+	afterID, err := formatAfterID(payload.AfterID)
+	if err != nil {
+		return nil, err
+	}
+
 	list := func(opts ...iterator.Option) iterator.DefinitionT[definition.Sink] {
 		opts = append(opts,
 			iterator.WithLimit(payload.Limit),
-			iterator.WithStartOffset(payload.AfterID, false),
+			iterator.WithStartOffset(afterID, false),
 		)
 		return s.definition.Sink().ListVersions(scope.SinkKey(), opts...)
 	}
 
-	return s.mapper.NewSinkVersions(ctx, payload.AfterID, payload.Limit, list)
+	return s.mapper.NewSinkVersions(ctx, afterID, payload.Limit, list)
 }
 
 func (s *service) sinkMustNotExist(ctx context.Context, k key.SinkKey) error {

--- a/internal/pkg/service/stream/api/service/source_test.go
+++ b/internal/pkg/service/stream/api/service/source_test.go
@@ -9,27 +9,21 @@ func Test_formatAfterID(t *testing.T) {
 		id string
 	}
 	tests := []struct {
-		name    string
-		args    args
-		want    string
-		wantErr bool
+		name string
+		args args
+		want string
 	}{
-		{name: "valid_padded_id", args: args{id: "0000000001"}, want: "0000000001", wantErr: false},
-		{name: "valid_unpadded_id", args: args{id: "12"}, want: "0000000012", wantErr: false},
-		{name: "empty_string_id", args: args{id: ""}, want: "", wantErr: false},
-		{name: "invalid_non_numeric_id", args: args{id: "dasd"}, want: "", wantErr: true},
+		{name: "valid_padded_id", args: args{id: "0000000001"}, want: "0000000001"},
+		{name: "valid_unpadded_id", args: args{id: "12"}, want: "0000000012"},
+		{name: "empty_string_id", args: args{id: ""}, want: ""},
+		{name: "invalid_non_numeric_id", args: args{id: "dasd"}, want: "000000dasd"},
 	}
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
 			t.Parallel()
 
-			got, err := formatAfterID(tt.args.id)
-			if (err != nil) != tt.wantErr {
-				t.Errorf("formatAfterID() error = %v, wantErr %v", err, tt.wantErr)
-				return
-			}
-			if got != tt.want {
-				t.Errorf("formatAfterID() got = %v, want %v", got, tt.want)
+			if got := formatAfterID(tt.args.id); got != tt.want {
+				t.Errorf("formatAfterID() = %v, want %v", got, tt.want)
 			}
 		})
 	}

--- a/internal/pkg/service/stream/api/service/source_test.go
+++ b/internal/pkg/service/stream/api/service/source_test.go
@@ -1,0 +1,36 @@
+package service
+
+import "testing"
+
+func Test_formatAfterID(t *testing.T) {
+	t.Parallel()
+
+	type args struct {
+		id string
+	}
+	tests := []struct {
+		name    string
+		args    args
+		want    string
+		wantErr bool
+	}{
+		{name: "valid_padded_id", args: args{id: "0000000001"}, want: "0000000001", wantErr: false},
+		{name: "valid_unpadded_id", args: args{id: "12"}, want: "0000000012", wantErr: false},
+		{name: "empty_string_id", args: args{id: ""}, want: "", wantErr: false},
+		{name: "invalid_non_numeric_id", args: args{id: "dasd"}, want: "", wantErr: true},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+
+			got, err := formatAfterID(tt.args.id)
+			if (err != nil) != tt.wantErr {
+				t.Errorf("formatAfterID() error = %v, wantErr %v", err, tt.wantErr)
+				return
+			}
+			if got != tt.want {
+				t.Errorf("formatAfterID() got = %v, want %v", got, tt.want)
+			}
+		})
+	}
+}

--- a/test/stream/api/sink/list-sink-versions/012-list-limit-afterId/request.json
+++ b/test/stream/api/sink/list-sink-versions/012-list-limit-afterId/request.json
@@ -1,5 +1,5 @@
 {
-  "path": "/v1/branches/%%TEST_DEFAULT_BRANCH_ID%%/sources/my-source/sinks/my-sink/versions?limit=2&afterId=0000000002",
+  "path": "/v1/branches/%%TEST_DEFAULT_BRANCH_ID%%/sources/my-source/sinks/my-sink/versions?limit=2&afterId=2",
   "method": "GET",
   "headers": {
     "X-StorageApi-Token": "%%TEST_KBC_STORAGE_API_TOKEN%%"

--- a/test/stream/api/source/list-source-versions/007-list-afterId/request.json
+++ b/test/stream/api/source/list-source-versions/007-list-afterId/request.json
@@ -1,5 +1,5 @@
 {
-  "path": "/v1/branches/default/sources/my-source/versions?afterId=0000000002",
+  "path": "/v1/branches/default/sources/my-source/versions?afterId=2",
   "method": "GET",
   "headers": {
     "X-StorageApi-Token": "%%TEST_KBC_STORAGE_API_TOKEN%%"


### PR DESCRIPTION
Jira: [PSGO-884](https://keboola.atlassian.net/browse/PSGO-884)

**Changes:**
- add formatAfterID function to parse and format AfterID
- updated e2e tests
- added unit test

-----------


[PSGO-884]: https://keboola.atlassian.net/browse/PSGO-884?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ