### PR TITLE
fix: Add -race command line argument only for development branches

### DIFF
--- a/.github/actions/go-setup/action.yml
+++ b/.github/actions/go-setup/action.yml
@@ -187,6 +187,6 @@ runs:
     # To find problematic dir/file: Run the workflow twice, download tests logs, sort lines and make a diff.
     # https://pkg.go.dev/cmd/go#hdr-Build_and_test_caching
     - name: Enable debugging of the Go test cache
-      if: false # disabled, enable for debugging
+      if: true # disabled, enable for debugging
       shell: bash
       run: echo "GODEBUG=gocachehash=1" >> $GITHUB_ENV

--- a/.github/workflows/test-unit.yml
+++ b/.github/workflows/test-unit.yml
@@ -151,8 +151,18 @@ jobs:
       - name: Upload test cache
         uses: actions/upload-artifact@v4
         with:
-          name: gotestcache
+          name: gotestcache-${{ runner.os }}
           path: ${{ github.workspace }}/cache.out
+
+      - name: Set env variable
+        run: |
+          echo "GOCACHE=`go env GOCACHE`" >> $GITHUB_ENV
+
+      - name: Uploade test cache folder
+        uses: actions/upload-artifact@v4
+        with:
+          name: gotestcachef-${{ runner.os }}
+          path: ${{ env.GOCACHE }}
 
       - name: Check how much space is left after unit test
         if: matrix.name == 'linux'

--- a/.github/workflows/test-unit.yml
+++ b/.github/workflows/test-unit.yml
@@ -148,6 +148,12 @@ jobs:
           TEST_KBC_PROJECTS_FILE: '${{ github.workspace }}/${{ vars.TEST_KBC_PROJECTS_FILE }}'
           UNIT_ETCD_ENABLED: ${{ matrix.name == 'linux' && 'true' || 'false' }}
 
+      - name: Upload test cache
+        uses: actions/upload-artifact@v4
+        with:
+          name: gotestcache
+          path: ${{ github.workspace }}/cache.out
+
       - name: Check how much space is left after unit test
         if: matrix.name == 'linux'
         shell: bash

--- a/.github/workflows/test-unit.yml
+++ b/.github/workflows/test-unit.yml
@@ -16,6 +16,7 @@ env:
   TEST_PARALLELISM: 12
   TEST_PARALLELISM_PKG: 6
   TEST_COVERAGE: ${{ inputs.without-cache == true }}
+  TEST_DETECT_RACE: ${{ inputs.without-cache == true }}
 
 # Required for aws-actions/configure-aws-credentials using OIDC, assume role
 permissions:
@@ -41,8 +42,10 @@ jobs:
         run: git config --global core.autocrlf false
 
       - name: Change default TEST_COVERAGE when on main branch
-        if: github.ref == 'refs/heads/main'
-        run: echo "TEST_COVERAGE=true" >> $GITHUB_ENV
+        if: github.ref == 'refs/heads/main' || startsWith(github.ref, 'refs/tags/')
+        run: |
+          echo "TEST_COVERAGE=true" >> $GITHUB_ENV
+          echo "TEST_DETECT_RACE=true" >> $GITHUB_ENV
 
       - name: Checkout
         uses: actions/checkout@v4
@@ -132,6 +135,7 @@ jobs:
             TEST_PARALLELISM="$TEST_PARALLELISM" \
             TEST_PARALLELISM_PKG="$TEST_PARALLELISM_PKG" \
             TEST_COVERAGE="$TEST_COVERAGE" \
+            TEST_DETECT_RACE="$TEST_DETECT_RACE" \
             TEST_CREATE_OUT_DIR="false" \
             TEST_KBC_PROJECTS_LOCK_HOST="$TEST_KBC_PROJECTS_LOCK_HOST" \
             TEST_KBC_PROJECTS_LOCK_PASSWORD="$TEST_KBC_PROJECTS_LOCK_PASSWORD" \

--- a/Makefile
+++ b/Makefile
@@ -61,7 +61,7 @@ tests-verbose:
 	TEST_VERBOSE=true TEST_LOG_FORMAT=standard-verbose TEST_PACKAGE=./... bash ./scripts/tests.sh
 
 tests-unit:
-	TEST_PACKAGE=./internal/pkg/... bash ./scripts/tests.sh
+	TEST_PACKAGE=./internal/pkg/diff/... bash ./scripts/tests.sh
 
 tests-unit-verbose:
 	TEST_VERBOSE=true TEST_LOG_FORMAT=standard-verbose TEST_PARALLELISM=1 TEST_PARALLELISM_PKG=1 TEST_PACKAGE=./internal/pkg... bash ./scripts/tests.sh

--- a/scripts/tests.sh
+++ b/scripts/tests.sh
@@ -36,7 +36,7 @@ fi
 # Run tests, sequentially because the API is shared resource
 echo "Running tests ..."
 export KBC_VERSION_CHECK=false # do not check the latest version in the tests
-cmd="gotestsum --no-color=false --format \"$TEST_LOG_FORMAT\" -- -timeout 1800s -p $TEST_PARALLELISM_PKG -parallel $TEST_PARALLELISM $TEST_ARGS "$TEST_PACKAGE" $@ 2> cache.out"
+cmd="GODEBUG=gocachehash=1 gotestsum --no-color=false --format \"$TEST_LOG_FORMAT\" -- -timeout 1800s -p $TEST_PARALLELISM_PKG -parallel $TEST_PARALLELISM $TEST_ARGS "$TEST_PACKAGE" $@ 2> cache.out"
 echo $cmd
 eval $cmd
 echo "Ok. All tests passed."

--- a/scripts/tests.sh
+++ b/scripts/tests.sh
@@ -36,7 +36,7 @@ fi
 # Run tests, sequentially because the API is shared resource
 echo "Running tests ..."
 export KBC_VERSION_CHECK=false # do not check the latest version in the tests
-cmd="gotestsum --no-color=false --format \"$TEST_LOG_FORMAT\" -- -timeout 1800s -p $TEST_PARALLELISM_PKG -parallel $TEST_PARALLELISM $TEST_ARGS "$TEST_PACKAGE" $@"
+cmd="gotestsum --no-color=false --format \"$TEST_LOG_FORMAT\" -- -timeout 1800s -p $TEST_PARALLELISM_PKG -parallel $TEST_PARALLELISM $TEST_ARGS "$TEST_PACKAGE" $@ 2> cache.out"
 echo $cmd
 eval $cmd
 echo "Ok. All tests passed."


### PR DESCRIPTION
Jira: [PSGO-944](https://keboola.atlassian.net/browse/PSGO-944)

**Changes:**
- on main and tagged branches the `-race` argument is always present.

-----------


[PSGO-944]: https://keboola.atlassian.net/browse/PSGO-944?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ