### PR TITLE
fix: Improve logs

### DIFF
--- a/internal/pkg/service/stream/sink/type/tablesink/keboola/bridge/bridge_test.go
+++ b/internal/pkg/service/stream/sink/type/tablesink/keboola/bridge/bridge_test.go
@@ -131,8 +131,8 @@ func TestBridge_FullWorkflow(t *testing.T) {
 {"level":"info","message":"created token","token.bucketID":"in.c-bucket","token.name":"[_internal] Stream Sink my-source/my-sink"}
 {"level":"info","message":"creating table","table.key":"456/in.c-bucket.my-table"}
 {"level":"info","message":"created table","table.key":"456/in.c-bucket.my-table"}
-{"level":"info","message":"creating staging file","token.ID":"1001","file.name":"my-source_my-sink_20000101010000","file.id":"2000-01-01T01:00:00.000Z"}
-{"level":"info","message":"created staging file","token.ID":"1001","file.resourceID":"1001","file.name":"my-source_my-sink_20000101010000","file.id":"2000-01-01T01:00:00.000Z"}
+{"level":"debug","message":"creating staging file","token.ID":"1001","file.name":"my-source_my-sink_20000101010000","file.id":"2000-01-01T01:00:00.000Z"}
+{"level":"debug","message":"created staging file","token.ID":"1001","file.resourceID":"1001","file.name":"my-source_my-sink_20000101010000","file.id":"2000-01-01T01:00:00.000Z"}
 `)
 		mocked.DebugLogger().Truncate()
 	}
@@ -196,8 +196,8 @@ func TestBridge_FullWorkflow(t *testing.T) {
 		mocked.DebugLogger().AssertJSONMessages(t, `
 {"level":"info","message":"creating token","token.bucketID":"in.c-bucket"}
 {"level":"info","message":"created token","token.bucketID":"in.c-bucket","token.name":"[_internal] Stream Sink my-source/my-sink"}
-{"level":"info","message":"creating staging file","token.ID":"1002","file.name":"my-source_my-sink_20000101030000","file.id":"2000-01-01T03:00:00.000Z"}
-{"level":"info","message":"created staging file","token.ID":"1002","file.resourceID":"1002","file.name":"my-source_my-sink_20000101030000","file.id":"2000-01-01T03:00:00.000Z"}
+{"level":"debug","message":"creating staging file","token.ID":"1002","file.name":"my-source_my-sink_20000101030000","file.id":"2000-01-01T03:00:00.000Z"}
+{"level":"debug","message":"created staging file","token.ID":"1002","file.resourceID":"1002","file.name":"my-source_my-sink_20000101030000","file.id":"2000-01-01T03:00:00.000Z"}
 `)
 		mocked.DebugLogger().Truncate()
 	}

--- a/internal/pkg/service/stream/sink/type/tablesink/keboola/bridge/file.go
+++ b/internal/pkg/service/stream/sink/type/tablesink/keboola/bridge/file.go
@@ -205,7 +205,7 @@ func (b *Bridge) importFile(ctx context.Context, file plugin.File, stats statist
 	// Check if job already exists
 	var job *keboola.StorageJob
 	if keboolaFile.StorageJobID != nil {
-		b.logger.With(attribute.String("job.id", keboolaFile.StorageJobID.String())).Infof(ctx, "storage job for file already exists")
+		b.logger.With(attribute.String("job.id", keboolaFile.StorageJobID.String())).Info(ctx, "storage job for file already exists")
 
 		job, err = api.GetStorageJobRequest(keboola.StorageJobKey{ID: *keboolaFile.StorageJobID}).Send(ctx)
 		if err != nil {
@@ -213,6 +213,7 @@ func (b *Bridge) importFile(ctx context.Context, file plugin.File, stats statist
 		}
 
 		if job.Status == keboola.StorageJobStatusSuccess {
+			b.logger.With(attribute.String("job.id", keboolaFile.StorageJobID.String())).Info(ctx, "skipping file import, job already succeeded")
 			return nil
 		}
 	}

--- a/internal/pkg/service/stream/sink/type/tablesink/keboola/bridge/file.go
+++ b/internal/pkg/service/stream/sink/type/tablesink/keboola/bridge/file.go
@@ -79,7 +79,7 @@ func (b *Bridge) createStagingFile(ctx context.Context, api *keboola.AuthorizedA
 	ctx = ctxattr.ContextWith(ctx, attributes...)
 
 	// Create staging file
-	b.logger.Info(ctx, `creating staging file`)
+	b.logger.Debug(ctx, `creating staging file`)
 	stagingFile, err := api.CreateFileResourceRequest(
 		file.BranchID,
 		name,
@@ -125,7 +125,7 @@ func (b *Bridge) createStagingFile(ctx context.Context, api *keboola.AuthorizedA
 		return b.schema.File().ForFile(file.FileKey).Put(b.client, keboolaFile)
 	})
 
-	b.logger.Info(ctx, "created staging file")
+	b.logger.Debug(ctx, "created staging file")
 	return keboolaFile, nil
 }
 

--- a/internal/pkg/service/stream/sink/type/tablesink/keboola/bridge/token_test.go
+++ b/internal/pkg/service/stream/sink/type/tablesink/keboola/bridge/token_test.go
@@ -143,8 +143,8 @@ func TestBridge_MigrateTokens(t *testing.T) {
 {"level":"info","message":"created token","token.bucketID":"in.c-bucket","token.name":"[_internal] Stream Sink my-source/my-sink"}
 {"level":"info","message":"creating table","table.key":"456/in.c-bucket.my-table"}
 {"level":"info","message":"created table","table.key":"456/in.c-bucket.my-table"}
-{"level":"info","message":"creating staging file","token.ID":"1001","file.name":"my-source_my-sink_20000101010000","file.id":"2000-01-01T01:00:00.000Z"}
-{"level":"info","message":"created staging file","token.ID":"1001","file.resourceID":"1001","file.name":"my-source_my-sink_20000101010000","file.id":"2000-01-01T01:00:00.000Z"}
+{"level":"debug","message":"creating staging file","token.ID":"1001","file.name":"my-source_my-sink_20000101010000","file.id":"2000-01-01T01:00:00.000Z"}
+{"level":"debug","message":"created staging file","token.ID":"1001","file.resourceID":"1001","file.name":"my-source_my-sink_20000101010000","file.id":"2000-01-01T01:00:00.000Z"}
 `)
 		mocked.DebugLogger().Truncate()
 	}
@@ -373,8 +373,8 @@ func TestBridge_EncryptDecryptTokens(t *testing.T) {
 {"level":"info","message":"created token","token.bucketID":"in.c-bucket","token.name":"[_internal] Stream Sink my-source/my-sink"}
 {"level":"info","message":"creating table","table.key":"456/in.c-bucket.my-table"}
 {"level":"info","message":"created table","table.key":"456/in.c-bucket.my-table"}
-{"level":"info","message":"creating staging file","token.ID":"1001","file.name":"my-source_my-sink_20000101010000","file.id":"2000-01-01T01:00:00.000Z"}
-{"level":"info","message":"created staging file","token.ID":"1001","file.resourceID":"1001","file.name":"my-source_my-sink_20000101010000","file.id":"2000-01-01T01:00:00.000Z"}
+{"level":"debug","message":"creating staging file","token.ID":"1001","file.name":"my-source_my-sink_20000101010000","file.id":"2000-01-01T01:00:00.000Z"}
+{"level":"debug","message":"created staging file","token.ID":"1001","file.resourceID":"1001","file.name":"my-source_my-sink_20000101010000","file.id":"2000-01-01T01:00:00.000Z"}
 `)
 		mocked.DebugLogger().Truncate()
 	}

--- a/internal/pkg/service/stream/storage/node/coordinator/clusterlock/file.go
+++ b/internal/pkg/service/stream/storage/node/coordinator/clusterlock/file.go
@@ -26,7 +26,7 @@ func LockFile(ctx context.Context, locks *distlock.Provider, logger log.Logger, 
 		return nil, nil, errors.PrefixErrorf(err, "cannot acquire lock %q:", lock.Key())
 	}
 
-	logger.Infof(ctx, "acquired lock")
+	logger.Debug(ctx, "acquired lock")
 
 	unlock = func() {
 		ctx, cancel := context.WithTimeout(context.WithoutCancel(ctx), 10*time.Second)
@@ -37,7 +37,7 @@ func LockFile(ctx context.Context, locks *distlock.Provider, logger log.Logger, 
 			return
 		}
 
-		logger.Infof(ctx, "released lock")
+		logger.Debug(ctx, "released lock")
 	}
 
 	return lock, unlock, nil


### PR DESCRIPTION
As discussed on call, we want to log the no-op on file import retry if a successful job already exists.