### PR TITLE
fix: Do not obtain notifier before writeRow

### DIFF
--- a/internal/pkg/service/stream/storage/level/local/encoding/encoder/csv/csv.go
+++ b/internal/pkg/service/stream/storage/level/local/encoding/encoder/csv/csv.go
@@ -29,7 +29,13 @@ var columnRenderer = column.NewRenderer() //nolint:gochecknoglobals // contains 
 // The order of the lines is not preserved, because we use the writers pool,
 // but also because there are several source nodes with a load balancer in front of them.
 // In case of encoder accepts too big csv row, it returns error.
-func NewEncoder(concurrency int, rowSizeLimit datasize.ByteSize, mapping any, out io.Writer, notifier func() *notify.Notifier) (*Encoder, error) {
+func NewEncoder(
+	concurrency int,
+	rowSizeLimit datasize.ByteSize,
+	mapping any,
+	out io.Writer,
+	notifier func() *notify.Notifier,
+) (*Encoder, error) {
 	tableMapping, ok := mapping.(table.Mapping)
 	if !ok {
 		return nil, errors.Errorf("csv encoder supports only table mapping, given %v", mapping)
@@ -49,7 +55,6 @@ func NewEncoder(concurrency int, rowSizeLimit datasize.ByteSize, mapping any, ou
 }
 
 func (w *Encoder) WriteRecord(record recordctx.Context) (result.WriteRecordResult, error) {
-	writeRecordResult := result.NewNotifierWriteRecordResult(w.notifier())
 	// Reduce memory allocations
 	values := w.valuesPool.Get().(*[]any)
 	defer w.valuesPool.Put(values)
@@ -58,29 +63,30 @@ func (w *Encoder) WriteRecord(record recordctx.Context) (result.WriteRecordResul
 	for i, col := range w.columns {
 		value, err := columnRenderer.CSVValue(col, record)
 		if err != nil {
-			return writeRecordResult, errors.PrefixErrorf(err, "cannot convert column %q to CSV value", col)
+			return result.WriteRecordResult{}, errors.PrefixErrorf(err, "cannot convert column %q to CSV value", col)
 		}
 		(*values)[i] = value
 	}
 
 	// Encode the values to CSV format
 	n, err := w.writersPool.WriteRow(values)
-	writeRecordResult.N = n
 	if err != nil {
 		var valErr fastcsv.ValueError
 		if errors.As(err, &valErr) {
 			columnName := w.columns[valErr.ColumnIndex].ColumnName()
-			return writeRecordResult, errors.Errorf(`cannot convert value of the column "%s" to the string: %w`, columnName, err)
+			return result.WriteRecordResult{}, errors.Errorf(`cannot convert value of the column "%s" to the string: %w`, columnName, err)
 		}
 		var limitErr fastcsv.LimitError
 		if errors.As(err, &limitErr) {
 			columnName := w.columns[limitErr.ColumnIndex].ColumnName()
-			return writeRecordResult, svcerrors.NewPayloadTooLargeError(errors.Errorf(`too big CSV row, column: "%s", row limit: %s`, columnName, limitErr.Limit.HumanReadable()))
+			return result.WriteRecordResult{}, svcerrors.NewPayloadTooLargeError(errors.Errorf(`too big CSV row, column: "%s", row limit: %s`, columnName, limitErr.Limit.HumanReadable()))
 		}
 
-		return writeRecordResult, err
+		return result.WriteRecordResult{}, err
 	}
 
+	// Get notifier after succcessful written record
+	writeRecordResult := result.NewNotifierWriteRecordResult(n, w.notifier())
 	// Buffers can be released
 	// Important: values slice contains reference to the body []byte buffer, so it can be released sooner.
 	record.ReleaseBuffers()

--- a/internal/pkg/service/stream/storage/level/local/encoding/encoder/csv/csv_test.go
+++ b/internal/pkg/service/stream/storage/level/local/encoding/encoder/csv/csv_test.go
@@ -2,6 +2,7 @@ package csv_test
 
 import (
 	"compress/gzip"
+	"context"
 	"fmt"
 	"io"
 	"net/http"
@@ -31,6 +32,40 @@ type fileCompression struct {
 	Config            compression.Config
 	FileDecoder       func(t *testing.T, r io.Reader) io.Reader
 	DisableValidation bool
+}
+
+type unknown struct {
+	Name string `json:"name" validate:"required"`
+}
+
+type staticNotifier struct {
+	notifier *notify.Notifier
+}
+
+func newStaticNotifier() *staticNotifier {
+	return &staticNotifier{}
+}
+
+func (v unknown) ColumnType() column.Type {
+	return column.Type("unknown")
+}
+
+func (v unknown) ColumnName() string {
+	return v.Name
+}
+
+func (v unknown) IsPrimaryKey() bool {
+	return true
+}
+
+func (s *staticNotifier) createStaticNotifier() *notify.Notifier {
+	if s.notifier == nil {
+		notifier := notify.New()
+		s.notifier = notifier
+		return notifier
+	}
+
+	return s.notifier
 }
 
 // nolint:tparallel // false positive
@@ -112,6 +147,41 @@ func TestCSVWriterAboveLimit(t *testing.T) {
 	)
 	_, err = csvEncoder.WriteRecord(record)
 	assert.Equal(t, "too big CSV row, column: \"body\", row limit: 40 B", err.Error())
+}
+
+// TestCSVWriterDoNotGetNotifierBeforeWrite guarantees that notifier is always obtained after successful writeRow
+// not before writeRow, during mapping CSV columns.
+func TestCSVWriterDoNotGetNotifierBeforeWrite(t *testing.T) {
+	t.Parallel()
+
+	ctx, cancel := context.WithTimeout(context.Background(), 5*time.Second)
+	defer cancel()
+	// Input rows
+	columns := table.Mapping{
+		Columns: column.Columns{
+			column.Datetime{Name: "datetime"},
+			column.Body{Name: "body"},
+			unknown{Name: "path"},
+		},
+	}
+	staticNotifier := newStaticNotifier()
+	csvEncoder, err := csv.NewEncoder(0, 40*datasize.B, columns, io.Discard, staticNotifier.createStaticNotifier)
+	require.NoError(t, err)
+	record := recordctx.FromHTTP(
+		utctime.MustParse("2000-01-01T03:00:00.000Z").Time(),
+		&http.Request{Body: io.NopCloser(strings.NewReader("foobar"))},
+	)
+	notifier := staticNotifier.createStaticNotifier()
+	notifier.Done(nil)
+	r, err := csvEncoder.WriteRecord(record)
+	require.Error(t, err)
+
+	// It is expected that no notifier is returned before writing actual record, but after writing record
+	if !assert.Nil(t, r.Notifier) {
+		err = r.Notifier.Wait(ctx)
+		require.NoError(t, err)
+		return
+	}
 }
 
 func newTestCase(comp fileCompression, syncMode writesync.Mode, syncWait bool, parallelWrite bool) *testcase.WriterTestCase {

--- a/internal/pkg/service/stream/storage/level/local/encoding/encoder/factory.go
+++ b/internal/pkg/service/stream/storage/level/local/encoding/encoder/factory.go
@@ -1,6 +1,7 @@
 package encoder
 
 import (
+	"context"
 	"io"
 
 	"github.com/keboola/keboola-as-code/internal/pkg/service/stream/storage/level/local/encoding/encoder/csv"
@@ -9,12 +10,12 @@ import (
 )
 
 type Factory interface {
-	NewEncoder(cfg Config, mapping any, out io.Writer, notifier func() *notify.Notifier) (Encoder, error)
+	NewEncoder(cfg Config, mapping any, out io.Writer, notifier func(ctx context.Context) *notify.Notifier) (Encoder, error)
 }
 
 type DefaultFactory struct{}
 
-func (DefaultFactory) NewEncoder(cfg Config, mapping any, out io.Writer, notifier func() *notify.Notifier) (Encoder, error) {
+func (DefaultFactory) NewEncoder(cfg Config, mapping any, out io.Writer, notifier func(ctx context.Context) *notify.Notifier) (Encoder, error) {
 	switch cfg.Type {
 	case TypeCSV:
 		return csv.NewEncoder(cfg.Concurrency, cfg.RowSizeLimit, mapping, out, notifier)
@@ -23,14 +24,14 @@ func (DefaultFactory) NewEncoder(cfg Config, mapping any, out io.Writer, notifie
 	}
 }
 
-func FactoryFn(fn func(cfg Config, mapping any, out io.Writer, notifier func() *notify.Notifier) (Encoder, error)) Factory {
+func FactoryFn(fn func(cfg Config, mapping any, out io.Writer, notifier func(ctx context.Context) *notify.Notifier) (Encoder, error)) Factory {
 	return factoryFn{Fn: fn}
 }
 
 type factoryFn struct {
-	Fn func(cfg Config, mapping any, out io.Writer, notifier func() *notify.Notifier) (Encoder, error)
+	Fn func(cfg Config, mapping any, out io.Writer, notifier func(ctx context.Context) *notify.Notifier) (Encoder, error)
 }
 
-func (f factoryFn) NewEncoder(cfg Config, mapping any, out io.Writer, notifier func() *notify.Notifier) (Encoder, error) {
+func (f factoryFn) NewEncoder(cfg Config, mapping any, out io.Writer, notifier func(ctx context.Context) *notify.Notifier) (Encoder, error) {
 	return f.Fn(cfg, mapping, out, notifier)
 }

--- a/internal/pkg/service/stream/storage/level/local/encoding/encoder/result/result.go
+++ b/internal/pkg/service/stream/storage/level/local/encoding/encoder/result/result.go
@@ -8,8 +8,9 @@ type WriteRecordResult struct {
 	Notifier *notify.Notifier
 }
 
-func NewNotifierWriteRecordResult(notifier *notify.Notifier) WriteRecordResult {
+func NewNotifierWriteRecordResult(n int, notifier *notify.Notifier) WriteRecordResult {
 	return WriteRecordResult{
+		N:        n,
 		Notifier: notifier,
 	}
 }

--- a/internal/pkg/service/stream/storage/level/local/encoding/pipeline_test.go
+++ b/internal/pkg/service/stream/storage/level/local/encoding/pipeline_test.go
@@ -640,21 +640,19 @@ func newDummyEncoder(out io.Writer, writeDone chan struct{}, notifier func() *no
 }
 
 func (w *dummyEncoder) WriteRecord(record recordctx.Context) (result.WriteRecordResult, error) {
-	wrr := result.NewNotifierWriteRecordResult(w.notifier())
-
 	body, err := record.BodyBytes()
 	if err != nil {
-		return wrr, err
+		return result.WriteRecordResult{}, err
 	}
 
 	body = append(body, '\n')
 
 	n, err := w.out.Write(body)
+	wrr := result.NewNotifierWriteRecordResult(n, w.notifier())
 	if err == nil && w.writeDone != nil {
 		w.writeDone <- struct{}{}
 	}
 
-	wrr.N = n
 	return wrr, err
 }
 

--- a/internal/pkg/service/stream/storage/level/local/encoding/pipeline_test.go
+++ b/internal/pkg/service/stream/storage/level/local/encoding/pipeline_test.go
@@ -227,21 +227,22 @@ foo3
 {"level":"debug","message":"starting sync to disk"}
 {"level":"debug","message":"flushing writers"}
 {"level":"debug","message":"chunk completed, aligned = true, size = \"10B\""}
-{"level":"debug","message":"writers flushed"}                 
-{"level":"debug","message":"sync to disk done"}             
-{"level":"info","message":"TEST: write unblocked"}          
-{"level":"info","message":"TEST: write unblocked"}          
-{"level":"debug","message":"starting sync to disk"}          
-{"level":"debug","message":"flushing writers"}              
-{"level":"debug","message":"chunk completed, aligned = true, size = \"5B\""}        
 {"level":"debug","message":"writers flushed"}
-{"level":"debug","message":"sync to disk done"}             
+{"level":"debug","message":"sync to disk done"}
+{"level":"info","message":"TEST: write unblocked"}
+{"level":"info","message":"TEST: write unblocked"}
+{"level":"debug","message":"notifier obtained"}
+{"level":"debug","message":"starting sync to disk"}
+{"level":"debug","message":"flushing writers"}
+{"level":"debug","message":"chunk completed, aligned = true, size = \"5B\""}
+{"level":"debug","message":"writers flushed"}
+{"level":"debug","message":"sync to disk done"}
 {"level":"info","message":"TEST: write unblocked"}
 {"level":"debug","message":"closing encoding pipeline"}
 {"level":"debug","message":"stopping syncer"}
-{"level":"debug","message":"starting sync to disk"}          
-{"level":"debug","message":"flushing writers"}              
-{"level":"debug","message":"chunk completed, aligned = true, size = \"5B\""}        
+{"level":"debug","message":"starting sync to disk"}
+{"level":"debug","message":"flushing writers"}
+{"level":"debug","message":"chunk completed, aligned = true, size = \"5B\""}
 {"level":"debug","message":"writers flushed"}
 {"level":"debug","message":"sync to disk done"}
 {"level":"debug","message":"syncer stopped"}
@@ -340,8 +341,8 @@ foo3
 {"level":"info","message":"TEST: write unblocked"}
 {"level":"debug","message":"closing encoding pipeline"}
 {"level":"debug","message":"stopping syncer"}
-{"level":"debug","message":"starting sync to cache"}          
-{"level":"debug","message":"flushing writers"}              
+{"level":"debug","message":"starting sync to cache"}
+{"level":"debug","message":"flushing writers"}
 {"level":"debug","message":"chunk completed, aligned = true, size = \"5B\""}
 {"level":"debug","message":"writers flushed"}
 {"level":"debug","message":"sync to cache done"}

--- a/internal/pkg/service/stream/storage/level/local/encoding/writesync/sync.go
+++ b/internal/pkg/service/stream/storage/level/local/encoding/writesync/sync.go
@@ -135,7 +135,9 @@ func (s *Syncer) Notifier() *notify.Notifier {
 		return nil
 	}
 
+	ctx := context.Background()
 	s.notifierLock.RLock()
+	s.logger.Debug(ctx, "notifier obtained")
 	notifier := s.notifier
 	s.notifierLock.RUnlock()
 	return notifier

--- a/internal/pkg/service/stream/storage/level/local/encoding/writesync/sync.go
+++ b/internal/pkg/service/stream/storage/level/local/encoding/writesync/sync.go
@@ -129,13 +129,12 @@ func NewSyncer(
 }
 
 // Notifier to wait for the next sync.
-func (s *Syncer) Notifier() *notify.Notifier {
+func (s *Syncer) Notifier(ctx context.Context) *notify.Notifier {
 	// Wait is disabled, return nil notifier, *notify.Notifier(nil).Wait() is valid NOP call.
 	if !s.config.Wait {
 		return nil
 	}
 
-	ctx := context.Background()
 	s.notifierLock.RLock()
 	s.logger.Debug(ctx, "notifier obtained")
 	notifier := s.notifier

--- a/internal/pkg/service/stream/storage/level/local/encoding/writesync/sync_test.go
+++ b/internal/pkg/service/stream/storage/level/local/encoding/writesync/sync_test.go
@@ -70,7 +70,7 @@ func TestSyncWriter_Write_Wait(t *testing.T) {
 	for i := 1; i <= 3; i++ {
 		syncerWriter.MustWriteTestData(t, i)
 	}
-	notifier := syncerWriter.Notifier()
+	notifier := syncerWriter.Notifier(ctx)
 
 	// Wait for the notifier
 	wg := &sync.WaitGroup{}
@@ -126,7 +126,7 @@ func TestSyncWriter_DoWithNotify_NoWait(t *testing.T) {
 	for i := 1; i <= 3; i++ {
 		syncerWriter.MustWriteTestData(t, i)
 	}
-	notifier := syncerWriter.Notifier()
+	notifier := syncerWriter.Notifier(ctx)
 
 	// Wait is disabled
 	require.Nil(t, notifier)
@@ -211,7 +211,7 @@ func TestSyncWriter_SyncToDisk_Wait_Ok(t *testing.T) {
 	for i := 1; i <= 3; i++ {
 		syncerWriter.MustWriteTestData(t, i)
 
-		notifier := syncerWriter.Notifier()
+		notifier := syncerWriter.Notifier(ctx)
 		assert.NotNil(t, notifier)
 
 		wg.Add(1)
@@ -230,7 +230,7 @@ func TestSyncWriter_SyncToDisk_Wait_Ok(t *testing.T) {
 	for i := 4; i <= 6; i++ {
 		syncerWriter.MustWriteTestData(t, i)
 
-		notifier := syncerWriter.Notifier()
+		notifier := syncerWriter.Notifier(ctx)
 		assert.NotNil(t, notifier)
 
 		wg.Add(1)
@@ -301,7 +301,7 @@ func TestSyncWriter_SyncToDisk_Wait_Error(t *testing.T) {
 	for i := 1; i <= 3; i++ {
 		syncerWriter.MustWriteTestData(t, i)
 
-		notifier := syncerWriter.Notifier()
+		notifier := syncerWriter.Notifier(ctx)
 		assert.NotNil(t, notifier)
 
 		wg.Add(1)
@@ -366,7 +366,7 @@ func TestSyncWriter_SyncToDisk_NoWait_Ok(t *testing.T) {
 	for i := 1; i <= 3; i++ {
 		syncerWriter.MustWriteTestData(t, i)
 
-		notifier := syncerWriter.Notifier()
+		notifier := syncerWriter.Notifier(ctx)
 		assert.Nil(t, notifier)
 		assert.NoError(t, notifier.WaitWithTimeout(testWaitTimeout))
 	}
@@ -417,7 +417,7 @@ func TestSyncWriter_SyncToDisk_NoWait_Error(t *testing.T) {
 	for i := 1; i <= 3; i++ {
 		syncerWriter.MustWriteTestData(t, i)
 
-		notifier := syncerWriter.Notifier()
+		notifier := syncerWriter.Notifier(ctx)
 		assert.Nil(t, notifier)
 		assert.NoError(t, notifier.WaitWithTimeout(testWaitTimeout))
 	}
@@ -473,7 +473,7 @@ func TestSyncWriter_SyncToCache_Wait_Ok(t *testing.T) {
 	for i := 1; i <= 3; i++ {
 		syncerWriter.MustWriteTestData(t, i)
 
-		notifier := syncerWriter.Notifier()
+		notifier := syncerWriter.Notifier(ctx)
 		assert.NotNil(t, notifier)
 
 		wg.Add(1)
@@ -492,7 +492,7 @@ func TestSyncWriter_SyncToCache_Wait_Ok(t *testing.T) {
 	for i := 4; i <= 6; i++ {
 		syncerWriter.MustWriteTestData(t, i)
 
-		notifier := syncerWriter.Notifier()
+		notifier := syncerWriter.Notifier(ctx)
 		assert.NotNil(t, notifier)
 
 		wg.Add(1)
@@ -563,7 +563,7 @@ func TestSyncWriter_SyncToCache_Wait_Error(t *testing.T) {
 	for i := 1; i <= 3; i++ {
 		syncerWriter.MustWriteTestData(t, i)
 
-		notifier := syncerWriter.Notifier()
+		notifier := syncerWriter.Notifier(ctx)
 		assert.NotNil(t, notifier)
 
 		wg.Add(1)
@@ -628,7 +628,7 @@ func TestSyncWriter_SyncToCache_NoWait_Ok(t *testing.T) {
 	for i := 1; i <= 3; i++ {
 		syncerWriter.MustWriteTestData(t, i)
 
-		notifier := syncerWriter.Notifier()
+		notifier := syncerWriter.Notifier(ctx)
 		assert.Nil(t, notifier)
 		assert.NoError(t, notifier.WaitWithTimeout(testWaitTimeout))
 	}
@@ -679,7 +679,7 @@ func TestSyncWriter_SyncToCache_NoWait_Err(t *testing.T) {
 	for i := 1; i <= 3; i++ {
 		syncerWriter.MustWriteTestData(t, i)
 
-		notifier := syncerWriter.Notifier()
+		notifier := syncerWriter.Notifier(ctx)
 		assert.Nil(t, notifier)
 		assert.NoError(t, notifier.WaitWithTimeout(testWaitTimeout))
 	}
@@ -734,7 +734,7 @@ func TestSyncWriter_WriteDuringSync(t *testing.T) {
 	for i := 1; i <= 3; i++ {
 		syncerWriter.MustWriteTestData(t, i)
 
-		notifier := syncerWriter.Notifier()
+		notifier := syncerWriter.Notifier(ctx)
 		assert.NotNil(t, notifier)
 
 		wg.Add(1)
@@ -814,7 +814,7 @@ func TestSyncWriter_OnlyOneRunningSync(t *testing.T) {
 	for i := 1; i <= 3; i++ {
 		syncerWriter.MustWriteTestData(t, i)
 
-		notifier := syncerWriter.Notifier()
+		notifier := syncerWriter.Notifier(ctx)
 		assert.NotNil(t, notifier)
 
 		wg.Add(1)
@@ -879,7 +879,7 @@ func TestSyncWriter_CountTrigger(t *testing.T) {
 	for i := 1; i <= 3; i++ {
 		syncerWriter.MustWriteTestData(t, i)
 
-		notifier := syncerWriter.Notifier()
+		notifier := syncerWriter.Notifier(ctx)
 		assert.NotNil(t, notifier)
 
 		wg.Add(1)
@@ -937,7 +937,7 @@ func TestSyncWriter_IntervalTrigger(t *testing.T) {
 	for i := 1; i <= 3; i++ {
 		syncerWriter.MustWriteTestData(t, i)
 
-		notifier := syncerWriter.Notifier()
+		notifier := syncerWriter.Notifier(ctx)
 		assert.NotNil(t, notifier)
 
 		wg.Add(1)
@@ -995,7 +995,7 @@ func TestSyncWriter_BytesTrigger(t *testing.T) {
 	n1, err1 := syncerWriter.Write([]byte(data1))
 	assert.Equal(t, 10, n1)
 
-	notifier1 := syncerWriter.Notifier()
+	notifier1 := syncerWriter.Notifier(ctx)
 	assert.NotNil(t, notifier1)
 	assert.NoError(t, err1)
 
@@ -1011,7 +1011,7 @@ func TestSyncWriter_BytesTrigger(t *testing.T) {
 	data2 := strings.Repeat("-", data2Len)
 	n2, err2 := syncerWriter.Write([]byte(data2))
 	assert.Equal(t, data2Len, n2)
-	notifier2 := syncerWriter.Notifier()
+	notifier2 := syncerWriter.Notifier(ctx)
 	assert.NotNil(t, notifier2)
 	assert.NoError(t, err2)
 


### PR DESCRIPTION
Jira: [PSGO-755](https://keboola.atlassian.net/browse/PSGO-755)

**Changes:**
- It causes incorrect behaviour of adding writeRow to previous notifier instead of the new one, which causes guarantees of writing to be not aligned.


-----------


[PSGO-755]: https://keboola.atlassian.net/browse/PSGO-755?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ