### PR TITLE
fix: Fix templates tests

### DIFF
--- a/internal/pkg/utils/testhelper/diff.go
+++ b/internal/pkg/utils/testhelper/diff.go
@@ -175,3 +175,10 @@ func normalizeString(input string) string {
 	return regexp.MustCompile(`-\d+`).
 		ReplaceAllString(input, "-%s")
 }
+
+func Normalize(t assert.TestingT, input string) string {
+	if h, ok := t.(tHelper); ok {
+		h.Helper()
+	}
+	return normalizeString(input)
+}

--- a/internal/pkg/utils/testhelper/diff_test.go
+++ b/internal/pkg/utils/testhelper/diff_test.go
@@ -211,3 +211,44 @@ func TestAssertDirectorySameWildcards(t *testing.T) {
 func newMockedT() *mockedT {
 	return &mockedT{buf: bytes.NewBuffer(nil)}
 }
+
+func TestNormalize(t *testing.T) {
+	t.Parallel()
+
+	type args struct {
+		input string
+	}
+	tests := []struct {
+		name string
+		args args
+		want string
+	}{
+		{
+			name: "Test with .json file",
+			args: args{
+				input: "/main/other/keboola.orchestrator/flow-mgmt-jira-instance/phases/003-load/001-keboola-wr-snowflake-10960305/task.json",
+			},
+			want: "/main/other/keboola.orchestrator/flow-mgmt-jira-instance/phases/003-load/001-keboola-wr-snowflake-%s/task.json",
+		},
+		{
+			name: "Test with .yaml file (numeric suffix at the end)",
+			args: args{
+				input: "/main/other/keboola.orchestrator/flow-mgmt-jira-instance/phases/003-load/001-keboola-wr-snowflake-98765432/task.yaml",
+			},
+			want: "/main/other/keboola.orchestrator/flow-mgmt-jira-instance/phases/003-load/001-keboola-wr-snowflake-%s/task.yaml",
+		},
+		{
+			name: "Test with path without digits before file extension",
+			args: args{
+				input: "/main/other/keboola.orchestrator/flow-mgmt-jira-instance/phases/003-load/001-keboola-wr-snowflake",
+			},
+			want: "/main/other/keboola.orchestrator/flow-mgmt-jira-instance/phases/003-load/001-keboola-wr-snowflake",
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+			assert.Equalf(t, tt.want, Normalize(t, tt.args.input), "Normalize(%v, %v)", t, tt.args.input)
+		})
+	}
+}


### PR DESCRIPTION
Jira: [PSGO-898](https://keboola.atlassian.net/browse/PSGO-898)

**Changes:**
- 

-----------
After running a local test we got this. We can see there, that dynamic IDs don't match. Therefore I am ignoring this IDs for tests.
<img width="1299" alt="image" src="https://github.com/user-attachments/assets/22ff9a30-71c8-4752-92a0-e93123840708">


[PSGO-898]: https://keboola.atlassian.net/browse/PSGO-898?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ