### PR TITLE
feat: Open file processing chunks

### DIFF
--- a/internal/pkg/service/common/etcdop/watch.go
+++ b/internal/pkg/service/common/etcdop/watch.go
@@ -1,9 +1,7 @@
 package etcdop
 
 import (
-	"bytes"
 	"context"
-	"sort"
 	"time"
 
 	"go.etcd.io/etcd/api/v3/mvccpb"
@@ -190,16 +188,6 @@ func (v Prefix) WatchWithoutRestart(ctx context.Context, client etcd.Watcher, op
 				stream.channel <- resp
 				continue
 			}
-
-			// Sort events from the batch (if multiple keys have been modified in one txn, in one revision)
-			// 1. By type, PUT before DELETE
-			// 2. By key, A->Z
-			sort.SliceStable(rawResp.Events, func(i, j int) bool {
-				if rawResp.Events[i].Type != rawResp.Events[j].Type {
-					return rawResp.Events[i].Type < rawResp.Events[j].Type
-				}
-				return bytes.Compare(rawResp.Events[i].Kv.Key, rawResp.Events[j].Kv.Key) == -1
-			})
 
 			if len(rawResp.Events) > 0 {
 				resp.Events = make([]WatchEvent[[]byte], 0, len(rawResp.Events))

--- a/internal/pkg/service/common/etcdop/watch_mirror_tree.go
+++ b/internal/pkg/service/common/etcdop/watch_mirror_tree.go
@@ -239,7 +239,7 @@ func (m *MirrorTree[T, V]) WaitForRevision(ctx context.Context, expected int64) 
 		case <-ctx.Done():
 			return ctx.Err()
 		case <-notifier:
-			// try again
+			// The revision has been updated, try again
 		}
 	}
 }

--- a/internal/pkg/service/stream/storage/level/local/diskwriter/network/connection/connection.go
+++ b/internal/pkg/service/stream/storage/level/local/diskwriter/network/connection/connection.go
@@ -148,7 +148,9 @@ func (m *Manager) ConnectionsCount() int {
 
 func (m *Manager) updateConnections(ctx context.Context) {
 	activeNodes := m.writerNodes()
-	m.logger.Infof(ctx, `the list of volumes has changed, updating connections: %v`, activeNodes)
+	for _, node := range activeNodes {
+		m.logger.Infof(ctx, `the list of volumes has changed, updating connections: %q - %q`, node.ID, node.Address)
+	}
 
 	// Detect new nodes - to open connection
 	var toOpen []*nodeData

--- a/internal/pkg/service/stream/storage/level/local/diskwriter/network/connection/connection.go
+++ b/internal/pkg/service/stream/storage/level/local/diskwriter/network/connection/connection.go
@@ -147,9 +147,8 @@ func (m *Manager) ConnectionsCount() int {
 }
 
 func (m *Manager) updateConnections(ctx context.Context) {
-	m.logger.Infof(ctx, `the list of volumes has changed, updating connections`)
-
 	activeNodes := m.writerNodes()
+	m.logger.Infof(ctx, `the list of volumes has changed, updating connections: %v`, activeNodes)
 
 	// Detect new nodes - to open connection
 	var toOpen []*nodeData

--- a/internal/pkg/service/stream/storage/level/local/diskwriter/network/connection/connection_test.go
+++ b/internal/pkg/service/stream/storage/level/local/diskwriter/network/connection/connection_test.go
@@ -41,7 +41,7 @@ func TestConnectionManager(t *testing.T) {
 	// Start source node
 	connManager, s := startSourceNode(t, ctx, etcdCfg, "s1")
 	sourceLogger := s.DebugLogger()
-	waitForLog(t, sourceLogger, `{"level":"info","message":"the list of volumes has changed, updating connections","component":"storage.router.connections"}`)
+	waitForLog(t, sourceLogger, `{"level":"info","message":"the list of volumes has changed, updating connections: \"%s\" - \"%s\"","component":"storage.router.connections"}`)
 	waitForLog(t, sourceLogger, `{"level":"info","message":"disk writer client connected from \"%s\" to \"w1\" - \"l%s\"","component":"storage.router.connections.client.transport"}`)
 	waitForLog(t, sourceLogger, `{"level":"info","message":"disk writer client connected from \"%s\" to \"w2\" - \"l%s\"","component":"storage.router.connections.client.transport"}`)
 	waitForLog(t, w1.DebugLogger(), `{"level":"info","message":"accepted connection from \"%s\" to \"%s\"","component":"storage.node.writer.rpc.transport"}`)
@@ -58,7 +58,7 @@ func TestConnectionManager(t *testing.T) {
 	// Start another 2 writer nodes
 	w3 := startWriterNode(t, ctx, etcdCfg, "w3")
 	w4 := startWriterNode(t, ctx, etcdCfg, "w4")
-	waitForLog(t, sourceLogger, `{"level":"info","message":"the list of volumes has changed, updating connections","component":"storage.router.connections"}`)
+	waitForLog(t, sourceLogger, `{"level":"info","message":"the list of volumes has changed, updating connections: \"%s\" - \"%s\"","component":"storage.router.connections"}`)
 	waitForLog(t, sourceLogger, `{"level":"info","message":"disk writer client connected from \"%s\" to \"w3\" - \"l%s\"","component":"storage.router.connections.client.transport"}`)
 	waitForLog(t, sourceLogger, `{"level":"info","message":"disk writer client connected from \"%s\" to \"w4\" - \"l%s\"","component":"storage.router.connections.client.transport"}`)
 	waitForLog(t, w3.DebugLogger(), `{"level":"info","message":"accepted connection from \"%s\" to \"%s\"","component":"storage.node.writer.rpc.transport"}`)
@@ -83,7 +83,7 @@ func TestConnectionManager(t *testing.T) {
 	w1.Process().WaitForShutdown()
 	w3.Process().Shutdown(ctx, errors.New("bye bye writer 3"))
 	w3.Process().WaitForShutdown()
-	waitForLog(t, sourceLogger, `{"level":"info","message":"the list of volumes has changed, updating connections","component":"storage.router.connections"}`)
+	waitForLog(t, sourceLogger, `{"level":"info","message":"the list of volumes has changed, updating connections: \"%s\" - \"%s\"","component":"storage.router.connections"}`)
 	waitForLog(t, sourceLogger, `{"level":"info","message":"disk writer client disconnected from \"w1\" - \"localhost:%s\": %s","component":"storage.router.connections.client.transport"}`)
 	waitForLog(t, sourceLogger, `{"level":"info","message":"disk writer client disconnected from \"w3\" - \"localhost:%s\": %s","component":"storage.router.connections.client.transport"}`)
 	sourceLogger.Truncate()

--- a/internal/pkg/service/stream/storage/level/local/diskwriter/network/router/pipeline/pipeline_sink.go
+++ b/internal/pkg/service/stream/storage/level/local/diskwriter/network/router/pipeline/pipeline_sink.go
@@ -93,7 +93,6 @@ func (p *SinkPipeline) ReopenOnSinkModification() bool {
 }
 
 func (p *SinkPipeline) WriteRecord(c recordctx.Context) (pipelinePkg.WriteResult, error) {
-
 	// Make a local copy of pipelines while holding the read lock
 	p.writeLock.RLock()
 	pipelines := make([]balancer.SlicePipeline, len(p.pipelines))

--- a/internal/pkg/service/stream/storage/level/local/diskwriter/network/router/pipeline/pipeline_sink.go
+++ b/internal/pkg/service/stream/storage/level/local/diskwriter/network/router/pipeline/pipeline_sink.go
@@ -93,9 +93,14 @@ func (p *SinkPipeline) ReopenOnSinkModification() bool {
 }
 
 func (p *SinkPipeline) WriteRecord(c recordctx.Context) (pipelinePkg.WriteResult, error) {
+
+	// Make a local copy of pipelines while holding the read lock
 	p.writeLock.RLock()
-	defer p.writeLock.RUnlock()
-	return p.balancer.WriteRecord(c, p.pipelines)
+	pipelines := make([]balancer.SlicePipeline, len(p.pipelines))
+	copy(pipelines, p.pipelines)
+	p.writeLock.RUnlock()
+
+	return p.balancer.WriteRecord(c, pipelines)
 }
 
 // UpdateSlicePipelines reacts on slices changes - closes old pipelines and open new pipelines.

--- a/internal/pkg/service/stream/storage/level/local/diskwriter/network/router/pipeline/pipeline_slice.go
+++ b/internal/pkg/service/stream/storage/level/local/diskwriter/network/router/pipeline/pipeline_slice.go
@@ -14,7 +14,6 @@ import (
 	pipelinePkg "github.com/keboola/keboola-as-code/internal/pkg/service/stream/sink/pipeline"
 	"github.com/keboola/keboola-as-code/internal/pkg/service/stream/storage/level/local/diskwriter/network/connection"
 	"github.com/keboola/keboola-as-code/internal/pkg/service/stream/storage/level/local/diskwriter/network/router/balancer"
-	"github.com/keboola/keboola-as-code/internal/pkg/service/stream/storage/level/local/diskwriter/network/rpc"
 	"github.com/keboola/keboola-as-code/internal/pkg/service/stream/storage/level/local/encoding"
 	encodingCfg "github.com/keboola/keboola-as-code/internal/pkg/service/stream/storage/level/local/encoding/config"
 	localModel "github.com/keboola/keboola-as-code/internal/pkg/service/stream/storage/level/local/model"
@@ -51,7 +50,16 @@ type SliceData struct {
 	LocalStorage localModel.Slice
 }
 
-func NewSlicePipeline(ctx context.Context, logger log.Logger, telemetry telemetry.Telemetry, connections *connection.Manager, encoding *encoding.Manager, ready *readyNotifier, slice *SliceData, onClose func(ctx context.Context, cause string)) *SlicePipeline {
+func NewSlicePipeline(
+	ctx context.Context,
+	logger log.Logger,
+	telemetry telemetry.Telemetry,
+	connections *connection.Manager,
+	encoding *encoding.Manager,
+	ready *readyNotifier,
+	slice *SliceData,
+	onClose func(ctx context.Context, cause string),
+) *SlicePipeline {
 	p := &SlicePipeline{
 		logger:      logger.With(slice.SliceKey.Telemetry()...),
 		telemetry:   telemetry,
@@ -159,17 +167,19 @@ func (p *SlicePipeline) tryOpen() error {
 
 	ctx := p.ctx
 
-	// Open remote RPC file
-	// The disk writer node can notify us of its termination. In that case, we have to gracefully close the pipeline, see Close method.
-	remoteFile, err := rpc.OpenNetworkFile(ctx, p.logger, p.telemetry, p.connections, p.slice.SliceKey, p.slice.LocalStorage, p.Close)
-	if err != nil {
-		return errors.PrefixErrorf(err, "cannot open network file for new slice pipeline")
-	}
-
 	// Open pipeline
-	p.pipeline, err = p.encoding.OpenPipeline(ctx, p.slice.SliceKey, p.slice.Mapping, p.slice.Encoding, remoteFile)
+	var err error
+	p.pipeline, err = p.encoding.OpenPipeline(
+		ctx,
+		p.slice.SliceKey,
+		p.telemetry,
+		p.connections,
+		p.slice.Mapping,
+		p.slice.Encoding,
+		p.slice.LocalStorage,
+		p.Close,
+	)
 	if err != nil {
-		_ = remoteFile.Close(ctx)
 		return errors.PrefixErrorf(err, "cannot open slice pipeline")
 	}
 

--- a/internal/pkg/service/stream/storage/level/local/diskwriter/network/router/pipeline/pipeline_slice.go
+++ b/internal/pkg/service/stream/storage/level/local/diskwriter/network/router/pipeline/pipeline_slice.go
@@ -178,6 +178,7 @@ func (p *SlicePipeline) tryOpen() error {
 		p.slice.Encoding,
 		p.slice.LocalStorage,
 		p.Close,
+		nil, // Do not override network output
 	)
 	if err != nil {
 		return errors.PrefixErrorf(err, "cannot open slice pipeline")

--- a/internal/pkg/service/stream/storage/level/local/diskwriter/network/router/router.go
+++ b/internal/pkg/service/stream/storage/level/local/diskwriter/network/router/router.go
@@ -194,7 +194,8 @@ func (r *Router) onSlicesModification(ctx context.Context, modifiedSinks []key.S
 			wg.Add(1)
 			go func() {
 				defer wg.Done()
-				if err := p.UpdateSlicePipelines(ctx, r.assignSinkSlices(sinkKey)); err != nil {
+				slices := r.assignSinkSlices(sinkKey)
+				if err := p.UpdateSlicePipelines(ctx, slices); err != nil {
 					r.logger.Errorf(ctx, `cannot update sink slices pipelines: %s, sink %q`, err, sinkKey)
 				}
 			}()

--- a/internal/pkg/service/stream/storage/level/local/diskwriter/network/rpc/rpc_test.go
+++ b/internal/pkg/service/stream/storage/level/local/diskwriter/network/rpc/rpc_test.go
@@ -127,13 +127,9 @@ func openNetworkFile(t *testing.T, ctx context.Context, etcdCfg etcdclient.Confi
 		commonDeps.WithEtcdConfig(etcdCfg),
 	)
 
-	// Obtain connection to the disk writer node
-	conn, found := d.ConnectionManager().ConnectionToVolume(sliceKey.VolumeID)
-	require.True(t, found)
-
 	// Open network file
 	onServerTermination := func(ctx context.Context, cause string) {}
-	file, err := rpc.OpenNetworkFile(ctx, d.Logger(), d.Telemetry(), sourceNodeID, conn, sliceKey, slice, onServerTermination)
+	file, err := rpc.OpenNetworkFile(ctx, d.Logger(), d.Telemetry(), d.ConnectionManager(), sliceKey, slice, onServerTermination)
 	require.NoError(t, err)
 
 	return file, m

--- a/internal/pkg/service/stream/storage/level/local/diskwriter/network/rpc/rpc_test.go
+++ b/internal/pkg/service/stream/storage/level/local/diskwriter/network/rpc/rpc_test.go
@@ -18,7 +18,6 @@ import (
 	"github.com/keboola/keboola-as-code/internal/pkg/service/stream/definition/key"
 	"github.com/keboola/keboola-as-code/internal/pkg/service/stream/dependencies"
 	"github.com/keboola/keboola-as-code/internal/pkg/service/stream/storage/level/local/diskwriter/network/rpc"
-	"github.com/keboola/keboola-as-code/internal/pkg/service/stream/storage/level/local/encoding"
 	localModel "github.com/keboola/keboola-as-code/internal/pkg/service/stream/storage/level/local/model"
 	volume "github.com/keboola/keboola-as-code/internal/pkg/service/stream/storage/level/local/volume/model"
 	"github.com/keboola/keboola-as-code/internal/pkg/service/stream/storage/model"
@@ -115,7 +114,14 @@ func startDiskWriterNode(t *testing.T, ctx context.Context, etcdCfg etcdclient.C
 	return m
 }
 
-func openNetworkFile(t *testing.T, ctx context.Context, etcdCfg etcdclient.Config, sourceNodeID string, sliceKey model.SliceKey, slice localModel.Slice) (encoding.NetworkOutput, dependencies.Mocked) {
+func openNetworkFile(
+	t *testing.T,
+	ctx context.Context,
+	etcdCfg etcdclient.Config,
+	sourceNodeID string,
+	sliceKey model.SliceKey,
+	slice localModel.Slice,
+) (rpc.NetworkOutput, dependencies.Mocked) {
 	t.Helper()
 
 	d, m := dependencies.NewMockedSourceScopeWithConfig(

--- a/internal/pkg/service/stream/storage/level/local/diskwriter/writer.go
+++ b/internal/pkg/service/stream/storage/level/local/diskwriter/writer.go
@@ -186,7 +186,7 @@ func (w *writer) Close(ctx context.Context) error {
 	}
 
 	// Sync file
-	if err := w.Sync(ctx); err != nil {
+	if err := w.file.Sync(); err != nil {
 		errs.Append(errors.Errorf(`cannot sync file: %w`, err))
 	}
 

--- a/internal/pkg/service/stream/storage/level/local/diskwriter/writer.go
+++ b/internal/pkg/service/stream/storage/level/local/diskwriter/writer.go
@@ -163,7 +163,6 @@ func (w *writer) Close(ctx context.Context) error {
 	w.logger.Debug(ctx, "closing disk writer")
 
 	// Close only once
-	errs := errors.NewMultiError()
 	if w.isClosed() {
 		return errors.New(`writer is already closed`)
 	}
@@ -172,6 +171,7 @@ func (w *writer) Close(ctx context.Context) error {
 	close(w.closed)
 	w.wg.Wait()
 
+	errs := errors.NewMultiError()
 	if w.writen != w.aligned {
 		w.logger.Warnf(ctx, `file is not aligned, truncating`)
 		seeked, err := w.file.Seek(w.aligned-w.writen, io.SeekCurrent)

--- a/internal/pkg/service/stream/storage/level/local/encoding/encoder/factory_test.go
+++ b/internal/pkg/service/stream/storage/level/local/encoding/encoder/factory_test.go
@@ -42,7 +42,17 @@ func TestDefaultFactory_FileTypeCSV(t *testing.T) {
 	slice := test.NewSlice()
 	slice.Encoding.Encoder.Type = encoder.TypeCSV
 
-	w, err := d.EncodingManager().OpenPipeline(ctx, slice.SliceKey, slice.Mapping, slice.Encoding, discardOutput{})
+	w, err := d.EncodingManager().OpenPipeline(
+		ctx,
+		slice.SliceKey,
+		d.Telemetry(),
+		d.ConnectionManager(),
+		slice.Mapping,
+		slice.Encoding,
+		slice.LocalStorage,
+		func(ctx context.Context, cause string) {},
+		discardOutput{},
+	)
 	require.NoError(t, err)
 	assert.NotNil(t, w)
 }
@@ -57,7 +67,17 @@ func TestDefaultFactory_FileTypeInvalid(t *testing.T) {
 	slice := test.NewSlice()
 	slice.Encoding.Encoder.Type = "invalid"
 
-	_, err := d.EncodingManager().OpenPipeline(ctx, slice.SliceKey, slice.Mapping, slice.Encoding, discardOutput{})
+	_, err := d.EncodingManager().OpenPipeline(
+		ctx,
+		slice.SliceKey,
+		d.Telemetry(),
+		d.ConnectionManager(),
+		slice.Mapping,
+		slice.Encoding,
+		slice.LocalStorage,
+		func(ctx context.Context, cause string) {},
+		discardOutput{},
+	)
 	if assert.Error(t, err) {
 		assert.Equal(t, `unexpected encoder type "invalid"`, err.Error())
 	}

--- a/internal/pkg/service/stream/storage/level/local/encoding/manager.go
+++ b/internal/pkg/service/stream/storage/level/local/encoding/manager.go
@@ -11,6 +11,7 @@ import (
 	"github.com/keboola/keboola-as-code/internal/pkg/service/common/servicectx"
 	"github.com/keboola/keboola-as-code/internal/pkg/service/stream/mapping/table"
 	"github.com/keboola/keboola-as-code/internal/pkg/service/stream/storage/level/local/diskwriter/network/connection"
+	"github.com/keboola/keboola-as-code/internal/pkg/service/stream/storage/level/local/diskwriter/network/rpc"
 	encoding "github.com/keboola/keboola-as-code/internal/pkg/service/stream/storage/level/local/encoding/config"
 	"github.com/keboola/keboola-as-code/internal/pkg/service/stream/storage/level/local/events"
 	localModel "github.com/keboola/keboola-as-code/internal/pkg/service/stream/storage/level/local/model"
@@ -92,6 +93,7 @@ func (m *Manager) OpenPipeline(
 	encodingCfg encoding.Config,
 	localStorage localModel.Slice,
 	closeFunc func(ctx context.Context, cause string),
+	network rpc.NetworkOutput,
 ) (w Pipeline, err error) {
 	// Check if the pipeline already exists, if not, register an empty reference to unlock immediately
 	ref, exists := m.addPipeline(sliceKey)
@@ -112,6 +114,7 @@ func (m *Manager) OpenPipeline(
 		localStorage,
 		m.events,
 		closeFunc,
+		network,
 	)
 	if err != nil {
 		m.removePipeline(sliceKey)

--- a/internal/pkg/service/stream/storage/level/local/encoding/manager.go
+++ b/internal/pkg/service/stream/storage/level/local/encoding/manager.go
@@ -114,6 +114,7 @@ func (m *Manager) OpenPipeline(
 		closeFunc,
 	)
 	if err != nil {
+		m.removePipeline(sliceKey)
 		return nil, err
 	}
 

--- a/internal/pkg/service/stream/storage/level/local/encoding/pipeline.go
+++ b/internal/pkg/service/stream/storage/level/local/encoding/pipeline.go
@@ -3,6 +3,8 @@ package encoding
 import (
 	"context"
 	"io"
+	"os"
+	"strings"
 	"sync"
 	"time"
 
@@ -16,6 +18,8 @@ import (
 	"github.com/keboola/keboola-as-code/internal/pkg/service/common/utctime"
 	"github.com/keboola/keboola-as-code/internal/pkg/service/stream/mapping/recordctx"
 	"github.com/keboola/keboola-as-code/internal/pkg/service/stream/mapping/table"
+	"github.com/keboola/keboola-as-code/internal/pkg/service/stream/storage/level/local/diskwriter/network/connection"
+	"github.com/keboola/keboola-as-code/internal/pkg/service/stream/storage/level/local/diskwriter/network/rpc"
 	"github.com/keboola/keboola-as-code/internal/pkg/service/stream/storage/level/local/encoding/chunk"
 	"github.com/keboola/keboola-as-code/internal/pkg/service/stream/storage/level/local/encoding/compression"
 	compressionWriter "github.com/keboola/keboola-as-code/internal/pkg/service/stream/storage/level/local/encoding/compression/writer"
@@ -27,7 +31,9 @@ import (
 	"github.com/keboola/keboola-as-code/internal/pkg/service/stream/storage/level/local/encoding/writechain"
 	"github.com/keboola/keboola-as-code/internal/pkg/service/stream/storage/level/local/encoding/writesync"
 	"github.com/keboola/keboola-as-code/internal/pkg/service/stream/storage/level/local/events"
+	localModel "github.com/keboola/keboola-as-code/internal/pkg/service/stream/storage/level/local/model"
 	"github.com/keboola/keboola-as-code/internal/pkg/service/stream/storage/model"
+	"github.com/keboola/keboola-as-code/internal/pkg/telemetry"
 	"github.com/keboola/keboola-as-code/internal/pkg/utils/errors"
 )
 
@@ -62,20 +68,6 @@ type StatisticsProvider interface {
 	UncompressedSize() datasize.ByteSize
 }
 
-// NetworkOutput represent a file on a disk writer node, connected via network.
-type NetworkOutput interface {
-	// IsReady returns true if the underlying network is working.
-	IsReady() bool
-	// Write bytes to a file in disk writer node.
-	// When write is aligned, it commits that already writen bytes are safely stored.
-	// The operation is used on Flush of the encoding pipeline.
-	Write(ctx context.Context, aligned bool, p []byte) (n int, err error)
-	// Sync OS disk cache to the physical disk.
-	Sync(ctx context.Context) error
-	// Close the underlying OS file and network connection.
-	Close(ctx context.Context) error
-}
-
 // pipeline implements Pipeline interface, it wraps common logic for all file types.
 // For conversion between record values and bytes, the encoder.Encoder is used.
 type pipeline struct {
@@ -84,11 +76,15 @@ type pipeline struct {
 	events    *events.Events[Pipeline]
 	flushLock sync.RWMutex
 
-	encoder encoder.Encoder
-	chain   *writechain.Chain
-	syncer  *writesync.Syncer
-	chunks  *chunk.Writer
-	network NetworkOutput
+	encoder      encoder.Encoder
+	chain        *writechain.Chain
+	syncer       *writesync.Syncer
+	chunks       *chunk.Writer
+	connections  *connection.Manager
+	telemetry    telemetry.Telemetry
+	localStorage localModel.Slice
+	network      rpc.NetworkOutput
+	closeFunc    func(ctx context.Context, cause string)
 
 	readyLock sync.RWMutex
 	ready     bool
@@ -113,18 +109,31 @@ func newPipeline(
 	logger log.Logger,
 	clk clockwork.Clock,
 	sliceKey model.SliceKey,
+	telemetry telemetry.Telemetry,
+	connections *connection.Manager,
 	mappingCfg table.Mapping,
 	encodingCfg encoding.Config,
-	network NetworkOutput,
+	localStorage localModel.Slice,
 	events *events.Events[Pipeline],
+	closeFunc func(ctx context.Context, cause string),
 ) (out Pipeline, err error) {
 	p := &pipeline{
-		logger:   logger.WithComponent("encoding.pipeline"),
-		sliceKey: sliceKey,
-		network:  network,
-		events:   events.Clone(), // clone passed events, so additional pipeline specific listeners can be added
-		ready:    true,
-		closed:   make(chan struct{}),
+		logger:       logger.WithComponent("encoding.pipeline"),
+		telemetry:    telemetry,
+		connections:  connections,
+		sliceKey:     sliceKey,
+		events:       events.Clone(), // clone passed events, so additional pipeline specific listeners can be added
+		ready:        true,
+		closeFunc:    closeFunc,
+		localStorage: localStorage,
+		closed:       make(chan struct{}),
+	}
+
+	// Open remote RPC file
+	// The disk writer node can notify us of its termination. In that case, we have to gracefully close the pipeline, see Close method.
+	p.network, err = rpc.OpenNetworkFile(ctx, p.logger, p.telemetry, p.connections, p.sliceKey, localStorage, p.closeFunc)
+	if err != nil {
+		return nil, errors.PrefixErrorf(err, "cannot open network file for new slice pipeline")
 	}
 
 	ctx = context.WithoutCancel(ctx)
@@ -139,6 +148,9 @@ func newPipeline(
 			}
 			if p.chain != nil {
 				_ = p.chain.Close(ctx)
+			}
+			if p.network != nil {
+				_ = p.network.Close(ctx)
 			}
 		}
 	}()
@@ -444,6 +456,22 @@ func (p *pipeline) processChunks(ctx context.Context, clk clockwork.Clock, encod
 			}
 			l := datasize.ByteSize(length)
 			if _, err := p.network.Write(ctx, chunk.Aligned(), chunk.Bytes()); err != nil {
+				if strings.HasSuffix(err.Error(), os.ErrClosed.Error()) {
+					// Open remote RPC file
+					p.network, err = rpc.OpenNetworkFile(
+						ctx,
+						p.logger,
+						p.telemetry,
+						p.connections,
+						p.sliceKey,
+						p.localStorage,
+						p.closeFunc,
+					)
+					if err != nil {
+						return errors.PrefixErrorf(err, "cannot open network file for new slice pipeline")
+					}
+				}
+
 				p.logger.Debugf(ctx, "chunk write failed, size %q: %s", l.String(), err)
 				return err
 			}

--- a/internal/pkg/service/stream/storage/level/local/encoding/pipeline.go
+++ b/internal/pkg/service/stream/storage/level/local/encoding/pipeline.go
@@ -434,6 +434,10 @@ func (p *pipeline) processChunks(ctx context.Context, clk clockwork.Clock, encod
 
 		// Write all chunks to the network output
 		err := p.chunks.ProcessCompletedChunks(func(chunk *chunk.Chunk) error {
+			if !p.network.IsReady() {
+				return errors.New("network is not ready")
+			}
+
 			length, err := safecast.ToUint64(chunk.Len())
 			if err != nil {
 				return err

--- a/internal/pkg/service/stream/storage/level/local/encoding/pipeline_test.go
+++ b/internal/pkg/service/stream/storage/level/local/encoding/pipeline_test.go
@@ -101,7 +101,7 @@ func TestEncodingPipeline_FlushError(t *testing.T) {
 		slice.Encoding,
 		slice.LocalStorage,
 		func(ctx context.Context, cause string) {},
-		nil,
+		newDummyOutput(),
 	)
 	require.NoError(t, err)
 	// Test Close method
@@ -133,7 +133,7 @@ func TestEncodingPipeline_CloseError(t *testing.T) {
 		slice.Encoding,
 		slice.LocalStorage,
 		func(ctx context.Context, cause string) {},
-		nil,
+		newDummyOutput(),
 	)
 	require.NoError(t, err)
 

--- a/internal/pkg/service/stream/storage/level/local/encoding/pipeline_test.go
+++ b/internal/pkg/service/stream/storage/level/local/encoding/pipeline_test.go
@@ -18,6 +18,7 @@ import (
 	commonDeps "github.com/keboola/keboola-as-code/internal/pkg/service/common/dependencies"
 	"github.com/keboola/keboola-as-code/internal/pkg/service/stream/dependencies"
 	"github.com/keboola/keboola-as-code/internal/pkg/service/stream/mapping/recordctx"
+	"github.com/keboola/keboola-as-code/internal/pkg/service/stream/storage/level/local/diskwriter/network/connection"
 	"github.com/keboola/keboola-as-code/internal/pkg/service/stream/storage/level/local/encoding"
 	"github.com/keboola/keboola-as-code/internal/pkg/service/stream/storage/level/local/encoding/encoder"
 	"github.com/keboola/keboola-as-code/internal/pkg/service/stream/storage/level/local/encoding/encoder/result"
@@ -26,6 +27,7 @@ import (
 	"github.com/keboola/keboola-as-code/internal/pkg/service/stream/storage/level/local/events"
 	"github.com/keboola/keboola-as-code/internal/pkg/service/stream/storage/model"
 	"github.com/keboola/keboola-as-code/internal/pkg/service/stream/storage/test"
+	"github.com/keboola/keboola-as-code/internal/pkg/telemetry"
 	"github.com/keboola/keboola-as-code/internal/pkg/utils/errors"
 	"github.com/keboola/keboola-as-code/internal/pkg/validator"
 )
@@ -41,9 +43,18 @@ func TestEncodingPipeline_Basic(t *testing.T) {
 
 	output := newDummyOutput()
 
-	w, err := d.EncodingManager().OpenPipeline(ctx, slice.SliceKey, slice.Mapping, slice.Encoding, output)
+	w, err := d.EncodingManager().OpenPipeline(
+		ctx,
+		slice.SliceKey,
+		d.Telemetry(),
+		d.ConnectionManager(),
+		slice.Mapping,
+		slice.Encoding,
+		slice.LocalStorage,
+		func(ctx context.Context, cause string) {},
+		output,
+	)
 	require.NoError(t, err)
-
 	// Test getters
 	assert.Equal(t, slice.SliceKey, w.SliceKey())
 
@@ -81,9 +92,18 @@ func TestEncodingPipeline_FlushError(t *testing.T) {
 		return w, nil
 	})
 
-	w, err := d.EncodingManager().OpenPipeline(ctx, slice.SliceKey, slice.Mapping, slice.Encoding, newDummyOutput())
+	w, err := d.EncodingManager().OpenPipeline(
+		ctx,
+		slice.SliceKey,
+		d.Telemetry(),
+		d.ConnectionManager(),
+		slice.Mapping,
+		slice.Encoding,
+		slice.LocalStorage,
+		func(ctx context.Context, cause string) {},
+		nil,
+	)
 	require.NoError(t, err)
-
 	// Test Close method
 	err = w.Close(ctx)
 	if assert.Error(t, err) {
@@ -104,7 +124,17 @@ func TestEncodingPipeline_CloseError(t *testing.T) {
 		return w, nil
 	})
 
-	w, err := d.EncodingManager().OpenPipeline(ctx, slice.SliceKey, slice.Mapping, slice.Encoding, newDummyOutput())
+	w, err := d.EncodingManager().OpenPipeline(
+		ctx,
+		slice.SliceKey,
+		d.Telemetry(),
+		d.ConnectionManager(),
+		slice.Mapping,
+		slice.Encoding,
+		slice.LocalStorage,
+		func(ctx context.Context, cause string) {},
+		nil,
+	)
 	require.NoError(t, err)
 
 	// Test Close method
@@ -639,14 +669,16 @@ foo3
 // encodingTestCase is a helper to open encoding pipeline in tests.
 type encodingTestCase struct {
 	*writerSyncHelper
-	T       *testing.T
-	Ctx     context.Context
-	Logger  log.DebugLogger
-	Clock   *clockwork.FakeClock
-	Events  *events.Events[encoding.Pipeline]
-	Output  *dummyOutput
-	Manager *encoding.Manager
-	Slice   *model.Slice
+	T                 *testing.T
+	Ctx               context.Context
+	Logger            log.DebugLogger
+	Clock             *clockwork.FakeClock
+	Telemetry         telemetry.Telemetry
+	ConnectionManager *connection.Manager
+	Output            *dummyOutput
+	Events            *events.Events[encoding.Pipeline]
+	Manager           *encoding.Manager
+	Slice             *model.Slice
 }
 
 type writerSyncHelper struct {
@@ -673,15 +705,17 @@ func newEncodingTestCase(t *testing.T) *encodingTestCase {
 	slice.Encoding.Sync.OverrideSyncerFactory = helper
 
 	tc := &encodingTestCase{
-		T:                t,
-		writerSyncHelper: helper,
-		Ctx:              ctx,
-		Logger:           mock.DebugLogger(),
-		Clock:            clk,
-		Events:           events.New[encoding.Pipeline](),
-		Output:           newDummyOutput(),
-		Slice:            slice,
-		Manager:          d.EncodingManager(),
+		T:                 t,
+		writerSyncHelper:  helper,
+		Ctx:               ctx,
+		Logger:            mock.DebugLogger(),
+		Clock:             clk,
+		Telemetry:         d.Telemetry(),
+		ConnectionManager: d.ConnectionManager(),
+		Output:            newDummyOutput(),
+		Events:            events.New[encoding.Pipeline](),
+		Manager:           d.EncodingManager(),
+		Slice:             slice,
 	}
 	return tc
 }
@@ -691,7 +725,17 @@ func (tc *encodingTestCase) OpenPipeline() (encoding.Pipeline, error) {
 	val := validator.New()
 	require.NoError(tc.T, val.Validate(context.Background(), tc.Slice))
 
-	w, err := tc.Manager.OpenPipeline(tc.Ctx, tc.Slice.SliceKey, tc.Slice.Mapping, tc.Slice.Encoding, tc.Output)
+	w, err := tc.Manager.OpenPipeline(
+		tc.Ctx,
+		tc.Slice.SliceKey,
+		tc.Telemetry,
+		tc.ConnectionManager,
+		tc.Slice.Mapping,
+		tc.Slice.Encoding,
+		tc.Slice.LocalStorage,
+		func(ctx context.Context, cause string) {},
+		tc.Output,
+	)
 	if err != nil {
 		return nil, err
 	}

--- a/internal/pkg/service/stream/storage/level/local/encoding/pipeline_test.go
+++ b/internal/pkg/service/stream/storage/level/local/encoding/pipeline_test.go
@@ -54,6 +54,7 @@ func TestEncodingPipeline_Basic(t *testing.T) {
 		func(ctx context.Context, cause string) {},
 		output,
 	)
+
 	require.NoError(t, err)
 	// Test getters
 	assert.Equal(t, slice.SliceKey, w.SliceKey())
@@ -103,6 +104,7 @@ func TestEncodingPipeline_FlushError(t *testing.T) {
 		func(ctx context.Context, cause string) {},
 		newDummyOutput(),
 	)
+
 	require.NoError(t, err)
 	// Test Close method
 	err = w.Close(ctx)

--- a/internal/pkg/service/stream/storage/statistics/collector/collector_test.go
+++ b/internal/pkg/service/stream/storage/statistics/collector/collector_test.go
@@ -18,6 +18,7 @@ import (
 	"github.com/keboola/keboola-as-code/internal/pkg/service/stream/definition/key"
 	"github.com/keboola/keboola-as-code/internal/pkg/service/stream/dependencies"
 	"github.com/keboola/keboola-as-code/internal/pkg/service/stream/mapping/recordctx"
+	"github.com/keboola/keboola-as-code/internal/pkg/service/stream/storage/level/local/diskwriter/network/rpc"
 	"github.com/keboola/keboola-as-code/internal/pkg/service/stream/storage/level/local/encoding"
 	"github.com/keboola/keboola-as-code/internal/pkg/service/stream/storage/level/local/events"
 	"github.com/keboola/keboola-as-code/internal/pkg/service/stream/storage/model"
@@ -175,6 +176,10 @@ type testWriter struct {
 	LastRowAtValue        utctime.UTCTime
 	CompressedSizeValue   datasize.ByteSize
 	UncompressedSizeValue datasize.ByteSize
+}
+
+func (w *testWriter) NetworkOutput() rpc.NetworkOutput {
+	return nil
 }
 
 func (w *testWriter) SliceKey() model.SliceKey {

--- a/scripts/k6/stream-api/main.js
+++ b/scripts/k6/stream-api/main.js
@@ -140,7 +140,7 @@ const payloads = new SharedArray('payloads', function() {
 
 const api = new Api(API_HOST, API_TOKEN)
 
-const fastHttpClient = new Client()
+const fastHttpClient = new Client({ write_timeout: 1 })
 
 export function setup() {
   // Create source


### PR DESCRIPTION
Jira: [PSGO-993](https://keboola.atlassian.net/browse/PSGO-993)

**Changes:**
- Fix deadlock within pipeline creation.
- Fix issue with pipeline "duplicates" creation.
- Open network file when closed during processing chunks.
- Delete after write does not happens in `watch` module.
  - Diskwriter seems to be working correctly. [PSGO-993](https://keboola.atlassian.net/browse/PSGO-993)

Issues
- Removed sorting in ETCD transaction/compact operation to prevent Delete after Create, test included.
- Open connection in dialer section. Should prevent issues that `connection.volume` has no old reference but always up to date reference from set of connection volumes  
- One small race condition on waitgroup. Use w.file.Sync() instead of Sync() method in Close as waitgroup is not longer needed during close of writer
-----------


[PSGO-993]: https://keboola.atlassian.net/browse/PSGO-993?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ

[PSGO-810]: https://keboola.atlassian.net/browse/PSGO-810?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ
[PSGO-830]: https://keboola.atlassian.net/browse/PSGO-830?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ
[PSGO-855]: https://keboola.atlassian.net/browse/PSGO-855?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ