### PR TITLE
fix: Dependabot branches not triggering CI

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -4,7 +4,7 @@ on:
   push:
     # Avoid tags
     branches:
-      - "*"
+      - "**"
 
 jobs:
   check-license:


### PR DESCRIPTION
Okay one more thing. The dependabot PRs are not triggering workflows. I thought it was a temporary GitHub Actions issue at first but it's actually because the branches contain a `/` character.

https://docs.github.com/en/actions/writing-workflows/workflow-syntax-for-github-actions#filter-pattern-cheat-sheet