### PR TITLE
fix: Use kbc-stacks trigger locally

### DIFF
--- a/.github/actions/trigger-image-tag-update/action.yaml
+++ b/.github/actions/trigger-image-tag-update/action.yaml
@@ -1,0 +1,66 @@
+name: Trigger image tag update
+description: 'Trigger image tag update workflow'
+inputs:
+  helm-chart:
+    description: "The Helm chart to update"
+    required: true
+  image-tag:
+    description: "The image tag to update to"
+    required: true
+  automerge:
+    description: "Automatically merge PRs"
+    required: false
+    default: 'true'
+  dry-run:
+    description: "Do a dry run"
+    required: false
+    default: 'false'
+  github-app-private-key:
+    description: 'The "Keboola - kbc-stacks trigger" GitHub App private key'
+    required: true
+
+
+runs:
+  using: 'composite'
+  steps:
+    - name: Generate a token
+      id: app-token
+      uses: actions/create-github-app-token@v1.11.0
+      with:
+        app-id: "1032801"
+        private-key: ${{ inputs.github-app-private-key }}
+        owner: ${{ github.repository_owner }}
+        repositories: "kbc-stacks"
+    - name: Trigger image tag update
+      shell: bash
+      env:
+        GH_TOKEN: ${{ steps.app-token.outputs.token }}
+      run: |
+        unset GITHUB_TOKEN
+
+        # Create metadata JSON with source information
+        METADATA=$(cat <<EOF
+        {
+          "source": {
+            "repository": "$GITHUB_REPOSITORY",
+            "repository_url": "$GITHUB_SERVER_URL/$GITHUB_REPOSITORY",
+            "sha": "$GITHUB_SHA",
+            "actor": "$GITHUB_ACTOR",
+            "workflow_url": "$GITHUB_SERVER_URL/$GITHUB_REPOSITORY/actions/runs/$GITHUB_RUN_ID",
+            "timestamp": "$(date -u +"%Y-%m-%dT%H:%M:%SZ")"
+          }
+        }
+        EOF
+        )
+
+        # Encode metadata to base64
+        ENCODED_METADATA=$(echo "$METADATA" | base64 -w 0)
+
+        gh workflow run update-image-tag.yaml \
+        -R keboola/kbc-stacks \
+        -r main \
+        -f helm-chart=${{ inputs.helm-chart }} \
+        -f image-tag=${{ inputs.image-tag }} \
+        -f automerge=${{ inputs.automerge }} \
+        -f dry-run=${{ inputs.dry-run }} \
+        -f metadata="$ENCODED_METADATA"

--- a/.github/workflows/release-service-apps-proxy.yml
+++ b/.github/workflows/release-service-apps-proxy.yml
@@ -89,7 +89,7 @@ jobs:
           acrPassword: ${{ secrets.APPS_PROXY_ACR_PASSWORD }}
 
       - name: Trigger image tag update
-        uses: keboola/kbc-stacks/.github/actions/trigger-image-tag-update@main
+        uses: ./.github/actions/trigger-image-tag-update
         with:
           helm-chart: "apps-proxy"
           image-tag: ${{ env.IMAGE_TAG }}

--- a/.github/workflows/release-service-stream.yml
+++ b/.github/workflows/release-service-stream.yml
@@ -41,10 +41,11 @@ jobs:
     name: "E2E: Stream"
     secrets: inherit
     uses: ./.github/workflows/test-e2e-service-stream.yml
-#  test-k8s-service-stream:
-#    name: "K8S: Stream"
-#    secrets: inherit
-#    uses: ./.github/workflows/test-k8s-service-stream.yml
+  # test-k8s-service-stream:
+  #   name: "K8S: Stream"
+  #   secrets: inherit
+  #   uses: ./.github/workflows/test-k8s-service-stream.yml
+
   build-and-push-api-image:
     name: "Build & Push Image"
     runs-on: ubuntu-latest
@@ -54,7 +55,7 @@ jobs:
       - test-lint
       - test-unit
       - test-e2e-service-stream
-#      - test-k8s-service-stream
+#     - test-k8s-service-stream
     steps:
       - name: Checkout
         uses: actions/checkout@v4
@@ -119,7 +120,7 @@ jobs:
           acrPassword: ${{ secrets.STREAM_ACR_PASSWORD }}
 
       - name: Trigger image tag update
-        uses: keboola/kbc-stacks/.github/actions/trigger-image-tag-update@main
+        uses: ./.github/actions/trigger-image-tag-update
         with:
           helm-chart: "stream"
           image-tag: ${{ env.IMAGE_TAG }}

--- a/.github/workflows/release-service-templates.yml
+++ b/.github/workflows/release-service-templates.yml
@@ -96,7 +96,7 @@ jobs:
           acrPassword: ${{ secrets.TEMPLATES_API_ACR_PASSWORD }}
 
       - name: Trigger image tag update
-        uses: keboola/kbc-stacks/.github/actions/trigger-image-tag-update@main
+        uses: ./.github/actions/trigger-image-tag-update
         with:
           helm-chart: "templates-api"
           image-tag: ${{ env.IMAGE_TAG }}


### PR DESCRIPTION
Public repos can't use GitHub Actions from private repos, so we're "forking" the kbc-stacks trigger here. The workflow itself still runs in kbc-stacks, it's just triggered from someplace else now 🤷 

Worked here: https://github.com/keboola/keboola-as-code/actions/runs/12256767310
Which triggered this (it is fine it's failed): https://github.com/keboola/kbc-stacks/actions/runs/12256770547/job/34192752960

You would need to presumably delete [this tag](https://github.com/keboola/keboola-as-code/tree/production-stream-v0.3.23) and create new one :( Sowwy.