### PR TITLE
fix: Disk writer cannot send remaining data after etcd shutdown

### DIFF
--- a/.cursorignore
+++ b/.cursorignore
@@ -1,0 +1,8 @@
+# Add directories or file patterns to ignore during indexing (e.g. foo/ or *.csv)
+vendor/*
+third_party/*
+.git/*
+.idea/*
+.vscode/*
+.DS_Store
+build/*

--- a/.cursorrules
+++ b/.cursorrules
@@ -1,0 +1,258 @@
+# Code Organization Principles
+- Keep modules under 500 lines (excluding tests)
+- Follow KISS (Keep It Simple, Stupid)
+  - Write clear, straightforward code
+  - Avoid unnecessary complexity
+  - Prefer readability over cleverness
+- Follow DRY (Don't Repeat Yourself)
+  - Extract common functionality into reusable components
+  - Use interfaces for common behavior patterns
+  - Avoid code duplication
+
+# Project Overview
+- Go-based project using ETCD for distributed storage and synchronization
+- Custom ETCD wrapper (`etcdop`) for enhanced functionality
+- Focus on filesystem operations, git integration, and data streaming
+
+# Tech Stack
+- **Language**: Go 1.24+
+- **Storage**: ETCD v3.5.17
+- **Key Libraries**:
+  - `go.etcd.io/etcd/client/v3`: ETCD client
+  - `go.opentelemetry.io/otel`: Telemetry and metrics
+  - `github.com/stretchr/testify`: Testing framework
+  - `github.com/spf13/cobra`: CLI framework
+  - `github.com/go-playground/validator/v10`: Struct validation
+- **Custom Components**:
+  - `etcdop`: ETCD operations wrapper
+  - Custom Go validator tags
+  - Filesystem operations
+  - Git integration
+  - Custom CLI testing suite:
+    - Integration test framework for CLI commands
+    - Snapshot testing for command outputs
+    - Mocked filesystem and ETCD operations
+    - Test fixtures and helpers
+
+# Testing Patterns
+- Unit tests with `*_test.go` suffix
+- Test files located next to implementation
+- Heavy use of ETCD testing utilities
+- Mirror tree and map testing for ETCD operations
+- Use testify/assert for assertions
+- Table-driven tests preferred
+- End-to-End API Testing:
+  - Templates API tests using `/test/` fixtures
+  - Stream API tests using `/test/` fixtures
+  - Integration tests with mocked dependencies
+  - Snapshot testing for API responses
+  - Serves as comprehensive end-to-end test suite
+  - Validates complete request-response cycles
+  - Tests full integration with ETCD and filesystem
+
+# Key Directories
+## API Design
+- `api/`: API definitions and interfaces
+  - `templates/`: Templates API specifications
+  - `stream/`: Stream API specifications
+  - `appsproxy/`: Apps Proxy API specifications
+  - `docs/`: API documentation in Markdown
+
+## Main Entry Points
+- `cmd/`: Main program entry points
+  - `templates-api/`: Templates service executable
+  - `stream-api/`: Stream service executable
+  - `appsproxy-api/`: Apps Proxy service executable
+  - `kbc/`: CLI part of Keboola Connection service
+
+## Internal Implementation
+- `internal/pkg/service/`:
+  - `appsproxy/`: Apps Proxy service implementation
+    - Handles proxy requests to apps
+    - Manages app lifecycle and routing
+    - Implements security and rate limiting
+  - `cli/`: CLI implementation
+    - Command-line interface tools
+    - Service management utilities
+    - Configuration handling
+  - `common/etcdop/`: ETCD operations and wrappers
+    - Custom ETCD client operations
+    - Watch and mirror implementations
+    - Transaction handling
+  - `stream/`: Stream service implementation
+    - Data streaming functionality
+    - Pipeline processing
+    - Event handling and routing
+  - `templates/`: Templates service implementation
+    - Template management
+    - Version control integration
+    - Template rendering and validation
+- `internal/pkg/telemetry/`: OpenTelemetry integration
+  - Metrics collection
+  - Tracing implementation
+  - Performance monitoring
+- `internal/pkg/utils/`: Shared utilities and helpers
+  - Common functions and tools
+  - Shared interfaces
+  - Helper utilities
+
+## Kubernetes Deployment
+- `provisioning/`: Kubernetes deployment and configuration
+  - `stream/`: Stream service deployment
+    - Service configuration
+    - Resource limits and scaling
+    - Network policies
+  - `templates-api/`: Templates API service deployment
+    - API server configuration
+    - Storage settings
+    - Service mesh integration
+  - `apps-proxy/`: Apps Proxy service deployment
+    - Proxy configuration
+    - Load balancing settings
+    - Security policies
+  - `cli-dist/`: CLI distribution configuration
+    - Binary packaging
+    - Distribution settings
+    - Version management
+  - `common/`: Shared deployment resources
+    - Common configurations
+    - Shared secrets
+    - Network policies
+  - `dev/`: Development environment setup
+    - Local development settings
+    - Testing configurations
+    - Debug tools
+
+## Documentation
+- `docs/`: Project documentation in Markdown
+  - Service-specific documentation:
+    - `stream/`: Stream service documentation
+    - `templates/`: Templates service documentation
+    - `apps-proxy/`: Apps Proxy documentation
+    - `cli/`: CLI documentation
+  - Core documentation files:
+    - `development.md`: Development setup and guidelines
+    - `telemetry.md`: Telemetry and metrics documentation
+    - `cli-release.md`: CLI release process
+    - `e2e_tests.md`: End-to-end testing guide
+    - `etcd.md`: ETCD usage and patterns
+    - `README.md`: Project overview
+
+# Common Patterns
+- Watch operations for ETCD (`watch_*.go`)
+- Mirror tree implementations
+- Network connections and disk writers
+- Telemetry integration with OpenTelemetry
+
+# Environment
+- Development uses Docker (see `docker-compose.yml`)
+- Local ETCD instance required for testing
+- Telemetry metrics collection
+
+# Code Style & Linting Rules
+## General
+- Line length: max 120 characters
+- File length: max 500 lines
+- Function length: max 50 lines
+- Package names: lowercase, single word
+
+## Naming Conventions
+- Interfaces: end with 'er' (e.g., `Reader`, `Writer`)
+- Test functions: `Test` prefix (e.g., `TestMyFunction`)
+- Benchmark functions: `Benchmark` prefix
+- Mock implementations: `Mock` prefix
+
+## Error Handling
+- Always handle errors
+- Use wrapped errors with `fmt.Errorf("... %w", err)`
+- Custom error types for domain-specific errors
+- No empty interface (`interface{}`) unless absolutely necessary
+
+## Comments
+- All exported symbols must be documented
+- Use complete sentences with proper punctuation
+- Start with the name of the thing being documented
+- Include examples in package documentation
+
+## Testing
+- Coverage target: 80%
+- Use subtests for table-driven tests
+- Mock external dependencies
+- One assertion per test when possible
+
+## Test Execution
+- Run all tests: `go test ./...`
+- Run tests with coverage: `go test -coverprofile=coverage.out ./...`
+- View coverage report: `go tool cover -func=coverage.out`
+- View HTML coverage report: `go tool cover -html=coverage.out`
+
+## Current Coverage Highlights
+- High coverage (>80%):
+  - `diff`: 91.6%
+  - `json/schema`: 84.5%
+  - `jsonnet/fsimporter`: 100%
+  - `template/replacevalues`: 84.3%
+  - `orchestrator`: 81.1%
+- Medium coverage (60-80%):
+  - Most filesystem operations
+  - Git operations: 74.5%
+  - Mapper components
+  - Environment handling
+- Areas needing improvement (<60%):
+  - Model package: 24.7%
+  - Some platform models
+  - Memory filesystem operations
+
+## Prohibited
+- Global variables (gochecknoglobals)
+- init() functions (gochecknoinits) 
+- Debug print statements (fmt.Print*, print, println) - use logger instead
+- Direct "os" package filesystem operations - use "internal/pkg/filesystem" instead
+- Direct "filepath" package usage - use "internal/pkg/filesystem" instead
+- "httpmock" singleton - use client.Transport = httpmock.NewMockTransport()
+- OS ENVs singleton (os.Setenv, etc.) - use env.Map instead
+- Direct os.Stdout/os.Stderr usage - use dependencies instead
+- fmt.Errorf - use errors.Errorf for stack traces
+- "gonanoid" package - use "internal/pkg/idgenerator" instead
+- Direct "errors" package - use "internal/pkg/utils/errors"
+- Direct "zap" logger - use "internal/pkg/log" package
+- Naked returns
+- Underscores in package names
+
+## Required
+- Context Handling:
+  - Pass context as first parameter
+  - Respect cancellation in long-running operations
+  - Use context timeouts for external calls
+  - Never store context in structs
+
+- Concurrency Patterns:
+  - Fan-out/Fan-in for parallel processing
+  - Worker pools for resource-intensive tasks
+  - Pipeline pattern for data streaming
+  - Use buffered channels appropriately
+  - Graceful shutdown with signal handling
+
+- Error Management:
+  - Use error wrapping with stack traces
+  - Custom error types for domain logic
+  - Error grouping for concurrent operations
+  - Sentinel errors for expected cases
+
+- Dependency Management:
+  - Constructor-based dependency injection
+  - Interface segregation (small interfaces)
+  - Use functional options for config
+  - Mock interfaces for testing
+
+- Performance:
+  - Use sync.Pool for frequent allocations
+  - Minimize allocations in hot paths
+  - Buffer reuse in IO operations
+  - Proper connection pooling
+
+- Observability:
+  - Structured logging with levels
+  - OpenTelemetry integration
+  - Metrics for critical paths
+  - Tracing for distributed operations

--- a/PROJECT_CONTEXT.md
+++ b/PROJECT_CONTEXT.md
@@ -1,0 +1,124 @@
+# Keboola-as-Code Project Context
+
+## Project Overview
+This is a Go-based distributed system project that provides several microservices:
+- Templates API: Manages and serves templates
+- Stream Service: Handles data streaming operations
+- Apps Proxy: Manages application proxying and routing
+
+The project uses ETCD for distributed storage and synchronization, with a custom wrapper (etcdop) for enhanced functionality.
+
+## Directory Structure
+
+### Core Components
+- `/api/`: API definitions and interfaces
+- `/cmd/`: Service entry points (templates-api, stream-api, apps-proxy, kbc)
+- `/internal/`: Core implementation
+  - `/pkg/service/`: Service implementations
+  - `/pkg/telemetry/`: OpenTelemetry integration
+  - `/pkg/utils/`: Shared utilities
+
+### Deployment & Infrastructure
+- `/provisioning/`: Kubernetes and deployment configurations
+  - `/stream/`: Stream service deployment
+  - `/templates-api/`: Templates API deployment
+  - `/apps-proxy/`: Apps Proxy deployment
+  - `/cli-dist/`: CLI distribution
+  - `/common/`: Shared resources
+  - `/dev/`: Development environment
+
+### Documentation & Testing
+- `/docs/`: Project documentation
+- `/test/`: Test fixtures and utilities
+- `/scripts/`: Utility scripts
+
+## Local Development
+
+### Docker Setup
+- Docker and Docker Compose
+- Go 1.24+
+- Make
+
+For Docker-based development, see [Development Guide](docs/development.md).
+
+### Local Machine Setup
+For development directly on your local machine without Docker, see [Local Development Guide](docs/local_development.md).
+
+### Services
+- Templates API: http://localhost:8000
+- Stream Service: http://localhost:8001
+- Apps Proxy: http://localhost:8002
+- Metrics:
+  - Templates: :9000
+  - Stream: :9001
+  - Apps Proxy: :9002
+
+### Development Tools
+- ETCD UI: http://localhost:2379
+- Prometheus: http://localhost:9090
+- Redis: localhost:6379
+
+## Deployment
+
+### Local Deployment
+```bash
+docker-compose up -d
+```
+
+### Production Deployment
+- Uses Kubernetes
+- Configuration in `/provisioning/{service}/`
+- Supports horizontal scaling
+- Uses ETCD for coordination
+
+### Infrastructure Requirements
+- ETCD cluster
+- Redis (for locking)
+- Prometheus (metrics)
+- Kubernetes cluster
+
+## CI/CD Pipeline
+
+### Testing
+- Unit tests: `make test`
+- Integration tests: `make integration-test`
+- E2E tests: `make e2e-test`
+
+### Build Process
+1. Code validation
+   - Linting
+   - Static analysis
+   - Security scanning
+2. Testing
+   - Unit tests
+   - Integration tests
+3. Build
+   - Docker images
+   - CLI binaries
+4. Deployment
+   - Staging
+   - Production
+
+### Monitoring & Observability
+- OpenTelemetry integration
+- Prometheus metrics
+- Service health checks
+- Distributed tracing
+
+## Configuration Management
+- Environment variables
+- ETCD for distributed configuration
+- Kubernetes ConfigMaps and Secrets
+
+## Security
+- ETCD authentication
+- API authentication
+- TLS encryption
+- Secure cookie handling
+- Sandboxed environments
+
+## Performance Considerations
+- ETCD operation batching
+- Connection pooling
+- Resource limits
+- Horizontal scaling support 

--- a/docs/development.md
+++ b/docs/development.md
@@ -1,5 +1,7 @@
 # Development
 
+This guide covers Docker-based development setup. For development directly on your local machine without Docker, see [Local Development Guide](local_development.md).
+
 ## Quick Start
 
 ### Clone

--- a/docs/local_development.md
+++ b/docs/local_development.md
@@ -1,0 +1,143 @@
+# Local Development Guide
+
+## Prerequisites
+
+- Go 1.24+
+- ETCD v3.5.17
+- Git
+- Make
+
+## Installation Steps
+
+### 1. Install Go
+```bash
+# For Ubuntu/Debian
+sudo apt-get update
+sudo apt-get install golang-1.24
+
+# For Arch Linux
+sudo pacman -S go
+
+# Verify installation
+go version
+```
+
+### 2. Install ETCD
+```bash
+# For Ubuntu/Debian
+sudo apt-get install etcd
+
+# For Arch Linux
+sudo pacman -S etcd
+
+# Start ETCD service
+sudo systemctl start etcd
+sudo systemctl enable etcd
+
+# Verify ETCD is running
+etcdctl endpoint health
+```
+
+### 3. Clone and Setup Project
+```bash
+# Clone repository
+git clone https://github.com/keboola/keboola-as-code
+cd keboola-as-code
+
+# Install dependencies
+go mod download
+go mod vendor
+
+# Create environment file
+cp .env.dist .env
+```
+
+### 4. Configure Environment
+
+Edit `.env` file with your settings:
+```bash
+TEST_KBC_TMP_DIR=/tmp
+TEST_KBC_PROJECTS_FILE=~/keboola-as-code/projects.json
+```
+
+Create `projects.json` with your project configuration:
+```json
+[
+  {
+    "host": "connection.keboola.com",
+    "project": 1234,
+    "stagingStorage": "s3",
+    "backend": "snowflake",
+    "token": "<your-token>",
+    "legacyTransformation": false
+  }
+]
+```
+
+### 5. Build and Test
+
+```bash
+# Run tests
+make test
+
+# Build local CLI binary
+make build-local
+
+# Run specific service (e.g., templates API)
+export TEMPLATES_STORAGE_API_HOST=connection.keboola.com
+go run cmd/templates-api/main.go
+
+# Run stream service
+export STREAM_STORAGE_API_HOST=connection.keboola.com
+go run cmd/stream-api/main.go
+```
+
+### 6. Development Tools
+
+#### Start Documentation Server
+```bash
+make godoc
+# Access at http://localhost:6060/pkg/github.com/keboola/keboola-as-code/?m=all
+```
+
+#### Run Tests with Verbose Output
+```bash
+# Verbose output
+TEST_VERBOSE=true go test -race -v ./...
+
+# HTTP client verbose
+TEST_HTTP_CLIENT_VERBOSE=true go test -race -v ./...
+
+# ETCD operations verbose
+ETCD_VERBOSE=true go test -race -v ./...
+```
+
+## Troubleshooting
+
+### Common Issues
+
+1. ETCD Connection Issues
+   - Verify ETCD is running: `systemctl status etcd`
+   - Check ETCD logs: `journalctl -u etcd`
+   - Ensure correct permissions on ETCD data directory
+
+2. Go Module Issues
+   - Run `go mod tidy` to clean up dependencies
+   - Run `go mod vendor` to update vendor directory
+   - Check `GOPATH` is set correctly
+
+3. Permission Issues
+   - Ensure correct ownership of project files
+   - Check ETCD data directory permissions
+   - Verify write permissions in `/tmp` directory
+
+## Service Endpoints
+
+When running locally:
+- Templates API: http://localhost:8000
+- Stream Service: http://localhost:8001
+- Apps Proxy: http://localhost:8002
+- Metrics endpoints:
+  - Templates: :9000
+  - Stream: :9001
+  - Apps Proxy: :9002 

--- a/internal/pkg/service/common/distribution/assigner.go
+++ b/internal/pkg/service/common/distribution/assigner.go
@@ -121,6 +121,6 @@ func (a *Assigner) addNode(nodeID string) {
 	a.nodes.Add(nodeID)
 }
 
-func (a *Assigner) removeNode(nodeID string) bool {
-	return a.nodes.Remove(nodeID)
+func (a *Assigner) removeNode(nodeID string) {
+	a.nodes.Remove(nodeID)
 }

--- a/internal/pkg/service/common/distribution/node.go
+++ b/internal/pkg/service/common/distribution/node.go
@@ -3,7 +3,6 @@ package distribution
 import (
 	"context"
 	"fmt"
-	"maps"
 	"sync"
 	"time"
 
@@ -251,12 +250,6 @@ func (n *GroupNode) updateNodesFrom(ctx context.Context, events []etcdop.WatchEv
 		}
 	}
 
-	// Make sure that nodes are updated only when there is maximum nodes
-	if len(n.duplicateNodes) > len(n.sameNodes) {
-		n.logger.Debugf(ctx, "more duplicate nodes than same nodes, skipping update")
-		return Events{}
-	}
-
 	for key, nodeChange := range n.sameNodes {
 		nodeChange.f(key)
 		if nodeChange.eventType == EventNodeRemoved {
@@ -265,6 +258,5 @@ func (n *GroupNode) updateNodesFrom(ctx context.Context, events []etcdop.WatchEv
 		n.logger.Infof(ctx, nodeChange.message)
 	}
 
-	maps.Copy(n.duplicateNodes, n.sameNodes)
 	return out
 }

--- a/internal/pkg/service/common/etcdop/watch.go
+++ b/internal/pkg/service/common/etcdop/watch.go
@@ -1,9 +1,7 @@
 package etcdop
 
 import (
-	"bytes"
 	"context"
-	"sort"
 	"time"
 
 	"go.etcd.io/etcd/api/v3/mvccpb"
@@ -190,16 +188,6 @@ func (v Prefix) WatchWithoutRestart(ctx context.Context, client etcd.Watcher, op
 				stream.channel <- resp
 				continue
 			}
-
-			// Sort events from the batch (if multiple keys have been modified in one txn, in one revision)
-			// 1. By type, PUT before DELETE
-			// 2. By key, A->Z
-			sort.SliceStable(rawResp.Events, func(i, j int) bool {
-				if rawResp.Events[i].Type != rawResp.Events[j].Type {
-					return rawResp.Events[i].Type < rawResp.Events[j].Type
-				}
-				return bytes.Compare(rawResp.Events[i].Kv.Key, rawResp.Events[j].Kv.Key) == -1
-			})
 
 			if len(rawResp.Events) > 0 {
 				resp.Events = make([]WatchEvent[[]byte], 0, len(rawResp.Events))

--- a/internal/pkg/service/common/etcdop/watch_mirror_tree.go
+++ b/internal/pkg/service/common/etcdop/watch_mirror_tree.go
@@ -226,7 +226,7 @@ func (m *MirrorTree[T, V]) WaitForRevision(ctx context.Context, expected int64) 
 		case <-ctx.Done():
 			return ctx.Err()
 		case <-notifier:
-			// try again
+			// The revision has been updated, try again
 		}
 	}
 }

--- a/internal/pkg/service/stream/sink/type/tablesink/keboola/bridge/job.go
+++ b/internal/pkg/service/stream/sink/type/tablesink/keboola/bridge/job.go
@@ -28,6 +28,7 @@ func (b *Bridge) createJob(ctx context.Context, file plugin.File, storageJob *ke
 
 	lock := b.locks.NewMutex(fmt.Sprintf("api.source.sink.jobs.%s", file.SinkKey))
 	if err := lock.Lock(ctx); err != nil {
+		b.logger.Errorf(ctx, "cannot lock the sink jobs: %s", err)
 		return err
 	}
 	defer func() {
@@ -110,6 +111,7 @@ func (b *Bridge) CleanJob(ctx context.Context, job model.Job) (err error, delete
 	// Acquire lock
 	mutex := b.locks.NewMutex(fmt.Sprintf("api.source.sink.jobs.%s", job.SinkKey))
 	if err = mutex.TryLock(ctx); err != nil {
+		b.logger.Errorf(ctx, "cannot lock the sink jobs: %s", err)
 		return err, false
 	}
 	defer func() {

--- a/internal/pkg/service/stream/storage/level/local/diskwriter/network/connection/connection_test.go
+++ b/internal/pkg/service/stream/storage/level/local/diskwriter/network/connection/connection_test.go
@@ -83,7 +83,6 @@ func TestConnectionManager(t *testing.T) {
 	w1.Process().WaitForShutdown()
 	w3.Process().Shutdown(ctx, errors.New("bye bye writer 3"))
 	w3.Process().WaitForShutdown()
-	waitForLog(t, sourceLogger, `{"level":"info","message":"the list of volumes has changed, updating connections","component":"storage.router.connections"}`)
 	waitForLog(t, sourceLogger, `{"level":"info","message":"disk writer client disconnected from \"w1\" - \"localhost:%s\": %s","component":"storage.router.connections.client.transport"}`)
 	waitForLog(t, sourceLogger, `{"level":"info","message":"disk writer client disconnected from \"w3\" - \"localhost:%s\": %s","component":"storage.router.connections.client.transport"}`)
 	sourceLogger.Truncate()

--- a/internal/pkg/service/stream/storage/level/local/diskwriter/network/router/pipeline/pipeline_slice.go
+++ b/internal/pkg/service/stream/storage/level/local/diskwriter/network/router/pipeline/pipeline_slice.go
@@ -2,6 +2,7 @@ package pipeline
 
 import (
 	"context"
+	"fmt"
 	"sync"
 	"time"
 
@@ -169,6 +170,7 @@ func (p *SlicePipeline) tryOpen() error {
 	// Open pipeline
 	p.pipeline, err = p.encoding.OpenPipeline(ctx, p.slice.SliceKey, p.slice.Mapping, p.slice.Encoding, remoteFile)
 	if err != nil {
+		fmt.Println("error opening pipeline", err)
 		_ = remoteFile.Close(ctx)
 		return errors.PrefixErrorf(err, "cannot open slice pipeline")
 	}

--- a/internal/pkg/service/stream/storage/level/local/diskwriter/network/rpc/client.go
+++ b/internal/pkg/service/stream/storage/level/local/diskwriter/network/rpc/client.go
@@ -2,8 +2,10 @@ package rpc
 
 import (
 	"context"
+	"fmt"
 	"io"
 	"net"
+	"strings"
 
 	"go.opentelemetry.io/otel/attribute"
 	"google.golang.org/grpc"
@@ -138,7 +140,8 @@ func OpenNetworkFile(
 		ctx := context.Background()
 		// It is expected to receive only one message, `io.EOF` or `message` that the termination is done
 		if _, err := termStream.Recv(); err != nil {
-			if errors.Is(err, io.EOF) {
+			fmt.Println("error when waiting for network file server termination", err, "unwrap", errors.Unwrap(err))
+			if strings.HasSuffix(err.Error(), "EOF") {
 				onServerTermination(ctx, "remote server shutdown")
 				return
 			}

--- a/internal/pkg/service/stream/storage/level/local/diskwriter/network/rpc/rpc_test.go
+++ b/internal/pkg/service/stream/storage/level/local/diskwriter/network/rpc/rpc_test.go
@@ -127,13 +127,9 @@ func openNetworkFile(t *testing.T, ctx context.Context, etcdCfg etcdclient.Confi
 		commonDeps.WithEtcdConfig(etcdCfg),
 	)
 
-	// Obtain connection to the disk writer node
-	conn, found := d.ConnectionManager().ConnectionToVolume(sliceKey.VolumeID)
-	require.True(t, found)
-
 	// Open network file
 	onServerTermination := func(ctx context.Context, cause string) {}
-	file, err := rpc.OpenNetworkFile(ctx, d.Logger(), d.Telemetry(), sourceNodeID, conn, sliceKey, slice, onServerTermination)
+	file, err := rpc.OpenNetworkFile(ctx, d.Logger(), d.Telemetry(), d.ConnectionManager(), sliceKey, slice, onServerTermination)
 	require.NoError(t, err)
 
 	return file, m

--- a/internal/pkg/service/stream/storage/level/local/diskwriter/network/rpc/server.go
+++ b/internal/pkg/service/stream/storage/level/local/diskwriter/network/rpc/server.go
@@ -167,6 +167,7 @@ func (s *NetworkFileServer) KeepAliveStream(req *pb.KeepAliveStreamRequest, stre
 			return nil
 		}
 
+		fmt.Println("closing writer on the other side", w.SliceKey().String())
 		ctx, cancel := context.WithTimeout(context.Background(), 30*time.Second)
 		defer cancel()
 		return w.Close(ctx)
@@ -196,6 +197,7 @@ func (s *NetworkFileServer) Sync(ctx context.Context, req *pb.SyncRequest) (*pb.
 }
 
 func (s *NetworkFileServer) Close(ctx context.Context, req *pb.CloseRequest) (*pb.CloseResponse, error) {
+	fmt.Println("close called from client")
 	w, err := s.writer(req.FileId)
 	if err != nil {
 		return nil, err

--- a/internal/pkg/service/stream/storage/level/local/diskwriter/writer.go
+++ b/internal/pkg/service/stream/storage/level/local/diskwriter/writer.go
@@ -186,7 +186,7 @@ func (w *writer) Close(ctx context.Context) error {
 	}
 
 	// Sync file
-	if err := w.Sync(ctx); err != nil {
+	if err := w.file.Sync(); err != nil {
 		errs.Append(errors.Errorf(`cannot sync file: %w`, err))
 	}
 

--- a/internal/pkg/service/stream/storage/level/local/encoding/pipeline.go
+++ b/internal/pkg/service/stream/storage/level/local/encoding/pipeline.go
@@ -2,6 +2,7 @@ package encoding
 
 import (
 	"context"
+	"fmt"
 	"io"
 	"sync"
 	"time"
@@ -407,6 +408,7 @@ func (p *pipeline) Close(ctx context.Context) error {
 	p.chunksWg.Wait()
 
 	// Close remote network file
+	fmt.Println("closing remote network file using pipeline", p.sliceKey.String())
 	if err := p.network.Close(ctx); err != nil {
 		errs.Append(err)
 	}

--- a/internal/pkg/service/stream/storage/level/local/encoding/pipeline.go
+++ b/internal/pkg/service/stream/storage/level/local/encoding/pipeline.go
@@ -434,6 +434,10 @@ func (p *pipeline) processChunks(ctx context.Context, clk clockwork.Clock, encod
 
 		// Write all chunks to the network output
 		err := p.chunks.ProcessCompletedChunks(func(chunk *chunk.Chunk) error {
+			if !p.network.IsReady() {
+				return errors.New("network is not ready")
+			}
+
 			length, err := safecast.ToUint64(chunk.Len())
 			if err != nil {
 				return err

--- a/internal/pkg/service/stream/storage/metacleanup/metacleanup.go
+++ b/internal/pkg/service/stream/storage/metacleanup/metacleanup.go
@@ -4,6 +4,7 @@ package metacleanup
 
 import (
 	"context"
+	"fmt"
 	"sync"
 	"time"
 
@@ -174,8 +175,9 @@ func (n *Node) cleanMetadata(ctx context.Context) (err error) {
 		ForEach(func(job keboolaBridgeModel.Job, _ *iterator.Header) error {
 			grp.Go(func() error {
 				// There can be several cleanup nodes, each node processes an own part.
-				if !n.dist.MustCheckIsOwner(job.ProjectID.String()) {
-					return nil
+				if _, err := n.dist.IsOwner(job.ProjectID.String()); err != nil {
+					fmt.Println("not owner job cleanup", job.ProjectID.String(), err)
+					return err
 				}
 
 				// Log/trace job details
@@ -208,8 +210,9 @@ func (n *Node) cleanMetadata(ctx context.Context) (err error) {
 
 func (n *Node) cleanFile(ctx context.Context, file model.File) (err error, deleted bool) {
 	// There can be several cleanup nodes, each node processes an own part.
-	if !n.dist.MustCheckIsOwner(file.ProjectID.String()) {
-		return nil, false
+	if _, err := n.dist.IsOwner(file.ProjectID.String()); err != nil {
+		fmt.Println("not owner file", file.ProjectID.String(), err)
+		return err, false
 	}
 
 	// Log/trace file details
@@ -231,6 +234,7 @@ func (n *Node) cleanFile(ctx context.Context, file model.File) (err error, delet
 	// Acquire lock
 	mutex := n.locks.NewMutex(file.FileKey.String())
 	if err = mutex.TryLock(ctx); err != nil {
+		n.logger.Errorf(ctx, "cannot lock the file: %s", err)
 		return err, false
 	}
 	defer func() {

--- a/internal/pkg/service/stream/storage/model/repository/volume/volume_repo.go
+++ b/internal/pkg/service/stream/storage/model/repository/volume/volume_repo.go
@@ -2,6 +2,7 @@ package volume
 
 import (
 	"context"
+	"fmt"
 	"sync"
 	"time"
 
@@ -66,6 +67,9 @@ func (r *Repository) watchVolumes() error {
 
 // AssignVolumes assigns volumes to a new file.
 func (r *Repository) AssignVolumes(cfg assignment.Config, fileOpenedAt time.Time) assignment.Assignment {
+	for _, v := range r.volumes.All() {
+		fmt.Println("assign volumes", v.ID, v.NodeID)
+	}
 	return assignment.VolumesFor(r.volumes.All(), cfg, fileOpenedAt.UnixNano())
 }
 

--- a/internal/pkg/service/stream/storage/node/coordinator/fileimport/operator.go
+++ b/internal/pkg/service/stream/storage/node/coordinator/fileimport/operator.go
@@ -155,7 +155,8 @@ func Start(d dependencies, config targetConfig.OperatorConfig) error {
 		).
 			// Check only files owned by the node
 			WithFilter(func(event etcdop.WatchEvent[model.File]) bool {
-				return o.distribution.MustCheckIsOwner(event.Value.SourceKey.String())
+				b, _ := o.distribution.IsOwner(event.Value.SourceKey.String())
+				return b
 			}).
 			BuildMirror()
 		if err = <-o.files.StartMirroring(ctx, wg, o.logger); err != nil {

--- a/internal/pkg/service/stream/storage/node/coordinator/filerotation/operator.go
+++ b/internal/pkg/service/stream/storage/node/coordinator/filerotation/operator.go
@@ -164,7 +164,8 @@ func Start(d dependencies, config targetConfig.OperatorConfig) error {
 		).
 			// Check only files owned by the node
 			WithFilter(func(event etcdop.WatchEvent[model.File]) bool {
-				return o.distribution.MustCheckIsOwner(event.Value.SourceKey.String())
+				b, _ := o.distribution.IsOwner(event.Value.SourceKey.String())
+				return b
 			}).
 			BuildMirror()
 		if err = <-o.files.StartMirroring(ctx, wg, o.logger); err != nil {
@@ -358,22 +359,30 @@ func (o *operator) rotateFile(ctx context.Context, file *fileData) {
 		return
 	}
 
-	// Skip filerotation if target provider is throttled
-	if !o.plugins.CanAcceptNewFile(ctx, file.Provider, file.FileKey.SinkKey) {
-		o.logger.Warnf(ctx, "skipping file rotation: sink is throttled")
-		return
-	}
-
-	// Log cause
-	o.logger.Infof(ctx, "rotating file, import conditions met: %s", result.Cause())
-
 	// Lock all file operations
 	lock, unlock, err := clusterlock.LockFile(ctx, o.locks, o.logger, file.FileKey)
 	if err != nil {
 		o.logger.Errorf(ctx, `file rotation lock error: %s`, err)
 		return
 	}
+
 	defer unlock()
+
+	// Skip filerotation if target provider is throttled
+	if !o.plugins.CanAcceptNewFile(ctx, file.Provider, file.FileKey.SinkKey) {
+		o.logger.Warnf(ctx, "skipping file rotation: sink is throttled")
+		// Increment retry delay
+		rErr := o.storage.File().IncrementRetryAttempt(file.FileKey, o.clock.Now(), "sink is throttled").RequireLock(lock).Do(ctx).Err()
+		if rErr != nil {
+			o.logger.Errorf(ctx, "cannot increment file rotation retry attempt: %s", rErr)
+			return
+		}
+
+		return
+	}
+
+	// Log cause
+	o.logger.Infof(ctx, "rotating file, import conditions met: %s", result.Cause())
 
 	// Rollback when error occurs in ETCD/StorageAPI
 	rb := rollback.New(o.logger)

--- a/internal/pkg/service/stream/storage/node/coordinator/slicerotation/operator.go
+++ b/internal/pkg/service/stream/storage/node/coordinator/slicerotation/operator.go
@@ -155,7 +155,8 @@ func Start(d dependencies, config stagingConfig.OperatorConfig) error {
 		).
 			// Check only slices owned by the node
 			WithFilter(func(event etcdop.WatchEvent[model.Slice]) bool {
-				return o.distribution.MustCheckIsOwner(event.Value.SourceKey.String())
+				b, _ := o.distribution.IsOwner(event.Value.SourceKey.String())
+				return b
 			}).
 			BuildMirror()
 		if err = <-o.slices.StartMirroring(ctx, wg, o.logger); err != nil {

--- a/scripts/k6/stream-api/main.js
+++ b/scripts/k6/stream-api/main.js
@@ -140,7 +140,7 @@ const payloads = new SharedArray('payloads', function() {
 
 const api = new Api(API_HOST, API_TOKEN)
 
-const fastHttpClient = new Client()
+const fastHttpClient = new Client({ write_timeout: 1 })
 
 export function setup() {
   // Create source


### PR DESCRIPTION
Jira: [PSGO-993](https://keboola.atlassian.net/browse/PSGO-993)

**Changes:**
- Delete after write does not happens in `watch` module.
  - Statistics seems to be working correctly. [PSGO-810](https://keboola.atlassian.net/browse/PSGO-810)
  - Diskwriter seems to be working correctly. [PSGO-993](https://keboola.atlassian.net/browse/PSGO-993)
  - Probablly solves this issue as well [PSGO-830](https://keboola.atlassian.net/browse/PSGO-830)
  - Probablly solves this issue as well [PSGO-855](https://keboola.atlassian.net/browse/PSGO-855) 

Issues
- Removed sorting in ETCD transaction/compact operation to prevent Delete after Create, test included.
- Do not change distribution nodes when no changes were made
- Do not change volumes within connection when no changes were made. Closing and recreating of transport is extensive operation, we save some CPU/MEM during ETCD shutdown.
- Open connection in dialer section. Should prevent issues that `connection.volume` has no old reference but always up to date reference from set of connection volumes  
- One small race condition on waitgroup. Use w.file.Sync() instead of Sync() method in Close as waitgroup is not longer needed during close of writer
-----------


[PSGO-993]: https://keboola.atlassian.net/browse/PSGO-993?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ

[PSGO-810]: https://keboola.atlassian.net/browse/PSGO-810?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ
[PSGO-830]: https://keboola.atlassian.net/browse/PSGO-830?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ
[PSGO-855]: https://keboola.atlassian.net/browse/PSGO-855?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ