### PR TITLE
build: Update build commands in .air.toml files to use 'task' instead of 'make'

### DIFF
--- a/provisioning/apps-proxy/dev/.air.toml
+++ b/provisioning/apps-proxy/dev/.air.toml
@@ -4,7 +4,7 @@ tmp_dir = "target/.watcher"
 [build]
   bin = "./target/apps-proxy/proxy"
   args_bin = ["--sandboxes-api-token", "my-token", "--metrics-listen", "0.0.0.0:9002", "--api-public-url", "http://hub.keboola.local", "--cookie-secret-salt", "cookie", "--csrf-token-salt", "bcc3add3bf72e628149fbfbc11932329de7f375db3d8503ef0e32b336adf46c4"]
-  cmd = "make build-apps-proxy"
+  cmd = "task build-apps-proxy"
   delay = 2000
   exclude_dir = []
   exclude_file = []

--- a/provisioning/stream/README.md
+++ b/provisioning/stream/README.md
@@ -2,7 +2,7 @@
 
 ## Components
 
-- The Stream service is compiled to a single binary using `make build-stream-service`.
+- The Stream service is compiled to a single binary using `task build-stream-service`.
 - There is also a single `docker/service/Dockerfile`.
 - The command line `args` defines which service components are started, at least one component must be specified.
 - All components may run in single process, but for scalability and resource management, they run in several pods.

--- a/provisioning/stream/dev/.air.toml
+++ b/provisioning/stream/dev/.air.toml
@@ -4,7 +4,7 @@ tmp_dir = "target/.watcher"
 [build]
   bin = "./target/stream/service"
   args_bin = ["--node-id", "my-node", "--hostname", "localhost", "--metrics-listen", "0.0.0.0:9001", "--storage-volumes-path", "/tmp/stream-volumes","api", "http-source", "storage-writer", "storage-reader", "storage-coordinator"]
-  cmd = "make build-stream-service"
+  cmd = "task build-stream-service"
   delay = 2000
   exclude_dir = ["internal/pkg/service/stream/api/gen"]
   exclude_file = []

--- a/provisioning/templates-api/dev/.air-api.toml
+++ b/provisioning/templates-api/dev/.air-api.toml
@@ -4,7 +4,7 @@ tmp_dir = "target/.watcher"
 [build]
   bin = "./target/templates/api"
   args_bin = ["--node-id", "local-node"]
-  cmd = "make build-templates-api"
+  cmd = "task build-templates-api"
   delay = 2000
   exclude_dir = ["internal/pkg/service/templates/api/gen"]
   exclude_file = []


### PR DESCRIPTION
This pull request standardizes the build commands across multiple services by replacing `make` with `task` in configuration files and documentation. This change ensures consistency and aligns with the updated build process.

### Standardization of build commands:

* [`provisioning/apps-proxy/dev/.air.toml`](diffhunk://#diff-869c1b63c7ea41a2cfa9c24228e619a1cfdff01e3b2a4e45fb475ea0ec75282fL7-R7): Updated the `cmd` field to use `task build-apps-proxy` instead of `make build-apps-proxy`.
* [`provisioning/stream/dev/.air.toml`](diffhunk://#diff-9cefc2b3516a021df1a4b8958a9b694cd50c6804f75046d3bc24c2490aee1936L7-R7): Updated the `cmd` field to use `task build-stream-service` instead of `make build-stream-service`.
* [`provisioning/templates-api/dev/.air-api.toml`](diffhunk://#diff-d0c8089464a712717d0ba96994c22cfdb952cde5e49d51347e10673e37a483b6L7-R7): Updated the `cmd` field to use `task build-templates-api` instead of `make build-templates-api`.
* [`provisioning/stream/README.md`](diffhunk://#diff-225cf89ade4fa2c8f7301b83bc89fa016dd8513d6ff1e431154c1cdd7c243470L5-R5): Updated the documentation to reflect the use of `task build-stream-service` for building the Stream service binary.
