### PR TITLE
Add context propagation to CLI subcommands

### DIFF
--- a/internal/pkg/service/cli/cmd/cmd.go
+++ b/internal/pkg/service/cli/cmd/cmd.go
@@ -26,6 +26,7 @@ import (
 	"github.com/keboola/keboola-as-code/internal/pkg/service/cli/dialog"
 	"github.com/keboola/keboola-as-code/internal/pkg/service/cli/flag"
 	"github.com/keboola/keboola-as-code/internal/pkg/service/cli/helpmsg"
+	cliutil "github.com/keboola/keboola-as-code/internal/pkg/service/cli/util"
 	"github.com/keboola/keboola-as-code/internal/pkg/service/common/configmap"
 	"github.com/keboola/keboola-as-code/internal/pkg/service/common/servicectx"
 	templateManifest "github.com/keboola/keboola-as-code/internal/pkg/template/manifest"
@@ -190,6 +191,9 @@ func NewRootCommand(stdin io.Reader, stdout io.Writer, stderr io.Writer, osEnvs 
 			stdout,
 			stderr,
 		))
+
+		// Propagate context to all subcommands
+		cliutil.PropagateContext(cmd)
 
 		// Check version
 		if err := versionCheck.Run(cmd.Context(), root.globalFlags.VersionCheck.Value, p.BaseScope()); err != nil {

--- a/internal/pkg/service/cli/util/context.go
+++ b/internal/pkg/service/cli/util/context.go
@@ -1,0 +1,16 @@
+package cmdutil
+
+import (
+	"github.com/spf13/cobra"
+)
+
+// PropagateContext ensures that the context is propagated to all subcommands.
+// This function should be called in the PersistentPreRunE of the root command.
+func PropagateContext(cmd *cobra.Command) {
+	// Set context for all subcommands
+	for _, subCmd := range cmd.Commands() {
+		subCmd.SetContext(cmd.Context())
+		// Recursively set context for all subcommands
+		PropagateContext(subCmd)
+	}
+}

--- a/internal/pkg/service/cli/util/context_test.go
+++ b/internal/pkg/service/cli/util/context_test.go
@@ -1,0 +1,42 @@
+package cmdutil
+
+import (
+	"context"
+	"testing"
+
+	"github.com/spf13/cobra"
+	"github.com/stretchr/testify/assert"
+)
+
+func TestPropagateContext(t *testing.T) {
+	t.Parallel()
+	// Create a context with a test value
+	type contextKey string
+	testKey := contextKey("test-key")
+	testValue := "test-value"
+	ctx := context.WithValue(t.Context(), testKey, testValue)
+
+	// Create a command hierarchy
+	rootCmd := &cobra.Command{Use: "root"}
+	rootCmd.SetContext(ctx)
+
+	// Add some subcommands
+	level1Cmd1 := &cobra.Command{Use: "level1-1"}
+	level1Cmd2 := &cobra.Command{Use: "level1-2"}
+	rootCmd.AddCommand(level1Cmd1, level1Cmd2)
+
+	// Add nested subcommands
+	level2Cmd1 := &cobra.Command{Use: "level2-1"}
+	level2Cmd2 := &cobra.Command{Use: "level2-2"}
+	level1Cmd1.AddCommand(level2Cmd1)
+	level1Cmd2.AddCommand(level2Cmd2)
+
+	// Propagate context
+	PropagateContext(rootCmd)
+
+	// Verify that context is propagated to all subcommands
+	assert.Equal(t, testValue, level1Cmd1.Context().Value(testKey))
+	assert.Equal(t, testValue, level1Cmd2.Context().Value(testKey))
+	assert.Equal(t, testValue, level2Cmd1.Context().Value(testKey))
+	assert.Equal(t, testValue, level2Cmd2.Context().Value(testKey))
+}


### PR DESCRIPTION
This pull request introduces a utility function to ensure that the context is propagated to all subcommands in the CLI application. The most important changes include adding the new `PropagateContext` function, integrating it into the root command, and updating imports to include the new utility.

### Context propagation improvements:

* **New utility function**: Added the `PropagateContext` function in `internal/pkg/service/cli/util/context.go` to recursively set the context for all subcommands of a root command. This ensures consistent context propagation throughout the CLI.
* **Integration into root command**: Updated the `NewRootCommand` function in `internal/pkg/service/cli/cmd/cmd.go` to call `PropagateContext` on the root command, ensuring the context is propagated to all subcommands.

### Code organization:

* **Import update**: Added a new import alias `cliutil` in `internal/pkg/service/cli/cmd/cmd.go` to reference the newly created utility package.

-----------
