### PR TITLE
build: Group dependabot changes to one PR

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -9,3 +9,6 @@ updates:
     directory: "/" # Location of package manifests
     schedule:
       interval: "weekly"
+    groups:
+      all:
+        dependency-type: "all"


### PR DESCRIPTION
Another week and dependabot opened five more PRs... How about we just have it open one instead?

This was a feature dependabot users were asking for for years. Luckily for us it was finally implemented last year.