### PR TITLE
Update syncmap tests and add sync test execution flag

### DIFF
--- a/scripts/tests.sh
+++ b/scripts/tests.sh
@@ -21,6 +21,7 @@ TEST_PACKAGE="${TEST_PACKAGE:=./...}"
 TEST_EXCEPT="${TEST_EXCEPT:=}"
 TEST_KBC_TMP_DIR="${TEST_KBC_TMP_DIR:=/tmp}"
 TEST_ARGS="${TEST_ARGS:=}"
+TEST_SYNCTEST="${TEST_SYNCTEST:=}"
 if [[ $TEST_VERBOSE == "true" ]]; then
   TEST_ARGS="$TEST_ARGS -v"
 fi
@@ -33,11 +34,14 @@ fi
 if [[ -n $TEST_EXCEPT ]]; then
   TEST_PACKAGE="\$($TEST_EXCEPT)"
 fi
+if [[ -z $TEST_SYNCTEST ]]; then
+  TEST_SYNCTEST="$TEST_SYNCTEST -tags=goexperiment.synctest"
+fi
 
 # Run tests, sequentially because the API is shared resource
 echo "Running tests ..."
 export KBC_VERSION_CHECK=false # do not check the latest version in the tests
-cmd="go tool gotestsum --no-color=false --format \"$TEST_LOG_FORMAT\" -- -timeout 1800s -p $TEST_PARALLELISM_PKG -parallel $TEST_PARALLELISM $TEST_ARGS "$TEST_PACKAGE" $@"
+cmd="go tool gotestsum --no-color=false --format \"$TEST_LOG_FORMAT\" -- $TEST_SYNCTEST -timeout 1800s -p $TEST_PARALLELISM_PKG -parallel $TEST_PARALLELISM $TEST_ARGS "$TEST_PACKAGE" $@"
 echo $cmd
 eval $cmd
 echo "Ok. All tests passed."


### PR DESCRIPTION
Jira: [PSGO-1039](https://keboola.atlassian.net/browse/PSGO-1039)

**Changes:**
- Refactored syncmap tests to utilize `synctest` for improved concurrency management.
- Introduced `TEST_SYNCTEST` variable to enable synchronization test tags during test execution

Doc: https://go.dev/blog/synctest

[PSGO-1039]: https://keboola.atlassian.net/browse/PSGO-1039?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ