### PR TITLE
feat: Commit pipeline's SHA next to the image tag for Argo deployments

### DIFF
--- a/.github/actions/trigger-image-tag-update/action.yaml
+++ b/.github/actions/trigger-image-tag-update/action.yaml
@@ -15,6 +15,10 @@ inputs:
     description: "Do a dry run"
     required: false
     default: 'false'
+  commit-sha:
+    description: "Enable to commit pipeline's SHA to tag.yaml"
+    required: false
+    default: 'true'
   github-app-private-key:
     description: 'The "Keboola - kbc-stacks trigger" GitHub App private key'
     required: true
@@ -63,4 +67,5 @@ runs:
         -f image-tag=${{ inputs.image-tag }} \
         -f automerge=${{ inputs.automerge }} \
         -f dry-run=${{ inputs.dry-run }} \
+        -f commit-sha=${{ inputs.commit-sha }} \
         -f metadata="$ENCODED_METADATA"


### PR DESCRIPTION
Jira: [ST-2598](https://keboola.atlassian.net/browse/ST-2598?atlOrigin=eyJpIjoiM2UzMWM4M2RjZDYxNGY2ZGI5YTI3ODI3ODg1OWJjNjIiLCJwIjoiaiJ9)

This is enablement allowing for Datadog annotation to show from which commit has been the deployed image actually built. Context: https://keboolaglobal.slack.com/archives/C055WKPHYSD/p1732634259450249?thread_ts=1732550113.610629&cid=C055WKPHYSD

When set to `true`, this flag will commit the SHA next to the image tag, [like so](https://github.com/keboola/sre-playground/pull/255/files). This can then be referenced for the Datadog in the [annotations](https://github.com/keboola/kbc-stacks/blob/3f17337cb8157ca798d9bce38a4af8ef7f845bfb/apps/stream/templates/api-deployment.yaml#L26).

This is in tandem with these implementations:
- https://github.com/keboola/helm-image-updater/pull/4
- https://github.com/keboola/helm-image-updater/pull/5
- https://github.com/keboola/kbc-stacks/pull/1719

[ST-2598]: https://keboola.atlassian.net/browse/ST-2598?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ