### PR TITLE
fix: unit test CI no space left on device

### DIFF
--- a/.github/workflows/test-unit.yml
+++ b/.github/workflows/test-unit.yml
@@ -53,11 +53,11 @@ jobs:
           android: true
           dotnet: true
           haskell: true
-          large-packages: false
-          docker-images: false
+          large-packages: true
+          docker-images: true
           swap-storage: false
 
-        # To free up disk space to not run out during the run
+      # To free up disk space to not run out during the run
       - name: Delete unused SDKs MacOS
         if: matrix.name == 'mac-os'
         run: |
@@ -75,6 +75,14 @@ jobs:
           without-cache: ${{ inputs.without-cache }}
           cache-s3-bucket: ${{ vars.CACHE_S3_BUCKET }}
 
+      - name: Check how much space is left after go setup
+        if: matrix.name == 'linux'
+        shell: bash
+        run: |
+          echo "AFTER GO SETUP:"
+          df -h /
+          df -a /
+
       - name: Set TEST_KBC_PROJECTS_FILE entries
         uses: ./.github/actions/export-kbc-projects
         with:
@@ -86,6 +94,14 @@ jobs:
           set -Eeuo pipefail
           docker compose run -d --rm --publish 2379:2379 etcd
           sudo echo "127.0.0.1 etcd" | sudo tee -a /etc/hosts
+
+      - name: Check how much space is left after etcd setup
+        if: matrix.name == 'linux'
+        shell: bash
+        run: |
+          echo "AFTER ETCD SETUP:"
+          df -h /
+          df -a /
 
       - name: Run tests
         shell: bash
@@ -127,4 +143,12 @@ jobs:
           TEST_KBC_PROJECTS_LOCK_PASSWORD: ${{ secrets.TEST_KBC_PROJECTS_LOCK_PASSWORD }}
           TEST_KBC_PROJECTS_FILE: '${{ github.workspace }}/${{ vars.TEST_KBC_PROJECTS_FILE }}'
           UNIT_ETCD_ENABLED: ${{ matrix.name == 'linux' && 'true' || 'false' }}
+
+      - name: Check how much space is left after unit test
+        if: matrix.name == 'linux'
+        shell: bash
+        run: |
+          echo "AFTER UNIT TEST:"
+          df -h /
+          df -a /
 

--- a/internal/pkg/service/stream/storage/level/local/diskwriter/network/rpc/client.go
+++ b/internal/pkg/service/stream/storage/level/local/diskwriter/network/rpc/client.go
@@ -5,7 +5,6 @@ import (
 	"io"
 	"net"
 
-	"go.opentelemetry.io/contrib/instrumentation/google.golang.org/grpc/otelgrpc"
 	"google.golang.org/grpc"
 	"google.golang.org/grpc/codes"
 	"google.golang.org/grpc/connectivity"
@@ -86,12 +85,6 @@ func OpenNetworkFile(ctx context.Context, logger log.Logger, telemetry telemetry
 		grpc.WithContextDialer(dialer),
 		grpc.WithTransportCredentials(insecure.NewCredentials()),
 		grpc.WithDefaultServiceConfig(serviceConfig),
-		grpc.WithStatsHandler(
-			otelgrpc.NewClientHandler(
-				otelgrpc.WithMeterProvider(telemetry.MeterProvider()),
-				otelgrpc.WithTracerProvider(telemetry.TracerProvider()),
-			),
-		),
 	)
 	if err != nil {
 		return nil, err

--- a/scripts/tests.sh
+++ b/scripts/tests.sh
@@ -36,7 +36,7 @@ fi
 # Run tests, sequentially because the API is shared resource
 echo "Running tests ..."
 export KBC_VERSION_CHECK=false # do not check the latest version in the tests
-cmd="gotestsum --no-color=false --format \"$TEST_LOG_FORMAT\" -- -timeout 1200s -p $TEST_PARALLELISM_PKG -parallel $TEST_PARALLELISM $TEST_ARGS "$TEST_PACKAGE" $@"
+cmd="gotestsum --no-color=false --format \"$TEST_LOG_FORMAT\" -- -timeout 1800s -p $TEST_PARALLELISM_PKG -parallel $TEST_PARALLELISM $TEST_ARGS "$TEST_PACKAGE" $@"
 echo $cmd
 eval $cmd
 echo "Ok. All tests passed."

--- a/test/stream/bridge/keboola/keboola_test.go
+++ b/test/stream/bridge/keboola/keboola_test.go
@@ -24,8 +24,7 @@ import (
 	"github.com/keboola/keboola-as-code/internal/pkg/service/stream/storage/model"
 )
 
-// To see details run: TEST_VERBOSE=true go test ./test/stream/bridge/... -v
-
+// To see details run: TEST_VERBOSE=true go test ./test/stream/bridge/... -v.
 func TestKeboolaBridgeWorkflow(t *testing.T) {
 	t.Parallel()
 


### PR DESCRIPTION
**Changes:**
- Remove more things from Ubuntu image due to no space left on device.
- Add new logs into CI to show how much space is left after unit tests.
- Remove custom gRPC metrics that we do not use to save money on DD.

-----------
