### PR TITLE
build: Disable exemplars

### DIFF
--- a/provisioning/apps-proxy/kubernetes/templates/proxy/deployment.yaml
+++ b/provisioning/apps-proxy/kubernetes/templates/proxy/deployment.yaml
@@ -95,6 +95,8 @@ spec:
               valueFrom:
                 fieldRef:
                   fieldPath: metadata.labels['tags.datadoghq.com/version']
+            - name: OTEL_METRICS_EXEMPLAR_FILTER
+              value: always_off
           startupProbe:
             httpGet:
               path: /health-check

--- a/provisioning/templates-api/kubernetes/templates/api/deployment.yaml
+++ b/provisioning/templates-api/kubernetes/templates/api/deployment.yaml
@@ -96,6 +96,8 @@ spec:
               valueFrom:
                 fieldRef:
                   fieldPath: metadata.labels['tags.datadoghq.com/version']
+            - name: OTEL_METRICS_EXEMPLAR_FILTER
+              value: always_off
           startupProbe:
             httpGet:
               path: /health-check


### PR DESCRIPTION
Applying #2138 for templates and apps proxy.

We can try to revert it later. The issue should be fixed by https://github.com/open-telemetry/opentelemetry-go/pull/5995 but it isn't tagged yet.