### PR TITLE
fix: Stabilize test of WriteRecord

### DIFF
--- a/internal/pkg/service/stream/storage/level/local/encoding/encoder/csv/csv.go
+++ b/internal/pkg/service/stream/storage/level/local/encoding/encoder/csv/csv.go
@@ -11,6 +11,8 @@ import (
 	"github.com/keboola/keboola-as-code/internal/pkg/service/stream/mapping/table"
 	"github.com/keboola/keboola-as-code/internal/pkg/service/stream/mapping/table/column"
 	"github.com/keboola/keboola-as-code/internal/pkg/service/stream/storage/level/local/encoding/encoder/csv/fastcsv"
+	"github.com/keboola/keboola-as-code/internal/pkg/service/stream/storage/level/local/encoding/encoder/result"
+	"github.com/keboola/keboola-as-code/internal/pkg/service/stream/storage/level/local/encoding/writesync/notify"
 	"github.com/keboola/keboola-as-code/internal/pkg/utils/errors"
 )
 
@@ -18,6 +20,7 @@ type Encoder struct {
 	columns     column.Columns
 	writersPool *fastcsv.WritersPool
 	valuesPool  *sync.Pool
+	notifier    func() *notify.Notifier
 }
 
 var columnRenderer = column.NewRenderer() //nolint:gochecknoglobals // contains Jsonnet VMs sync.Pool
@@ -26,7 +29,7 @@ var columnRenderer = column.NewRenderer() //nolint:gochecknoglobals // contains 
 // The order of the lines is not preserved, because we use the writers pool,
 // but also because there are several source nodes with a load balancer in front of them.
 // In case of encoder accepts too big csv row, it returns error.
-func NewEncoder(concurrency int, rowSizeLimit datasize.ByteSize, mapping any, out io.Writer) (*Encoder, error) {
+func NewEncoder(concurrency int, rowSizeLimit datasize.ByteSize, mapping any, out io.Writer, notifier func() *notify.Notifier) (*Encoder, error) {
 	tableMapping, ok := mapping.(table.Mapping)
 	if !ok {
 		return nil, errors.Errorf("csv encoder supports only table mapping, given %v", mapping)
@@ -41,10 +44,12 @@ func NewEncoder(concurrency int, rowSizeLimit datasize.ByteSize, mapping any, ou
 				return &v
 			},
 		},
+		notifier: notifier,
 	}, nil
 }
 
-func (w *Encoder) WriteRecord(record recordctx.Context) (int, error) {
+func (w *Encoder) WriteRecord(record recordctx.Context) (result.WriteRecordResult, error) {
+	writeRecordResult := result.NewNotifierWriteRecordResult(w.notifier())
 	// Reduce memory allocations
 	values := w.valuesPool.Get().(*[]any)
 	defer w.valuesPool.Put(values)
@@ -53,32 +58,34 @@ func (w *Encoder) WriteRecord(record recordctx.Context) (int, error) {
 	for i, col := range w.columns {
 		value, err := columnRenderer.CSVValue(col, record)
 		if err != nil {
-			return 0, errors.PrefixErrorf(err, "cannot convert column %q to CSV value", col)
+			return writeRecordResult, errors.PrefixErrorf(err, "cannot convert column %q to CSV value", col)
 		}
 		(*values)[i] = value
 	}
 
 	// Encode the values to CSV format
 	n, err := w.writersPool.WriteRow(values)
+	writeRecordResult.N = n
 	if err != nil {
 		var valErr fastcsv.ValueError
 		if errors.As(err, &valErr) {
 			columnName := w.columns[valErr.ColumnIndex].ColumnName()
-			return n, errors.Errorf(`cannot convert value of the column "%s" to the string: %w`, columnName, err)
+			return writeRecordResult, errors.Errorf(`cannot convert value of the column "%s" to the string: %w`, columnName, err)
 		}
 		var limitErr fastcsv.LimitError
 		if errors.As(err, &limitErr) {
 			columnName := w.columns[limitErr.ColumnIndex].ColumnName()
-			return n, svcerrors.NewPayloadTooLargeError(errors.Errorf(`too big CSV row, column: "%s", row limit: %s`, columnName, limitErr.Limit.HumanReadable()))
+			return writeRecordResult, svcerrors.NewPayloadTooLargeError(errors.Errorf(`too big CSV row, column: "%s", row limit: %s`, columnName, limitErr.Limit.HumanReadable()))
 		}
-		return n, err
+
+		return writeRecordResult, err
 	}
 
 	// Buffers can be released
 	// Important: values slice contains reference to the body []byte buffer, so it can be released sooner.
 	record.ReleaseBuffers()
 
-	return n, nil
+	return writeRecordResult, nil
 }
 
 func (w *Encoder) Flush() error {

--- a/internal/pkg/service/stream/storage/level/local/encoding/encoder/csv/csv_test.go
+++ b/internal/pkg/service/stream/storage/level/local/encoding/encoder/csv/csv_test.go
@@ -21,6 +21,7 @@ import (
 	"github.com/keboola/keboola-as-code/internal/pkg/service/stream/storage/level/local/encoding/compression"
 	"github.com/keboola/keboola-as-code/internal/pkg/service/stream/storage/level/local/encoding/encoder/csv"
 	"github.com/keboola/keboola-as-code/internal/pkg/service/stream/storage/level/local/encoding/writesync"
+	"github.com/keboola/keboola-as-code/internal/pkg/service/stream/storage/level/local/encoding/writesync/notify"
 	"github.com/keboola/keboola-as-code/internal/pkg/service/stream/storage/test/testcase"
 	"github.com/keboola/keboola-as-code/internal/pkg/utils/errors"
 )
@@ -96,7 +97,7 @@ func TestCSVWriterAboveLimit(t *testing.T) {
 			column.Body{Name: "body"},
 		},
 	}
-	csvEncoder, err := csv.NewEncoder(0, 40*datasize.B, columns, io.Discard)
+	csvEncoder, err := csv.NewEncoder(0, 40*datasize.B, columns, io.Discard, notify.New)
 	require.NoError(t, err)
 	record := recordctx.FromHTTP(
 		utctime.MustParse("2000-01-01T03:00:00.000Z").Time(),

--- a/internal/pkg/service/stream/storage/level/local/encoding/encoder/encoder.go
+++ b/internal/pkg/service/stream/storage/level/local/encoding/encoder/encoder.go
@@ -1,11 +1,14 @@
 package encoder
 
-import "github.com/keboola/keboola-as-code/internal/pkg/service/stream/mapping/recordctx"
+import (
+	"github.com/keboola/keboola-as-code/internal/pkg/service/stream/mapping/recordctx"
+	"github.com/keboola/keboola-as-code/internal/pkg/service/stream/storage/level/local/encoding/encoder/result"
+)
 
 // Encoder writers record values as bytes to the underlying writer.
 // It is used inside the Writer pipeline, at the beginning, before the compression.
 type Encoder interface {
-	WriteRecord(record recordctx.Context) (int, error)
+	WriteRecord(record recordctx.Context) (result.WriteRecordResult, error)
 	Flush() error
 	Close() error
 }

--- a/internal/pkg/service/stream/storage/level/local/encoding/encoder/factory.go
+++ b/internal/pkg/service/stream/storage/level/local/encoding/encoder/factory.go
@@ -4,32 +4,33 @@ import (
 	"io"
 
 	"github.com/keboola/keboola-as-code/internal/pkg/service/stream/storage/level/local/encoding/encoder/csv"
+	"github.com/keboola/keboola-as-code/internal/pkg/service/stream/storage/level/local/encoding/writesync/notify"
 	"github.com/keboola/keboola-as-code/internal/pkg/utils/errors"
 )
 
 type Factory interface {
-	NewEncoder(cfg Config, mapping any, out io.Writer) (Encoder, error)
+	NewEncoder(cfg Config, mapping any, out io.Writer, notifier func() *notify.Notifier) (Encoder, error)
 }
 
 type DefaultFactory struct{}
 
-func (DefaultFactory) NewEncoder(cfg Config, mapping any, out io.Writer) (Encoder, error) {
+func (DefaultFactory) NewEncoder(cfg Config, mapping any, out io.Writer, notifier func() *notify.Notifier) (Encoder, error) {
 	switch cfg.Type {
 	case TypeCSV:
-		return csv.NewEncoder(cfg.Concurrency, cfg.RowSizeLimit, mapping, out)
+		return csv.NewEncoder(cfg.Concurrency, cfg.RowSizeLimit, mapping, out, notifier)
 	default:
 		return nil, errors.Errorf(`unexpected encoder type "%s"`, cfg.Type)
 	}
 }
 
-func FactoryFn(fn func(cfg Config, mapping any, out io.Writer) (Encoder, error)) Factory {
+func FactoryFn(fn func(cfg Config, mapping any, out io.Writer, notifier func() *notify.Notifier) (Encoder, error)) Factory {
 	return factoryFn{Fn: fn}
 }
 
 type factoryFn struct {
-	Fn func(cfg Config, mapping any, out io.Writer) (Encoder, error)
+	Fn func(cfg Config, mapping any, out io.Writer, notifier func() *notify.Notifier) (Encoder, error)
 }
 
-func (f factoryFn) NewEncoder(cfg Config, mapping any, out io.Writer) (Encoder, error) {
-	return f.Fn(cfg, mapping, out)
+func (f factoryFn) NewEncoder(cfg Config, mapping any, out io.Writer, notifier func() *notify.Notifier) (Encoder, error) {
+	return f.Fn(cfg, mapping, out, notifier)
 }

--- a/internal/pkg/service/stream/storage/level/local/encoding/encoder/result/result.go
+++ b/internal/pkg/service/stream/storage/level/local/encoding/encoder/result/result.go
@@ -1,0 +1,15 @@
+package result
+
+import "github.com/keboola/keboola-as-code/internal/pkg/service/stream/storage/level/local/encoding/writesync/notify"
+
+// WriteRecordResult returns result of WriteRecord method.
+type WriteRecordResult struct {
+	N        int
+	Notifier *notify.Notifier
+}
+
+func NewNotifierWriteRecordResult(notifier *notify.Notifier) WriteRecordResult {
+	return WriteRecordResult{
+		Notifier: notifier,
+	}
+}

--- a/internal/pkg/service/stream/storage/level/local/encoding/pipeline_test.go
+++ b/internal/pkg/service/stream/storage/level/local/encoding/pipeline_test.go
@@ -20,7 +20,9 @@ import (
 	"github.com/keboola/keboola-as-code/internal/pkg/service/stream/mapping/recordctx"
 	"github.com/keboola/keboola-as-code/internal/pkg/service/stream/storage/level/local/encoding"
 	"github.com/keboola/keboola-as-code/internal/pkg/service/stream/storage/level/local/encoding/encoder"
+	"github.com/keboola/keboola-as-code/internal/pkg/service/stream/storage/level/local/encoding/encoder/result"
 	"github.com/keboola/keboola-as-code/internal/pkg/service/stream/storage/level/local/encoding/writesync"
+	"github.com/keboola/keboola-as-code/internal/pkg/service/stream/storage/level/local/encoding/writesync/notify"
 	"github.com/keboola/keboola-as-code/internal/pkg/service/stream/storage/level/local/events"
 	"github.com/keboola/keboola-as-code/internal/pkg/service/stream/storage/model"
 	"github.com/keboola/keboola-as-code/internal/pkg/service/stream/storage/test"
@@ -73,8 +75,8 @@ func TestEncodingPipeline_FlushError(t *testing.T) {
 	d, _ := dependencies.NewMockedSourceScope(t, ctx)
 
 	slice := test.NewSlice()
-	slice.Encoding.Encoder.OverrideEncoderFactory = encoder.FactoryFn(func(cfg encoder.Config, mapping any, out io.Writer) (encoder.Encoder, error) {
-		w := newDummyEncoder(out, nil)
+	slice.Encoding.Encoder.OverrideEncoderFactory = encoder.FactoryFn(func(cfg encoder.Config, mapping any, out io.Writer, notifier func() *notify.Notifier) (encoder.Encoder, error) {
+		w := newDummyEncoder(out, nil, notifier)
 		w.FlushError = errors.New("some error")
 		return w, nil
 	})
@@ -96,8 +98,8 @@ func TestEncodingPipeline_CloseError(t *testing.T) {
 	d, _ := dependencies.NewMockedSourceScope(t, ctx)
 
 	slice := test.NewSlice()
-	slice.Encoding.Encoder.OverrideEncoderFactory = encoder.FactoryFn(func(cfg encoder.Config, mapping any, out io.Writer) (encoder.Encoder, error) {
-		w := newDummyEncoder(out, nil)
+	slice.Encoding.Encoder.OverrideEncoderFactory = encoder.FactoryFn(func(cfg encoder.Config, mapping any, out io.Writer, notifier func() *notify.Notifier) (encoder.Encoder, error) {
+		w := newDummyEncoder(out, nil, notifier)
 		w.CloseError = errors.New("some error")
 		return w, nil
 	})
@@ -175,6 +177,8 @@ func TestEncodingPipeline_Sync_Wait_ToDisk(t *testing.T) {
 		tc.Logger.Infof(ctx, "TEST: write unblocked")
 	}()
 	tc.ExpectWritesCount(t, 2)
+	// Pri triger sync sa vytvori novy notifier, stary sa uzavrie a odblokuje 2 writy.
+	// Novy notifier sa musi predat do encoderu aby sa zablokoval dalsi zapis
 	tc.TriggerSync(t)
 	wg.Wait()
 
@@ -571,8 +575,8 @@ func (tc *encodingTestCase) AssertLogs(expected string) bool {
 	return tc.Logger.AssertJSONMessages(tc.T, expected)
 }
 
-func (h *writerSyncHelper) NewEncoder(cfg encoder.Config, mapping any, out io.Writer) (encoder.Encoder, error) {
-	return newDummyEncoder(out, h.writeDone), nil
+func (h *writerSyncHelper) NewEncoder(cfg encoder.Config, mapping any, out io.Writer, notifier func() *notify.Notifier) (encoder.Encoder, error) {
+	return newDummyEncoder(out, h.writeDone, notifier), nil
 }
 
 // NewSyncer implements writesync.SyncerFactory.
@@ -608,7 +612,8 @@ func (h *writerSyncHelper) TriggerSync(tb testing.TB) {
 		wg.Add(1)
 		go func() {
 			defer wg.Done()
-			assert.NoError(tb, s.TriggerSync(true).Wait(context.Background()))
+			notifier := s.TriggerSync(true)
+			assert.NoError(tb, notifier.Wait(context.Background()))
 		}()
 	}
 	wg.Wait()
@@ -621,22 +626,25 @@ func (h *writerSyncHelper) TriggerSync(tb testing.TB) {
 type dummyEncoder struct {
 	out        io.Writer
 	writeDone  chan struct{}
+	notifier   func() *notify.Notifier
 	FlushError error
 	CloseError error
 }
 
-func dummyEncoderFactory(cfg encoder.Config, mapping any, out io.Writer) (encoder.Encoder, error) {
-	return newDummyEncoder(out, nil), nil
+func dummyEncoderFactory(cfg encoder.Config, mapping any, out io.Writer, notifier func() *notify.Notifier) (encoder.Encoder, error) {
+	return newDummyEncoder(out, nil, notifier), nil
 }
 
-func newDummyEncoder(out io.Writer, writeDone chan struct{}) *dummyEncoder {
-	return &dummyEncoder{out: out, writeDone: writeDone}
+func newDummyEncoder(out io.Writer, writeDone chan struct{}, notifier func() *notify.Notifier) *dummyEncoder {
+	return &dummyEncoder{out: out, writeDone: writeDone, notifier: notifier}
 }
 
-func (w *dummyEncoder) WriteRecord(record recordctx.Context) (int, error) {
+func (w *dummyEncoder) WriteRecord(record recordctx.Context) (result.WriteRecordResult, error) {
+	wrr := result.NewNotifierWriteRecordResult(w.notifier())
+
 	body, err := record.BodyBytes()
 	if err != nil {
-		return 0, err
+		return wrr, err
 	}
 
 	body = append(body, '\n')
@@ -645,7 +653,9 @@ func (w *dummyEncoder) WriteRecord(record recordctx.Context) (int, error) {
 	if err == nil && w.writeDone != nil {
 		w.writeDone <- struct{}{}
 	}
-	return n, err
+
+	wrr.N = n
+	return wrr, err
 }
 
 func (w *dummyEncoder) Flush() error {


### PR DESCRIPTION
Jira: [PSGO-755](https://keboola.atlassian.net/browse/PSGO-755)

**Changes:**
- The notifier is taken on encoder level, as we want to get notifier before writing actual record.
- In previous code we took notifier after WriteRecord. If we move notifier before WriteRecord within encoding pipeline, we change behaviour and add unwanted entries to be synced together.


-----------
