### PR TITLE
fix: build stream dev images with race

### DIFF
--- a/.github/workflows/release-service-stream.yml
+++ b/.github/workflows/release-service-stream.yml
@@ -76,6 +76,14 @@ jobs:
           context: .
           file: provisioning/stream/docker/service/Dockerfile
 
+      - name: Build Service image with race detector
+        uses: docker/build-push-action@v6
+        with:
+          load: true
+          tags: ${{ env.IMAGE_NAME }}-race:${{ env.IMAGE_TAG }}
+          context: .
+          file: provisioning/stream/docker/service/race/Dockerfile
+
       - name: Push Service image to Amazon ECR, Azure ACR and GCP GAR
         uses: ./.github/actions/push-image-aws-azure-gcp
         with:
@@ -92,6 +100,24 @@ jobs:
           acrRepository: ${{ env.ACR_REPOSITORY }}
           acrUsername: ${{ env.ACR_USERNAME }}
           acrPassword: ${{ secrets.STREAM_ACR_PASSWORD }}
+
+      - name: Push Service image with race detector to Amazon ECR, Azure ACR and GCP GAR
+        uses: ./.github/actions/push-image-aws-azure-gcp
+        with:
+          imageName: ${{ env.IMAGE_NAME }}-race
+          imageTag: ${{ env.IMAGE_TAG }}
+          ecrRegion: ${{ env.ECR_REGION }}
+          ecrRepository: ${{ env.ECR_REPOSITORY }}
+          ecrPushRole: ${{ env.ECR_PUSH_ROLE }}
+          gcpRegistry: ${{ env.GCP_REGISTRY }}
+          gcpRepository: ${{ env.GCP_REPOSITORY }}
+          gcpIdentityProvider: ${{ env.GCP_IDENTITY_PROVIDER }}
+          gcpServiceAccount: ${{ env.GCP_ACCOUNT }}
+          acrRegistry: ${{ env.ACR_REGISTRY }}
+          acrRepository: ${{ env.ACR_REPOSITORY }}
+          acrUsername: ${{ env.ACR_USERNAME }}
+          acrPassword: ${{ secrets.STREAM_ACR_PASSWORD }}
+
       - name: Trigger image tag update
         uses: keboola/kbc-stacks/.github/actions/trigger-image-tag-update@main
         with:

--- a/Makefile
+++ b/Makefile
@@ -37,12 +37,15 @@ run-templates-api:
 build-stream-service:
 	CGO_ENABLED=0 go build -v -mod mod -ldflags "-s -w" -o "$(or $(BUILD_TARGET_PATH), ./target/stream/service)" ./cmd/stream
 
+build-stream-service-with-race:
+	CGO_ENABLED=1 go build -race -v -mod mod -ldflags "-s -w" -o "$(or $(BUILD_TARGET_PATH), ./target/stream/service)" ./cmd/stream
+
 run-stream-service:
 	rm -rf /tmp/stream-volumes && \
     mkdir -p /tmp/stream-volumes/hdd/my-volume && \
 	air -c ./provisioning/stream/dev/.air.toml
 
-run-stream-service-once: build-stream-service
+run-stream-service-once: build-stream-service-with-race
 	./target/stream/service api http-source storage-writer storage-reader storage-coordinator
 
 build-apps-proxy:

--- a/provisioning/apps-proxy/docker/Dockerfile
+++ b/provisioning/apps-proxy/docker/Dockerfile
@@ -15,7 +15,7 @@ COPY . .
 RUN make build-apps-proxy
 
 # Production container
-FROM alpine:3.19
+FROM alpine:3.20
 RUN apk add -U --no-cache ca-certificates git
 
 COPY --from=buildContainer /app/target/apps-proxy/proxy /app/server

--- a/provisioning/dev/docker/Dockerfile
+++ b/provisioning/dev/docker/Dockerfile
@@ -18,6 +18,7 @@ COPY Makefile /tmp/build/Makefile
 COPY scripts  /tmp/build/scripts
 RUN cd /tmp/build && make tools && cd / && rm -rf /tmp/build && go clean -cache -modcache
 RUN apt update && apt install -y graphviz
+RUN apt-get install --no-install-recommends --assume-yes build-essential libsqlite3-0
 
 # Install envsubstr and helm
 RUN curl -L https://github.com/a8m/envsubst/releases/download/v1.2.0/envsubst-$(uname -s)-$(uname -m) -o /usr/local/bin/envsubst && \

--- a/provisioning/dev/docker/Dockerfile
+++ b/provisioning/dev/docker/Dockerfile
@@ -18,7 +18,7 @@ COPY Makefile /tmp/build/Makefile
 COPY scripts  /tmp/build/scripts
 RUN cd /tmp/build && make tools && cd / && rm -rf /tmp/build && go clean -cache -modcache
 RUN apt update && apt install -y graphviz
-RUN apt-get install --no-install-recommends --assume-yes build-essential libsqlite3-0
+RUN apt-get install --no-install-recommends --assume-yes build-essential
 
 # Install envsubstr and helm
 RUN curl -L https://github.com/a8m/envsubst/releases/download/v1.2.0/envsubst-$(uname -s)-$(uname -m) -o /usr/local/bin/envsubst && \

--- a/provisioning/stream/docker/service/Dockerfile
+++ b/provisioning/stream/docker/service/Dockerfile
@@ -1,6 +1,7 @@
 # Build container
 FROM golang:1.23.3-alpine3.20 AS buildContainer
 RUN apk add -U --no-cache bash make curl
+RUN apk add --no-cache --update gcc g++
 WORKDIR /app
 
 COPY Makefile Makefile
@@ -15,7 +16,7 @@ COPY . .
 RUN make build-stream-service
 
 # Production container
-FROM alpine:3.19
+FROM alpine:3.20
 RUN apk add -U --no-cache ca-certificates git
 
 COPY --from=buildContainer /app/target/stream/service /app/service

--- a/provisioning/stream/docker/service/race/Dockerfile
+++ b/provisioning/stream/docker/service/race/Dockerfile
@@ -1,6 +1,7 @@
 # Build container
 FROM golang:1.23.3-alpine3.20 AS buildContainer
 RUN apk add -U --no-cache bash make curl
+RUN apk add --no-cache --update gcc g++
 WORKDIR /app
 
 COPY Makefile Makefile
@@ -12,7 +13,7 @@ COPY go.sum go.sum
 RUN go mod download
 
 COPY . .
-RUN make build-stream-service
+RUN make build-stream-service-with-race
 
 # Production container
 FROM alpine:3.20

--- a/provisioning/stream/docker/service/race/Dockerfile
+++ b/provisioning/stream/docker/service/race/Dockerfile
@@ -1,7 +1,8 @@
 # Build container
 FROM golang:1.23.3-alpine3.20 AS buildContainer
 RUN apk add -U --no-cache bash make curl
-RUN apk add --no-cache --update gcc g++
+# This is needed for CGO_ENABLED racer
+RUN apk add -U --no-cache gcc g++
 WORKDIR /app
 
 COPY Makefile Makefile

--- a/provisioning/stream/local.sh
+++ b/provisioning/stream/local.sh
@@ -65,9 +65,9 @@ fi
 # Build Docker image in the local Docker, so it is cached, if Minikube is destroyed
 SERVICE_IMAGE="$STREAM_IMAGE_REPOSITORY:$STREAM_IMAGE_TAG"
 echo
-echo "Building Service image ..."
+echo "Building Service image with race detector ..."
 echo "--------------------------"
-docker build -t "$SERVICE_IMAGE" -f "./docker/service/Dockerfile" "../../"
+docker build -t "$SERVICE_IMAGE" -f "./docker/service/race/Dockerfile" "../../"
 echo
 
 # Load the images to the Minikube

--- a/provisioning/templates-api/docker/Dockerfile
+++ b/provisioning/templates-api/docker/Dockerfile
@@ -15,7 +15,7 @@ COPY . .
 RUN make build-templates-api
 
 # Production container
-FROM alpine:3.19
+FROM alpine:3.20
 RUN apk add -U --no-cache ca-certificates git
 
 COPY --from=buildContainer /app/target/templates/api /app/server


### PR DESCRIPTION
Jira: [PSGO-950](https://keboola.atlassian.net/browse/PSGO-950)

**Changes:**
- Introduce build with `-race`.
- Introduce new dockerfile inside stream service, that is build with `-race`.
- Adjust CI to include build of both containers and push it into docker registries for potential use
- Update local development environment that we use by default images build with `-race` to get rid of unnecessary defects

-----------


[PSGO-950]: https://keboola.atlassian.net/browse/PSGO-950?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ