### PR TITLE
fix: Replace typo in error messages

### DIFF
--- a/internal/pkg/service/cli/dependencies/fsinfo.go
+++ b/internal/pkg/service/cli/dependencies/fsinfo.go
@@ -44,7 +44,7 @@ func (v DirNotFoundError) Found() DirType {
 }
 
 func (v DirNotFoundError) Error() string {
-	return fmt.Sprintf("directory \"%s\" it not %s, found %s", v.path, v.expected, v.found)
+	return fmt.Sprintf("directory \"%s\" is not %s, found %s", v.path, v.expected, v.found)
 }
 
 type DirNotEmptyError struct {
@@ -53,7 +53,7 @@ type DirNotEmptyError struct {
 }
 
 func (v DirNotEmptyError) Error() string {
-	return fmt.Sprintf("directory \"%s\" it not empty", v.path)
+	return fmt.Sprintf("directory \"%s\" is not empty", v.path)
 }
 
 // WriteError print an example of the found files to the output.

--- a/test/cli/project-init/not-empty-dir/expected-stderr
+++ b/test/cli/project-init/not-empty-dir/expected-stderr
@@ -1,4 +1,4 @@
 Error:
-- Directory "%s" it not empty, found:
+- Directory "%s" is not empty, found:
   - bar
   - foo.txt

--- a/test/cli/template-repository-init/not-empty-dir/expected-stderr
+++ b/test/cli/template-repository-init/not-empty-dir/expected-stderr
@@ -1,4 +1,4 @@
 Error:
-- Directory "%s" it not empty, found:
+- Directory "%s" is not empty, found:
   - bar
   - foo.txt


### PR DESCRIPTION
This pull request includes corrections to error messages in the `internal/pkg/service/cli/dependencies/fsinfo.go` file and updates to associated test files to reflect these corrections.

Corrections to error messages:

* [`internal/pkg/service/cli/dependencies/fsinfo.go`](diffhunk://#diff-d9c891c74721995eb93cbcfc9d8cbc1c12f8885b3c881e2d9b14c69e4f86b4ddL47-R47): Fixed typo in `DirNotFoundError` and `DirNotEmptyError` error messages to use "is" instead of "it". [[1]](diffhunk://#diff-d9c891c74721995eb93cbcfc9d8cbc1c12f8885b3c881e2d9b14c69e4f86b4ddL47-R47) [[2]](diffhunk://#diff-d9c891c74721995eb93cbcfc9d8cbc1c12f8885b3c881e2d9b14c69e4f86b4ddL56-R56)

Updates to test files:

* [`test/cli/project-init/not-empty-dir/expected-stderr`](diffhunk://#diff-2c52c7b572e51f2762cdf04d35e2bd2fcde924b1d9488d9c4ebd08a32f2980aaL2-R2): Updated expected error message to reflect the corrected "is not empty" message.
* [`test/cli/template-repository-init/not-empty-dir/expected-stderr`](diffhunk://#diff-2c52c7b572e51f2762cdf04d35e2bd2fcde924b1d9488d9c4ebd08a32f2980aaL2-R2): Updated expected error message to reflect the corrected "is not empty" message.