### PR TITLE
fix: Prevent merge operation issues logger as error

### DIFF
--- a/internal/pkg/service/stream/storage/model/repository/file/file_state.go
+++ b/internal/pkg/service/stream/storage/model/repository/file/file_state.go
@@ -9,6 +9,9 @@ import (
 	"github.com/keboola/keboola-as-code/internal/pkg/utils/errors"
 )
 
+// ErrInvalidStateTransition is a sentinel error returned when a file state transition fails due to the file being in an unexpected state.
+var ErrInvalidStateTransition = errors.New("invalid file state transition")
+
 type switchStateOption func(file *model.File)
 
 func withIsEmpty(isEmpty bool) switchStateOption {
@@ -42,7 +45,8 @@ func (r *Repository) stateTransition(k model.FileKey, now time.Time, from, to mo
 func (r *Repository) switchState(ctx context.Context, oldValue model.File, now time.Time, from, to model.FileState, opts ...switchStateOption) *op.TxnOp[model.File] {
 	// Validate from state
 	if oldValue.State != from {
-		return op.ErrorTxn[model.File](errors.Errorf(`file "%s" is in "%s" state, expected "%s"`, oldValue.FileKey, oldValue.State, from))
+		return op.ErrorTxn[model.File](errors.Errorf(`%w: file "%s" is in "%s" state, expected "%s"`,
+			ErrInvalidStateTransition, oldValue.FileKey, oldValue.State, from))
 	}
 
 	// Switch file state

--- a/internal/pkg/service/stream/storage/node/coordinator/fileimport/operator.go
+++ b/internal/pkg/service/stream/storage/node/coordinator/fileimport/operator.go
@@ -382,6 +382,8 @@ func (o *operator) doImportFile(ctx context.Context, lock *etcdop.Mutex, file *f
 	result := o.storage.File().SwitchToImported(file.FileKey, o.clock.Now()).RequireLock(lock).Do(dbCtx)
 	err = result.Err()
 	// Check specifically for invalid state transition errors
+	// This happens only when ETCD is restarted and the mirror is constructed again from scratch.
+	// The file local lock is empty and therefore the switch to imported state is done > n times.
 	if errors.Is(err, fileRepo.ErrInvalidStateTransition) {
 		o.logger.Warnf(dbCtx, "skipping file transition to imported state: %s", err)
 		// Mark as processed to avoid retry for known state transition errors

--- a/internal/pkg/service/stream/storage/node/coordinator/filerotation/operator.go
+++ b/internal/pkg/service/stream/storage/node/coordinator/filerotation/operator.go
@@ -29,6 +29,7 @@ import (
 	targetModel "github.com/keboola/keboola-as-code/internal/pkg/service/stream/storage/level/target/model"
 	"github.com/keboola/keboola-as-code/internal/pkg/service/stream/storage/model"
 	storageRepo "github.com/keboola/keboola-as-code/internal/pkg/service/stream/storage/model/repository"
+	fileRepo "github.com/keboola/keboola-as-code/internal/pkg/service/stream/storage/model/repository/file"
 	"github.com/keboola/keboola-as-code/internal/pkg/service/stream/storage/node"
 	"github.com/keboola/keboola-as-code/internal/pkg/service/stream/storage/node/coordinator/clusterlock"
 	"github.com/keboola/keboola-as-code/internal/pkg/service/stream/storage/statistics"
@@ -477,8 +478,16 @@ func (o *operator) closeFile(ctx context.Context, file *fileData) {
 		isEmpty := stats.Total.RecordsCount == 0
 		result := o.storage.File().SwitchToImporting(file.FileKey, o.clock.Now(), isEmpty).RequireLock(lock).Do(dbCtx)
 		err = result.Err()
+		// Check specifically for invalid state transition errors
+		if errors.Is(err, fileRepo.ErrInvalidStateTransition) {
+			o.logger.Warnf(dbCtx, "skipping file transition to importing state: %s", err)
+			// Mark as processed to avoid retry for known state transition errors
+			file.Processed = true
+			return
+		}
+
 		if err != nil {
-			o.logger.Infof(ctx, `Switch file "%s" to importing state used %d operations`, file.FileKey.String(), result.MaxOps())
+			o.logger.Infof(ctx, `Not switching file "%s" to importing state used %d operations`, file.FileKey.String(), result.MaxOps())
 			err = errors.PrefixError(err, "cannot switch file to the importing state")
 		}
 	}

--- a/internal/pkg/service/stream/storage/node/coordinator/filerotation/operator.go
+++ b/internal/pkg/service/stream/storage/node/coordinator/filerotation/operator.go
@@ -479,6 +479,8 @@ func (o *operator) closeFile(ctx context.Context, file *fileData) {
 		result := o.storage.File().SwitchToImporting(file.FileKey, o.clock.Now(), isEmpty).RequireLock(lock).Do(dbCtx)
 		err = result.Err()
 		// Check specifically for invalid state transition errors
+		// This happens only when ETCD is restarted and the mirror is constructed again from scratch.
+		// The file local lock is empty and therefore the switch to imported state is done > n times.
 		if errors.Is(err, fileRepo.ErrInvalidStateTransition) {
 			o.logger.Warnf(dbCtx, "skipping file transition to importing state: %s", err)
 			// Mark as processed to avoid retry for known state transition errors


### PR DESCRIPTION
Jira: [PSGO-855](https://keboola.atlassian.net/browse/PSGO-855)

**Changes:**
- It is expected that during downtime of ETCD, the `o.files` are all reseted, therefore also local locks are created again and it starts 2 go routines for closing/importing/rotating instead of having 1 go routine chagning state.
- Let other go routine switch state but report it as warning. Should not happen in other case


-----------


[PSGO-855]: https://keboola.atlassian.net/browse/PSGO-855?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ