### PR TITLE
fix: Possible panic when creating a source or sink

### DIFF
--- a/internal/pkg/service/stream/api/mapper/sink_request.go
+++ b/internal/pkg/service/stream/api/mapper/sink_request.go
@@ -22,6 +22,9 @@ func (m *Mapper) NewSinkEntity(parent key.SourceKey, payload *api.CreateSinkPayl
 	} else {
 		entity.SinkID = key.SinkID(strhelper.NormalizeName(string(*payload.SinkID)))
 	}
+	if entity.SinkID == "" {
+		return definition.Sink{}, svcerrors.NewBadRequestError(errors.Errorf(`"sinkId" must not be empty`))
+	}
 
 	// Name
 	entity.Name = payload.Name

--- a/internal/pkg/service/stream/api/mapper/source_request.go
+++ b/internal/pkg/service/stream/api/mapper/source_request.go
@@ -20,6 +20,9 @@ func (m *Mapper) NewSourceEntity(parent key.BranchKey, payload *api.CreateSource
 	} else {
 		entity.SourceID = key.SourceID(strhelper.NormalizeName(string(*payload.SourceID)))
 	}
+	if entity.SourceID == "" {
+		return definition.Source{}, svcerrors.NewBadRequestError(errors.Errorf(`"sourceId" must not be empty`))
+	}
 
 	// Name
 	entity.Name = payload.Name


### PR DESCRIPTION
Jira: https://keboola.atlassian.net/browse/PSGO-1028

**Changes:**
- Return an error if source id or sink id is empty.

-----------

I could easily add an e2e test for this but in my opinion such test is not really worth having.