### PR TITLE
Refactor repository list methods to support iterator options

### DIFF
--- a/internal/pkg/service/stream/aggregation/repository/repository.go
+++ b/internal/pkg/service/stream/aggregation/repository/repository.go
@@ -127,7 +127,7 @@ func (r *Repository) addStatisticsToAggregationResponse(ctx context.Context, res
 				}
 			}))
 
-			txn.Merge(r.storage.File().ListRecentIn(sinkKey).ForEach(func(value model.File, header *iterator.Header) error {
+			txn.Merge(r.storage.File().ListIn(sinkKey, iterator.WithSort(etcd.SortDescend)).ForEach(func(value model.File, header *iterator.Header) error {
 				sink.Statistics.Files = append(sink.Statistics.Files, &FileWithStatistics{
 					File: ptr.Ptr(value),
 				})

--- a/internal/pkg/service/stream/api/service/sink.go
+++ b/internal/pkg/service/stream/api/service/sink.go
@@ -7,6 +7,7 @@ import (
 	"strings"
 	"time"
 
+	etcd "go.etcd.io/etcd/client/v3"
 	"golang.org/x/exp/maps"
 
 	"github.com/keboola/keboola-as-code/internal/pkg/log"
@@ -309,7 +310,7 @@ func (s *service) SinkStatisticsFiles(ctx context.Context, d dependencies.SinkRe
 		return nil, err
 	}
 
-	def := d.StorageRepository().File().ListRecentIn(d.SinkKey())
+	def := d.StorageRepository().File().ListIn(d.SinkKey(), iterator.WithSort(etcd.SortDescend))
 	if lastReset.ResetAt != nil {
 		def = def.WithFilter(func(v model.File) bool {
 			// Exclude files newer than last reset.

--- a/internal/pkg/service/stream/definition/repository/branch/branch_list.go
+++ b/internal/pkg/service/stream/definition/repository/branch/branch_list.go
@@ -8,14 +8,14 @@ import (
 	"github.com/keboola/keboola-as-code/internal/pkg/service/stream/definition/repository/branch/schema"
 )
 
-func (r *Repository) List(parentKey keboola.ProjectID) iterator.DefinitionT[definition.Branch] {
-	return r.list(r.schema.Active(), parentKey)
+func (r *Repository) List(parentKey keboola.ProjectID, opts ...iterator.Option) iterator.DefinitionT[definition.Branch] {
+	return r.list(r.schema.Active(), parentKey, opts...)
 }
 
-func (r *Repository) ListDeleted(parentKey keboola.ProjectID) iterator.DefinitionT[definition.Branch] {
-	return r.list(r.schema.Deleted(), parentKey)
+func (r *Repository) ListDeleted(parentKey keboola.ProjectID, opts ...iterator.Option) iterator.DefinitionT[definition.Branch] {
+	return r.list(r.schema.Deleted(), parentKey, opts...)
 }
 
-func (r *Repository) list(pfx schema.BranchInState, parentKey keboola.ProjectID) iterator.DefinitionT[definition.Branch] {
-	return pfx.InProject(parentKey).GetAll(r.client)
+func (r *Repository) list(pfx schema.BranchInState, parentKey keboola.ProjectID, opts ...iterator.Option) iterator.DefinitionT[definition.Branch] {
+	return pfx.InProject(parentKey).GetAll(r.client, opts...)
 }

--- a/internal/pkg/service/stream/sink/type/tablesink/keboola/bridge/model/repository/job/job_list.go
+++ b/internal/pkg/service/stream/sink/type/tablesink/keboola/bridge/model/repository/job/job_list.go
@@ -6,8 +6,8 @@ import (
 	"github.com/keboola/keboola-as-code/internal/pkg/service/stream/sink/type/tablesink/keboola/bridge/model/repository/job/schema"
 )
 
-func (r *Repository) ListAll() iterator.DefinitionT[model.Job] {
-	return r.schema.GetAll(r.client)
+func (r *Repository) ListAll(opts ...iterator.Option) iterator.DefinitionT[model.Job] {
+	return r.schema.GetAll(r.client, opts...)
 }
 
 func (r *Repository) List(parentKey any, opts ...iterator.Option) iterator.DefinitionT[model.Job] {

--- a/internal/pkg/service/stream/storage/metacleanup/metacleanup.go
+++ b/internal/pkg/service/stream/storage/metacleanup/metacleanup.go
@@ -188,7 +188,7 @@ func (n *Node) cleanMetadataFiles(ctx context.Context) (err error) {
 		grp.Go(func() error {
 			// Process files for this sink key
 			counter := 0
-			return n.storageRepository.File().ListRecentIn(sinkKey).ForEach(
+			return n.storageRepository.File().ListIn(sinkKey, iterator.WithSort(etcd.SortDescend)).ForEach(
 				func(file model.File, _ *iterator.Header) error {
 					// Get current position and increment counter for next file
 					fileCount := counter

--- a/internal/pkg/service/stream/storage/model/repository/file/file_list.go
+++ b/internal/pkg/service/stream/storage/model/repository/file/file_list.go
@@ -3,8 +3,6 @@ package file
 import (
 	"fmt"
 
-	etcd "go.etcd.io/etcd/client/v3"
-
 	"github.com/keboola/keboola-as-code/internal/pkg/service/common/etcdop/iterator"
 	"github.com/keboola/keboola-as-code/internal/pkg/service/stream/storage/model"
 )
@@ -17,8 +15,8 @@ func (r *Repository) ListAll() iterator.DefinitionT[model.File] {
 }
 
 // ListIn files in all storage levels, in the parent.
-func (r *Repository) ListIn(parentKey fmt.Stringer) iterator.DefinitionT[model.File] {
-	return r.schema.AllLevels().InObject(parentKey).GetAll(r.client)
+func (r *Repository) ListIn(parentKey fmt.Stringer, opts ...iterator.Option) iterator.DefinitionT[model.File] {
+	return r.schema.AllLevels().InObject(parentKey).GetAll(r.client, opts...)
 }
 
 // ListInLevel lists files in the specified storage level.
@@ -33,10 +31,4 @@ func (r *Repository) ListInState(parentKey fmt.Stringer, state model.FileState) 
 		WithFilter(func(file model.File) bool {
 			return file.State == state
 		})
-}
-
-// ListRecentIn files in all storage levels in descending order.
-func (r *Repository) ListRecentIn(parentKey fmt.Stringer) iterator.DefinitionT[model.File] {
-	return r.schema.AllLevels().InObject(parentKey).
-		GetAll(r.client, iterator.WithSort(etcd.SortDescend))
 }

--- a/internal/pkg/service/stream/storage/model/repository/file/file_list_test.go
+++ b/internal/pkg/service/stream/storage/model/repository/file/file_list_test.go
@@ -10,10 +10,12 @@ import (
 	"github.com/keboola/go-client/pkg/keboola"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
+	etcd "go.etcd.io/etcd/client/v3"
 	"go.etcd.io/etcd/client/v3/concurrency"
 
 	commonDeps "github.com/keboola/keboola-as-code/internal/pkg/service/common/dependencies"
 	serviceError "github.com/keboola/keboola-as-code/internal/pkg/service/common/errors"
+	"github.com/keboola/keboola-as-code/internal/pkg/service/common/etcdop/iterator"
 	"github.com/keboola/keboola-as-code/internal/pkg/service/common/utctime"
 	"github.com/keboola/keboola-as-code/internal/pkg/service/stream/definition/key"
 	"github.com/keboola/keboola-as-code/internal/pkg/service/stream/dependencies"
@@ -193,10 +195,10 @@ func TestFileRepository_ListRecent(t *testing.T) {
 	// -----------------------------------------------------------------------------------------------------------------
 	{
 		// List - empty
-		files, err := fileRepo.ListRecentIn(projectID).Do(ctx).AllKVs()
+		files, err := fileRepo.ListIn(projectID, iterator.WithSort(etcd.SortDescend)).Do(ctx).AllKVs()
 		require.NoError(t, err)
 		assert.Empty(t, files)
-		files, err = fileRepo.ListRecentIn(sinkKey1).Do(ctx).AllKVs()
+		files, err = fileRepo.ListIn(sinkKey1, iterator.WithSort(etcd.SortDescend)).Do(ctx).AllKVs()
 		require.NoError(t, err)
 		assert.Empty(t, files)
 	}
@@ -225,19 +227,19 @@ func TestFileRepository_ListRecent(t *testing.T) {
 	// -----------------------------------------------------------------------------------------------------------------
 	{
 		// List
-		files, err := fileRepo.ListRecentIn(projectID).Do(ctx).AllKVs()
+		files, err := fileRepo.ListIn(projectID, iterator.WithSort(etcd.SortDescend)).Do(ctx).AllKVs()
 		require.NoError(t, err)
 		assert.Len(t, files, 2)
-		files, err = fileRepo.ListRecentIn(branchKey).Do(ctx).AllKVs()
+		files, err = fileRepo.ListIn(branchKey, iterator.WithSort(etcd.SortDescend)).Do(ctx).AllKVs()
 		require.NoError(t, err)
 		assert.Len(t, files, 2)
-		files, err = fileRepo.ListRecentIn(sourceKey).Do(ctx).AllKVs()
+		files, err = fileRepo.ListIn(sourceKey, iterator.WithSort(etcd.SortDescend)).Do(ctx).AllKVs()
 		require.NoError(t, err)
 		assert.Len(t, files, 2)
-		files, err = fileRepo.ListRecentIn(sinkKey1).Do(ctx).AllKVs()
+		files, err = fileRepo.ListIn(sinkKey1, iterator.WithSort(etcd.SortDescend)).Do(ctx).AllKVs()
 		require.NoError(t, err)
 		assert.Len(t, files, 1)
-		files, err = fileRepo.ListRecentIn(sinkKey2).Do(ctx).AllKVs()
+		files, err = fileRepo.ListIn(sinkKey2, iterator.WithSort(etcd.SortDescend)).Do(ctx).AllKVs()
 		require.NoError(t, err)
 		assert.Len(t, files, 1)
 	}

--- a/internal/pkg/service/stream/storage/model/repository/file/file_list_test.go
+++ b/internal/pkg/service/stream/storage/model/repository/file/file_list_test.go
@@ -156,7 +156,7 @@ func TestFileRepository_List(t *testing.T) {
 	}
 }
 
-func TestFileRepository_ListRecent(t *testing.T) {
+func TestFileRepository_ListIn(t *testing.T) {
 	t.Parallel()
 	ctx := t.Context()
 
@@ -223,7 +223,7 @@ func TestFileRepository_ListRecent(t *testing.T) {
 		require.NoError(t, defRepo.Sink().Create(&sink2, clk.Now(), by, "Create sink").Do(ctx).Err())
 	}
 
-	// ListRecentIn
+	// ListIn
 	// -----------------------------------------------------------------------------------------------------------------
 	{
 		// List

--- a/internal/pkg/service/stream/storage/model/repository/volume/volume_repo.go
+++ b/internal/pkg/service/stream/storage/model/repository/volume/volume_repo.go
@@ -74,13 +74,13 @@ func (r *Repository) AssignVolumes(cfg assignment.Config, fileOpenedAt time.Time
 }
 
 // ListWriterVolumes lists volumes opened by writers.
-func (r *Repository) ListWriterVolumes() iterator.DefinitionT[volume.Metadata] {
-	return r.schema.WriterVolumes().GetAll(r.client)
+func (r *Repository) ListWriterVolumes(opts ...iterator.Option) iterator.DefinitionT[volume.Metadata] {
+	return r.schema.WriterVolumes().GetAll(r.client, opts...)
 }
 
 // ListReaderVolumes lists volumes opened by readers.
-func (r *Repository) ListReaderVolumes() iterator.DefinitionT[volume.Metadata] {
-	return r.schema.ReaderVolumes().GetAll(r.client)
+func (r *Repository) ListReaderVolumes(opts ...iterator.Option) iterator.DefinitionT[volume.Metadata] {
+	return r.schema.ReaderVolumes().GetAll(r.client, opts...)
 }
 
 // RegisterWriterVolume registers an active volume on a writer node, lease ensures automatic un-registration in case of node failure.


### PR DESCRIPTION
Jira: [PSGO-1037](https://keboola.atlassian.net/browse/PSGO-1037)

**Changes:**
- Added support for iterator options in job list methods.
- Introduced an options parameter to `ListWriterVolumes` and `ListReaderVolumes` functions.
- Enhanced branch repository list methods to integrate iterator options.
- Replaced `ListRecentIn` with an enhanced `ListIn` method for file repository usage. 

-----------

[PSGO-1037]: https://keboola.atlassian.net/browse/PSGO-1037?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ