### PR TITLE
chore: Swap xxd tool for hexdump

### DIFF
--- a/provisioning/apps-proxy/common.sh
+++ b/provisioning/apps-proxy/common.sh
@@ -33,7 +33,7 @@ if ! kubectl get secret apps-proxy-salt --namespace apps-proxy > /dev/null 2>&1;
 fi
 
 if ! kubectl get secret apps-proxy-csrf-token-salt --namespace apps-proxy > /dev/null 2>&1; then
-  APPS_PROXY_CSRF_TOKEN_SALT=$(head -c 32 /dev/urandom | openssl enc | xxd -p -c 32)
+  APPS_PROXY_CSRF_TOKEN_SALT=$(head -c 32 /dev/urandom | openssl enc | hexdump -v -e '/1 "%02x"' -n 32)
   export APPS_PROXY_CSRF_TOKEN_SALT
   envsubst < kubernetes/templates/proxy/csrf-salt.yaml > kubernetes/deploy/proxy/csrf-salt.yaml
   kubectl apply -f ./kubernetes/deploy/proxy/csrf-salt.yaml


### PR DESCRIPTION
`xxd` seems now [absent](https://dev.azure.com/keboola-prod/Keboola%20Connection%20AWS/_releaseProgress?_a=release-environment-logs&releaseId=43832&environmentId=112583) from Azure DevOps workers. Swapping for hexdump, [which is available](https://dev.azure.com/keboola-prod/Keboola%20Connection%20AWS/_releaseProgress?_a=release-environment-logs&releaseId=43837&environmentId=112604).

It provides the same output:
```sh
$ head -c 32 /dev/urandom | tee >(xxd -p -c 32 > xxd_output.txt) | hexdump -v -e '/1 "%02x"' -n 32 > hexdump_output.txt
diff xxd_output.txt hexdump_output.txt
1c1
< 9e48e7b001af467ac8e1d9375f876ebc8130da2aa6c4540c6ccb4af75f5b46a1
---
> 9e48e7b001af467ac8e1d9375f876ebc8130da2aa6c4540c6ccb4af75f5b46a1
\ No newline at end of file
```