### PR TITLE
fix: Dependabot grouping

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -10,7 +10,7 @@ updates:
     schedule:
       interval: "weekly"
     groups:
-      all:
+      go:
         patterns:
           - "*"
 
@@ -19,6 +19,6 @@ updates:
     schedule:
       interval: "weekly"
     groups:
-      all:
+      actions:
         patterns:
           - "*"


### PR DESCRIPTION
Okay the PRs are now grouped, just one small change to improve the PR titles.