### PR TITLE
fix: Preserve decrypted tokens on migration

### DIFF
--- a/internal/pkg/service/stream/sink/type/tablesink/keboola/bridge/file.go
+++ b/internal/pkg/service/stream/sink/type/tablesink/keboola/bridge/file.go
@@ -173,7 +173,8 @@ func (b *Bridge) importFile(ctx context.Context, file plugin.File, stats statist
 	// Decrypt token
 	token, err := existingToken.DecryptToken(ctx, b.tokenEncryptor, metadata)
 	if err != nil {
-		return err
+		b.logger.Errorf(ctx, "cannot decrypt token: %s", err)
+		token = *existingToken.Token
 	}
 
 	// Authorized API

--- a/internal/pkg/service/stream/sink/type/tablesink/keboola/bridge/job.go
+++ b/internal/pkg/service/stream/sink/type/tablesink/keboola/bridge/job.go
@@ -86,7 +86,8 @@ func (b *Bridge) CleanJob(ctx context.Context, job model.Job) (err error, delete
 	// Decrypt token
 	token, err := existingToken.DecryptToken(ctx, b.tokenEncryptor, metadata)
 	if err != nil {
-		return err, false
+		b.logger.Errorf(ctx, "cannot decrypt token: %s", err)
+		token = *existingToken.Token
 	}
 
 	// Get job details from storage API

--- a/internal/pkg/service/stream/sink/type/tablesink/keboola/bridge/slice.go
+++ b/internal/pkg/service/stream/sink/type/tablesink/keboola/bridge/slice.go
@@ -43,7 +43,8 @@ func (b *Bridge) uploadSlice(ctx context.Context, volume *diskreader.Volume, sli
 	// Decrypt token
 	token, err := existingToken.DecryptToken(ctx, b.tokenEncryptor, metadata)
 	if err != nil {
-		return err
+		b.logger.Errorf(ctx, "cannot decrypt token: %s", err)
+		token = *existingToken.Token
 	}
 
 	// Error when sending the event is not a fatal error

--- a/internal/pkg/service/stream/sink/type/tablesink/keboola/bridge/token.go
+++ b/internal/pkg/service/stream/sink/type/tablesink/keboola/bridge/token.go
@@ -87,7 +87,8 @@ func (b *Bridge) tokenForSink(ctx context.Context, now time.Time, sink definitio
 		// Decrypt token
 		token, err := existingToken.DecryptToken(ctx, b.tokenEncryptor, metadata)
 		if err != nil {
-			return keboola.Token{}, err
+			b.logger.Errorf(ctx, "cannot decrypt token: %s", err)
+			token = *existingToken.Token
 		}
 
 		// Operation is not called from the API and there is a token in the database, so we are using the token.

--- a/internal/pkg/service/stream/sink/type/tablesink/keboola/bridge/token.go
+++ b/internal/pkg/service/stream/sink/type/tablesink/keboola/bridge/token.go
@@ -201,7 +201,7 @@ func (b *Bridge) encryptRawTokens(ctx context.Context, tokens []keboolasink.Toke
 	var updated []keboolasink.Token
 	txn := op.TxnWithResult(b.client, &updated)
 	for _, token := range tokens {
-		if token.Token == nil {
+		if token.Token == nil || token.EncryptedToken != "" {
 			continue
 		}
 
@@ -220,7 +220,6 @@ func (b *Bridge) encryptToken(ctx context.Context, token keboolasink.Token) *op.
 	}
 	token.TokenID = token.Token.ID
 	token.EncryptedToken = string(ciphertext)
-	token.Token = nil
 
 	return b.saveToken(ctx, token)
 }

--- a/internal/pkg/service/stream/sink/type/tablesink/keboola/bridge/token_test.go
+++ b/internal/pkg/service/stream/sink/type/tablesink/keboola/bridge/token_test.go
@@ -216,7 +216,7 @@ func TestBridge_MigrateTokens(t *testing.T) {
 	{
 		err := bridgeSchema.Token().ForSink(sinkKey1).GetOrErr(client).WithResultTo(&token1).Do(ctx).Err()
 		require.NoError(t, err)
-		assert.Nil(t, token1.Token)
+		assert.NotNil(t, token1.Token)
 		assert.Equal(t, "1", token1.TokenID)
 		assert.NotNil(t, token1.EncryptedToken)
 
@@ -229,7 +229,7 @@ func TestBridge_MigrateTokens(t *testing.T) {
 	{
 		err := bridgeSchema.Token().ForSink(sinkKey2).GetOrErr(client).WithResultTo(&token2).Do(ctx).Err()
 		require.NoError(t, err)
-		assert.Nil(t, token2.Token)
+		assert.NotNil(t, token2.Token)
 		assert.Equal(t, "2", token2.TokenID)
 		assert.NotNil(t, token2.EncryptedToken)
 
@@ -249,7 +249,7 @@ func TestBridge_MigrateTokens(t *testing.T) {
 		var token keboolasink.Token
 		err := bridgeSchema.Token().ForSink(sinkKey1).GetOrErr(client).WithResultTo(&token).Do(ctx).Err()
 		require.NoError(t, err)
-		assert.Nil(t, token.Token)
+		assert.NotNil(t, token.Token)
 		assert.Equal(t, "1", token.TokenID)
 		assert.Equal(t, token.EncryptedToken, token1.EncryptedToken)
 	}
@@ -257,7 +257,7 @@ func TestBridge_MigrateTokens(t *testing.T) {
 		var token keboolasink.Token
 		err := bridgeSchema.Token().ForSink(sinkKey2).GetOrErr(client).WithResultTo(&token).Do(ctx).Err()
 		require.NoError(t, err)
-		assert.Nil(t, token.Token)
+		assert.NotNil(t, token.Token)
 		assert.Equal(t, "2", token.TokenID)
 		assert.Equal(t, token.EncryptedToken, token2.EncryptedToken)
 	}


### PR DESCRIPTION
Migration now preserves the decrypted tokens. The script still tries to use and decrypt the encrypted token if it exists but if decryption fails it will just log an error and use the decrypted token.