### PR TITLE
feat: Add apps proxy local development docs

### DIFF
--- a/.github/workflows/test-lint.yml
+++ b/.github/workflows/test-lint.yml
@@ -45,6 +45,7 @@ jobs:
             --exclude '^https://app.datadoghq.eu/.*'
             --exclude '^https://community.chocolatey.org/.*'
             --exclude '^https://packages.debian.org/$'
+            --exclude '^https://test.hub.keboola.local/$'
 
       - name: Run code linters
         run: make lint

--- a/.gitignore
+++ b/.gitignore
@@ -50,3 +50,7 @@ vendor/*
 
 # CPU profiles
 /**/*.prof
+
+# Certificates
+/ca
+/certs

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -5,19 +5,20 @@ services:
       context: .
       dockerfile: ./provisioning/dev/docker/Dockerfile
     # Uncomment when you would like to inspect metrics of your service using prometheus container.
-    # Change the <your-service> placeholder with desired service to be inspected.
+    # Change the <your-service> placeholder with desired service to be inspected. E.g apps-proxy
     # See ./docs/development.md for more information how to startup the compose etc.
     #command: >
     #       sh -c "git config --global --add safe.directory /code
-    #       make run-<your-service>"
+    #              make run-<your-service>"
     links:
       - etcd
       - redis
-      - sandboxesMock
+      - sandboxesmock
       - prometheus
     networks:
       - prometheus
       - etcd
+      - apps-proxy
     volumes:
       - ./:/code:z
       - cache:/tmp/cache
@@ -49,6 +50,7 @@ services:
       - APPS_PROXY_LISTEN_ADDRESS=0.0.0.0:8002
       - APPS_PROXY_METRICS_LISTEN_ADDRESS=0.0.0.0:9002
       - APPS_PROXY_API_PUBLIC_URL=https://hub.keboola.local
+      - APPS_PROXY_SANDBOXES_API_URL=http://sandboxesmock:1080/
       - APPS_PROXY_COOKIE_SECRET_SALT=secret
       # Disable DataDog integration
       - TEMPLATES_DATADOG_ENABLED=false
@@ -145,7 +147,7 @@ services:
       - K6_RAMPING_DOWN_DURATION
       - STREAM_PAYLOAD_SIZE
 
-  sandboxesMock:
+  sandboxesmock:
     image: mockserver/mockserver:latest
     ports:
       - 1080:1080
@@ -155,6 +157,23 @@ services:
       MOCKSERVER_INITIALIZATION_JSON_PATH: /config/sandboxesMock.json
     volumes:
       - ./provisioning/apps-proxy/dev/sandboxesMock.json:/config/sandboxesMock.json:Z
+    networks:
+      - apps-proxy
+
+  https-proxy:
+    image: https-proxy
+    volumes:
+      - ./ca:/etc/nginx/ca
+      - ./certs:/etc/nginx/certs
+    environment:
+      - DOMAIN=hub.keboola.local
+      - TARGET_HOST=dev
+      - TARGET_HOST_HEADER=test.hub.keboola.local
+      - TARGET_PORT=8000
+    ports:
+      - 443:443
+    networks:
+      - apps-proxy
 
   prometheus:
     image: prom/prometheus
@@ -172,3 +191,4 @@ networks:
   prometheus:
     driver: bridge
   etcd:
+  apps-proxy:

--- a/docs/apps-proxy/overview.md
+++ b/docs/apps-proxy/overview.md
@@ -1,7 +1,7 @@
 # Apps proxy Architecture Overview
 
 - Serves for data apps authentication and authorization.
-- Typicall usage is to perform OIDC login through some OIDC provider (e.g Microsoft login, google login etc.)
+- Typicall usage is to perform OIDC login through some OIDC provider (e.g Microsoft login, Google login etc.)
 - Has possibility to add basic authorization which consists of password prompt on a web page.
 
 
@@ -19,27 +19,19 @@ In `/etc/hosts` add this:
 127.0.0.1 test.hub.keboola.local
 127.0.0.1 hub.keboola.local
 ```
-In project directory run:
-
+In project directory uncommect in [docker-compose.yml](../../docker-compose.yml) the `command` section and fill it with `apps-proxy` service. It should look like this
 ```
-docker compose run --rm --service-ports dev --net=my-test bash
+command: >
+    sh -c "git config --global --add safe.directory /code
+           make run-apps-proxy"
 ```
 
-Inside this bash run:
-
+Then launch the dev container
 ```
-make run-app-proxy
+docker compose up -d dev
 ```
 
 There is a sandboxes service mock in place which returns configuration of data app. Simply adjust the [provisioning/apps-proxy/dev/sandboxesMock.json](../../provisioning/apps-proxy/dev/sandboxesMock.json) if you want to change received configuration by local testing.
-
-Out of the container check for <containerid> using
-
-```
-docker ps -a
-```
-
-Find ID of the container running the `dev` environment.
 
 Next clone this repository: GitHub - [fsouza/docker-ssl-proxy](https://github.com/fsouza/docker-ssl-proxy)
 
@@ -49,18 +41,10 @@ In its directory run this:
 docker build -t https-proxy .
 ```
 
-And then in this command replace <containerid> with the id from earlier:
+And then go back to the root repository and launch the https-proxy:
 
 ```
-docker run --net=cli_default --rm \
-  --env DOMAIN=test.hub.keboola.local \
-  --env TARGET_HOST=<containerid> \
-  --env TARGET_HOST_HEADER=test.hub.keboola.local \
-  --env TARGET_PORT=8002 \
-  -p 443:443 \
-  --volume=./ca:/etc/nginx/ca \
-  --volume=./certs:/etc/nginx/certs \
-  https-proxy
+docker compose up https-proxy 
 ```
 
 Now the proxy should be available under https://test.hub.keboola.local/.

--- a/docs/apps-proxy/overview.md
+++ b/docs/apps-proxy/overview.md
@@ -1,0 +1,68 @@
+# Apps proxy Architecture Overview
+
+- Serves for data apps authentication and authorization.
+- Typicall usage is to perform OIDC login through some OIDC provider (e.g Microsoft login, google login etc.)
+- Has possibility to add basic authorization which consists of password prompt on a web page.
+
+
+## Entrypoint
+
+[cmd/apps-proxy/main.go](../../cmd/apps-proxy/main.go)
+
+## Apps Proxy Options
+
+## Operations
+
+In `/etc/hosts` add this:
+
+```
+127.0.0.1 test.hub.keboola.local
+127.0.0.1 hub.keboola.local
+```
+In project directory run:
+
+```
+docker compose run --rm --service-ports dev --net=my-test bash
+```
+
+Inside this bash run:
+
+```
+make run-app-proxy
+```
+
+There is a sandboxes service mock in place which returns configuration of data app. Simply adjust the [provisioning/apps-proxy/dev/sandboxesMock.json](../../provisioning/apps-proxy/dev/sandboxesMock.json) if you want to change received configuration by local testing.
+
+Out of the container check for <containerid> using
+
+```
+docker ps -a
+```
+
+Find ID of the container running the `dev` environment.
+
+Next clone this repository: GitHub - [fsouza/docker-ssl-proxy](https://github.com/fsouza/docker-ssl-proxy)
+
+In its directory run this:
+
+```
+docker build -t https-proxy .
+```
+
+And then in this command replace <containerid> with the id from earlier:
+
+```
+docker run --net=cli_default --rm \
+  --env DOMAIN=test.hub.keboola.local \
+  --env TARGET_HOST=<containerid> \
+  --env TARGET_HOST_HEADER=test.hub.keboola.local \
+  --env TARGET_PORT=8002 \
+  -p 443:443 \
+  --volume=./ca:/etc/nginx/ca \
+  --volume=./certs:/etc/nginx/certs \
+  https-proxy
+```
+
+Now the proxy should be available under https://test.hub.keboola.local/.
+
+

--- a/provisioning/apps-proxy/dev/.air.toml
+++ b/provisioning/apps-proxy/dev/.air.toml
@@ -3,7 +3,7 @@ tmp_dir = "target/.watcher"
 
 [build]
   bin = "./target/apps-proxy/proxy"
-  args_bin = ["--sandboxes-api-url",  "http://localhost:1080", "--sandboxes-api-token", "my-token", "--metrics-listen", "0.0.0.0:9002", "--api-public-url", "http://localhost:8000", "--cookie-secret-salt", "cookie", "--csrf-token-salt", "bcc3add3bf72e628149fbfbc11932329de7f375db3d8503ef0e32b336adf46c4"]
+  args_bin = ["--sandboxes-api-token", "my-token", "--metrics-listen", "0.0.0.0:9002", "--api-public-url", "http://hub.keboola.local", "--cookie-secret-salt", "cookie", "--csrf-token-salt", "bcc3add3bf72e628149fbfbc11932329de7f375db3d8503ef0e32b336adf46c4"]
   cmd = "make build-apps-proxy"
   delay = 2000
   exclude_dir = []

--- a/provisioning/apps-proxy/dev/sandboxesMock.json
+++ b/provisioning/apps-proxy/dev/sandboxesMock.json
@@ -2,11 +2,11 @@
   {
     "httpRequest": {
       "method": "GET",
-      "path": "/apps/123/proxy-config"
+      "path": "/apps/test/proxy-config"
     },
     "httpResponse": {
       "body": {
-        "appId": "123",
+        "appId": "test",
         "appName": "app",
         "projectId": "11",
         "upstreamAppUrl": "http://localhost:1235",


### PR DESCRIPTION
Jira: [PSGO-919](https://keboola.atlassian.net/browse/PSGO-919)

**Changes:**
- Add apps proxy documentation for local development.
- Include short overview of apps proxy, what is it, why we have it and how to use it.
- Add basic configuration of the apps proxy for development on local machine.

-----------


[PSGO-919]: https://keboola.atlassian.net/browse/PSGO-919?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ