### PR TITLE
feat: Record metric for retried file imports in case of failure

### DIFF
--- a/internal/pkg/service/stream/storage/node/coordinator/fileimport/operator.go
+++ b/internal/pkg/service/stream/storage/node/coordinator/fileimport/operator.go
@@ -364,12 +364,11 @@ func (o *operator) doImportFile(ctx context.Context, lock *etcdop.Mutex, file *f
 	if err != nil {
 		// Record metric for failed file imports
 		if file.Retry.RetryAttempt < 4 {
-			counter := o.metrics.FileImportFailed
 			attrs := append(
 				file.FileKey.SinkKey.Telemetry(),
 				attribute.String("operation", "fileimport"),
 			)
-			counter.Add(ctx, 1, metric.WithAttributes(attrs...))
+			o.metrics.FileImportFailed.Add(ctx, 1, metric.WithAttributes(attrs...))
 		}
 
 		return stats.Staging, errors.PrefixError(err, "file import failed")

--- a/internal/pkg/service/stream/storage/node/coordinator/fileimport/operator.go
+++ b/internal/pkg/service/stream/storage/node/coordinator/fileimport/operator.go
@@ -363,13 +363,12 @@ func (o *operator) doImportFile(ctx context.Context, lock *etcdop.Mutex, file *f
 	err = o.plugins.ImportFile(ctx, file.File, stats.Staging)
 	if err != nil {
 		// Record metric for failed file imports
-		if file.Retry.RetryAttempt < 4 {
-			attrs := append(
-				file.FileKey.SinkKey.Telemetry(),
-				attribute.String("operation", "fileimport"),
-			)
-			o.metrics.FileImportFailed.Add(ctx, 1, metric.WithAttributes(attrs...))
-		}
+		attrs := append(
+			file.FileKey.SinkKey.Telemetry(),
+			attribute.String("operation", "fileimport"),
+		)
+
+		o.metrics.FileImportFailed.Record(ctx, int64(file.Retry.RetryAttempt), metric.WithAttributes(attrs...))
 
 		return stats.Staging, errors.PrefixError(err, "file import failed")
 	}

--- a/internal/pkg/service/stream/storage/node/readernode/sliceupload/operator.go
+++ b/internal/pkg/service/stream/storage/node/readernode/sliceupload/operator.go
@@ -332,12 +332,11 @@ func (o *operator) doUploadSlice(ctx context.Context, volume *diskreader.Volume,
 	if err != nil {
 		// Record metric for failed slice uploads
 		if slice.Retry.RetryAttempt < 4 {
-			counter := o.metrics.SliceUploadFailed
 			attrs := append(
 				slice.SliceKey.SinkKey.Telemetry(),
 				attribute.String("operation", "sliceupload"),
 			)
-			counter.Add(ctx, 1, metric.WithAttributes(attrs...))
+			o.metrics.SliceUploadFailed.Add(ctx, 1, metric.WithAttributes(attrs...))
 		}
 		return stats.Local, errors.PrefixError(err, "slice upload failed")
 	}

--- a/internal/pkg/service/stream/storage/node/readernode/sliceupload/operator.go
+++ b/internal/pkg/service/stream/storage/node/readernode/sliceupload/operator.go
@@ -331,13 +331,12 @@ func (o *operator) doUploadSlice(ctx context.Context, volume *diskreader.Volume,
 	err = o.plugins.UploadSlice(ctx, volume, slice.Slice, stats.Local)
 	if err != nil {
 		// Record metric for failed slice uploads
-		if slice.Retry.RetryAttempt < 4 {
-			attrs := append(
-				slice.SliceKey.SinkKey.Telemetry(),
-				attribute.String("operation", "sliceupload"),
-			)
-			o.metrics.SliceUploadFailed.Add(ctx, 1, metric.WithAttributes(attrs...))
-		}
+		attrs := append(
+			slice.SliceKey.SinkKey.Telemetry(),
+			attribute.String("operation", "sliceupload"),
+		)
+		o.metrics.SliceUploadFailed.Record(ctx, int64(slice.Retry.RetryAttempt), metric.WithAttributes(attrs...))
+
 		return stats.Local, errors.PrefixError(err, "slice upload failed")
 	}
 

--- a/internal/pkg/service/stream/storage/node/trace.go
+++ b/internal/pkg/service/stream/storage/node/trace.go
@@ -10,8 +10,8 @@ type Metrics struct {
 	Duration          metric.Float64Histogram
 	Compressed        metric.Int64Counter
 	Uncompressed      metric.Int64Counter
-	FileImportFailed  metric.Int64Counter
-	SliceUploadFailed metric.Int64Counter
+	FileImportFailed  metric.Int64Histogram
+	SliceUploadFailed metric.Int64Histogram
 }
 
 func NewMetrics(meter telemetry.Meter) *Metrics {
@@ -24,7 +24,7 @@ func NewMetrics(meter telemetry.Meter) *Metrics {
 		),
 		Compressed:        meter.IntCounter("keboola.go.stream.operation.bytes.compressed", "Compressed bytes processed by operator.", "B"),
 		Uncompressed:      meter.IntCounter("keboola.go.stream.operation.bytes.uncompressed", "Uncompressed bytes processed by operator.", "B"),
-		FileImportFailed:  meter.IntCounter("keboola.go.stream.operation.fileimport.failed", "Count of file imports that will be retried", "count"),
-		SliceUploadFailed: meter.IntCounter("keboola.go.stream.operation.sliceupload.failed", "Count of slices that will be retried", "count"),
+		FileImportFailed:  meter.IntHistogram("keboola.go.stream.operation.fileimport.failed", "Count of file imports that will be retried", "count"),
+		SliceUploadFailed: meter.IntHistogram("keboola.go.stream.operation.sliceupload.failed", "Count of slices that will be retried", "count"),
 	}
 }

--- a/internal/pkg/service/stream/storage/node/trace.go
+++ b/internal/pkg/service/stream/storage/node/trace.go
@@ -7,9 +7,10 @@ import (
 )
 
 type Metrics struct {
-	Duration     metric.Float64Histogram
-	Compressed   metric.Int64Counter
-	Uncompressed metric.Int64Counter
+	Duration         metric.Float64Histogram
+	Compressed       metric.Int64Counter
+	Uncompressed     metric.Int64Counter
+	FileImportFailed metric.Int64Counter
 }
 
 func NewMetrics(meter telemetry.Meter) *Metrics {
@@ -20,7 +21,8 @@ func NewMetrics(meter telemetry.Meter) *Metrics {
 			"ms",
 			metric.WithExplicitBucketBoundaries(0, 10, 30, 100, 300, 1000, 3000, 10000, 30000, 100000, 300000, 1000000),
 		),
-		Compressed:   meter.IntCounter("keboola.go.stream.operation.bytes.compressed", "Compressed bytes processed by operator.", "B"),
-		Uncompressed: meter.IntCounter("keboola.go.stream.operation.bytes.uncompressed", "Uncompressed bytes processed by operator.", "B"),
+		Compressed:       meter.IntCounter("keboola.go.stream.operation.bytes.compressed", "Compressed bytes processed by operator.", "B"),
+		Uncompressed:     meter.IntCounter("keboola.go.stream.operation.bytes.uncompressed", "Uncompressed bytes processed by operator.", "B"),
+		FileImportFailed: meter.IntCounter("keboola.go.stream.operation.fileimport.failed", "Count of file imports that will be retried", "count"),
 	}
 }

--- a/internal/pkg/service/stream/storage/node/trace.go
+++ b/internal/pkg/service/stream/storage/node/trace.go
@@ -7,10 +7,11 @@ import (
 )
 
 type Metrics struct {
-	Duration         metric.Float64Histogram
-	Compressed       metric.Int64Counter
-	Uncompressed     metric.Int64Counter
-	FileImportFailed metric.Int64Counter
+	Duration          metric.Float64Histogram
+	Compressed        metric.Int64Counter
+	Uncompressed      metric.Int64Counter
+	FileImportFailed  metric.Int64Counter
+	SliceUploadFailed metric.Int64Counter
 }
 
 func NewMetrics(meter telemetry.Meter) *Metrics {
@@ -21,8 +22,9 @@ func NewMetrics(meter telemetry.Meter) *Metrics {
 			"ms",
 			metric.WithExplicitBucketBoundaries(0, 10, 30, 100, 300, 1000, 3000, 10000, 30000, 100000, 300000, 1000000),
 		),
-		Compressed:       meter.IntCounter("keboola.go.stream.operation.bytes.compressed", "Compressed bytes processed by operator.", "B"),
-		Uncompressed:     meter.IntCounter("keboola.go.stream.operation.bytes.uncompressed", "Uncompressed bytes processed by operator.", "B"),
-		FileImportFailed: meter.IntCounter("keboola.go.stream.operation.fileimport.failed", "Count of file imports that will be retried", "count"),
+		Compressed:        meter.IntCounter("keboola.go.stream.operation.bytes.compressed", "Compressed bytes processed by operator.", "B"),
+		Uncompressed:      meter.IntCounter("keboola.go.stream.operation.bytes.uncompressed", "Uncompressed bytes processed by operator.", "B"),
+		FileImportFailed:  meter.IntCounter("keboola.go.stream.operation.fileimport.failed", "Count of file imports that will be retried", "count"),
+		SliceUploadFailed: meter.IntCounter("keboola.go.stream.operation.sliceupload.failed", "Count of slices that will be retried", "count"),
 	}
 }


### PR DESCRIPTION
Jira: [PSGO-1029](https://keboola.atlassian.net/browse/PSGO-1029)

This Pull Request adds failure metrics for file imports and slice uploads and updates the metrics structure to include relevant counters for these operations.

**Changes:**
- Introduced metrics to track failed file imports (FileImportFailed) in fileimport/operator.go.
- Added similar metrics for failed slice uploads (SliceUploadFailed) in sliceupload/operator.go.
- Updated the Metrics structure in trace.go to include two new counters for failed file imports and slice uploads.
- Extended appropriate metric recording logic in both file import and slice upload processes, with retry limit checks.


-----------

[PSGO-1029]: https://keboola.atlassian.net/browse/PSGO-1029?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ