### PR TITLE
fix: add branchId and streamid into events

### DIFF
--- a/internal/pkg/service/stream/api/service/source.go
+++ b/internal/pkg/service/stream/api/service/source.go
@@ -58,6 +58,7 @@ func (s *service) CreateSource(ctx context.Context, d dependencies.BranchRequest
 					formatMsg,
 					bridge.Params{
 						ProjectID:  d.ProjectID(),
+						BranchID:   d.Branch().BranchID,
 						SourceID:   source.SourceID,
 						SourceName: source.Name,
 					},
@@ -190,6 +191,7 @@ func (s *service) DeleteSource(ctx context.Context, d dependencies.SourceRequest
 					formatMsg,
 					bridge.Params{
 						ProjectID:  d.ProjectID(),
+						BranchID:   d.Branch().BranchID,
 						SourceID:   source.SourceID,
 						SourceName: source.Name,
 					},

--- a/internal/pkg/service/stream/api/service/source.go
+++ b/internal/pkg/service/stream/api/service/source.go
@@ -60,6 +60,7 @@ func (s *service) CreateSource(ctx context.Context, d dependencies.BranchRequest
 						ProjectID:  d.ProjectID(),
 						BranchID:   d.Branch().BranchID,
 						SourceID:   source.SourceID,
+						SourceKey:  source.SourceKey,
 						SourceName: source.Name,
 					},
 				)
@@ -193,6 +194,7 @@ func (s *service) DeleteSource(ctx context.Context, d dependencies.SourceRequest
 						ProjectID:  d.ProjectID(),
 						BranchID:   d.Branch().BranchID,
 						SourceID:   source.SourceID,
+						SourceKey:  source.SourceKey,
 						SourceName: source.Name,
 					},
 				)

--- a/internal/pkg/service/stream/sink/type/tablesink/keboola/bridge/event.go
+++ b/internal/pkg/service/stream/sink/type/tablesink/keboola/bridge/event.go
@@ -34,6 +34,7 @@ type Params struct {
 	ProjectID  keboola.ProjectID
 	BranchID   keboola.BranchID
 	SourceID   key.SourceID
+	SourceKey  key.SourceKey
 	SourceName string
 	SinkID     key.SinkID
 	Stats      statistics.Value
@@ -78,6 +79,7 @@ func (b *Bridge) SendSliceUploadEvent(
 			ProjectID: sliceKey.ProjectID,
 			BranchID:  sliceKey.BranchID,
 			SourceID:  sliceKey.SourceID,
+			SourceKey: sliceKey.SourceKey,
 			SinkID:    sliceKey.SinkID,
 			Stats:     stats,
 		},
@@ -130,6 +132,7 @@ func (b *Bridge) SendFileImportEvent(
 			ProjectID: fileKey.ProjectID,
 			BranchID:  fileKey.BranchID,
 			SourceID:  fileKey.SourceID,
+			SourceKey: fileKey.SourceKey,
 			SinkID:    fileKey.SinkID,
 			Stats:     stats,
 		},
@@ -162,7 +165,7 @@ func SendEvent(
 			"projectId": params.ProjectID,
 			"branchId":  params.BranchID,
 			"sourceId":  params.SourceID,
-			"streamId":  params.SourceID.String(),
+			"streamId":  params.SourceKey.String(),
 			"sinkId":    params.SinkID,
 		},
 	}

--- a/internal/pkg/service/stream/sink/type/tablesink/keboola/bridge/event.go
+++ b/internal/pkg/service/stream/sink/type/tablesink/keboola/bridge/event.go
@@ -32,6 +32,7 @@ const (
 
 type Params struct {
 	ProjectID  keboola.ProjectID
+	BranchID   keboola.BranchID
 	SourceID   key.SourceID
 	SourceName string
 	SinkID     key.SinkID
@@ -75,6 +76,7 @@ func (b *Bridge) SendSliceUploadEvent(
 		formatMsg,
 		Params{
 			ProjectID: sliceKey.ProjectID,
+			BranchID:  sliceKey.BranchID,
 			SourceID:  sliceKey.SourceID,
 			SinkID:    sliceKey.SinkID,
 			Stats:     stats,
@@ -126,6 +128,7 @@ func (b *Bridge) SendFileImportEvent(
 		formatMsg,
 		Params{
 			ProjectID: fileKey.ProjectID,
+			BranchID:  fileKey.BranchID,
 			SourceID:  fileKey.SourceID,
 			SinkID:    fileKey.SinkID,
 			Stats:     stats,
@@ -157,7 +160,9 @@ func SendEvent(
 		Duration:    client.DurationSeconds(duration),
 		Results: map[string]any{
 			"projectId": params.ProjectID,
+			"branchId":  params.BranchID,
 			"sourceId":  params.SourceID,
+			"streamId":  params.SourceID.String(),
 			"sinkId":    params.SinkID,
 		},
 	}

--- a/internal/pkg/service/stream/sink/type/tablesink/keboola/bridge/event_test.go
+++ b/internal/pkg/service/stream/sink/type/tablesink/keboola/bridge/event_test.go
@@ -52,7 +52,7 @@ func TestBridge_SendSliceUploadEvent_OkEvent(t *testing.T) {
   "duration": 3,
   "message": "Slice upload done.",
   "params": "null",
-  "results": "{\"projectId\":123,\"sinkId\":\"my-sink\",\"sourceId\":\"my-source\",\"statistics\":{\"compressedSize\":52428800,\"firstRecordAt\":\"2000-01-01T20:00:00.000Z\",\"lastRecordAt\":\"2000-01-02T01:00:00.000Z\",\"recordsCount\":123,\"slicesCount\":1,\"stagingSize\":26214400,\"uncompressedSize\":104857600}}",
+  "results": "{\"branchId\":456,\"projectId\":123,\"sinkId\":\"my-sink\",\"sourceId\":\"my-source\",\"statistics\":{\"compressedSize\":52428800,\"firstRecordAt\":\"2000-01-01T20:00:00.000Z\",\"lastRecordAt\":\"2000-01-02T01:00:00.000Z\",\"recordsCount\":123,\"slicesCount\":1,\"stagingSize\":26214400,\"uncompressedSize\":104857600},\"streamId\":\"123/456/my-source\"}",
   "type": "info"
 }`, body)
 }
@@ -84,7 +84,7 @@ func TestBridge_SendSliceUploadEvent_ErrorEvent(t *testing.T) {
   "duration": 3,
   "message": "Slice upload failed.",
   "params": "null",
-  "results": "{\"error\":\"some error\",\"projectId\":123,\"sinkId\":\"my-sink\",\"sourceId\":\"my-source\"}",
+  "results": "{\"branchId\":456,\"error\":\"some error\",\"projectId\":123,\"sinkId\":\"my-sink\",\"sourceId\":\"my-source\",\"streamId\":\"123/456/my-source\"}",
   "type": "error"
 }`, body)
 }
@@ -139,7 +139,7 @@ func TestBridge_SendFileImportEvent_OkEvent(t *testing.T) {
   "duration": 3,
   "message": "File import done.",
   "params": "null",
-  "results": "{\"projectId\":123,\"sinkId\":\"my-sink\",\"sourceId\":\"my-source\",\"statistics\":{\"compressedSize\":52428800,\"firstRecordAt\":\"2000-01-01T01:00:00.000Z\",\"lastRecordAt\":\"2000-01-02T01:00:00.000Z\",\"recordsCount\":123,\"slicesCount\":1,\"stagingSize\":26214400,\"uncompressedSize\":104857600}}",
+  "results": "{\"branchId\":456,\"projectId\":123,\"sinkId\":\"my-sink\",\"sourceId\":\"my-source\",\"statistics\":{\"compressedSize\":52428800,\"firstRecordAt\":\"2000-01-01T01:00:00.000Z\",\"lastRecordAt\":\"2000-01-02T01:00:00.000Z\",\"recordsCount\":123,\"slicesCount\":1,\"stagingSize\":26214400,\"uncompressedSize\":104857600},\"streamId\":\"123/456/my-source\"}",
   "type": "info"
 }`, body)
 }
@@ -171,7 +171,7 @@ func TestBridge_SendFileImportEvent_ErrorEvent(t *testing.T) {
   "duration": 3,
   "message": "File import failed.",
   "params": "null",
-  "results": "{\"error\":\"some error\",\"projectId\":123,\"sinkId\":\"my-sink\",\"sourceId\":\"my-source\"}",
+  "results": "{\"branchId\":456,\"error\":\"some error\",\"projectId\":123,\"sinkId\":\"my-sink\",\"sourceId\":\"my-source\",\"streamId\":\"123/456/my-source\"}",
   "type": "error"
 }`, body)
 }


### PR DESCRIPTION
Jira: [PSGO-870](https://keboola.atlassian.net/browse/PSGO-870)

**Changes:**
- Add streamId into events for temeletry purposes.
- Add missing branchId property

-----------


[PSGO-870]: https://keboola.atlassian.net/browse/PSGO-870?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ

Related: https://github.com/keboola/event-schema/pull/21