### PR TITLE
feat: Notify sandboxes API while active websocket exists

### DIFF
--- a/internal/pkg/service/appsproxy/proxy/apphandler/upstream/upstream.go
+++ b/internal/pkg/service/appsproxy/proxy/apphandler/upstream/upstream.go
@@ -9,6 +9,7 @@ import (
 	"net/url"
 	"strings"
 	"sync"
+	"sync/atomic"
 	"time"
 
 	"go.opentelemetry.io/otel/attribute"
@@ -48,12 +49,13 @@ type Manager struct {
 }
 
 type AppUpstream struct {
-	manager   *Manager
-	app       api.AppConfig
-	target    *url.URL
-	handler   *chain.Chain
-	wsHandler *chain.Chain
-	cancelWs  context.CancelCauseFunc
+	manager       *Manager
+	app           api.AppConfig
+	target        *url.URL
+	handler       *chain.Chain
+	wsHandler     *chain.Chain
+	cancelWs      context.CancelCauseFunc
+	activeWsCount atomic.Int64
 }
 
 type dependencies interface {
@@ -109,6 +111,17 @@ func (m *Manager) NewUpstream(ctx context.Context, app api.AppConfig) (upstream 
 	upstream = &AppUpstream{manager: m, app: app, target: target}
 	upstream.handler = upstream.newProxy(m.config.Upstream.HTTPTimeout)
 	upstream.wsHandler = upstream.newWebsocketProxy(m.config.Upstream.WsTimeout)
+
+	// Call notify while there is an active websocket connection
+	go func() {
+		for {
+			if upstream.activeWsCount.Load() > 0 {
+				upstream.notify(ctx)
+			}
+			time.Sleep(30 * time.Second)
+		}
+	}()
+
 	return upstream, nil
 }
 
@@ -152,6 +165,9 @@ func (u *AppUpstream) newWebsocketProxy(timeout time.Duration) *chain.Chain {
 
 			ctx, c := context.WithCancelCause(ctx)
 			u.cancelWs = c
+
+			u.activeWsCount.Add(1)
+			defer u.activeWsCount.Add(-1)
 
 			proxy.ServeHTTP(w, req.WithContext(ctx))
 			return nil

--- a/internal/pkg/service/stream/storage/level/local/encoding/encoder/csv/csv.go
+++ b/internal/pkg/service/stream/storage/level/local/encoding/encoder/csv/csv.go
@@ -86,7 +86,7 @@ func (w *Encoder) WriteRecord(record recordctx.Context) (result.WriteRecordResul
 		return result.WriteRecordResult{}, err
 	}
 
-	// Get notifier after succcessful written record
+	// Get notifier after successful written record
 	writeRecordResult := result.NewNotifierWriteRecordResult(n, w.notifier(record.Ctx()))
 	// Buffers can be released
 	// Important: values slice contains reference to the body []byte buffer, so it can be released sooner.


### PR DESCRIPTION
JIRA: https://keboola.atlassian.net/browse/AJDA-37

This change fixes the recently reported scenario where an app is stopped because there are no requests coming to it despite there being an active websocket connection. With this change any active websocket connection will keep the app active.