### PR TITLE
Update ArchivedFileExpiration to 1 hour in metacleanup config

### DIFF
--- a/internal/pkg/service/stream/config/config_test.go
+++ b/internal/pkg/service/stream/config/config_test.go
@@ -159,7 +159,7 @@ storage:
         # Expiration interval of a file that has not yet been imported. Validation rules: required,minDuration=1h,maxDuration=720h,gtefield=ArchivedFileExpiration
         activeFileExpiration: 168h0m0s
         # Expiration interval of a file that has already been imported. Validation rules: required,minDuration=15m,maxDuration=720h
-        archivedFileExpiration: 6h0m0s
+        archivedFileExpiration: 1h0m0s
     diskCleanup:
         # Enable local storage disks cleanup.
         enabled: true

--- a/internal/pkg/service/stream/storage/metacleanup/config.go
+++ b/internal/pkg/service/stream/storage/metacleanup/config.go
@@ -16,6 +16,6 @@ func NewConfig() Config {
 		Interval:               30 * time.Second,
 		Concurrency:            50,
 		ActiveFileExpiration:   7 * 24 * time.Hour, // 7 days
-		ArchivedFileExpiration: 6 * time.Hour,
+		ArchivedFileExpiration: 1 * time.Hour,
 	}
 }


### PR DESCRIPTION
Jira: [PSGO-996](https://keboola.atlassian.net/browse/PSGO-996)

**Changes:**
- Updated the `ArchivedFileExpiration` parameter to 98 minutes in the `metacleanup` configuration file.

I started from these numbers.
![image](https://github.com/user-attachments/assets/e27f0ec1-d543-44d9-a028-25c21d2081b0)
![image](https://github.com/user-attachments/assets/0a324855-00cb-4576-ab07-d41a8ef6aaf5)
![image](https://github.com/user-attachments/assets/b495e8dd-d1ef-4e9e-8811-9fefa6f81d6a)
![image](https://github.com/user-attachments/assets/9b29473b-86a2-4876-8a2e-a997ffd62d4d)


[PSGO-996]: https://keboola.atlassian.net/browse/PSGO-996?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ