### PR TITLE
feat: Add prometheus in docker compose to inspect metrics

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -4,6 +4,12 @@ services:
     build:
       context: .
       dockerfile: ./provisioning/dev/docker/Dockerfile
+    # Uncomment when you would like to inspect metrics of your service using prometheus container.
+    # Change the <your-service> placeholder with desired service to be inspected.
+    # See ./docs/development.md for more information how to startup the compose etc.
+    #command: >
+    #       sh -c "git config --global --add safe.directory /code
+    #       make run-<your-service>"
     links:
       - etcd
       - redis

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -8,6 +8,9 @@ services:
       - etcd
       - redis
       - sandboxesMock
+      - prometheus
+    networks:
+      - localprom
     volumes:
       - ./:/code:z
       - cache:/tmp/cache
@@ -141,5 +144,18 @@ services:
       volumes:
         - ./provisioning/apps-proxy/dev/sandboxesMock.json:/config/sandboxesMock.json:Z
 
+  prometheus:
+    image: prom/prometheus
+    volumes:
+      - "./provisioning/dev/prometheus/prometheus.yml:/etc/prometheus/prometheus.yml"
+    networks:
+      - localprom
+    ports:
+      - 9090:9090
+
 volumes:
   cache:
+
+networks:
+  localprom:
+    driver: bridge

--- a/docs/development.md
+++ b/docs/development.md
@@ -37,6 +37,26 @@ Start an interactive console in a container, run:
 docker compose run --rm -u "$UID:$GID" --service-ports dev bash
 ```
 
+### Start Dev Container inspecting metrics
+
+When we would like to inspect metrics of our services, there have to be made adjustement under `dev` service.
+Use following command there, so the prometheus and dev service is connected
+```
+command: >
+sh -c "git config --global --add safe.directory /code
+       make run-<your-service>"
+```
+
+This ensures that the `/code` is safe directory to run. Make sure that under `<your-service>` you replace with desired service. E.g `make run-apps-proxy`.
+Then run this docker compose command
+```
+docker compose up -d
+```
+
+### Inspecting prometheus
+
+On `localhost:9090` the prometheus is running the UI where your service should be scraped. You can simply check them as graph visually.
+
 ### Troubleshooting
 
 Strange issues are usually caused by incorrect permissions or file owner somewhere. Here are some tips:

--- a/provisioning/apps-proxy/dev/.air.toml
+++ b/provisioning/apps-proxy/dev/.air.toml
@@ -3,7 +3,7 @@ tmp_dir = "target/.watcher"
 
 [build]
   bin = "./target/apps-proxy/proxy"
-  args_bin = ["--sandboxes-api-url",  "http://localhost:1080", "--sandboxes-api-token", "my-token", "--api-public-url", "http://localhost:8000", "--cookie-secret-salt", "cookie", "--csrf-token-salt", "bcc3add3bf72e628149fbfbc11932329de7f375db3d8503ef0e32b336adf46c4"]
+  args_bin = ["--sandboxes-api-url",  "http://localhost:1080", "--sandboxes-api-token", "my-token", "--metrics-listen", "0.0.0.0:9002", "--api-public-url", "http://localhost:8000", "--cookie-secret-salt", "cookie", "--csrf-token-salt", "bcc3add3bf72e628149fbfbc11932329de7f375db3d8503ef0e32b336adf46c4"]
   cmd = "make build-apps-proxy"
   delay = 2000
   exclude_dir = []

--- a/provisioning/dev/prometheus/prometheus.yml
+++ b/provisioning/dev/prometheus/prometheus.yml
@@ -1,0 +1,19 @@
+global:
+  scrape_interval: 10s
+scrape_configs:
+ - job_name: prometheus
+   static_configs:
+    - targets:
+       - 'prometheus:9090'
+ - job_name: templatesAPI
+   static_configs:
+    - targets:
+       - 'dev:9000'
+ - job_name: streamAPI
+   static_configs:
+    - targets:
+       - 'dev:9001'
+ - job_name: AppsProxy
+   static_configs:
+    - targets:
+       - 'dev:9002'

--- a/provisioning/dev/prometheus/prometheus.yml
+++ b/provisioning/dev/prometheus/prometheus.yml
@@ -13,7 +13,7 @@ scrape_configs:
    static_configs:
     - targets:
        - 'dev:9001'
- - job_name: AppsProxy
+ - job_name: appsProxy
    static_configs:
     - targets:
        - 'dev:9002'

--- a/provisioning/stream/dev/.air.toml
+++ b/provisioning/stream/dev/.air.toml
@@ -3,7 +3,7 @@ tmp_dir = "target/.watcher"
 
 [build]
   bin = "./target/stream/service"
-  args_bin = ["--node-id", "my-node", "--hostname", "localhost", "--source-http-public-url", "http://localhost:1234", "--storage-volumes-path", "/tmp/stream-volumes", "api", "http-source", "storage-writer", "storage-reader", "storage-coordinator"]
+  args_bin = ["--node-id", "my-node", "--hostname", "localhost", "--metrics-listen", "0.0.0.0:9001", "--source-http-public-url", "http://localhost:1234", "--storage-volumes-path", "/tmp/stream-volumes", "api", "http-source", "storage-writer", "storage-reader", "storage-coordinator"]
   cmd = "make build-stream-service"
   delay = 2000
   exclude_dir = ["internal/pkg/service/stream/api/gen"]


### PR DESCRIPTION
Jira: [PSGO-854](https://keboola.atlassian.net/browse/PSGO-854)

**Changes:**
- Add prometheus container into docker compose
- Adjust documentation to be able to retrieve metrics using prometheus and services
- Change port numbers for metrics scraping to be set same as in docker-compose.yml for development environment.

-----------


[PSGO-854]: https://keboola.atlassian.net/browse/PSGO-854?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ