### PR TITLE
fix: Report waiting for import operation as warning

### DIFF
--- a/internal/pkg/service/stream/plugin/file.go
+++ b/internal/pkg/service/stream/plugin/file.go
@@ -18,6 +18,9 @@ type File struct {
 	Provider targetModel.Provider
 }
 
+// ErrWaitForImportOperationDeadlineExceeded is a sentinel error used when waiting for import operation times out.
+var ErrWaitForImportOperationDeadlineExceeded = errors.New("wait for import operation deadline exceeded")
+
 type (
 	importFileFn       func(ctx context.Context, file File, stats statistics.Value) error
 	canAcceptNewFileFn func(ctx context.Context, sinkKey key.SinkKey) bool

--- a/internal/pkg/service/stream/sink/type/tablesink/keboola/bridge/file.go
+++ b/internal/pkg/service/stream/sink/type/tablesink/keboola/bridge/file.go
@@ -252,7 +252,9 @@ func (b *Bridge) importFile(ctx context.Context, file plugin.File, stats statist
 
 	// Wait for job to complete
 	err = api.WaitForStorageJob(ctx, job)
-	if err != nil {
+	if err != nil && errors.Is(err, context.DeadlineExceeded) {
+		return plugin.ErrWaitForImportOperationDeadlineExceeded
+	} else if err != nil {
 		return err
 	}
 

--- a/internal/pkg/service/stream/storage/node/coordinator/fileimport/operator.go
+++ b/internal/pkg/service/stream/storage/node/coordinator/fileimport/operator.go
@@ -307,7 +307,11 @@ func (o *operator) importFile(ctx context.Context, file *fileData) {
 	// Import file
 	stats, err := o.doImportFile(ctx, lock, file)
 	if err != nil {
-		o.logger.Error(ctx, err.Error())
+		if errors.Is(err, plugin.ErrWaitForImportOperationDeadlineExceeded) {
+			o.logger.Warn(ctx, err.Error())
+		} else {
+			o.logger.Error(ctx, err.Error())
+		}
 
 		// Update the entity, the ctx may be cancelled
 		dbCtx, dbCancel := context.WithTimeoutCause(context.WithoutCancel(ctx), dbOperationTimeout, errors.New("retry increment timeout"))


### PR DESCRIPTION
**Changes:**
- Reason to change: The job can take up to 24 hours and we have 15 minute context, so the deadline can be exceeded on single job up to ~96 times.
- Made it universal in plugin as it can be also issue of any other system.

-----------
