### PR TITLE
fix: add aliases parameter to Windows code signing

### DIFF
--- a/.github/workflows/release-cli.yml
+++ b/.github/workflows/release-cli.yml
@@ -425,6 +425,7 @@ jobs:
         run: |
           java -jar jsign-6.0.jar --storetype AZUREKEYVAULT \
             --keystore kbc-cli-code-signing \
+            --alias codesigning \
             --storepass ${{ env.WINDOWS_SIGNING_ACCESS_TOKEN }} \
             --tsaurl http://timestamp.digicert.com \
             --replace \
@@ -459,6 +460,7 @@ jobs:
           msi="./build/package/windows/msi/${{ env.MSI_FILE }}"
           java -jar jsign-6.0.jar --storetype AZUREKEYVAULT \
             --keystore kbc-cli-code-signing \
+            --alias codesigning \
             --storepass ${{ env.WINDOWS_SIGNING_ACCESS_TOKEN }} \
             --tsaurl http://timestamp.digicert.com \
             --replace \


### PR DESCRIPTION
This pull request makes a minor update to the `.github/workflows/release-cli.yml` file to enhance the signing process for Windows builds. The change adds the `--aliases codesigning` argument to the `jsign` commands in two places.

Workflow improvements:

* [`.github/workflows/release-cli.yml`](diffhunk://#diff-6ba0eeeb9cdfe6d2493769e2c1b9d3b249ab70bf3d9f1e9d0dc28296446f5a46R428): Added the `--aliases codesigning` argument to the `jsign` command for both the main signing step and the MSI signing step, ensuring the correct alias is used during the signing process. [[1]](diffhunk://#diff-6ba0eeeb9cdfe6d2493769e2c1b9d3b249ab70bf3d9f1e9d0dc28296446f5a46R428) [[2]](diffhunk://#diff-6ba0eeeb9cdfe6d2493769e2c1b9d3b249ab70bf3d9f1e9d0dc28296446f5a46R463)
