### PR TITLE
build: Disable free-disk-space

### DIFF
--- a/.github/workflows/test-k8s-service-stream.yml
+++ b/.github/workflows/test-k8s-service-stream.yml
@@ -40,16 +40,6 @@ jobs:
         with:
           ref: ${{ github.event.pull_request.head.ref }}
 
-      - name: Free Disk Space (Ubuntu)
-        uses: jlumbroso/free-disk-space@main
-        with:
-          android: true
-          dotnet: true
-          haskell: true
-          large-packages: false
-          docker-images: false
-          swap-storage: false
-
       - name: Create artifacts directory
         run: mkdir -p /tmp/artifacts
 

--- a/.github/workflows/test-lint.yml
+++ b/.github/workflows/test-lint.yml
@@ -20,16 +20,6 @@ jobs:
       - name: Checkout
         uses: actions/checkout@v4
 
-      - name: Free Disk Space (Ubuntu)
-        uses: jlumbroso/free-disk-space@main
-        with:
-          android: true
-          dotnet: true
-          haskell: true
-          large-packages: false
-          docker-images: false
-          swap-storage: false
-
       - name: Setup Go, tools and caching
         uses: ./.github/actions/go-setup
         with:

--- a/.github/workflows/test-unit.yml
+++ b/.github/workflows/test-unit.yml
@@ -49,27 +49,6 @@ jobs:
       - name: Checkout
         uses: actions/checkout@v4
 
-      - name: Free Disk Space (Ubuntu)
-        uses: jlumbroso/free-disk-space@main
-        with:
-          android: true
-          dotnet: true
-          haskell: true
-          large-packages: true
-          docker-images: true
-          swap-storage: false
-
-      # To free up disk space to not run out during the run
-      - name: Delete unused SDKs MacOS
-        if: matrix.name == 'mac-os'
-        run: |
-          echo "BEFORE CLEAN-UP:"
-          df -hI /dev/disk3s1s1
-          sudo rm -rf /Applications/Xcode_*.app
-          echo "AFTER CLEAN-UP:"
-          df -hI /dev/disk3s1s1
-        continue-on-error: true
-
       - name: Setup Go, tools and caching
         uses: ./.github/actions/go-setup
         with:


### PR DESCRIPTION
Considering that we didn't run into out of space issues on CI lately, it's possible we no longer need this. And since the free disk space step can take up to a few minutes I think it's worth it to try and disable it to speedup the pipelines.