### PR TITLE
fix: Add ACL for CUD stream API endpoints

### DIFF
--- a/build/ci/projects.json
+++ b/build/ci/projects.json
@@ -430,5 +430,21 @@
     "backend": "snowflake",
     "token": "$TEST_KBC_PROJECT_20474_TOKEN",
     "legacyTransformation": true
+  },
+  {
+    "host": "connection.keboola.com",
+    "project": 10166,
+    "stagingStorage": "s3",
+    "backend": "snowflake",
+    "token": "$TEST_KBC_PROJECT_10166_TOKEN",
+    "isGuest": true
+  },
+  {
+    "host": "connection.keboola.com",
+    "project": 10169,
+    "stagingStorage": "s3",
+    "backend": "snowflake",
+    "token": "$TEST_KBC_PROJECT_10169_TOKEN",
+    "isGuest": true
   }
 ]

--- a/go.mod
+++ b/go.mod
@@ -41,7 +41,7 @@ require (
 	github.com/jpillora/longestcommon v0.0.0-20161227235612-adb9d91ee629
 	github.com/json-iterator/go v1.1.12
 	github.com/keboola/go-client v1.27.0
-	github.com/keboola/go-utils v1.1.1-0.20241022085311-95c2a7afd3b8
+	github.com/keboola/go-utils v1.2.0
 	github.com/klauspost/compress v1.17.10
 	github.com/klauspost/pgzip v1.2.6
 	github.com/kylelemons/godebug v1.1.0

--- a/go.mod
+++ b/go.mod
@@ -41,7 +41,7 @@ require (
 	github.com/jpillora/longestcommon v0.0.0-20161227235612-adb9d91ee629
 	github.com/json-iterator/go v1.1.12
 	github.com/keboola/go-client v1.27.0
-	github.com/keboola/go-utils v1.1.0
+	github.com/keboola/go-utils v1.1.1-0.20241017114551-17d86ac3b1a4
 	github.com/klauspost/compress v1.17.10
 	github.com/klauspost/pgzip v1.2.6
 	github.com/kylelemons/godebug v1.1.0

--- a/go.mod
+++ b/go.mod
@@ -41,7 +41,7 @@ require (
 	github.com/jpillora/longestcommon v0.0.0-20161227235612-adb9d91ee629
 	github.com/json-iterator/go v1.1.12
 	github.com/keboola/go-client v1.27.0
-	github.com/keboola/go-utils v1.1.1-0.20241017114551-17d86ac3b1a4
+	github.com/keboola/go-utils v1.1.1-0.20241022085311-95c2a7afd3b8
 	github.com/klauspost/compress v1.17.10
 	github.com/klauspost/pgzip v1.2.6
 	github.com/kylelemons/godebug v1.1.0

--- a/go.sum
+++ b/go.sum
@@ -430,8 +430,8 @@ github.com/keboola/go-mockoidc v0.0.0-20240405064136-5229d2b53db6 h1:HcvX1VQkiav
 github.com/keboola/go-mockoidc v0.0.0-20240405064136-5229d2b53db6/go.mod h1:eDjgYHYDJbPLBLsyZ6qRaugP0mX8vePOhZ5id1fdzJw=
 github.com/keboola/go-oauth2-proxy/v7 v7.6.1-0.20240418143152-9d00aaa29562 h1:EiwSnkbGt2i6XxvjDMrWx6/bGlQjVs+yq1mDJ5b3U1U=
 github.com/keboola/go-oauth2-proxy/v7 v7.6.1-0.20240418143152-9d00aaa29562/go.mod h1:uPrZkzwsuFyIPP04hIt6TG2KvWujglvkOnUUnQJyIdw=
-github.com/keboola/go-utils v1.1.1-0.20241022085311-95c2a7afd3b8 h1:2RqFyuwdWWF7K0P96KdMFOBxyih8MwOkRw+nvokIxmw=
-github.com/keboola/go-utils v1.1.1-0.20241022085311-95c2a7afd3b8/go.mod h1:4YVC2/V0QwgHqxtch8JAVDNVI1aINF2arJ7sh6TO1GY=
+github.com/keboola/go-utils v1.2.0 h1:mz12Eo+/XW+V0qcEGN4mkXQjrFOdxy+muWe0hLj2n/c=
+github.com/keboola/go-utils v1.2.0/go.mod h1:4YVC2/V0QwgHqxtch8JAVDNVI1aINF2arJ7sh6TO1GY=
 github.com/kisielk/errcheck v1.5.0/go.mod h1:pFxgyoBC7bSaBwPgfKdkLd5X25qrDl4LWUI2bnpBCr8=
 github.com/kisielk/gotool v1.0.0/go.mod h1:XhKaO+MFFWcvkIS/tQcRk01m1F5IRFswLeQ+oQHNcck=
 github.com/klauspost/compress v1.17.10 h1:oXAz+Vh0PMUvJczoi+flxpnBEPxoER1IaAnU/NMPtT0=

--- a/go.sum
+++ b/go.sum
@@ -432,6 +432,8 @@ github.com/keboola/go-oauth2-proxy/v7 v7.6.1-0.20240418143152-9d00aaa29562 h1:Ei
 github.com/keboola/go-oauth2-proxy/v7 v7.6.1-0.20240418143152-9d00aaa29562/go.mod h1:uPrZkzwsuFyIPP04hIt6TG2KvWujglvkOnUUnQJyIdw=
 github.com/keboola/go-utils v1.1.1-0.20241017114551-17d86ac3b1a4 h1:0kbF5WbDU5aYdEBPgjyLdrHY6F9q7rouXbKrdJPoMGw=
 github.com/keboola/go-utils v1.1.1-0.20241017114551-17d86ac3b1a4/go.mod h1:4YVC2/V0QwgHqxtch8JAVDNVI1aINF2arJ7sh6TO1GY=
+github.com/keboola/go-utils v1.1.1-0.20241022085311-95c2a7afd3b8 h1:2RqFyuwdWWF7K0P96KdMFOBxyih8MwOkRw+nvokIxmw=
+github.com/keboola/go-utils v1.1.1-0.20241022085311-95c2a7afd3b8/go.mod h1:4YVC2/V0QwgHqxtch8JAVDNVI1aINF2arJ7sh6TO1GY=
 github.com/kisielk/errcheck v1.5.0/go.mod h1:pFxgyoBC7bSaBwPgfKdkLd5X25qrDl4LWUI2bnpBCr8=
 github.com/kisielk/gotool v1.0.0/go.mod h1:XhKaO+MFFWcvkIS/tQcRk01m1F5IRFswLeQ+oQHNcck=
 github.com/klauspost/compress v1.17.10 h1:oXAz+Vh0PMUvJczoi+flxpnBEPxoER1IaAnU/NMPtT0=

--- a/go.sum
+++ b/go.sum
@@ -430,8 +430,6 @@ github.com/keboola/go-mockoidc v0.0.0-20240405064136-5229d2b53db6 h1:HcvX1VQkiav
 github.com/keboola/go-mockoidc v0.0.0-20240405064136-5229d2b53db6/go.mod h1:eDjgYHYDJbPLBLsyZ6qRaugP0mX8vePOhZ5id1fdzJw=
 github.com/keboola/go-oauth2-proxy/v7 v7.6.1-0.20240418143152-9d00aaa29562 h1:EiwSnkbGt2i6XxvjDMrWx6/bGlQjVs+yq1mDJ5b3U1U=
 github.com/keboola/go-oauth2-proxy/v7 v7.6.1-0.20240418143152-9d00aaa29562/go.mod h1:uPrZkzwsuFyIPP04hIt6TG2KvWujglvkOnUUnQJyIdw=
-github.com/keboola/go-utils v1.1.1-0.20241017114551-17d86ac3b1a4 h1:0kbF5WbDU5aYdEBPgjyLdrHY6F9q7rouXbKrdJPoMGw=
-github.com/keboola/go-utils v1.1.1-0.20241017114551-17d86ac3b1a4/go.mod h1:4YVC2/V0QwgHqxtch8JAVDNVI1aINF2arJ7sh6TO1GY=
 github.com/keboola/go-utils v1.1.1-0.20241022085311-95c2a7afd3b8 h1:2RqFyuwdWWF7K0P96KdMFOBxyih8MwOkRw+nvokIxmw=
 github.com/keboola/go-utils v1.1.1-0.20241022085311-95c2a7afd3b8/go.mod h1:4YVC2/V0QwgHqxtch8JAVDNVI1aINF2arJ7sh6TO1GY=
 github.com/kisielk/errcheck v1.5.0/go.mod h1:pFxgyoBC7bSaBwPgfKdkLd5X25qrDl4LWUI2bnpBCr8=

--- a/go.sum
+++ b/go.sum
@@ -430,8 +430,8 @@ github.com/keboola/go-mockoidc v0.0.0-20240405064136-5229d2b53db6 h1:HcvX1VQkiav
 github.com/keboola/go-mockoidc v0.0.0-20240405064136-5229d2b53db6/go.mod h1:eDjgYHYDJbPLBLsyZ6qRaugP0mX8vePOhZ5id1fdzJw=
 github.com/keboola/go-oauth2-proxy/v7 v7.6.1-0.20240418143152-9d00aaa29562 h1:EiwSnkbGt2i6XxvjDMrWx6/bGlQjVs+yq1mDJ5b3U1U=
 github.com/keboola/go-oauth2-proxy/v7 v7.6.1-0.20240418143152-9d00aaa29562/go.mod h1:uPrZkzwsuFyIPP04hIt6TG2KvWujglvkOnUUnQJyIdw=
-github.com/keboola/go-utils v1.1.0 h1:2tJikVr1kESR88qeGy/Vtmendw7TXB1UrJKLfPKceSk=
-github.com/keboola/go-utils v1.1.0/go.mod h1:4YVC2/V0QwgHqxtch8JAVDNVI1aINF2arJ7sh6TO1GY=
+github.com/keboola/go-utils v1.1.1-0.20241017114551-17d86ac3b1a4 h1:0kbF5WbDU5aYdEBPgjyLdrHY6F9q7rouXbKrdJPoMGw=
+github.com/keboola/go-utils v1.1.1-0.20241017114551-17d86ac3b1a4/go.mod h1:4YVC2/V0QwgHqxtch8JAVDNVI1aINF2arJ7sh6TO1GY=
 github.com/kisielk/errcheck v1.5.0/go.mod h1:pFxgyoBC7bSaBwPgfKdkLd5X25qrDl4LWUI2bnpBCr8=
 github.com/kisielk/gotool v1.0.0/go.mod h1:XhKaO+MFFWcvkIS/tQcRk01m1F5IRFswLeQ+oQHNcck=
 github.com/klauspost/compress v1.17.10 h1:oXAz+Vh0PMUvJczoi+flxpnBEPxoER1IaAnU/NMPtT0=

--- a/internal/pkg/service/stream/api/service/service.go
+++ b/internal/pkg/service/stream/api/service/service.go
@@ -14,6 +14,7 @@ import (
 	"github.com/keboola/keboola-as-code/internal/pkg/service/stream/config"
 	definitionRepo "github.com/keboola/keboola-as-code/internal/pkg/service/stream/definition/repository"
 	"github.com/keboola/keboola-as-code/internal/pkg/service/stream/dependencies"
+	"github.com/keboola/keboola-as-code/internal/pkg/utils/errors"
 )
 
 const (
@@ -28,6 +29,7 @@ type service struct {
 	locks      *distlock.Provider
 	definition *definitionRepo.Repository
 	mapper     *mapper.Mapper
+	adminError error
 }
 
 func New(d dependencies.APIScope, cfg config.Config) api.Service {
@@ -39,6 +41,7 @@ func New(d dependencies.APIScope, cfg config.Config) api.Service {
 		locks:      d.DistributedLockProvider(),
 		definition: d.DefinitionRepository(),
 		mapper:     mapper.New(d, cfg),
+		adminError: errors.New("only admin token can do write operations on streams"),
 	}
 }
 

--- a/internal/pkg/service/stream/api/service/service.go
+++ b/internal/pkg/service/stream/api/service/service.go
@@ -16,6 +16,10 @@ import (
 	"github.com/keboola/keboola-as-code/internal/pkg/service/stream/dependencies"
 )
 
+const (
+	adminRole = "admin"
+)
+
 type service struct {
 	logger     log.Logger
 	clock      clock.Clock

--- a/internal/pkg/service/stream/api/service/sink.go
+++ b/internal/pkg/service/stream/api/service/sink.go
@@ -27,7 +27,7 @@ func (s *service) CreateSink(ctx context.Context, d dependencies.SourceRequestSc
 	// If user is not admin deny access for write
 	token := d.StorageAPIToken()
 	if token.Admin == nil || token.Admin.Role != adminRole {
-		return nil, svcerrors.NewForbiddenError(errors.New("only admin token can do write operations on streams"))
+		return nil, svcerrors.NewForbiddenError(s.adminError)
 	}
 
 	// Create entity
@@ -123,7 +123,7 @@ func (s *service) UpdateSink(ctx context.Context, d dependencies.SinkRequestScop
 	// If user is not admin deny access for write
 	token := d.StorageAPIToken()
 	if token.Admin == nil || token.Admin.Role != adminRole {
-		return nil, svcerrors.NewForbiddenError(errors.New("only admin token can do write operations on streams"))
+		return nil, svcerrors.NewForbiddenError(s.adminError)
 	}
 
 	// Get the change description
@@ -187,7 +187,7 @@ func (s *service) DeleteSink(ctx context.Context, d dependencies.SinkRequestScop
 	// If user is not admin deny access for write
 	token := d.StorageAPIToken()
 	if token.Admin == nil || token.Admin.Role != adminRole {
-		return nil, svcerrors.NewForbiddenError(errors.New("only admin token can do write operations on streams"))
+		return nil, svcerrors.NewForbiddenError(s.adminError)
 	}
 
 	// Quick check before the task
@@ -230,7 +230,7 @@ func (s *service) UpdateSinkSettings(ctx context.Context, d dependencies.SinkReq
 	// If user is not admin deny access for write
 	token := d.StorageAPIToken()
 	if token.Admin == nil || token.Admin.Role != adminRole {
-		return nil, svcerrors.NewForbiddenError(errors.New("only admin token can do write operations on streams"))
+		return nil, svcerrors.NewForbiddenError(s.adminError)
 	}
 
 	// Quick check before the task
@@ -355,7 +355,7 @@ func (s *service) SinkStatisticsClear(ctx context.Context, d dependencies.SinkRe
 	// If user is not admin deny access for write
 	token := d.StorageAPIToken()
 	if token.Admin == nil || token.Admin.Role != adminRole {
-		return svcerrors.NewForbiddenError(errors.New("only admin token can do write operations on streams"))
+		return svcerrors.NewForbiddenError(s.adminError)
 	}
 
 	if err := s.sinkMustExist(ctx, d.SinkKey()); err != nil {
@@ -369,7 +369,7 @@ func (s *service) DisableSink(ctx context.Context, d dependencies.SinkRequestSco
 	// If user is not admin deny access for write
 	token := d.StorageAPIToken()
 	if token.Admin == nil || token.Admin.Role != adminRole {
-		return nil, svcerrors.NewForbiddenError(errors.New("only admin token can do write operations on streams"))
+		return nil, svcerrors.NewForbiddenError(s.adminError)
 	}
 
 	if err := s.sinkMustExist(ctx, d.SinkKey()); err != nil {
@@ -403,7 +403,7 @@ func (s *service) EnableSink(ctx context.Context, d dependencies.SinkRequestScop
 	// If user is not admin deny access for write
 	token := d.StorageAPIToken()
 	if token.Admin == nil || token.Admin.Role != adminRole {
-		return nil, svcerrors.NewForbiddenError(errors.New("only admin token can do write operations on streams"))
+		return nil, svcerrors.NewForbiddenError(s.adminError)
 	}
 
 	if err := s.sinkMustExist(ctx, d.SinkKey()); err != nil {

--- a/internal/pkg/service/stream/api/service/sink.go
+++ b/internal/pkg/service/stream/api/service/sink.go
@@ -26,7 +26,7 @@ import (
 func (s *service) CreateSink(ctx context.Context, d dependencies.SourceRequestScope, payload *api.CreateSinkPayload) (*api.Task, error) {
 	// If user is not admin deny access for write
 	token := d.StorageAPIToken()
-	if token.Admin == nil {
+	if token.Admin == nil || token.Admin.Role != adminRole {
 		return nil, svcerrors.NewForbiddenError(errors.New("only admin token can do write operations on streams"))
 	}
 
@@ -122,7 +122,7 @@ func (s *service) ListDeletedSinks(ctx context.Context, scope dependencies.Sourc
 func (s *service) UpdateSink(ctx context.Context, d dependencies.SinkRequestScope, payload *api.UpdateSinkPayload) (*api.Task, error) {
 	// If user is not admin deny access for write
 	token := d.StorageAPIToken()
-	if token.Admin == nil {
+	if token.Admin == nil || token.Admin.Role != adminRole {
 		return nil, svcerrors.NewForbiddenError(errors.New("only admin token can do write operations on streams"))
 	}
 
@@ -186,7 +186,7 @@ func (s *service) UpdateSink(ctx context.Context, d dependencies.SinkRequestScop
 func (s *service) DeleteSink(ctx context.Context, d dependencies.SinkRequestScope, _ *api.DeleteSinkPayload) (*api.Task, error) {
 	// If user is not admin deny access for write
 	token := d.StorageAPIToken()
-	if token.Admin == nil {
+	if token.Admin == nil || token.Admin.Role != adminRole {
 		return nil, svcerrors.NewForbiddenError(errors.New("only admin token can do write operations on streams"))
 	}
 
@@ -229,7 +229,7 @@ func (s *service) GetSinkSettings(ctx context.Context, d dependencies.SinkReques
 func (s *service) UpdateSinkSettings(ctx context.Context, d dependencies.SinkRequestScope, payload *api.UpdateSinkSettingsPayload) (*api.Task, error) {
 	// If user is not admin deny access for write
 	token := d.StorageAPIToken()
-	if token.Admin == nil {
+	if token.Admin == nil || token.Admin.Role != adminRole {
 		return nil, svcerrors.NewForbiddenError(errors.New("only admin token can do write operations on streams"))
 	}
 
@@ -354,7 +354,7 @@ func (s *service) SinkStatisticsFiles(ctx context.Context, d dependencies.SinkRe
 func (s *service) SinkStatisticsClear(ctx context.Context, d dependencies.SinkRequestScope, payload *api.SinkStatisticsClearPayload) (err error) {
 	// If user is not admin deny access for write
 	token := d.StorageAPIToken()
-	if token.Admin == nil {
+	if token.Admin == nil || token.Admin.Role != adminRole {
 		return svcerrors.NewForbiddenError(errors.New("only admin token can do write operations on streams"))
 	}
 
@@ -368,7 +368,7 @@ func (s *service) SinkStatisticsClear(ctx context.Context, d dependencies.SinkRe
 func (s *service) DisableSink(ctx context.Context, d dependencies.SinkRequestScope, payload *api.DisableSinkPayload) (res *api.Task, err error) {
 	// If user is not admin deny access for write
 	token := d.StorageAPIToken()
-	if token.Admin == nil {
+	if token.Admin == nil || token.Admin.Role != adminRole {
 		return nil, svcerrors.NewForbiddenError(errors.New("only admin token can do write operations on streams"))
 	}
 
@@ -402,7 +402,7 @@ func (s *service) DisableSink(ctx context.Context, d dependencies.SinkRequestSco
 func (s *service) EnableSink(ctx context.Context, d dependencies.SinkRequestScope, payload *api.EnableSinkPayload) (res *api.Task, err error) {
 	// If user is not admin deny access for write
 	token := d.StorageAPIToken()
-	if token.Admin == nil {
+	if token.Admin == nil || token.Admin.Role != adminRole {
 		return nil, svcerrors.NewForbiddenError(errors.New("only admin token can do write operations on streams"))
 	}
 

--- a/internal/pkg/service/stream/api/service/sink.go
+++ b/internal/pkg/service/stream/api/service/sink.go
@@ -24,6 +24,12 @@ import (
 
 //nolint:dupl // CreateSource method is similar
 func (s *service) CreateSink(ctx context.Context, d dependencies.SourceRequestScope, payload *api.CreateSinkPayload) (*api.Task, error) {
+	// If user is not admin deny access for write
+	token := d.StorageAPIToken()
+	if token.Admin == nil {
+		return nil, svcerrors.NewForbiddenError(errors.New("only admin token can do write operations on streams"))
+	}
+
 	// Create entity
 	sink, err := s.mapper.NewSinkEntity(d.SourceKey(), payload)
 	if err != nil {
@@ -114,6 +120,12 @@ func (s *service) ListDeletedSinks(ctx context.Context, scope dependencies.Sourc
 }
 
 func (s *service) UpdateSink(ctx context.Context, d dependencies.SinkRequestScope, payload *api.UpdateSinkPayload) (*api.Task, error) {
+	// If user is not admin deny access for write
+	token := d.StorageAPIToken()
+	if token.Admin == nil {
+		return nil, svcerrors.NewForbiddenError(errors.New("only admin token can do write operations on streams"))
+	}
+
 	// Get the change description
 	var changeDesc string
 	if payload.ChangeDescription == nil {
@@ -172,6 +184,12 @@ func (s *service) UpdateSink(ctx context.Context, d dependencies.SinkRequestScop
 }
 
 func (s *service) DeleteSink(ctx context.Context, d dependencies.SinkRequestScope, _ *api.DeleteSinkPayload) (*api.Task, error) {
+	// If user is not admin deny access for write
+	token := d.StorageAPIToken()
+	if token.Admin == nil {
+		return nil, svcerrors.NewForbiddenError(errors.New("only admin token can do write operations on streams"))
+	}
+
 	// Quick check before the task
 	if err := s.sinkMustExist(ctx, d.SinkKey()); err != nil {
 		return nil, err
@@ -209,6 +227,12 @@ func (s *service) GetSinkSettings(ctx context.Context, d dependencies.SinkReques
 }
 
 func (s *service) UpdateSinkSettings(ctx context.Context, d dependencies.SinkRequestScope, payload *api.UpdateSinkSettingsPayload) (*api.Task, error) {
+	// If user is not admin deny access for write
+	token := d.StorageAPIToken()
+	if token.Admin == nil {
+		return nil, svcerrors.NewForbiddenError(errors.New("only admin token can do write operations on streams"))
+	}
+
 	// Quick check before the task
 	if err := s.sinkMustExist(ctx, d.SinkKey()); err != nil {
 		return nil, err
@@ -328,6 +352,12 @@ func (s *service) SinkStatisticsFiles(ctx context.Context, d dependencies.SinkRe
 }
 
 func (s *service) SinkStatisticsClear(ctx context.Context, d dependencies.SinkRequestScope, payload *api.SinkStatisticsClearPayload) (err error) {
+	// If user is not admin deny access for write
+	token := d.StorageAPIToken()
+	if token.Admin == nil {
+		return svcerrors.NewForbiddenError(errors.New("only admin token can do write operations on streams"))
+	}
+
 	if err := s.sinkMustExist(ctx, d.SinkKey()); err != nil {
 		return err
 	}
@@ -336,6 +366,12 @@ func (s *service) SinkStatisticsClear(ctx context.Context, d dependencies.SinkRe
 }
 
 func (s *service) DisableSink(ctx context.Context, d dependencies.SinkRequestScope, payload *api.DisableSinkPayload) (res *api.Task, err error) {
+	// If user is not admin deny access for write
+	token := d.StorageAPIToken()
+	if token.Admin == nil {
+		return nil, svcerrors.NewForbiddenError(errors.New("only admin token can do write operations on streams"))
+	}
+
 	if err := s.sinkMustExist(ctx, d.SinkKey()); err != nil {
 		return nil, err
 	}
@@ -364,6 +400,12 @@ func (s *service) DisableSink(ctx context.Context, d dependencies.SinkRequestSco
 }
 
 func (s *service) EnableSink(ctx context.Context, d dependencies.SinkRequestScope, payload *api.EnableSinkPayload) (res *api.Task, err error) {
+	// If user is not admin deny access for write
+	token := d.StorageAPIToken()
+	if token.Admin == nil {
+		return nil, svcerrors.NewForbiddenError(errors.New("only admin token can do write operations on streams"))
+	}
+
 	if err := s.sinkMustExist(ctx, d.SinkKey()); err != nil {
 		return nil, err
 	}

--- a/internal/pkg/service/stream/api/service/source.go
+++ b/internal/pkg/service/stream/api/service/source.go
@@ -7,6 +7,7 @@ import (
 	"time"
 
 	"github.com/keboola/keboola-as-code/internal/pkg/log"
+	svcerrors "github.com/keboola/keboola-as-code/internal/pkg/service/common/errors"
 	"github.com/keboola/keboola-as-code/internal/pkg/service/common/etcdop/iterator"
 	"github.com/keboola/keboola-as-code/internal/pkg/service/common/task"
 	api "github.com/keboola/keboola-as-code/internal/pkg/service/stream/api/gen/stream"
@@ -15,10 +16,17 @@ import (
 	"github.com/keboola/keboola-as-code/internal/pkg/service/stream/dependencies"
 	"github.com/keboola/keboola-as-code/internal/pkg/service/stream/mapping/recordctx"
 	"github.com/keboola/keboola-as-code/internal/pkg/service/stream/sink/type/tablesink/keboola/bridge"
+	"github.com/keboola/keboola-as-code/internal/pkg/utils/errors"
 )
 
 //nolint:dupl // CreateSink method is similar
 func (s *service) CreateSource(ctx context.Context, d dependencies.BranchRequestScope, payload *api.CreateSourcePayload) (*api.Task, error) {
+	// If user is not admin deny access for write
+	token := d.StorageAPIToken()
+	if token.Admin == nil {
+		return nil, svcerrors.NewForbiddenError(errors.New("only admin token can do write operations on streams"))
+	}
+
 	// Create entity
 	source, err := s.mapper.NewSourceEntity(d.BranchKey(), payload)
 	if err != nil {
@@ -83,6 +91,12 @@ func (s *service) CreateSource(ctx context.Context, d dependencies.BranchRequest
 }
 
 func (s *service) UpdateSource(ctx context.Context, d dependencies.SourceRequestScope, payload *api.UpdateSourcePayload) (*api.Task, error) {
+	// If user is not admin deny access for write
+	token := d.StorageAPIToken()
+	if token.Admin == nil {
+		return nil, svcerrors.NewForbiddenError(errors.New("only admin token can do write operations on streams"))
+	}
+
 	// Get the change description
 	var changeDesc string
 	if payload.ChangeDescription == nil {
@@ -157,6 +171,12 @@ func (s *service) GetSource(ctx context.Context, d dependencies.SourceRequestSco
 }
 
 func (s *service) DeleteSource(ctx context.Context, d dependencies.SourceRequestScope, _ *api.DeleteSourcePayload) (*api.Task, error) {
+	// If user is not admin deny access for write
+	token := d.StorageAPIToken()
+	if token.Admin == nil {
+		return nil, svcerrors.NewForbiddenError(errors.New("only admin token can do write operations on streams"))
+	}
+
 	// Quick check before the task
 	if err := s.sourceMustExist(ctx, d.SourceKey()); err != nil {
 		return nil, err
@@ -224,6 +244,12 @@ func (s *service) GetSourceSettings(ctx context.Context, d dependencies.SourceRe
 }
 
 func (s *service) UpdateSourceSettings(ctx context.Context, d dependencies.SourceRequestScope, payload *api.UpdateSourceSettingsPayload) (*api.Task, error) {
+	// If user is not admin deny access for write
+	token := d.StorageAPIToken()
+	if token.Admin == nil {
+		return nil, svcerrors.NewForbiddenError(errors.New("only admin token can do write operations on streams"))
+	}
+
 	// Quick check before the task
 	if err := s.sourceMustExist(ctx, d.SourceKey()); err != nil {
 		return nil, err
@@ -311,6 +337,12 @@ func (s *service) SourceStatisticsClear(ctx context.Context, d dependencies.Sour
 }
 
 func (s *service) DisableSource(ctx context.Context, d dependencies.SourceRequestScope, payload *api.DisableSourcePayload) (res *api.Task, err error) {
+	// If user is not admin deny access for write
+	token := d.StorageAPIToken()
+	if token.Admin == nil {
+		return nil, svcerrors.NewForbiddenError(errors.New("only admin token can do write operations on streams"))
+	}
+
 	if err := s.sourceMustExist(ctx, d.SourceKey()); err != nil {
 		return nil, err
 	}
@@ -339,6 +371,12 @@ func (s *service) DisableSource(ctx context.Context, d dependencies.SourceReques
 }
 
 func (s *service) EnableSource(ctx context.Context, d dependencies.SourceRequestScope, payload *api.EnableSourcePayload) (res *api.Task, err error) {
+	// If user is not admin deny access for write
+	token := d.StorageAPIToken()
+	if token.Admin == nil {
+		return nil, svcerrors.NewForbiddenError(errors.New("only admin token can do write operations on streams"))
+	}
+
 	if err := s.sourceMustExist(ctx, d.SourceKey()); err != nil {
 		return nil, err
 	}

--- a/internal/pkg/service/stream/api/service/source.go
+++ b/internal/pkg/service/stream/api/service/source.go
@@ -16,7 +16,6 @@ import (
 	"github.com/keboola/keboola-as-code/internal/pkg/service/stream/dependencies"
 	"github.com/keboola/keboola-as-code/internal/pkg/service/stream/mapping/recordctx"
 	"github.com/keboola/keboola-as-code/internal/pkg/service/stream/sink/type/tablesink/keboola/bridge"
-	"github.com/keboola/keboola-as-code/internal/pkg/utils/errors"
 )
 
 //nolint:dupl // CreateSink method is similar
@@ -24,7 +23,7 @@ func (s *service) CreateSource(ctx context.Context, d dependencies.BranchRequest
 	// If user is not admin deny access for write
 	token := d.StorageAPIToken()
 	if token.Admin == nil || token.Admin.Role != adminRole {
-		return nil, svcerrors.NewForbiddenError(errors.New("only admin token can do write operations on streams"))
+		return nil, svcerrors.NewForbiddenError(s.adminError)
 	}
 
 	// Create entity
@@ -94,7 +93,7 @@ func (s *service) UpdateSource(ctx context.Context, d dependencies.SourceRequest
 	// If user is not admin deny access for write
 	token := d.StorageAPIToken()
 	if token.Admin == nil || token.Admin.Role != adminRole {
-		return nil, svcerrors.NewForbiddenError(errors.New("only admin token can do write operations on streams"))
+		return nil, svcerrors.NewForbiddenError(s.adminError)
 	}
 
 	// Get the change description
@@ -174,7 +173,7 @@ func (s *service) DeleteSource(ctx context.Context, d dependencies.SourceRequest
 	// If user is not admin deny access for write
 	token := d.StorageAPIToken()
 	if token.Admin == nil || token.Admin.Role != adminRole {
-		return nil, svcerrors.NewForbiddenError(errors.New("only admin token can do write operations on streams"))
+		return nil, svcerrors.NewForbiddenError(s.adminError)
 	}
 
 	// Quick check before the task
@@ -247,7 +246,7 @@ func (s *service) UpdateSourceSettings(ctx context.Context, d dependencies.Sourc
 	// If user is not admin deny access for write
 	token := d.StorageAPIToken()
 	if token.Admin == nil || token.Admin.Role != adminRole {
-		return nil, svcerrors.NewForbiddenError(errors.New("only admin token can do write operations on streams"))
+		return nil, svcerrors.NewForbiddenError(s.adminError)
 	}
 
 	// Quick check before the task
@@ -340,7 +339,7 @@ func (s *service) DisableSource(ctx context.Context, d dependencies.SourceReques
 	// If user is not admin deny access for write
 	token := d.StorageAPIToken()
 	if token.Admin == nil || token.Admin.Role != adminRole {
-		return nil, svcerrors.NewForbiddenError(errors.New("only admin token can do write operations on streams"))
+		return nil, svcerrors.NewForbiddenError(s.adminError)
 	}
 
 	if err := s.sourceMustExist(ctx, d.SourceKey()); err != nil {
@@ -374,7 +373,7 @@ func (s *service) EnableSource(ctx context.Context, d dependencies.SourceRequest
 	// If user is not admin deny access for write
 	token := d.StorageAPIToken()
 	if token.Admin == nil || token.Admin.Role != adminRole {
-		return nil, svcerrors.NewForbiddenError(errors.New("only admin token can do write operations on streams"))
+		return nil, svcerrors.NewForbiddenError(s.adminError)
 	}
 
 	if err := s.sourceMustExist(ctx, d.SourceKey()); err != nil {

--- a/internal/pkg/service/stream/api/service/source.go
+++ b/internal/pkg/service/stream/api/service/source.go
@@ -23,7 +23,7 @@ import (
 func (s *service) CreateSource(ctx context.Context, d dependencies.BranchRequestScope, payload *api.CreateSourcePayload) (*api.Task, error) {
 	// If user is not admin deny access for write
 	token := d.StorageAPIToken()
-	if token.Admin == nil {
+	if token.Admin == nil || token.Admin.Role != adminRole {
 		return nil, svcerrors.NewForbiddenError(errors.New("only admin token can do write operations on streams"))
 	}
 
@@ -93,7 +93,7 @@ func (s *service) CreateSource(ctx context.Context, d dependencies.BranchRequest
 func (s *service) UpdateSource(ctx context.Context, d dependencies.SourceRequestScope, payload *api.UpdateSourcePayload) (*api.Task, error) {
 	// If user is not admin deny access for write
 	token := d.StorageAPIToken()
-	if token.Admin == nil {
+	if token.Admin == nil || token.Admin.Role != adminRole {
 		return nil, svcerrors.NewForbiddenError(errors.New("only admin token can do write operations on streams"))
 	}
 
@@ -173,7 +173,7 @@ func (s *service) GetSource(ctx context.Context, d dependencies.SourceRequestSco
 func (s *service) DeleteSource(ctx context.Context, d dependencies.SourceRequestScope, _ *api.DeleteSourcePayload) (*api.Task, error) {
 	// If user is not admin deny access for write
 	token := d.StorageAPIToken()
-	if token.Admin == nil {
+	if token.Admin == nil || token.Admin.Role != adminRole {
 		return nil, svcerrors.NewForbiddenError(errors.New("only admin token can do write operations on streams"))
 	}
 
@@ -246,7 +246,7 @@ func (s *service) GetSourceSettings(ctx context.Context, d dependencies.SourceRe
 func (s *service) UpdateSourceSettings(ctx context.Context, d dependencies.SourceRequestScope, payload *api.UpdateSourceSettingsPayload) (*api.Task, error) {
 	// If user is not admin deny access for write
 	token := d.StorageAPIToken()
-	if token.Admin == nil {
+	if token.Admin == nil || token.Admin.Role != adminRole {
 		return nil, svcerrors.NewForbiddenError(errors.New("only admin token can do write operations on streams"))
 	}
 
@@ -339,7 +339,7 @@ func (s *service) SourceStatisticsClear(ctx context.Context, d dependencies.Sour
 func (s *service) DisableSource(ctx context.Context, d dependencies.SourceRequestScope, payload *api.DisableSourcePayload) (res *api.Task, err error) {
 	// If user is not admin deny access for write
 	token := d.StorageAPIToken()
-	if token.Admin == nil {
+	if token.Admin == nil || token.Admin.Role != adminRole {
 		return nil, svcerrors.NewForbiddenError(errors.New("only admin token can do write operations on streams"))
 	}
 
@@ -373,7 +373,7 @@ func (s *service) DisableSource(ctx context.Context, d dependencies.SourceReques
 func (s *service) EnableSource(ctx context.Context, d dependencies.SourceRequestScope, payload *api.EnableSourcePayload) (res *api.Task, err error) {
 	// If user is not admin deny access for write
 	token := d.StorageAPIToken()
-	if token.Admin == nil {
+	if token.Admin == nil || token.Admin.Role != adminRole {
 		return nil, svcerrors.NewForbiddenError(errors.New("only admin token can do write operations on streams"))
 	}
 

--- a/internal/pkg/utils/testproject/project.go
+++ b/internal/pkg/utils/testproject/project.go
@@ -52,6 +52,7 @@ func GetTestProjectForTest(t *testing.T, path string, options ...testproject.Opt
 
 	p, unlockFn, err := GetTestProject(path, env.Empty(), options...)
 	if err != nil {
+		fmt.Println("here")
 		t.Fatal(err)
 	}
 
@@ -121,7 +122,7 @@ func GetTestProject(path string, envs *env.Map, options ...testproject.Option) (
 	p.logf(`■ ️Initialization done.`)
 
 	// Remove all objects
-	if err := p.Clean(); err != nil {
+	if err := p.Clean(); !p.IsGuest() && err != nil {
 		cleanupFn()
 		return nil, nil, err
 	}
@@ -217,9 +218,11 @@ func (p *Project) SetState(stateFilePath string) error {
 	}
 
 	// Create branches
-	err = p.createBranches(stateFile.Branches)
-	if err != nil {
-		return err
+	if !p.IsGuest() {
+		err = p.createBranches(stateFile.Branches)
+		if err != nil {
+			return err
+		}
 	}
 
 	// Create configs in branches
@@ -240,10 +243,12 @@ func (p *Project) SetState(stateFilePath string) error {
 		return err
 	}
 
-	// Create sandboxes in default branch
-	err = p.createSandboxes(p.defaultBranch.ID, stateFile.Sandboxes)
-	if err != nil {
-		return err
+	if !p.IsGuest() {
+		// Create sandboxes in default branch
+		err = p.createSandboxes(p.defaultBranch.ID, stateFile.Sandboxes)
+		if err != nil {
+			return err
+		}
 	}
 
 	p.logf("■ Project state set.")

--- a/internal/pkg/utils/testproject/project.go
+++ b/internal/pkg/utils/testproject/project.go
@@ -52,7 +52,6 @@ func GetTestProjectForTest(t *testing.T, path string, options ...testproject.Opt
 
 	p, unlockFn, err := GetTestProject(path, env.Empty(), options...)
 	if err != nil {
-		fmt.Println("here")
 		t.Fatal(err)
 	}
 

--- a/test/stream/bridge/keboola/guest_test.go
+++ b/test/stream/bridge/keboola/guest_test.go
@@ -1,0 +1,72 @@
+package keboola_test
+
+import (
+	"context"
+	"net/http"
+	"net/url"
+	"strconv"
+	"testing"
+	"time"
+
+	utilsproject "github.com/keboola/go-utils/pkg/testproject"
+	"github.com/stretchr/testify/require"
+
+	commonDeps "github.com/keboola/keboola-as-code/internal/pkg/service/common/dependencies"
+	"github.com/keboola/keboola-as-code/internal/pkg/service/stream/api"
+	"github.com/keboola/keboola-as-code/internal/pkg/service/stream/config"
+	"github.com/keboola/keboola-as-code/internal/pkg/service/stream/dependencies"
+	"github.com/keboola/keboola-as-code/internal/pkg/utils/errors"
+	"github.com/keboola/keboola-as-code/internal/pkg/utils/netutils"
+)
+
+// To see details run: TEST_VERBOSE=true go test ./test/stream/bridge/... -v
+
+func TestGuestUserWorkflow(t *testing.T) {
+	t.Parallel()
+
+	ctx, cancel := context.WithTimeout(context.Background(), 300*time.Second)
+	defer cancel()
+	modifyConfig := func(cfg *config.Config) {
+		apiPort := netutils.FreePortForTest(t)
+		cfg.API.Listen = "0.0.0.0:" + strconv.FormatInt(int64(apiPort), 10)
+		u, err := url.Parse("http://localhost:" + strconv.FormatInt(int64(apiPort), 10))
+		require.NoError(t, err)
+		cfg.API.PublicURL = u
+	}
+	ts := setup(
+		t,
+		ctx,
+		modifyConfig,
+		utilsproject.WithIsGuest(),
+	)
+	ts.setupSourceThroughAPI(t, ctx, http.StatusForbidden)
+	defer ts.teardown(t, ctx)
+	recreateStreamAPI(t, &ts, ctx, modifyConfig)
+	ts.setupSourceThroughAPI(t, ctx, http.StatusOK)
+
+	recreateStreamAPI(t, &ts, ctx, modifyConfig, utilsproject.WithIsGuest())
+	ts.setupSinkThroughAPI(t, ctx, http.StatusForbidden)
+}
+
+func recreateStreamAPI(t *testing.T, ts *testState, ctx context.Context, modifyConfig func(cfg *config.Config), options ...utilsproject.Option) {
+	t.Helper()
+
+	// Kill existing API as we are changing project
+	ts.apiScp.Process().Shutdown(ctx, errors.New("bye bye"))
+	ts.apiScp.Process().WaitForShutdown()
+
+	// Setup new project without guest user to setup source
+	ts.setupProject(t, options...)
+	ts.apiScp, ts.apiMock = dependencies.NewMockedAPIScopeWithConfig(
+		t,
+		ctx,
+		func(c *config.Config) {
+			c.NodeID = "api"
+			modifyConfig(c)
+		},
+		commonDeps.WithEtcdConfig(ts.etcdConfig),
+		commonDeps.WithDebugLogger(ts.logger),
+		commonDeps.WithTestProject(ts.project),
+	)
+	require.NoError(t, api.Start(ctx, ts.apiScp, ts.apiMock.TestConfig()))
+}

--- a/test/stream/bridge/keboola/keboola_test.go
+++ b/test/stream/bridge/keboola/keboola_test.go
@@ -66,6 +66,7 @@ func TestKeboolaBridgeWorkflow(t *testing.T) {
 	}
 
 	ts := setup(t, ctx, configFn)
+	ts.setupSink(t, ctx)
 	defer ts.teardown(t, ctx)
 
 	// Check initial state

--- a/test/stream/bridge/keboola/setup_test.go
+++ b/test/stream/bridge/keboola/setup_test.go
@@ -106,6 +106,7 @@ func (ts *testState) setupProject(t *testing.T, options ...utilsproject.Option) 
 	ts.project = testproject.GetTestProjectForTest(t, "", options...)
 
 	ts.logSection(t, "clearing testing project")
+	fmt.Println("here")
 	require.NoError(t, ts.project.SetState("empty.json"))
 	ts.projectID = keboola.ProjectID(ts.project.ID())
 	defaultBranch, err := ts.project.DefaultBranch()

--- a/test/stream/bridge/keboola/setup_test.go
+++ b/test/stream/bridge/keboola/setup_test.go
@@ -1,8 +1,11 @@
 package keboola_test
 
 import (
+	"bytes"
 	"context"
+	"encoding/json"
 	"fmt"
+	"io"
 	"net/http"
 	"os"
 	"path/filepath"
@@ -10,6 +13,7 @@ import (
 	"time"
 
 	"github.com/keboola/go-client/pkg/keboola"
+	utilsproject "github.com/keboola/go-utils/pkg/testproject"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 	etcd "go.etcd.io/etcd/client/v3"
@@ -18,7 +22,10 @@ import (
 	commonDeps "github.com/keboola/keboola-as-code/internal/pkg/service/common/dependencies"
 	"github.com/keboola/keboola-as-code/internal/pkg/service/common/etcdclient"
 	"github.com/keboola/keboola-as-code/internal/pkg/service/common/rollback"
+	"github.com/keboola/keboola-as-code/internal/pkg/service/stream/api"
+	genApi "github.com/keboola/keboola-as-code/internal/pkg/service/stream/api/gen/stream"
 	"github.com/keboola/keboola-as-code/internal/pkg/service/stream/config"
+	"github.com/keboola/keboola-as-code/internal/pkg/service/stream/definition"
 	"github.com/keboola/keboola-as-code/internal/pkg/service/stream/definition/key"
 	"github.com/keboola/keboola-as-code/internal/pkg/service/stream/dependencies"
 	"github.com/keboola/keboola-as-code/internal/pkg/service/stream/source/type/httpsource"
@@ -73,7 +80,7 @@ type testState struct {
 	tableID keboola.TableID
 }
 
-func setup(t *testing.T, ctx context.Context, modifyConfig func(cfg *config.Config)) testState {
+func setup(t *testing.T, ctx context.Context, modifyConfig func(cfg *config.Config), options ...utilsproject.Option) testState {
 	t.Helper()
 
 	ts := testState{}
@@ -83,21 +90,20 @@ func setup(t *testing.T, ctx context.Context, modifyConfig func(cfg *config.Conf
 
 	ts.logSection(t, "setup")
 
-	ts.setupProject(t)
+	ts.setupProject(t, options...)
 	ts.setupEtcd(t)
 	ts.startNodes(t, ctx, modifyConfig)
-	ts.setupSink(t, ctx)
 
 	ts.logSection(t, "setup done")
 
 	return ts
 }
 
-func (ts *testState) setupProject(t *testing.T) {
+func (ts *testState) setupProject(t *testing.T, options ...utilsproject.Option) {
 	t.Helper()
 
 	ts.logSection(t, "obtaining testing project")
-	ts.project = testproject.GetTestProjectForTest(t, "")
+	ts.project = testproject.GetTestProjectForTest(t, "", options...)
 
 	ts.logSection(t, "clearing testing project")
 	require.NoError(t, ts.project.SetState("empty.json"))
@@ -251,6 +257,7 @@ func (ts *testState) startNodes(t *testing.T, ctx context.Context, modifyConfig 
 
 	// Start nodes
 	ts.logSection(t, "starting nodes")
+	require.NoError(t, api.Start(ctx, ts.apiScp, ts.apiMock.TestConfig()))
 	require.NoError(t, httpsource.Start(ctx, ts.sourceScp1, ts.sourceMock1.TestConfig().Source.HTTP))
 	require.NoError(t, httpsource.Start(ctx, ts.sourceScp2, ts.sourceMock2.TestConfig().Source.HTTP))
 	require.NoError(t, writernode.Start(ctx, ts.writerScp1, ts.writerMock1.TestConfig()))
@@ -299,4 +306,104 @@ func (ts *testState) setupSink(t *testing.T, ctx context.Context) {
 	ts.logSection(t, "created sink")
 	ts.sinkKey = sink.SinkKey
 	ts.tableID = sink.Table.Keboola.TableID
+}
+
+func (ts *testState) setupSourceThroughAPI(t *testing.T, ctx context.Context, expectedStatusCode int) {
+	t.Helper()
+
+	sourceKey := key.SourceKey{SourceID: "my-source"}
+	payload := &genApi.CreateSourcePayload{
+		SourceID: &sourceKey.SourceID,
+		Type:     "http",
+		Name:     "testSource",
+	}
+	out, err := json.Marshal(payload)
+	if !assert.NoError(t, err) {
+		ts.logger.Errorf(ctx, "unable to marshal source create payload: %v", err)
+		return
+	}
+
+	req, err := http.NewRequestWithContext(ctx, "POST", ts.apiScp.APIPublicURL().String()+"/v1/branches/"+ts.branchID.String()+"/sources", bytes.NewBuffer(out))
+	require.NoError(t, err)
+	req.Header.Add("X-StorageAPI-Token", ts.project.StorageAPIToken().Token)
+	req.Header.Add("Content-Type", "application/json")
+	resp, err := http.DefaultClient.Do(req)
+	if !assert.NoError(t, err) {
+		ts.logger.Errorf(ctx, "to create source: %v", err)
+		return
+	}
+
+	// When we expect success, the API returns accepted instead of status OK
+	if expectedStatusCode < 400 {
+		expectedStatusCode = http.StatusAccepted
+	}
+
+	if assert.Equal(t, expectedStatusCode, resp.StatusCode) {
+		return
+	}
+
+	out, err = io.ReadAll(resp.Body)
+	require.NoError(t, err)
+	task := make(map[string]any)
+	err = json.Unmarshal(out, &task)
+	require.NoError(t, err)
+
+	url := task["url"].(string)
+	req, err = http.NewRequestWithContext(ctx, "GET", url, nil)
+	require.NoError(t, err)
+	req.Header.Add("X-StorageAPI-Token", ts.project.StorageAPIToken().Token)
+	resp, err = http.DefaultClient.Do(req)
+	require.NoError(t, err)
+	assert.Equal(t, expectedStatusCode, resp.StatusCode)
+}
+
+func (ts *testState) setupSinkThroughAPI(t *testing.T, ctx context.Context, expectedStatusCode int) {
+	t.Helper()
+
+	sourceKey := key.SourceKey{SourceID: "my-source"}
+	sinkKey := key.SinkKey{SinkID: "my-sink"}
+	payload := &genApi.CreateSinkPayload{
+		SourceID: sourceKey.SourceID,
+		SinkID:   &sinkKey.SinkID,
+		Type:     definition.SinkTypeTable,
+		Name:     "testSink",
+	}
+	out, err := json.Marshal(payload)
+	if !assert.NoError(t, err) {
+		ts.logger.Errorf(ctx, "unable to marshal sink create payload: %v", err)
+		return
+	}
+
+	req, err := http.NewRequestWithContext(ctx, "POST", ts.apiScp.APIPublicURL().String()+"/v1/branches/"+ts.branchID.String()+"/sources/"+sourceKey.SourceID.String()+"/sinks", bytes.NewBuffer(out))
+	require.NoError(t, err)
+	req.Header.Add("X-StorageAPI-Token", ts.project.StorageAPIToken().Token)
+	req.Header.Add("Content-Type", "application/json")
+	resp, err := http.DefaultClient.Do(req)
+	if !assert.NoError(t, err) {
+		ts.logger.Errorf(ctx, "to create sink: %v", err)
+		return
+	}
+
+	// When we expect success, the API returns accepted instead of status OK
+	if expectedStatusCode < 400 {
+		expectedStatusCode = http.StatusAccepted
+	}
+
+	if assert.Equal(t, expectedStatusCode, resp.StatusCode) {
+		return
+	}
+
+	out, err = io.ReadAll(resp.Body)
+	require.NoError(t, err)
+	task := make(map[string]any)
+	err = json.Unmarshal(out, &task)
+	require.NoError(t, err)
+
+	url := task["url"].(string)
+	req, err = http.NewRequestWithContext(ctx, "GET", url, nil)
+	require.NoError(t, err)
+	req.Header.Add("X-StorageAPI-Token", ts.project.StorageAPIToken().Token)
+	resp, err = http.DefaultClient.Do(req)
+	require.NoError(t, err)
+	assert.Equal(t, expectedStatusCode, resp.StatusCode)
 }

--- a/test/stream/bridge/keboola/setup_test.go
+++ b/test/stream/bridge/keboola/setup_test.go
@@ -106,8 +106,6 @@ func (ts *testState) setupProject(t *testing.T, options ...utilsproject.Option) 
 	ts.project = testproject.GetTestProjectForTest(t, "", options...)
 
 	ts.logSection(t, "clearing testing project")
-	fmt.Println("here")
-	require.NoError(t, ts.project.SetState("empty.json"))
 	ts.projectID = keboola.ProjectID(ts.project.ID())
 	defaultBranch, err := ts.project.DefaultBranch()
 	require.NoError(t, err)
@@ -324,7 +322,9 @@ func (ts *testState) setupSourceThroughAPI(t *testing.T, ctx context.Context, ex
 		return
 	}
 
-	req, err := http.NewRequestWithContext(ctx, "POST", ts.apiScp.APIPublicURL().String()+"/v1/branches/"+ts.branchID.String()+"/sources", bytes.NewBuffer(out))
+	url := ts.apiScp.APIPublicURL()
+	url.Path = fmt.Sprintf("/v1/branches/%s/sources", ts.branchID.String())
+	req, err := http.NewRequestWithContext(ctx, "POST", url.String(), bytes.NewBuffer(out))
 	require.NoError(t, err)
 	req.Header.Add("X-StorageAPI-Token", ts.project.StorageAPIToken().Token)
 	req.Header.Add("Content-Type", "application/json")
@@ -349,8 +349,8 @@ func (ts *testState) setupSourceThroughAPI(t *testing.T, ctx context.Context, ex
 	err = json.Unmarshal(out, &task)
 	require.NoError(t, err)
 
-	url := task["url"].(string)
-	req, err = http.NewRequestWithContext(ctx, "GET", url, nil)
+	urlString := task["url"].(string)
+	req, err = http.NewRequestWithContext(ctx, "GET", urlString, nil)
 	require.NoError(t, err)
 	req.Header.Add("X-StorageAPI-Token", ts.project.StorageAPIToken().Token)
 	resp, err = http.DefaultClient.Do(req)
@@ -375,7 +375,9 @@ func (ts *testState) setupSinkThroughAPI(t *testing.T, ctx context.Context, expe
 		return
 	}
 
-	req, err := http.NewRequestWithContext(ctx, "POST", ts.apiScp.APIPublicURL().String()+"/v1/branches/"+ts.branchID.String()+"/sources/"+sourceKey.SourceID.String()+"/sinks", bytes.NewBuffer(out))
+	url := ts.apiScp.APIPublicURL()
+	url.Path = fmt.Sprintf("/v1/branches/%s/sources/%s/sinks", ts.branchID.String(), sourceKey.SourceID.String())
+	req, err := http.NewRequestWithContext(ctx, "POST", url.String(), bytes.NewBuffer(out))
 	require.NoError(t, err)
 	req.Header.Add("X-StorageAPI-Token", ts.project.StorageAPIToken().Token)
 	req.Header.Add("Content-Type", "application/json")
@@ -400,8 +402,8 @@ func (ts *testState) setupSinkThroughAPI(t *testing.T, ctx context.Context, expe
 	err = json.Unmarshal(out, &task)
 	require.NoError(t, err)
 
-	url := task["url"].(string)
-	req, err = http.NewRequestWithContext(ctx, "GET", url, nil)
+	urlString := task["url"].(string)
+	req, err = http.NewRequestWithContext(ctx, "GET", urlString, nil)
 	require.NoError(t, err)
 	req.Header.Add("X-StorageAPI-Token", ts.project.StorageAPIToken().Token)
 	resp, err = http.DefaultClient.Do(req)


### PR DESCRIPTION
Jira: [PSGO-903](https://keboola.atlassian.net/browse/PSGO-903)

**Changes:**
- Read endpoint remain without token checking.

-----------


[PSGO-903]: https://keboola.atlassian.net/browse/PSGO-903?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ