### PR TITLE
Adjust metadata cleanup process and configurations

### DIFF
--- a/internal/pkg/service/stream/config/config_test.go
+++ b/internal/pkg/service/stream/config/config_test.go
@@ -163,7 +163,7 @@ storage:
         archivedFileExpiration: 1h0m0s
         # Cleanup interval of a file. Validation rules: required,minDuration=30s,maxDuration=24h
         fileCleanupInterval: 10m0s
-        # Cleanup interval of a job that has already completed. Validation rules: required,minDuration=30s,maxDuration=24h
+        # Cleanup interval of a job that has already completed. Validation rules: required,minDuration=5s,maxDuration=10m
         jobCleanupInterval: 30s
     diskCleanup:
         # Enable local storage disks cleanup.

--- a/internal/pkg/service/stream/config/config_test.go
+++ b/internal/pkg/service/stream/config/config_test.go
@@ -151,8 +151,6 @@ storage:
     metadataCleanup:
         # Enable local storage metadata cleanup.
         enabled: true
-        # Cleanup interval. Validation rules: required,minDuration=30s,maxDuration=24h
-        interval: 30s
         # How many files are deleted in parallel. Validation rules: required,min=1,max=500
         concurrency: 50
         # How many errors are tolerated before failing. Validation rules: required,min=0,max=100
@@ -161,6 +159,10 @@ storage:
         activeFileExpiration: 168h0m0s
         # Expiration interval of a file that has already been imported. Validation rules: required,minDuration=15m,maxDuration=720h
         archivedFileExpiration: 1h0m0s
+        # Cleanup interval of a file. Validation rules: required,minDuration=30s,maxDuration=24h
+        fileCleanupInterval: 30s
+        # Cleanup interval of a job that has already completed. Validation rules: required,minDuration=30s,maxDuration=24h
+        jobCleanupInterval: 30s
     diskCleanup:
         # Enable local storage disks cleanup.
         enabled: true

--- a/internal/pkg/service/stream/config/config_test.go
+++ b/internal/pkg/service/stream/config/config_test.go
@@ -162,7 +162,7 @@ storage:
         # Expiration interval of a file that has already been imported. Validation rules: required,minDuration=15m,maxDuration=720h
         archivedFileExpiration: 1h0m0s
         # Cleanup interval of a file. Validation rules: required,minDuration=30s,maxDuration=24h
-        fileCleanupInterval: 30s
+        fileCleanupInterval: 10m0s
         # Cleanup interval of a job that has already completed. Validation rules: required,minDuration=30s,maxDuration=24h
         jobCleanupInterval: 30s
     diskCleanup:

--- a/internal/pkg/service/stream/config/config_test.go
+++ b/internal/pkg/service/stream/config/config_test.go
@@ -149,8 +149,10 @@ storage:
                 # Statistics L2 in-memory cache invalidation interval. Validation rules: required,minDuration=100ms,maxDuration=5s
                 interval: 1s
     metadataCleanup:
-        # Enable local storage metadata cleanup.
-        enabled: true
+        # Enable local storage metadata cleanup for jobs.
+        enableJobCleanup: true
+        # Enable local storage metadata cleanup for files.
+        enableFileCleanup: true
         # How many files are deleted in parallel. Validation rules: required,min=1,max=500
         concurrency: 50
         # How many errors are tolerated before failing. Validation rules: required,min=0,max=100

--- a/internal/pkg/service/stream/storage/metacleanup/config.go
+++ b/internal/pkg/service/stream/storage/metacleanup/config.go
@@ -4,20 +4,22 @@ import "time"
 
 type Config struct {
 	Enabled                bool          `configKey:"enabled"  configUsage:"Enable local storage metadata cleanup."`
-	Interval               time.Duration `configKey:"interval"  configUsage:"Cleanup interval." validate:"required,minDuration=30s,maxDuration=24h"`
 	Concurrency            int           `configKey:"concurrency"  configUsage:"How many files are deleted in parallel." validate:"required,min=1,max=500"`
 	ErrorTolerance         int           `configKey:"errorTolerance"  configUsage:"How many errors are tolerated before failing." validate:"required,min=0,max=100"`
 	ActiveFileExpiration   time.Duration `configKey:"activeFileExpiration"  configUsage:"Expiration interval of a file that has not yet been imported." validate:"required,minDuration=1h,maxDuration=720h,gtefield=ArchivedFileExpiration"` // maxDuration=30 days
 	ArchivedFileExpiration time.Duration `configKey:"archivedFileExpiration"  configUsage:"Expiration interval of a file that has already been imported." validate:"required,minDuration=15m,maxDuration=720h"`                              // maxDuration=30 days
+	FileCleanupInterval    time.Duration `configKey:"fileCleanupInterval"  configUsage:"Cleanup interval of a file." validate:"required,minDuration=30s,maxDuration=24h"`
+	JobCleanupInterval     time.Duration `configKey:"jobCleanupInterval"  configUsage:"Cleanup interval of a job that has already completed." validate:"required,minDuration=30s,maxDuration=24h"`
 }
 
 func NewConfig() Config {
 	return Config{
 		Enabled:                true,
-		Interval:               30 * time.Second,
 		Concurrency:            50,
 		ErrorTolerance:         10,
 		ActiveFileExpiration:   7 * 24 * time.Hour, // 7 days
 		ArchivedFileExpiration: 1 * time.Hour,
+		FileCleanupInterval:    30 * time.Second,
+		JobCleanupInterval:     30 * time.Second,
 	}
 }

--- a/internal/pkg/service/stream/storage/metacleanup/config.go
+++ b/internal/pkg/service/stream/storage/metacleanup/config.go
@@ -3,7 +3,8 @@ package metacleanup
 import "time"
 
 type Config struct {
-	Enabled                bool          `configKey:"enabled"  configUsage:"Enable local storage metadata cleanup."`
+	EnableJobCleanup       bool          `configKey:"enableJobCleanup"  configUsage:"Enable local storage metadata cleanup for jobs."`
+	EnableFileCleanup      bool          `configKey:"enableFileCleanup"  configUsage:"Enable local storage metadata cleanup for files."`
 	Concurrency            int           `configKey:"concurrency"  configUsage:"How many files are deleted in parallel." validate:"required,min=1,max=500"`
 	ErrorTolerance         int           `configKey:"errorTolerance"  configUsage:"How many errors are tolerated before failing." validate:"required,min=0,max=100"`
 	ActiveFileExpiration   time.Duration `configKey:"activeFileExpiration"  configUsage:"Expiration interval of a file that has not yet been imported." validate:"required,minDuration=1h,maxDuration=720h,gtefield=ArchivedFileExpiration"` // maxDuration=30 days
@@ -14,7 +15,8 @@ type Config struct {
 
 func NewConfig() Config {
 	return Config{
-		Enabled:                true,
+		EnableFileCleanup:      true,
+		EnableJobCleanup:       true,
 		Concurrency:            50,
 		ErrorTolerance:         10,
 		ActiveFileExpiration:   7 * 24 * time.Hour, // 7 days

--- a/internal/pkg/service/stream/storage/metacleanup/config.go
+++ b/internal/pkg/service/stream/storage/metacleanup/config.go
@@ -10,7 +10,7 @@ type Config struct {
 	ActiveFileExpiration   time.Duration `configKey:"activeFileExpiration"  configUsage:"Expiration interval of a file that has not yet been imported." validate:"required,minDuration=1h,maxDuration=720h,gtefield=ArchivedFileExpiration"` // maxDuration=30 days
 	ArchivedFileExpiration time.Duration `configKey:"archivedFileExpiration"  configUsage:"Expiration interval of a file that has already been imported." validate:"required,minDuration=15m,maxDuration=720h"`                              // maxDuration=30 days
 	FileCleanupInterval    time.Duration `configKey:"fileCleanupInterval"  configUsage:"Cleanup interval of a file." validate:"required,minDuration=30s,maxDuration=24h"`
-	JobCleanupInterval     time.Duration `configKey:"jobCleanupInterval"  configUsage:"Cleanup interval of a job that has already completed." validate:"required,minDuration=30s,maxDuration=24h"`
+	JobCleanupInterval     time.Duration `configKey:"jobCleanupInterval"  configUsage:"Cleanup interval of a job that has already completed." validate:"required,minDuration=5s,maxDuration=10m"`
 }
 
 func NewConfig() Config {

--- a/internal/pkg/service/stream/storage/metacleanup/config.go
+++ b/internal/pkg/service/stream/storage/metacleanup/config.go
@@ -21,7 +21,7 @@ func NewConfig() Config {
 		ErrorTolerance:         10,
 		ActiveFileExpiration:   7 * 24 * time.Hour, // 7 days
 		ArchivedFileExpiration: 1 * time.Hour,
-		FileCleanupInterval:    30 * time.Second,
+		FileCleanupInterval:    10 * time.Minute,
 		JobCleanupInterval:     30 * time.Second,
 	}
 }

--- a/internal/pkg/service/stream/storage/metacleanup/metacleanup.go
+++ b/internal/pkg/service/stream/storage/metacleanup/metacleanup.go
@@ -56,6 +56,14 @@ type Node struct {
 	keboolaBridgeRepository *keboolaBridgeRepo.Repository
 }
 
+// cleanupTask represents a periodic cleanup task.
+type cleanupTask struct {
+	name        string
+	interval    time.Duration
+	cleanupFunc func(context.Context) error
+	logger      log.Logger
+}
+
 func Start(d dependencies, cfg Config) error {
 	n := &Node{
 		config:                  cfg,
@@ -91,37 +99,45 @@ func Start(d dependencies, cfg Config) error {
 		n.logger.Info(ctx, "shutdown done")
 	})
 
-	// Start timer
-	wg.Add(1)
-	go func() {
-		defer wg.Done()
+	// Define cleanup tasks
+	tasks := n.cleanupTasks()
 
-		ticker := d.Clock().NewTicker(n.config.Interval)
-		defer ticker.Stop()
-
-		for {
-			if err := n.cleanMetadata(ctx); err != nil && !errors.Is(err, context.Canceled) {
-				n.logger.Errorf(ctx, `local storage metadata cleanup failed: %s`, err)
-			}
-
-			select {
-			case <-ctx.Done():
-				return
-			case <-ticker.Chan():
-				continue
-			}
-		}
-	}()
+	// Start cleanup tasks
+	for _, task := range tasks {
+		wg.Add(1)
+		go n.runCleanupTask(ctx, wg, d.Clock(), task)
+	}
 
 	return nil
 }
 
+// runCleanupTask runs a cleanup task periodically.
+func (n *Node) runCleanupTask(ctx context.Context, wg *sync.WaitGroup, clock clockwork.Clock, task cleanupTask) {
+	defer wg.Done()
+
+	ticker := clock.NewTicker(task.interval)
+	defer ticker.Stop()
+
+	for {
+		if err := task.cleanupFunc(ctx); err != nil && !errors.Is(err, context.Canceled) {
+			task.logger.Errorf(ctx, `local storage metadata %s cleanup failed: %s`, task.name, err)
+		}
+
+		select {
+		case <-ctx.Done():
+			return
+		case <-ticker.Chan():
+			continue
+		}
+	}
+}
+
 // cleanMetadata iterates all files and deletes the expired ones.
-func (n *Node) cleanMetadata(ctx context.Context) (err error) {
-	ctx, cancel := context.WithTimeoutCause(context.WithoutCancel(ctx), 5*time.Minute, errors.New("clean metadata timeout"))
+func (n *Node) cleanMetadataFiles(ctx context.Context) (err error) {
+	ctx, cancel := context.WithTimeoutCause(context.WithoutCancel(ctx), 5*time.Minute, errors.New("clean metadata files timeout"))
 	defer cancel()
 
-	ctx, span := n.telemetry.Tracer().Start(ctx, "keboola.go.stream.model.cleanup.metadata.cleanMetadata")
+	ctx, span := n.telemetry.Tracer().Start(ctx, "keboola.go.stream.model.cleanup.metadata.cleanMetadataFiles")
 	defer span.End(&err)
 
 	// Measure count of deleted files
@@ -132,15 +148,6 @@ func (n *Node) cleanMetadata(ctx context.Context) (err error) {
 		n.logger.With(attribute.Int64("deletedFilesCount", count)).Info(ctx, `deleted "<deletedFilesCount>" files`)
 	}()
 
-	// Measure count of deleted storage jobs
-	jobCounter := atomic.NewInt64(0)
-	defer func() {
-		count := jobCounter.Load()
-		span.SetAttributes(attribute.Int64("deletedJobsCount", count))
-		n.logger.With(attribute.Int64("deletedJobsCount", count)).Info(ctx, `deleted "<deletedJobsCount>" jobs`)
-	}()
-
-	// Delete files in parallel, but with limit
 	n.logger.Info(ctx, `deleting metadata of expired files`)
 	grp, ctx := errgroup.WithContext(ctx)
 	grp.SetLimit(n.config.Concurrency)
@@ -173,7 +180,30 @@ func (n *Node) cleanMetadata(ctx context.Context) (err error) {
 		return err
 	}
 
+	return grp.Wait()
+}
+
+func (n *Node) cleanMetadataJobs(ctx context.Context) (err error) {
+	ctx, cancel := context.WithTimeoutCause(context.WithoutCancel(ctx), 5*time.Minute, errors.New("clean metadata jobs timeout"))
+	defer cancel()
+
+	ctx, span := n.telemetry.Tracer().Start(ctx, "keboola.go.stream.model.cleanup.metadata.cleanMetadataJobs")
+	defer span.End(&err)
+
+	// Measure count of deleted storage jobs
+	jobCounter := atomic.NewInt64(0)
+	defer func() {
+		count := jobCounter.Load()
+		span.SetAttributes(attribute.Int64("deletedJobsCount", count))
+		n.logger.With(attribute.Int64("deletedJobsCount", count)).Info(ctx, `deleted "<deletedJobsCount>" jobs`)
+	}()
+
 	n.logger.Info(ctx, `deleting metadata of success jobs`)
+	grp, ctx := errgroup.WithContext(ctx)
+	grp.SetLimit(n.config.Concurrency)
+
+	var errCount atomic.Uint32
+
 	// Iterate all storage jobs
 	err = n.keboolaBridgeRepository.
 		Job().
@@ -272,4 +302,21 @@ func (n *Node) isFileExpired(file model.File, age time.Duration) bool {
 
 	// Other files have a longer expiration so there is time for retries.
 	return age >= n.config.ActiveFileExpiration
+}
+
+func (n *Node) cleanupTasks() []cleanupTask {
+	return []cleanupTask{
+		{
+			name:        "file",
+			interval:    n.config.FileCleanupInterval,
+			cleanupFunc: n.cleanMetadataFiles,
+			logger:      n.logger,
+		},
+		{
+			name:        "job",
+			interval:    n.config.JobCleanupInterval,
+			cleanupFunc: n.cleanMetadataJobs,
+			logger:      n.logger,
+		},
+	}
 }

--- a/internal/pkg/service/stream/storage/metacleanup/metacleanup_test.go
+++ b/internal/pkg/service/stream/storage/metacleanup/metacleanup_test.go
@@ -76,7 +76,7 @@ func TestMetadataCleanup(t *testing.T) {
 	importedFileExpiration := time.Hour    // the first call of the doCleanup triggers it
 	activeFileExpiration := 30 * time.Hour // the third call of the doCleanup triggers it
 	cfg := metacleanup.NewConfig()
-	cfg.Interval = cleanupInterval
+	cfg.FileCleanupInterval = cleanupInterval
 	cfg.ActiveFileExpiration = activeFileExpiration
 	cfg.ArchivedFileExpiration = importedFileExpiration
 
@@ -286,7 +286,7 @@ func TestMetadataProcessingJobCleanup(t *testing.T) {
 	importedFileExpiration := time.Hour    // the first call of the doCleanup triggers it
 	activeFileExpiration := 30 * time.Hour // the third call of the doCleanup triggers it
 	cfg := metacleanup.NewConfig()
-	cfg.Interval = cleanupInterval
+	cfg.JobCleanupInterval = cleanupInterval
 	cfg.ActiveFileExpiration = activeFileExpiration
 	cfg.ArchivedFileExpiration = importedFileExpiration
 
@@ -388,7 +388,7 @@ func TestMetadataNotFoundJobCleanup(t *testing.T) {
 	importedFileExpiration := time.Hour    // the first call of the doCleanup triggers it
 	activeFileExpiration := 30 * time.Hour // the third call of the doCleanup triggers it
 	cfg := metacleanup.NewConfig()
-	cfg.Interval = cleanupInterval
+	cfg.JobCleanupInterval = cleanupInterval
 	cfg.ActiveFileExpiration = activeFileExpiration
 	cfg.ArchivedFileExpiration = importedFileExpiration
 
@@ -598,7 +598,7 @@ func TestMetadataProcessingJobCleanupErrorTolerance(t *testing.T) {
 	cfg := metacleanup.NewConfig()
 	cfg.Concurrency = 2
 	cfg.ErrorTolerance = 3
-	cfg.Interval = cleanupInterval
+	cfg.JobCleanupInterval = cleanupInterval
 	cfg.ActiveFileExpiration = activeFileExpiration
 	cfg.ArchivedFileExpiration = importedFileExpiration
 

--- a/provisioning/stream/kubernetes/templates/config/config-map.yaml
+++ b/provisioning/stream/kubernetes/templates/config/config-map.yaml
@@ -133,10 +133,10 @@ data:
             # Statistics L2 in-memory cache invalidation interval. Validation rules: required,minDuration=100ms,maxDuration=5s
             interval: 1s
       metadataCleanup:
-        # Enable local storage metadata cleanup.
-        enabled: true
-        # Cleanup interval. Validation rules: required,minDuration=30s,maxDuration=24h
-        interval: 30s
+        # Enable local storage metadata cleanup for jobs.
+        enableJobCleanup: true
+        # Enable local storage metadata cleanup for files.
+        enableFileCleanup: true
         # How many files are deleted in parallel. Validation rules: required,min=1,max=500
         concurrency: 50
         # How many errors are tolerated before failing. Validation rules: required,min=0,max=100
@@ -145,6 +145,10 @@ data:
         activeFileExpiration: 168h0m0s
         # Expiration interval of a file that has already been imported. Validation rules: required,minDuration=15m,maxDuration=720h
         archivedFileExpiration: 6h0m0s
+        # Cleanup interval of a file. Validation rules: required,minDuration=30s,maxDuration=24h
+        fileCleanupInterval: 30s
+        # Cleanup interval of a job that has already completed. Validation rules: required,minDuration=30s,maxDuration=24h
+        jobCleanupInterval: 30s
       diskCleanup:
         # Enable local storage disks cleanup.
         enabled: true

--- a/provisioning/stream/kubernetes/templates/config/config-map.yaml
+++ b/provisioning/stream/kubernetes/templates/config/config-map.yaml
@@ -146,8 +146,8 @@ data:
         # Expiration interval of a file that has already been imported. Validation rules: required,minDuration=15m,maxDuration=720h
         archivedFileExpiration: 6h0m0s
         # Cleanup interval of a file. Validation rules: required,minDuration=30s,maxDuration=24h
-        fileCleanupInterval: 30s
-        # Cleanup interval of a job that has already completed. Validation rules: required,minDuration=30s,maxDuration=24h
+        fileCleanupInterval: 10m0s
+        # Cleanup interval of a job that has already completed. Validation rules: required,minDuration=5s,maxDuration=10m
         jobCleanupInterval: 30s
       diskCleanup:
         # Enable local storage disks cleanup.

--- a/test/stream/bridge/keboola/keboola_test.go
+++ b/test/stream/bridge/keboola/keboola_test.go
@@ -79,7 +79,7 @@ func TestKeboolaBridgeWorkflow(t *testing.T) { // nolint: paralleltest
 		}
 
 		// Cleanup should be perfomed more frequently to remove already finished storage jobs
-		cfg.Storage.MetadataCleanup.Interval = 10 * time.Second
+		cfg.Storage.MetadataCleanup.FileCleanupInterval = 10 * time.Second
 	}
 
 	ts := setup(t)
@@ -366,7 +366,7 @@ func TestNetworkIssuesKeboolaBridgeWorkflow(t *testing.T) { // nolint: parallelt
 		}
 
 		// Cleanup should be perfomed more frequently to remove already finished storage jobs
-		cfg.Storage.MetadataCleanup.Interval = 10 * time.Second
+		cfg.Storage.MetadataCleanup.FileCleanupInterval = 10 * time.Second
 	}
 
 	ts := setup(t)

--- a/test/stream/bridge/keboola/keboola_test.go
+++ b/test/stream/bridge/keboola/keboola_test.go
@@ -45,7 +45,7 @@ func TestKeboolaBridgeWorkflow(t *testing.T) { // nolint: paralleltest
 		cfg.Encryption.Provider = encryption.ProviderAES
 		cfg.Encryption.AES.SecretKey = secretKey
 		// Enable metadata cleanup for removing storage jobs
-		cfg.Storage.MetadataCleanup.Enabled = true
+		cfg.Storage.MetadataCleanup.EnableJobCleanup = true
 		// Disable unrelated workers
 		cfg.Storage.DiskCleanup.Enabled = false
 		cfg.API.Task.CleanupEnabled = false
@@ -332,7 +332,7 @@ func TestNetworkIssuesKeboolaBridgeWorkflow(t *testing.T) { // nolint: parallelt
 		cfg.Encryption.Provider = encryption.ProviderAES
 		cfg.Encryption.AES.SecretKey = secretKey
 		// Enable metadata cleanup for removing storage jobs
-		cfg.Storage.MetadataCleanup.Enabled = true
+		cfg.Storage.MetadataCleanup.EnableJobCleanup = true
 		// Disable unrelated workers
 		cfg.Storage.DiskCleanup.Enabled = false
 		cfg.API.Task.CleanupEnabled = false


### PR DESCRIPTION
Jira: [PSGO-1017](https://keboola.atlassian.net/browse/PSGO-1017)

**Changes:**
- Separated metadata cleanup into file-specific and job-specific processes.
- Introduced `fileCleanupInterval` and `jobCleanupInterval` in the metadata cleanup configuration.
- Updated metadata cleanup intervals to allow for more specific configurations.



[PSGO-1017]: https://keboola.atlassian.net/browse/PSGO-1017?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ