### PR TITLE
BC: Remove ticket generator

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -42,11 +42,7 @@ require (
 	github.com/json-iterator/go v1.1.12
 	github.com/keboola/go-cloud-encrypt v0.0.0-20250422071622-41a5d5547c43
 	github.com/keboola/go-utils v1.3.3
-<<<<<<< HEAD
-	github.com/keboola/keboola-sdk-go/v2 v2.1.2-0.20250603080622-3cbb8db044d7
-=======
-	github.com/keboola/keboola-sdk-go/v2 v2.1.2-0.20250603081542-5b53d3826cfa
->>>>>>> 9f74bf799 (BC: Remove ticket generator)
+	github.com/keboola/keboola-sdk-go/v2 v2.3.0
 	github.com/klauspost/compress v1.18.0
 	github.com/klauspost/pgzip v1.2.6
 	github.com/kylelemons/godebug v1.1.0

--- a/go.mod
+++ b/go.mod
@@ -42,7 +42,11 @@ require (
 	github.com/json-iterator/go v1.1.12
 	github.com/keboola/go-cloud-encrypt v0.0.0-20250422071622-41a5d5547c43
 	github.com/keboola/go-utils v1.3.3
+<<<<<<< HEAD
 	github.com/keboola/keboola-sdk-go/v2 v2.1.2-0.20250603080622-3cbb8db044d7
+=======
+	github.com/keboola/keboola-sdk-go/v2 v2.1.2-0.20250603081542-5b53d3826cfa
+>>>>>>> 9f74bf799 (BC: Remove ticket generator)
 	github.com/klauspost/compress v1.18.0
 	github.com/klauspost/pgzip v1.2.6
 	github.com/kylelemons/godebug v1.1.0
@@ -53,6 +57,7 @@ require (
 	github.com/mitchellh/hashstructure/v2 v2.0.2
 	github.com/oauth2-proxy/mockoidc v0.0.0-20240214162133-caebfff84d25
 	github.com/oauth2-proxy/oauth2-proxy/v7 v7.9.0
+	github.com/oklog/ulid/v2 v2.1.1
 	github.com/pquerna/cachecontrol v0.2.0
 	github.com/prometheus/client_golang v1.22.0
 	github.com/qiangxue/fasthttp-routing v0.0.0-20160225050629-6ccdc2a18d87

--- a/go.sum
+++ b/go.sum
@@ -604,13 +604,8 @@ github.com/keboola/go-oauth2-proxy/v7 v7.0.0-20250325124709-f4d482276c37 h1:asV4
 github.com/keboola/go-oauth2-proxy/v7 v7.0.0-20250325124709-f4d482276c37/go.mod h1:obobYo1zYAcAt8cjTbsj6o7ZI1x0hhZuQSUPRlzwZ1k=
 github.com/keboola/go-utils v1.3.3 h1:H3FuF8aRQ5eO529aFXja6Z6PQ+iADnsTb3Ilnc6EwhA=
 github.com/keboola/go-utils v1.3.3/go.mod h1:xBr4P0ErJTbuQihw5Fq4fE7VYMhBWxDQj+UWInV4x/k=
-<<<<<<< HEAD
-github.com/keboola/keboola-sdk-go/v2 v2.1.2-0.20250603080622-3cbb8db044d7 h1:dKrQCsjHv/Z9uLe+ojWHFnbV0hxll9DEzkFF6OdnldM=
-github.com/keboola/keboola-sdk-go/v2 v2.1.2-0.20250603080622-3cbb8db044d7/go.mod h1:dvrwbY9TDwlX/muPn0mjU+uzQTxVkPITUVgyUX4sUOs=
-=======
-github.com/keboola/keboola-sdk-go/v2 v2.1.2-0.20250603081542-5b53d3826cfa h1:5IeQr8VdKyOOKhUhKBjnEja9K3xVmvSEJV0qsx571HU=
-github.com/keboola/keboola-sdk-go/v2 v2.1.2-0.20250603081542-5b53d3826cfa/go.mod h1:dvrwbY9TDwlX/muPn0mjU+uzQTxVkPITUVgyUX4sUOs=
->>>>>>> 9f74bf799 (BC: Remove ticket generator)
+github.com/keboola/keboola-sdk-go/v2 v2.3.0 h1:gspW0qpdTVBXTj+QtS4hQhpMncOmcfLFDVwF2WWwor8=
+github.com/keboola/keboola-sdk-go/v2 v2.3.0/go.mod h1:dvrwbY9TDwlX/muPn0mjU+uzQTxVkPITUVgyUX4sUOs=
 github.com/keybase/go-keychain v0.0.1 h1:way+bWYa6lDppZoZcgMbYsvC7GxljxrskdNInRtuthU=
 github.com/keybase/go-keychain v0.0.1/go.mod h1:PdEILRW3i9D8JcdM+FmY6RwkHGnhHxXwkPPMeUgOK1k=
 github.com/kisielk/errcheck v1.5.0/go.mod h1:pFxgyoBC7bSaBwPgfKdkLd5X25qrDl4LWUI2bnpBCr8=

--- a/go.sum
+++ b/go.sum
@@ -604,8 +604,13 @@ github.com/keboola/go-oauth2-proxy/v7 v7.0.0-20250325124709-f4d482276c37 h1:asV4
 github.com/keboola/go-oauth2-proxy/v7 v7.0.0-20250325124709-f4d482276c37/go.mod h1:obobYo1zYAcAt8cjTbsj6o7ZI1x0hhZuQSUPRlzwZ1k=
 github.com/keboola/go-utils v1.3.3 h1:H3FuF8aRQ5eO529aFXja6Z6PQ+iADnsTb3Ilnc6EwhA=
 github.com/keboola/go-utils v1.3.3/go.mod h1:xBr4P0ErJTbuQihw5Fq4fE7VYMhBWxDQj+UWInV4x/k=
+<<<<<<< HEAD
 github.com/keboola/keboola-sdk-go/v2 v2.1.2-0.20250603080622-3cbb8db044d7 h1:dKrQCsjHv/Z9uLe+ojWHFnbV0hxll9DEzkFF6OdnldM=
 github.com/keboola/keboola-sdk-go/v2 v2.1.2-0.20250603080622-3cbb8db044d7/go.mod h1:dvrwbY9TDwlX/muPn0mjU+uzQTxVkPITUVgyUX4sUOs=
+=======
+github.com/keboola/keboola-sdk-go/v2 v2.1.2-0.20250603081542-5b53d3826cfa h1:5IeQr8VdKyOOKhUhKBjnEja9K3xVmvSEJV0qsx571HU=
+github.com/keboola/keboola-sdk-go/v2 v2.1.2-0.20250603081542-5b53d3826cfa/go.mod h1:dvrwbY9TDwlX/muPn0mjU+uzQTxVkPITUVgyUX4sUOs=
+>>>>>>> 9f74bf799 (BC: Remove ticket generator)
 github.com/keybase/go-keychain v0.0.1 h1:way+bWYa6lDppZoZcgMbYsvC7GxljxrskdNInRtuthU=
 github.com/keybase/go-keychain v0.0.1/go.mod h1:PdEILRW3i9D8JcdM+FmY6RwkHGnhHxXwkPPMeUgOK1k=
 github.com/kisielk/errcheck v1.5.0/go.mod h1:pFxgyoBC7bSaBwPgfKdkLd5X25qrDl4LWUI2bnpBCr8=
@@ -727,6 +732,8 @@ github.com/oasdiff/yaml v0.0.0-20250309154309-f31be36b4037 h1:G7ERwszslrBzRxj//J
 github.com/oasdiff/yaml v0.0.0-20250309154309-f31be36b4037/go.mod h1:2bpvgLBZEtENV5scfDFEtB/5+1M4hkQhDQrccEJ/qGw=
 github.com/oasdiff/yaml3 v0.0.0-20250309153720-d2182401db90 h1:bQx3WeLcUWy+RletIKwUIt4x3t8n2SxavmoclizMb8c=
 github.com/oasdiff/yaml3 v0.0.0-20250309153720-d2182401db90/go.mod h1:y5+oSEHCPT/DGrS++Wc/479ERge0zTFxaF8PbGKcg2o=
+github.com/oklog/ulid/v2 v2.1.1 h1:suPZ4ARWLOJLegGFiZZ1dFAkqzhMjL3J1TzI+5wHz8s=
+github.com/oklog/ulid/v2 v2.1.1/go.mod h1:rcEKHmBBKfef9DhnvX7y1HZBYxjXb0cP5ExxNsTT1QQ=
 github.com/olekukonko/tablewriter v0.0.5 h1:P2Ga83D34wi1o9J6Wh1mRuqd4mF/x/lgBS7N7AbDhec=
 github.com/olekukonko/tablewriter v0.0.5/go.mod h1:hPp6KlRPjbx+hW8ykQs1w3UBbZlj6HuIJcUGPhkA7kY=
 github.com/oligot/go-mod-upgrade v0.11.0 h1:KgKHv6VKilvUKXR+SjhIzR/Q8czJapA5F2ce+KqXH7A=
@@ -752,6 +759,7 @@ github.com/outcaste-io/ristretto v0.2.3 h1:AK4zt/fJ76kjlYObOeNwh4T3asEuaCmp26pOv
 github.com/outcaste-io/ristretto v0.2.3/go.mod h1:W8HywhmtlopSB1jeMg3JtdIhf+DYkLAr0VN/s4+MHac=
 github.com/pbnjay/memory v0.0.0-20210728143218-7b4eea64cf58 h1:onHthvaw9LFnH4t2DcNVpwGmV9E1BkGknEliJkfwQj0=
 github.com/pbnjay/memory v0.0.0-20210728143218-7b4eea64cf58/go.mod h1:DXv8WO4yhMYhSNPKjeNKa5WY9YCIEBRbNzFFPJbWO6Y=
+github.com/pborman/getopt v0.0.0-20170112200414-7148bc3a4c30/go.mod h1:85jBQOZwpVEaDAr341tbn15RS4fCAsIst0qp7i8ex1o=
 github.com/pelletier/go-toml v1.0.1-0.20170904195809-1d6b12b7cb29/go.mod h1:5z9KED0ma1S8pY6P1sdut58dfprrGBbd/94hg7ilaic=
 github.com/pelletier/go-toml v1.9.5 h1:4yBQzkHv+7BHq2PQUZF3Mx0IYxG7LsP222s7Agd3ve8=
 github.com/pelletier/go-toml v1.9.5/go.mod h1:u1nR/EPcESfeI/szUZKdtJ0xRNbUoANCkoOuaOx1Y+c=

--- a/internal/pkg/plan/persist/executor.go
+++ b/internal/pkg/plan/persist/executor.go
@@ -2,8 +2,11 @@ package persist
 
 import (
 	"context"
+	"math/rand"
+	"time"
 
 	"github.com/keboola/keboola-sdk-go/v2/pkg/keboola"
+	"github.com/oklog/ulid/v2"
 
 	"github.com/keboola/keboola-as-code/internal/pkg/log"
 	"github.com/keboola/keboola-as-code/internal/pkg/model"
@@ -15,20 +18,18 @@ import (
 type executor struct {
 	*Plan
 	*state.State
-	logger  log.Logger
-	tickets *keboola.TicketProvider
-	uow     *local.UnitOfWork
-	errors  errors.MultiError
+	logger log.Logger
+	uow    *local.UnitOfWork
+	errors errors.MultiError
 }
 
 func newExecutor(ctx context.Context, logger log.Logger, keboolaProjectAPI *keboola.AuthorizedAPI, projectState *state.State, plan *Plan) *executor {
 	return &executor{
-		Plan:    plan,
-		State:   projectState,
-		logger:  logger,
-		tickets: keboola.NewTicketProvider(ctx, keboolaProjectAPI),
-		uow:     projectState.LocalManager().NewUnitOfWork(ctx),
-		errors:  errors.NewMultiError(),
+		Plan:   plan,
+		State:  projectState,
+		logger: logger,
+		uow:    projectState.LocalManager().NewUnitOfWork(ctx),
+		errors: errors.NewMultiError(),
 	}
 }
 
@@ -44,12 +45,6 @@ func (e *executor) invoke() error {
 			panic(errors.Errorf(`unexpected type "%T"`, action))
 		}
 	}
-
-	// Let's wait until all new IDs are generated
-	if err := e.tickets.Resolve(); err != nil {
-		e.errors.Append(err)
-	}
-
 	// Wait for all local operations
 	if err := e.uow.Invoke(); err != nil {
 		e.errors.Append(err)
@@ -60,64 +55,67 @@ func (e *executor) invoke() error {
 
 func (e *executor) persistNewObject(action *newObjectAction) {
 	// Generate unique ID
-	e.tickets.Request(func(ticket *keboola.Ticket) {
-		key := action.Key
+	key := action.Key
 
-		// Set new id to the key
-		switch k := key.(type) {
-		case model.ConfigKey:
-			k.ID = keboola.ConfigID(ticket.ID)
-			key = k
-		case model.ConfigRowKey:
-			k.ID = keboola.RowID(ticket.ID)
-			key = k
-		default:
-			panic(errors.Errorf(`unexpected type "%s" of the persisted object "%s"`, key.Kind(), key.Desc()))
-		}
+	// Generate ULID
+	ms := ulid.Timestamp(time.Now())
+	entropy := ulid.Monotonic(rand.New(rand.NewSource(time.Now().UnixNano())), 0)
+	newID := ulid.MustNew(ms, entropy).String()
 
-		// The parent was not persisted for some error -> skip
-		if action.ParentKey != nil && action.ParentKey.ObjectID() == `` {
-			return
-		}
+	// Set new id to the key
+	switch k := key.(type) {
+	case model.ConfigKey:
+		k.ID = keboola.ConfigID(newID)
+		key = k
+	case model.ConfigRowKey:
+		k.ID = keboola.RowID(newID)
+		key = k
+	default:
+		panic(errors.Errorf(`unexpected type "%s" of the persisted object "%s"`, key.Kind(), key.Desc()))
+	}
 
-		// Create manifest record
-		record, found, err := e.Manifest().CreateOrGetRecord(key)
-		if err != nil {
-			e.errors.Append(err)
-			return
-		} else if found {
-			panic(errors.Errorf(`unexpected state: manifest record "%s" exists, but it should not`, record))
-		}
+	// The parent was not persisted for some error -> skip
+	if action.ParentKey != nil && action.ParentKey.ObjectID() == `` {
+		return
+	}
 
-		// Invoke mapper
-		err = e.Mapper().MapBeforePersist(e.Ctx(), &model.PersistRecipe{
-			ParentKey: action.ParentKey,
-			Manifest:  record,
-		})
-		if err != nil {
-			e.errors.Append(err)
-			return
-		}
+	// Create manifest record
+	record, found, err := e.Manifest().CreateOrGetRecord(key)
+	if err != nil {
+		e.errors.Append(err)
+		return
+	} else if found {
+		panic(errors.Errorf(`unexpected state: manifest record "%s" exists, but it should not`, record))
+	}
 
-		// Update parent path - may be affected by relations
-		if err := e.Manifest().ResolveParentPath(record); err != nil {
-			e.errors.Append(errors.Errorf(`cannot resolve path: %w`, err))
-			return
-		}
-
-		// Set local path
-		record.SetRelativePath(action.GetRelativePath())
-
-		// Load model
-		e.uow.LoadObject(record, model.NoFilter())
-
-		// Save to manifest.json
-		if err := e.Manifest().PersistRecord(record); err != nil {
-			e.errors.Append(err)
-			return
-		}
-
-		// Setup related objects
-		action.InvokeOnPersist(key)
+	// Invoke mapper
+	err = e.Mapper().MapBeforePersist(e.Ctx(), &model.PersistRecipe{
+		ParentKey: action.ParentKey,
+		Manifest:  record,
 	})
+	if err != nil {
+		e.errors.Append(err)
+		return
+	}
+
+	// Update parent path - may be affected by relations
+	if err := e.Manifest().ResolveParentPath(record); err != nil {
+		e.errors.Append(errors.Errorf(`cannot resolve path: %w`, err))
+		return
+	}
+
+	// Set local path
+	record.SetRelativePath(action.GetRelativePath())
+
+	// Load model
+	e.uow.LoadObject(record, model.NoFilter())
+
+	// Save to manifest.json
+	if err := e.Manifest().PersistRecord(record); err != nil {
+		e.errors.Append(err)
+		return
+	}
+
+	// Setup related objects
+	action.InvokeOnPersist(key)
 }

--- a/internal/pkg/plan/persist/persist_test.go
+++ b/internal/pkg/plan/persist/persist_test.go
@@ -1,7 +1,6 @@
 package persist
 
 import (
-	"fmt"
 	"runtime"
 	"strconv"
 	"sync"
@@ -988,7 +987,6 @@ func (tc *testCase) run(t *testing.T) {
 	// Assert state after
 	assert.Empty(t, projectState.UntrackedPaths())
 	for _, objectState := range tc.expectedStates {
-		fmt.Println(objectState.Key())
 		realState, found := projectState.Get(objectState.Key())
 		assert.Truef(t, found, `%s should exists`, objectState.Desc())
 		assert.Equalf(t, objectState, realState, `object "%s" has unexpected content`, objectState.Desc())

--- a/internal/pkg/plan/persist/persist_test.go
+++ b/internal/pkg/plan/persist/persist_test.go
@@ -2,8 +2,6 @@ package persist
 
 import (
 	"runtime"
-	"strconv"
-	"sync"
 	"testing"
 
 	"github.com/keboola/go-utils/pkg/orderedmap"
@@ -29,27 +27,6 @@ type testCase struct {
 	expectedPlan    []action
 	expectedStates  []model.ObjectState
 	expectedMissing []model.Key
-}
-
-// mockUlidGenerator generates sequential IDs for testing.
-type mockUlidGenerator struct {
-	mutex  sync.Mutex
-	nextID int
-}
-
-// newMockUlidGenerator creates a generator that will produce IDs "1001", "1002", ...
-func newMockUlidGenerator() *mockUlidGenerator {
-	return &mockUlidGenerator{
-		nextID: 1001, // Start IDs from 1001 as per test expectations
-	}
-}
-
-func (g *mockUlidGenerator) NewULID() string {
-	g.mutex.Lock()
-	defer g.mutex.Unlock()
-	idStr := strconv.Itoa(g.nextID)
-	g.nextID++
-	return idStr
 }
 
 func TestPersistNoChange(t *testing.T) {
@@ -947,9 +924,6 @@ func (tc *testCase) run(t *testing.T) {
 	// Container
 	d := dependencies.NewMocked(t, t.Context())
 
-	// Create mock ULID generator
-	mockIDGenerator := newMockUlidGenerator()
-
 	// Load state
 	projectState, err := d.MockedProject(fs).LoadState(loadState.Options{LoadLocalState: true, IgnoreNotFoundErr: true}, d)
 	require.NoError(t, err)
@@ -982,7 +956,7 @@ func (tc *testCase) run(t *testing.T) {
 	// Invoke
 	plan, err = NewPlan(ctx, projectState.State()) // plan with callbacks
 	require.NoError(t, err)
-	require.NoError(t, plan.Invoke(ctx, d.Logger(), projectState.State(), mockIDGenerator))
+	require.NoError(t, plan.Invoke(ctx, d.Logger(), projectState.State(), d.NewIDGenerator()))
 
 	// Assert state after
 	assert.Empty(t, projectState.UntrackedPaths())

--- a/internal/pkg/plan/persist/plan.go
+++ b/internal/pkg/plan/persist/plan.go
@@ -5,10 +5,9 @@ import (
 	"fmt"
 	"io"
 
-	"github.com/keboola/keboola-sdk-go/v2/pkg/keboola"
-
 	"github.com/keboola/keboola-as-code/internal/pkg/log"
 	"github.com/keboola/keboola-as-code/internal/pkg/state"
+	"github.com/keboola/keboola-as-code/internal/pkg/utils/ulid"
 )
 
 type Plan struct {
@@ -35,6 +34,6 @@ func (p *Plan) Log(w io.Writer) {
 	}
 }
 
-func (p *Plan) Invoke(ctx context.Context, logger log.Logger, keboolaProjectAPI *keboola.AuthorizedAPI, projectState *state.State) error {
-	return newExecutor(ctx, logger, keboolaProjectAPI, projectState, p).invoke()
+func (p *Plan) Invoke(ctx context.Context, logger log.Logger, projectState *state.State, idGenerator ulid.Generator) error {
+	return newExecutor(ctx, logger, projectState, p, idGenerator).invoke()
 }

--- a/internal/pkg/service/appsproxy/dependencies/dependencies.go
+++ b/internal/pkg/service/appsproxy/dependencies/dependencies.go
@@ -37,6 +37,7 @@ import (
 	"github.com/keboola/keboola-as-code/internal/pkg/service/common/httpclient"
 	"github.com/keboola/keboola-as-code/internal/pkg/service/common/servicectx"
 	"github.com/keboola/keboola-as-code/internal/pkg/telemetry"
+	"github.com/keboola/keboola-as-code/internal/pkg/utils/ulid"
 )
 
 const (
@@ -149,7 +150,17 @@ func newParentScopes(
 	)
 
 	d := &parentScopesImpl{}
-	d.BaseScope = dependencies.NewBaseScope(ctx, logger, tel, stdout, stderr, clockwork.NewRealClock(), proc, httpClient)
+	d.BaseScope = dependencies.NewBaseScope(
+		ctx,
+		logger,
+		tel,
+		stdout,
+		stderr,
+		clockwork.NewRealClock(),
+		proc,
+		httpClient,
+		ulid.NewDefaultGenerator(),
+	)
 	return d
 }
 

--- a/internal/pkg/service/cli/dependencies/base.go
+++ b/internal/pkg/service/cli/dependencies/base.go
@@ -17,6 +17,7 @@ import (
 	"github.com/keboola/keboola-as-code/internal/pkg/service/common/dependencies"
 	"github.com/keboola/keboola-as-code/internal/pkg/service/common/servicectx"
 	"github.com/keboola/keboola-as-code/internal/pkg/telemetry"
+	"github.com/keboola/keboola-as-code/internal/pkg/utils/ulid"
 )
 
 // baseScope dependencies container implements BaseScope interface.
@@ -50,7 +51,17 @@ func newBaseScope(
 	envs *env.Map,
 ) *baseScope {
 	return &baseScope{
-		BaseScope:    dependencies.NewBaseScope(ctx, logger, telemetry.NewNop(), stdout, stderr, clockwork.NewRealClock(), proc, httpClient),
+		BaseScope: dependencies.NewBaseScope(
+			ctx,
+			logger,
+			telemetry.NewNop(),
+			stdout,
+			stderr,
+			clockwork.NewRealClock(),
+			proc,
+			httpClient,
+			ulid.NewDefaultGenerator(),
+		),
 		envs:         envs,
 		fs:           fs,
 		fsInfo:       FsInfo{fs: fs},

--- a/internal/pkg/service/common/dependencies/base.go
+++ b/internal/pkg/service/common/dependencies/base.go
@@ -11,19 +11,21 @@ import (
 	"github.com/keboola/keboola-as-code/internal/pkg/service/common/servicectx"
 	"github.com/keboola/keboola-as-code/internal/pkg/telemetry"
 	"github.com/keboola/keboola-as-code/internal/pkg/utils/errors"
+	"github.com/keboola/keboola-as-code/internal/pkg/utils/ulid"
 	"github.com/keboola/keboola-as-code/internal/pkg/validator"
 )
 
 // baseScope dependencies container implements BaseScope interface.
 type baseScope struct {
-	logger     log.Logger
-	telemetry  telemetry.Telemetry
-	stdout     io.Writer
-	stderr     io.Writer
-	clock      clockwork.Clock
-	httpClient client.Client
-	validator  validator.Validator
-	process    *servicectx.Process
+	logger        log.Logger
+	telemetry     telemetry.Telemetry
+	stdout        io.Writer
+	stderr        io.Writer
+	clock         clockwork.Clock
+	httpClient    client.Client
+	validator     validator.Validator
+	process       *servicectx.Process
+	ulidGenerator ulid.Generator
 }
 
 func NewBaseScope(
@@ -35,8 +37,9 @@ func NewBaseScope(
 	clk clockwork.Clock,
 	process *servicectx.Process,
 	httpClient client.Client,
+	ulidGenerator ulid.Generator,
 ) BaseScope {
-	return newBaseScope(ctx, logger, tel, stdout, stderr, clk, process, httpClient)
+	return newBaseScope(ctx, logger, tel, stdout, stderr, clk, process, httpClient, ulidGenerator)
 }
 
 func newBaseScope(
@@ -48,18 +51,20 @@ func newBaseScope(
 	clk clockwork.Clock,
 	process *servicectx.Process,
 	httpClient client.Client,
+	ulidGenerator ulid.Generator,
 ) *baseScope {
 	_, span := tel.Tracer().Start(ctx, "keboola.go.common.dependencies.NewBaseScope")
 	defer span.End(nil)
 	return &baseScope{
-		logger:     logger,
-		telemetry:  tel,
-		stdout:     stdout,
-		stderr:     stderr,
-		clock:      clk,
-		process:    process,
-		httpClient: httpClient,
-		validator:  validator.New(),
+		logger:        logger,
+		telemetry:     tel,
+		stdout:        stdout,
+		stderr:        stderr,
+		clock:         clk,
+		process:       process,
+		httpClient:    httpClient,
+		validator:     validator.New(),
+		ulidGenerator: ulidGenerator,
 	}
 }
 
@@ -107,4 +112,9 @@ func (v *baseScope) Stdout() io.Writer {
 func (v *baseScope) Stderr() io.Writer {
 	v.check()
 	return v.stderr
+}
+
+func (v *baseScope) NewIDGenerator() ulid.Generator {
+	v.check()
+	return v.ulidGenerator
 }

--- a/internal/pkg/service/common/dependencies/dependencies.go
+++ b/internal/pkg/service/common/dependencies/dependencies.go
@@ -77,6 +77,7 @@ import (
 	taskPkg "github.com/keboola/keboola-as-code/internal/pkg/service/common/task"
 	"github.com/keboola/keboola-as-code/internal/pkg/state"
 	"github.com/keboola/keboola-as-code/internal/pkg/telemetry"
+	"github.com/keboola/keboola-as-code/internal/pkg/utils/ulid"
 	"github.com/keboola/keboola-as-code/internal/pkg/validator"
 )
 
@@ -90,6 +91,7 @@ type BaseScope interface {
 	Process() *servicectx.Process
 	Stdout() io.Writer
 	Stderr() io.Writer
+	NewIDGenerator() ulid.Generator
 }
 
 // PublicScope dependencies are available from the Storage API and other sources without authentication / Storage API token.

--- a/internal/pkg/service/common/dependencies/dependencies.go
+++ b/internal/pkg/service/common/dependencies/dependencies.go
@@ -55,7 +55,6 @@
 package dependencies
 
 import (
-	"context"
 	"io"
 	"net/http"
 
@@ -106,7 +105,6 @@ type PublicScope interface {
 // ProjectScope dependencies require authentication - Storage API token.
 type ProjectScope interface {
 	KeboolaProjectAPI() *keboola.AuthorizedAPI
-	ObjectIDGeneratorFactory() func(ctx context.Context) *keboola.TicketProvider
 	ProjectID() keboola.ProjectID
 	ProjectBackends() []string
 	ProjectName() string

--- a/internal/pkg/service/common/dependencies/project.go
+++ b/internal/pkg/service/common/dependencies/project.go
@@ -169,13 +169,6 @@ func (v *projectScope) KeboolaProjectAPI() *keboola.AuthorizedAPI {
 	return v.keboolaProjectAPI
 }
 
-func (v *projectScope) ObjectIDGeneratorFactory() func(ctx context.Context) *keboola.TicketProvider {
-	v.check()
-	return func(ctx context.Context) *keboola.TicketProvider {
-		return keboola.NewTicketProvider(ctx, v.KeboolaProjectAPI())
-	}
-}
-
 type MasterTokenRequiredError struct{}
 
 func (MasterTokenRequiredError) StatusCode() int {

--- a/internal/pkg/service/common/dependencies/public_test.go
+++ b/internal/pkg/service/common/dependencies/public_test.go
@@ -18,7 +18,17 @@ func TestNewPublicDeps_LazyLoadComponents(t *testing.T) {
 	t.Parallel()
 	ctx := t.Context()
 	httpClient := httpclient.New()
-	baseDeps := newBaseScope(ctx, log.NewNopLogger(), telemetry.NewNop(), os.Stdout, os.Stderr, clockwork.NewRealClock(), servicectx.NewForTest(t), httpClient)
+	baseDeps := newBaseScope(
+		ctx,
+		log.NewNopLogger(),
+		telemetry.NewNop(),
+		os.Stdout,
+		os.Stderr,
+		clockwork.NewRealClock(),
+		servicectx.NewForTest(t),
+		httpClient,
+		newMockUlidGenerator(),
+	)
 
 	// Create public deps without loading components.
 	deps, err := newPublicScope(t.Context(), baseDeps, "https://connection.keboola.com")

--- a/internal/pkg/service/stream/dependencies/service.go
+++ b/internal/pkg/service/stream/dependencies/service.go
@@ -28,6 +28,7 @@ import (
 	statsRepo "github.com/keboola/keboola-as-code/internal/pkg/service/stream/storage/statistics/repository"
 	"github.com/keboola/keboola-as-code/internal/pkg/service/stream/storage/test/dummy"
 	"github.com/keboola/keboola-as-code/internal/pkg/telemetry"
+	"github.com/keboola/keboola-as-code/internal/pkg/utils/ulid"
 )
 
 const (
@@ -111,7 +112,17 @@ func newParentScopes(
 
 	d := &parentScopes{}
 
-	d.BaseScope = dependencies.NewBaseScope(ctx, logger, tel, stdout, stderr, clockwork.NewRealClock(), proc, httpClient)
+	d.BaseScope = dependencies.NewBaseScope(
+		ctx,
+		logger,
+		tel,
+		stdout,
+		stderr,
+		clockwork.NewRealClock(),
+		proc,
+		httpClient,
+		ulid.NewDefaultGenerator(),
+	)
 
 	d.PublicScope, err = dependencies.NewPublicScope(ctx, d, cfg.StorageAPIHost, dependencies.WithLogIndexLoading(true))
 	if err != nil {

--- a/internal/pkg/service/stream/sink/type/tablesink/keboola/bridge/event_test.go
+++ b/internal/pkg/service/stream/sink/type/tablesink/keboola/bridge/event_test.go
@@ -53,6 +53,7 @@ func TestBridge_SendSliceUploadEvent_OkEvent(t *testing.T) {
   "message": "Slice upload done.",
   "params": "{\"branchId\":456,\"projectId\":123,\"sinkId\":\"my-sink\",\"sourceId\":\"my-source\",\"streamId\":\"123/456/my-source\"}",
   "results": "{\"statistics\":{\"compressedSize\":52428800,\"firstRecordAt\":\"2000-01-01T20:00:00.000Z\",\"lastRecordAt\":\"2000-01-02T01:00:00.000Z\",\"recordsCount\":123,\"slicesCount\":1,\"stagingSize\":26214400,\"uncompressedSize\":104857600}}",
+  "runId": "",
   "type": "info"
 }`, body)
 }
@@ -86,6 +87,7 @@ func TestBridge_SendSliceUploadEvent_ErrorEvent(t *testing.T) {
   "message": "Slice upload failed.",
   "params": "{\"branchId\":456,\"projectId\":123,\"sinkId\":\"my-sink\",\"sourceId\":\"my-source\",\"streamId\":\"123/456/my-source\"}",
   "results": "{\"error\":\"some error\"}",
+  "runId": "",
   "type": "error"
 }`, body)
 }
@@ -143,6 +145,7 @@ func TestBridge_SendFileImportEvent_OkEvent(t *testing.T) {
   "message": "File import done.",
   "params": "{\"branchId\":456,\"projectId\":123,\"sinkId\":\"my-sink\",\"sourceId\":\"my-source\",\"streamId\":\"123/456/my-source\"}",
   "results": "{\"statistics\":{\"compressedSize\":52428800,\"firstRecordAt\":\"2000-01-01T01:00:00.000Z\",\"lastRecordAt\":\"2000-01-02T01:00:00.000Z\",\"recordsCount\":123,\"slicesCount\":1,\"stagingSize\":26214400,\"uncompressedSize\":104857600}}",
+  "runId": "",
   "type": "info"
 }`, body)
 }
@@ -176,6 +179,7 @@ func TestBridge_SendFileImportEvent_ErrorEvent(t *testing.T) {
   "message": "File import failed.",
   "params": "{\"branchId\":456,\"projectId\":123,\"sinkId\":\"my-sink\",\"sourceId\":\"my-source\",\"streamId\":\"123/456/my-source\"}",
   "results": "{\"error\":\"some error\"}",
+  "runId": "",
   "type": "error"
 }`, body)
 }

--- a/internal/pkg/service/templates/api/service/service.go
+++ b/internal/pkg/service/templates/api/service/service.go
@@ -29,6 +29,7 @@ import (
 	"github.com/keboola/keboola-as-code/internal/pkg/template/repository"
 	"github.com/keboola/keboola-as-code/internal/pkg/template/repository/manifest"
 	"github.com/keboola/keboola-as-code/internal/pkg/utils/errors"
+	"github.com/keboola/keboola-as-code/internal/pkg/utils/ulid"
 	deleteTemplate "github.com/keboola/keboola-as-code/pkg/lib/operation/project/local/template/delete"
 	renameInst "github.com/keboola/keboola-as-code/pkg/lib/operation/project/local/template/rename"
 	upgradeTemplate "github.com/keboola/keboola-as-code/pkg/lib/operation/project/local/template/upgrade"
@@ -876,6 +877,7 @@ func generateTemplatePreview(
 		d.Components(),
 		projectState.State(),
 		d.ProjectBackends(),
+		ulid.NewDefaultGenerator(),
 	)
 	plan, err := useTemplate.PrepareTemplate(ctx, d, useTemplate.ExtendedOptions{
 		TargetBranch:          o.TargetBranch,

--- a/internal/pkg/service/templates/api/service/service.go
+++ b/internal/pkg/service/templates/api/service/service.go
@@ -855,15 +855,28 @@ func tryLockProject(ctx context.Context, d dependencies.ProjectRequestScope) (un
 	return unlockFn, nil
 }
 
-func generateTemplatePreview(ctx context.Context, tmpl *template.Template, d dependencies.ProjectRequestScope, projectState *project.State, o preview.Options) (result *use.Result, err error) {
+func generateTemplatePreview(
+	ctx context.Context,
+	tmpl *template.Template,
+	d dependencies.ProjectRequestScope,
+	projectState *project.State,
+	o preview.Options,
+) (result *use.Result, err error) {
 	ctx, span := d.Telemetry().Tracer().Start(ctx, "keboola.go.operation.project.local.template.preview")
 	defer span.End(&err)
 
-	// Create tickets provider, to generate new IDS
-	tickets := d.ObjectIDGeneratorFactory()(ctx)
-
 	// Prepare template
-	tmplCtx := preview.NewContext(ctx, tmpl.Reference(), tmpl.ObjectsRoot(), o.TargetBranch, o.Inputs, tmpl.Inputs().InputsMap(), tickets, d.Components(), projectState.State(), d.ProjectBackends())
+	tmplCtx := preview.NewContext(
+		ctx,
+		tmpl.Reference(),
+		tmpl.ObjectsRoot(),
+		o.TargetBranch,
+		o.Inputs,
+		tmpl.Inputs().InputsMap(),
+		d.Components(),
+		projectState.State(),
+		d.ProjectBackends(),
+	)
 	plan, err := useTemplate.PrepareTemplate(ctx, d, useTemplate.ExtendedOptions{
 		TargetBranch:          o.TargetBranch,
 		Inputs:                o.Inputs,

--- a/internal/pkg/service/templates/dependencies/api.go
+++ b/internal/pkg/service/templates/dependencies/api.go
@@ -17,6 +17,7 @@ import (
 	"github.com/keboola/keboola-as-code/internal/pkg/service/templates/store/schema"
 	"github.com/keboola/keboola-as-code/internal/pkg/telemetry"
 	repositoryManager "github.com/keboola/keboola-as-code/internal/pkg/template/repository/manager"
+	"github.com/keboola/keboola-as-code/internal/pkg/utils/ulid"
 )
 
 const (
@@ -91,7 +92,17 @@ func newParentScopes(
 
 	d := &parentScopes{}
 
-	d.BaseScope = dependencies.NewBaseScope(ctx, logger, tel, stdout, stderr, clockwork.NewRealClock(), proc, httpClient)
+	d.BaseScope = dependencies.NewBaseScope(
+		ctx,
+		logger,
+		tel,
+		stdout,
+		stderr,
+		clockwork.NewRealClock(),
+		proc,
+		httpClient,
+		ulid.NewDefaultGenerator(),
+	)
 
 	d.PublicScope, err = dependencies.NewPublicScope(
 		ctx, d, cfg.StorageAPIHost,

--- a/internal/pkg/template/context/preview/context.go
+++ b/internal/pkg/template/context/preview/context.go
@@ -4,11 +4,14 @@ package preview
 import (
 	"context"
 	"fmt"
+	"math/rand"
 	"sync"
+	"time"
 
 	jsonnetLib "github.com/google/go-jsonnet"
 	"github.com/keboola/go-utils/pkg/orderedmap"
 	"github.com/keboola/keboola-sdk-go/v2/pkg/keboola"
+	"github.com/oklog/ulid/v2"
 
 	"github.com/keboola/keboola-as-code/internal/pkg/encoding/jsonnet"
 	"github.com/keboola/keboola-as-code/internal/pkg/encoding/jsonnet/fsimporter"
@@ -29,10 +32,8 @@ type Context struct {
 	jsonnetCtx        *jsonnet.Context
 	replacements      *replacevalues.Values
 	inputsValues      map[string]template.InputValue
-	tickets           *keboola.TicketProvider
 	components        *model.ComponentsMap
 	placeholdersCount int
-	ticketsResolved   bool
 	projectBackends   []string
 
 	lock          *sync.Mutex
@@ -78,7 +79,17 @@ const (
 	placeholderEnd   = "~~>>"
 )
 
-func NewContext(ctx context.Context, templateRef model.TemplateRef, objectsRoot filesystem.Fs, targetBranch model.BranchKey, inputsValues template.InputsValues, inputsDefsMap map[string]*template.Input, tickets *keboola.TicketProvider, components *model.ComponentsMap, projectState *state.State, projectBackends []string) *Context {
+func NewContext(
+	ctx context.Context,
+	templateRef model.TemplateRef,
+	objectsRoot filesystem.Fs,
+	targetBranch model.BranchKey,
+	inputsValues template.InputsValues,
+	inputsDefsMap map[string]*template.Input,
+	components *model.ComponentsMap,
+	projectState *state.State,
+	projectBackends []string,
+) *Context {
 	ctx = template.NewContext(ctx)
 	c := &Context{
 		_context:        ctx,
@@ -86,7 +97,6 @@ func NewContext(ctx context.Context, templateRef model.TemplateRef, objectsRoot 
 		jsonnetCtx:      jsonnet.NewContext().WithCtx(ctx).WithImporter(fsimporter.New(objectsRoot)),
 		replacements:    replacevalues.NewValues(),
 		inputsValues:    make(map[string]template.InputValue),
-		tickets:         tickets,
 		components:      components,
 		lock:            &sync.Mutex{},
 		placeholders:    make(PlaceholdersMap),
@@ -146,12 +156,6 @@ func (c *Context) Placeholders() PlaceholdersMap {
 
 func (c *Context) Replacements() (*replacevalues.Values, error) {
 	// Generate new IDs
-	if !c.ticketsResolved {
-		if err := c.tickets.Resolve(); err != nil {
-			return nil, err
-		}
-		c.ticketsResolved = true
-	}
 	return c.replacements, nil
 }
 
@@ -219,17 +223,20 @@ func (c *Context) mapID(oldID any) string {
 	p := c.RegisterPlaceholder(oldID, func(p Placeholder, cb ResolveCallback) {
 		// Placeholder -> new ID
 		var newID any
-		c.tickets.Request(func(ticket *keboola.Ticket) {
-			switch p.asValue.(type) {
-			case keboola.ConfigID:
-				newID = keboola.ConfigID(ticket.ID)
-			case keboola.RowID:
-				newID = keboola.RowID(ticket.ID)
-			default:
-				panic(errors.New("unexpected ID type"))
-			}
-			cb(newID)
-		})
+		// Generate ULID
+		ms := ulid.Timestamp(time.Now())
+		entropy := ulid.Monotonic(rand.New(rand.NewSource(time.Now().UnixNano())), 0)
+		generatedID := ulid.MustNew(ms, entropy).String()
+
+		switch p.asValue.(type) {
+		case keboola.ConfigID:
+			newID = keboola.ConfigID(generatedID)
+		case keboola.RowID:
+			newID = keboola.RowID(generatedID)
+		default:
+			panic(errors.New("unexpected ID type"))
+		}
+		cb(newID)
 	})
 	return p.asString
 }

--- a/internal/pkg/template/context/preview/context.go
+++ b/internal/pkg/template/context/preview/context.go
@@ -4,14 +4,11 @@ package preview
 import (
 	"context"
 	"fmt"
-	"math/rand"
 	"sync"
-	"time"
 
 	jsonnetLib "github.com/google/go-jsonnet"
 	"github.com/keboola/go-utils/pkg/orderedmap"
 	"github.com/keboola/keboola-sdk-go/v2/pkg/keboola"
-	"github.com/oklog/ulid/v2"
 
 	"github.com/keboola/keboola-as-code/internal/pkg/encoding/jsonnet"
 	"github.com/keboola/keboola-as-code/internal/pkg/encoding/jsonnet/fsimporter"
@@ -24,6 +21,7 @@ import (
 	"github.com/keboola/keboola-as-code/internal/pkg/template"
 	"github.com/keboola/keboola-as-code/internal/pkg/template/jsonnet/function"
 	"github.com/keboola/keboola-as-code/internal/pkg/utils/errors"
+	"github.com/keboola/keboola-as-code/internal/pkg/utils/ulid"
 )
 
 type Context struct {
@@ -35,6 +33,7 @@ type Context struct {
 	components        *model.ComponentsMap
 	placeholdersCount int
 	projectBackends   []string
+	idGenerator       ulid.Generator
 
 	lock          *sync.Mutex
 	placeholders  PlaceholdersMap
@@ -89,6 +88,7 @@ func NewContext(
 	components *model.ComponentsMap,
 	projectState *state.State,
 	projectBackends []string,
+	idGenerator ulid.Generator,
 ) *Context {
 	ctx = template.NewContext(ctx)
 	c := &Context{
@@ -104,6 +104,7 @@ func NewContext(
 		inputsUsage:     metadata.NewInputsUsage(),
 		inputsDefsMap:   inputsDefsMap,
 		projectBackends: projectBackends,
+		idGenerator:     idGenerator,
 	}
 
 	// Convert inputsValues to map
@@ -224,9 +225,7 @@ func (c *Context) mapID(oldID any) string {
 		// Placeholder -> new ID
 		var newID any
 		// Generate ULID
-		ms := ulid.Timestamp(time.Now())
-		entropy := ulid.Monotonic(rand.New(rand.NewSource(time.Now().UnixNano())), 0)
-		generatedID := ulid.MustNew(ms, entropy).String()
+		generatedID := c.idGenerator.NewULID()
 
 		switch p.asValue.(type) {
 		case keboola.ConfigID:

--- a/internal/pkg/template/context/upgrade/context.go
+++ b/internal/pkg/template/context/upgrade/context.go
@@ -29,9 +29,31 @@ type Context struct {
 	*use.Context
 }
 
-func NewContext(ctx context.Context, templateRef model.TemplateRef, objectsRoot filesystem.Fs, instanceID string, targetBranch model.BranchKey, inputsValues template.InputsValues, inputsDefs map[string]*template.Input, tickets *keboola.TicketProvider, components *model.ComponentsMap, projectState *state.State, backends []string) *Context {
+func NewContext(
+	ctx context.Context,
+	templateRef model.TemplateRef,
+	objectsRoot filesystem.Fs,
+	instanceID string,
+	targetBranch model.BranchKey,
+	inputsValues template.InputsValues,
+	inputsDefs map[string]*template.Input,
+	components *model.ComponentsMap,
+	projectState *state.State,
+	backends []string,
+) *Context {
 	c := &Context{
-		Context: use.NewContext(ctx, templateRef, objectsRoot, instanceID, targetBranch, inputsValues, inputsDefs, tickets, components, projectState, backends),
+		Context: use.NewContext(
+			ctx,
+			templateRef,
+			objectsRoot,
+			instanceID,
+			targetBranch,
+			inputsValues,
+			inputsDefs,
+			components,
+			projectState,
+			backends,
+		),
 	}
 
 	// Register existing IDs, so they will be reused

--- a/internal/pkg/template/context/upgrade/context.go
+++ b/internal/pkg/template/context/upgrade/context.go
@@ -13,6 +13,7 @@ import (
 	"github.com/keboola/keboola-as-code/internal/pkg/state"
 	"github.com/keboola/keboola-as-code/internal/pkg/template"
 	"github.com/keboola/keboola-as-code/internal/pkg/template/context/use"
+	"github.com/keboola/keboola-as-code/internal/pkg/utils/ulid"
 )
 
 // dataAppInstanceIDContentPath contains path to the app instance ID in the configuration content.
@@ -40,6 +41,7 @@ func NewContext(
 	components *model.ComponentsMap,
 	projectState *state.State,
 	backends []string,
+	idGenerator ulid.Generator,
 ) *Context {
 	c := &Context{
 		Context: use.NewContext(
@@ -53,6 +55,7 @@ func NewContext(
 			components,
 			projectState,
 			backends,
+			idGenerator,
 		),
 	}
 

--- a/internal/pkg/template/context/upgrade/context_test.go
+++ b/internal/pkg/template/context/upgrade/context_test.go
@@ -1,9 +1,7 @@
 package upgrade_test
 
 import (
-	"strconv"
 	"strings"
-	"sync"
 	"testing"
 
 	"github.com/go-resty/resty/v2"
@@ -22,27 +20,6 @@ import (
 	. "github.com/keboola/keboola-as-code/internal/pkg/template/context/upgrade"
 	"github.com/keboola/keboola-as-code/internal/pkg/utils/testapi"
 )
-
-// mockUlidGenerator generates sequential IDs for testing.
-type mockUlidGenerator struct {
-	mutex  sync.Mutex
-	nextID int
-}
-
-// newMockUlidGenerator creates a generator that will produce IDs "1001", "1002", ...
-func newMockUlidGenerator() *mockUlidGenerator {
-	return &mockUlidGenerator{
-		nextID: 1001, // Start IDs from 1001 as per test expectations
-	}
-}
-
-func (g *mockUlidGenerator) NewULID() string {
-	g.mutex.Lock()
-	defer g.mutex.Unlock()
-	idStr := strconv.Itoa(g.nextID)
-	g.nextID++
-	return idStr
-}
 
 func TestContext(t *testing.T) {
 	t.Parallel()
@@ -108,7 +85,6 @@ func TestContext(t *testing.T) {
 
 	// Create context
 	fs := aferofs.NewMemoryFs()
-	mockIDGenerator := newMockUlidGenerator() // Create mock generator
 	tmplContext := NewContext(
 		t.Context(),
 		templateRef,
@@ -120,7 +96,7 @@ func TestContext(t *testing.T) {
 		testapi.MockedComponentsMap(),
 		projectState,
 		d.ProjectBackends(),
-		mockIDGenerator, // Pass mock generator
+		d.NewIDGenerator(),
 	)
 
 	// Check Jsonnet functions

--- a/internal/pkg/template/context/use/context_test.go
+++ b/internal/pkg/template/context/use/context_test.go
@@ -7,10 +7,7 @@ import (
 	"sync"
 	"testing"
 
-	"github.com/go-resty/resty/v2"
-	"github.com/jarcoal/httpmock"
 	"github.com/keboola/go-utils/pkg/orderedmap"
-	"github.com/keboola/keboola-sdk-go/v2/pkg/client"
 	"github.com/keboola/keboola-sdk-go/v2/pkg/keboola"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
@@ -53,15 +50,6 @@ func (g *mockUlidGenerator) NewULID() string {
 
 func TestContext(t *testing.T) {
 	t.Parallel()
-
-	// Mocked ticket provider
-	_, httpTransport := client.NewMockedClient()
-	httpTransport.RegisterResponder(resty.MethodGet, `/v2/storage/?exclude=components`,
-		httpmock.NewStringResponder(200, `{
-			"services": [],
-			"features": []
-		}`),
-	)
 	ctx := t.Context()
 
 	// Inputs
@@ -209,15 +197,6 @@ func TestContext(t *testing.T) {
 
 func TestComponentsFunctions(t *testing.T) {
 	t.Parallel()
-
-	// Mocked ticket provider
-	_, httpTransport := client.NewMockedClient()
-	httpTransport.RegisterResponder(resty.MethodGet, `/v2/storage/?exclude=components`,
-		httpmock.NewStringResponder(200, `{
-			"services": [],
-			"features": []
-		}`),
-	)
 	ctx := t.Context()
 
 	d := dependenciesPkg.NewMocked(t, ctx, dependenciesPkg.WithSnowflakeBackend())
@@ -334,15 +313,6 @@ func TestComponentsFunctions(t *testing.T) {
 
 func TestHasBackendFunction(t *testing.T) {
 	t.Parallel()
-
-	// Mocked ticket provider
-	_, httpTransport := client.NewMockedClient()
-	httpTransport.RegisterResponder(resty.MethodGet, `/v2/storage/?exclude=components`,
-		httpmock.NewStringResponder(200, `{
-			"services": [],
-			"features": []
-		}`),
-	)
 	ctx := t.Context()
 
 	d := dependenciesPkg.NewMocked(t, ctx, dependenciesPkg.WithSnowflakeBackend())

--- a/internal/pkg/template/context/use/context_test.go
+++ b/internal/pkg/template/context/use/context_test.go
@@ -2,9 +2,7 @@ package use_test
 
 import (
 	"context"
-	"strconv"
 	"strings"
-	"sync"
 	"testing"
 
 	"github.com/keboola/go-utils/pkg/orderedmap"
@@ -25,28 +23,6 @@ import (
 	"github.com/keboola/keboola-as-code/internal/pkg/template/jsonnet/function"
 	"github.com/keboola/keboola-as-code/internal/pkg/utils/testapi"
 )
-
-// mockUlidGenerator generates sequential IDs for testing.
-// Copied from upgrade_test, ensure it meets the needs of this test or adjust.
-type mockUlidGenerator struct {
-	mutex  sync.Mutex
-	nextID int
-}
-
-// newMockUlidGenerator creates a generator that will produce IDs "1001", "1002", ...
-func newMockUlidGenerator() *mockUlidGenerator {
-	return &mockUlidGenerator{
-		nextID: 1001, // Default starting ID, adjust if tests expect different sequences
-	}
-}
-
-func (g *mockUlidGenerator) NewULID() string {
-	g.mutex.Lock()
-	defer g.mutex.Unlock()
-	idStr := strconv.Itoa(g.nextID)
-	g.nextID++
-	return idStr
-}
 
 func TestContext(t *testing.T) {
 	t.Parallel()
@@ -93,7 +69,6 @@ func TestContext(t *testing.T) {
 	// Create template use context
 	d := dependenciesPkg.NewMocked(t, ctx)
 	projectState := d.MockedState()
-	mockIDGenerator := newMockUlidGenerator()
 	useCtx := NewContext(
 		ctxWithVal,
 		templateRef,
@@ -105,7 +80,7 @@ func TestContext(t *testing.T) {
 		testapi.MockedComponentsMap(),
 		projectState,
 		d.ProjectBackends(),
-		mockIDGenerator,
+		d.NewIDGenerator(),
 	)
 
 	// Check Jsonnet functions
@@ -211,7 +186,6 @@ func TestComponentsFunctions(t *testing.T) {
 
 	// Context factory for template use operation
 	newUseCtx := func() *Context {
-		mockIDGen := newMockUlidGenerator()
 		return NewContext(
 			ctx,
 			templateRef,
@@ -223,7 +197,7 @@ func TestComponentsFunctions(t *testing.T) {
 			components,
 			projectState,
 			d.ProjectBackends(),
-			mockIDGen,
+			d.NewIDGenerator(),
 		)
 	}
 
@@ -328,7 +302,6 @@ func TestHasBackendFunction(t *testing.T) {
 
 	// Context factory for template use operation
 	newUseCtxFactory := func() *Context {
-		mockIDGen := newMockUlidGenerator()
 		return NewContext(
 			ctx,
 			templateRef,
@@ -340,7 +313,7 @@ func TestHasBackendFunction(t *testing.T) {
 			components,
 			projectState,
 			d.ProjectBackends(),
-			mockIDGen,
+			d.NewIDGenerator(),
 		)
 	}
 

--- a/internal/pkg/template/template.go
+++ b/internal/pkg/template/template.go
@@ -428,6 +428,7 @@ func (c *evaluatedTemplate) MainConfig() (*model.TemplateMainConfig, error) {
 	if err != nil {
 		return nil, err
 	}
+
 	mainConfig := mainConfigRaw.(*model.ConfigKey)
 	if mainConfig == nil {
 		return nil, nil

--- a/internal/pkg/template/test/project.go
+++ b/internal/pkg/template/test/project.go
@@ -19,6 +19,7 @@ import (
 	"github.com/keboola/keboola-as-code/internal/pkg/service/common/servicectx"
 	"github.com/keboola/keboola-as-code/internal/pkg/telemetry"
 	"github.com/keboola/keboola-as-code/internal/pkg/utils/testproject"
+	"github.com/keboola/keboola-as-code/internal/pkg/utils/ulid"
 	loadState "github.com/keboola/keboola-as-code/pkg/lib/operation/state/load"
 )
 
@@ -124,7 +125,17 @@ func newTestDependencies(
 	apiHost,
 	apiToken string,
 ) (*Dependencies, error) {
-	baseDeps := dependenciesPkg.NewBaseScope(ctx, logger, tel, stdout, stderr, clockwork.NewRealClock(), proc, client.NewTestClient())
+	baseDeps := dependenciesPkg.NewBaseScope(
+		ctx,
+		logger,
+		tel,
+		stdout,
+		stderr,
+		clockwork.NewRealClock(),
+		proc,
+		client.NewTestClient(),
+		ulid.NewDefaultGenerator(),
+	)
 	publicDeps, err := dependenciesPkg.NewPublicScope(ctx, baseDeps, apiHost, dependenciesPkg.WithPreloadComponents(true))
 	if err != nil {
 		return nil, err

--- a/internal/pkg/utils/testhelper/runner/runner.go
+++ b/internal/pkg/utils/testhelper/runner/runner.go
@@ -94,7 +94,7 @@ func (r *Runner) newTest(t *testing.T, testDirName string) (*Test, context.Cance
 	ctx, cancelFn := context.WithTimeout(t.Context(), testTimeout)
 
 	// Create ENV provider
-	envProvider := storageenv.CreateStorageEnvTicketProvider(ctx, project.ProjectAPI(), project.Env())
+	envProvider := storageenv.CreateStorageEnvTicketProvider(ctx, project.Env())
 
 	envMap := project.Env()
 	// Disable version check

--- a/internal/pkg/utils/testhelper/storageenv/storageenv.go
+++ b/internal/pkg/utils/testhelper/storageenv/storageenv.go
@@ -2,15 +2,13 @@ package storageenv
 
 import (
 	"context"
-	"math/rand"
 	"strings"
-	"time"
 
-	"github.com/oklog/ulid/v2"
 	"github.com/umisama/go-regexpcache"
 
 	"github.com/keboola/keboola-as-code/internal/pkg/env"
 	"github.com/keboola/keboola-as-code/internal/pkg/utils/testhelper"
+	"github.com/keboola/keboola-as-code/internal/pkg/utils/ulid"
 )
 
 type storageEnvTicketProvider struct {
@@ -42,9 +40,7 @@ func (p *storageEnvTicketProvider) getForTicket(key string) string {
 	nameRegexp := regexpcache.MustCompile(`^TEST_NEW_TICKET_\d+$`)
 	if _, found := p.envs.Lookup(key); !found && nameRegexp.MatchString(key) {
 		// Generate ULID
-		ms := ulid.Timestamp(time.Now())
-		entropy := ulid.Monotonic(rand.New(rand.NewSource(time.Now().UnixNano())), 0)
-		newID := ulid.MustNew(ms, entropy).String()
+		newID := ulid.NewDefaultGenerator().NewULID()
 
 		p.envs.Set(key, newID)
 		return newID

--- a/internal/pkg/utils/testproject/project.go
+++ b/internal/pkg/utils/testproject/project.go
@@ -612,6 +612,7 @@ func (p *Project) prepareConfigs(
 	names []string,
 	branch *keboola.Branch,
 ) {
+	generator := ulid.NewDefaultGenerator()
 	for _, name := range names {
 		configFixture := fixtures.LoadConfig(name)
 		configWithRows := configFixture.ToAPI()
@@ -620,7 +621,6 @@ func (p *Project) prepareConfigs(
 		// Generate ID for config
 		p.logf("▶ ID for config \"%s\"...", configDesc)
 		// Generate ULID
-		generator := ulid.NewDefaultGenerator()
 		newID := generator.NewULID()
 		configWithRows.BranchID = branch.ID
 		configWithRows.ID = keboola.ConfigID(newID)

--- a/internal/pkg/utils/ulid/generator.go
+++ b/internal/pkg/utils/ulid/generator.go
@@ -2,7 +2,6 @@ package ulid
 
 import (
 	"crypto/rand"
-	crand "crypto/rand"
 	"encoding/binary"
 	"io"
 	"log"
@@ -21,18 +20,18 @@ type defaultGenerator struct {
 	entropy io.Reader
 }
 
-// Generates a secure random seed
+// Generates a secure random seed.
 func secureRandomSeed() uint64 {
 	var b [8]byte
 	if _, err := rand.Read(b[:]); err != nil {
 		log.Fatal("cannot read random seed:", err)
 	}
-	return uint64(binary.BigEndian.Uint64(b[:]))
+	return binary.BigEndian.Uint64(b[:])
 }
 
 // NewDefaultGenerator creates a new standard ULID generator.
 func NewDefaultGenerator() Generator {
-	entropyReader := ulid.Monotonic(crand.Reader, secureRandomSeed())
+	entropyReader := ulid.Monotonic(rand.Reader, secureRandomSeed())
 
 	return &defaultGenerator{
 		entropy: entropyReader,

--- a/internal/pkg/utils/ulid/generator.go
+++ b/internal/pkg/utils/ulid/generator.go
@@ -1,0 +1,31 @@
+package ulid
+
+import (
+	"math/rand"
+	"time"
+
+	"github.com/oklog/ulid/v2"
+)
+
+// Generator defines an interface for generating ULIDs.
+type Generator interface {
+	NewULID() string
+}
+
+// defaultGenerator is the standard ULID generator using oklog/ulid.
+type defaultGenerator struct{}
+
+// NewDefaultGenerator creates a new standard ULID generator.
+func NewDefaultGenerator() Generator {
+	return &defaultGenerator{}
+}
+
+// NewULID generates a new ULID string.
+// It replicates the entropy generation logic previously in the executor.
+func (g *defaultGenerator) NewULID() string {
+	ms := ulid.Timestamp(time.Now())
+	// A new rand.Source is created for each ULID to ensure entropy,
+	// similar to the original implementation.
+	entropy := ulid.Monotonic(rand.New(rand.NewSource(time.Now().UnixNano())), 0)
+	return ulid.MustNew(ms, entropy).String()
+}

--- a/internal/pkg/utils/ulid/generator.go
+++ b/internal/pkg/utils/ulid/generator.go
@@ -1,8 +1,8 @@
 package ulid
 
 import (
+	crand "crypto/rand"
 	"io"
-	"math/rand"
 	"time"
 
 	"github.com/oklog/ulid/v2"
@@ -20,9 +20,7 @@ type defaultGenerator struct {
 
 // NewDefaultGenerator creates a new standard ULID generator.
 func NewDefaultGenerator() Generator {
-	source := rand.NewSource(time.Now().UnixNano())
-	random := rand.New(source)
-	entropyReader := ulid.Monotonic(random, 0)
+	entropyReader := ulid.Monotonic(crand.Reader, 0)
 
 	return &defaultGenerator{
 		entropy: entropyReader,

--- a/internal/pkg/utils/ulid/generator.go
+++ b/internal/pkg/utils/ulid/generator.go
@@ -1,8 +1,11 @@
 package ulid
 
 import (
+	"crypto/rand"
 	crand "crypto/rand"
+	"encoding/binary"
 	"io"
+	"log"
 	"time"
 
 	"github.com/oklog/ulid/v2"
@@ -18,9 +21,18 @@ type defaultGenerator struct {
 	entropy io.Reader
 }
 
+// Generates a secure random seed
+func secureRandomSeed() uint64 {
+	var b [8]byte
+	if _, err := rand.Read(b[:]); err != nil {
+		log.Fatal("cannot read random seed:", err)
+	}
+	return uint64(binary.BigEndian.Uint64(b[:]))
+}
+
 // NewDefaultGenerator creates a new standard ULID generator.
 func NewDefaultGenerator() Generator {
-	entropyReader := ulid.Monotonic(crand.Reader, 0)
+	entropyReader := ulid.Monotonic(crand.Reader, secureRandomSeed())
 
 	return &defaultGenerator{
 		entropy: entropyReader,

--- a/pkg/lib/operation/project/local/create/config/operation.go
+++ b/pkg/lib/operation/project/local/create/config/operation.go
@@ -2,17 +2,15 @@ package config
 
 import (
 	"context"
-	"math/rand"
-	"time"
 
 	"github.com/keboola/keboola-sdk-go/v2/pkg/keboola"
-	"github.com/oklog/ulid/v2"
 
 	"github.com/keboola/keboola-as-code/internal/pkg/log"
 	"github.com/keboola/keboola-as-code/internal/pkg/model"
 	"github.com/keboola/keboola-as-code/internal/pkg/project"
 	"github.com/keboola/keboola-as-code/internal/pkg/telemetry"
 	"github.com/keboola/keboola-as-code/internal/pkg/utils/errors"
+	"github.com/keboola/keboola-as-code/internal/pkg/utils/ulid"
 	saveManifest "github.com/keboola/keboola-as-code/pkg/lib/operation/project/local/manifest/save"
 )
 
@@ -40,9 +38,7 @@ func Run(ctx context.Context, projectState *project.State, o Options, d dependen
 	}
 
 	// Generate unique ID
-	ms := ulid.Timestamp(time.Now())
-	entropy := ulid.Monotonic(rand.New(rand.NewSource(time.Now().UnixNano())), 0)
-	newID := ulid.MustNew(ms, entropy).String()
+	newID := ulid.NewDefaultGenerator().NewULID()
 	key.ID = keboola.ConfigID(newID)
 
 	// Create and save object

--- a/pkg/lib/operation/project/local/create/config/operation.go
+++ b/pkg/lib/operation/project/local/create/config/operation.go
@@ -23,6 +23,7 @@ type Options struct {
 type dependencies interface {
 	Logger() log.Logger
 	Telemetry() telemetry.Telemetry
+	NewIDGenerator() ulid.Generator
 }
 
 func Run(ctx context.Context, projectState *project.State, o Options, d dependencies) (err error) {
@@ -38,7 +39,7 @@ func Run(ctx context.Context, projectState *project.State, o Options, d dependen
 	}
 
 	// Generate unique ID
-	newID := ulid.NewDefaultGenerator().NewULID()
+	newID := d.NewIDGenerator().NewULID()
 	key.ID = keboola.ConfigID(newID)
 
 	// Create and save object

--- a/pkg/lib/operation/project/local/create/row/operation.go
+++ b/pkg/lib/operation/project/local/create/row/operation.go
@@ -24,6 +24,7 @@ type Options struct {
 type dependencies interface {
 	Logger() log.Logger
 	Telemetry() telemetry.Telemetry
+	NewIDGenerator() ulid.Generator
 }
 
 func Run(ctx context.Context, projectState *project.State, o Options, d dependencies) (err error) {
@@ -40,7 +41,7 @@ func Run(ctx context.Context, projectState *project.State, o Options, d dependen
 	}
 
 	// Generate unique ID
-	newID := ulid.NewDefaultGenerator().NewULID()
+	newID := d.NewIDGenerator().NewULID()
 	key.ID = keboola.RowID(newID)
 
 	// Create and save object

--- a/pkg/lib/operation/project/local/create/row/operation.go
+++ b/pkg/lib/operation/project/local/create/row/operation.go
@@ -2,17 +2,15 @@ package row
 
 import (
 	"context"
-	"math/rand"
-	"time"
 
 	"github.com/keboola/keboola-sdk-go/v2/pkg/keboola"
-	"github.com/oklog/ulid/v2"
 
 	"github.com/keboola/keboola-as-code/internal/pkg/log"
 	"github.com/keboola/keboola-as-code/internal/pkg/model"
 	"github.com/keboola/keboola-as-code/internal/pkg/project"
 	"github.com/keboola/keboola-as-code/internal/pkg/telemetry"
 	"github.com/keboola/keboola-as-code/internal/pkg/utils/errors"
+	"github.com/keboola/keboola-as-code/internal/pkg/utils/ulid"
 	saveManifest "github.com/keboola/keboola-as-code/pkg/lib/operation/project/local/manifest/save"
 )
 
@@ -42,9 +40,7 @@ func Run(ctx context.Context, projectState *project.State, o Options, d dependen
 	}
 
 	// Generate unique ID
-	ms := ulid.Timestamp(time.Now())
-	entropy := ulid.Monotonic(rand.New(rand.NewSource(time.Now().UnixNano())), 0)
-	newID := ulid.MustNew(ms, entropy).String()
+	newID := ulid.NewDefaultGenerator().NewULID()
 	key.ID = keboola.RowID(newID)
 
 	// Create and save object

--- a/pkg/lib/operation/project/local/create/row/operation.go
+++ b/pkg/lib/operation/project/local/create/row/operation.go
@@ -2,8 +2,11 @@ package row
 
 import (
 	"context"
+	"math/rand"
+	"time"
 
 	"github.com/keboola/keboola-sdk-go/v2/pkg/keboola"
+	"github.com/oklog/ulid/v2"
 
 	"github.com/keboola/keboola-as-code/internal/pkg/log"
 	"github.com/keboola/keboola-as-code/internal/pkg/model"
@@ -21,7 +24,6 @@ type Options struct {
 }
 
 type dependencies interface {
-	KeboolaProjectAPI() *keboola.AuthorizedAPI
 	Logger() log.Logger
 	Telemetry() telemetry.Telemetry
 }
@@ -32,9 +34,6 @@ func Run(ctx context.Context, projectState *project.State, o Options, d dependen
 
 	logger := d.Logger()
 
-	// Get Storage API
-	api := d.KeboolaProjectAPI()
-
 	// Config row key
 	key := model.ConfigRowKey{
 		BranchID:    o.BranchID,
@@ -43,13 +42,10 @@ func Run(ctx context.Context, projectState *project.State, o Options, d dependen
 	}
 
 	// Generate unique ID
-	ticketProvider := keboola.NewTicketProvider(ctx, api)
-	ticketProvider.Request(func(ticket *keboola.Ticket) {
-		key.ID = keboola.RowID(ticket.ID)
-	})
-	if err := ticketProvider.Resolve(); err != nil {
-		return errors.Errorf(`cannot generate new ID: %w`, err)
-	}
+	ms := ulid.Timestamp(time.Now())
+	entropy := ulid.Monotonic(rand.New(rand.NewSource(time.Now().UnixNano())), 0)
+	newID := ulid.MustNew(ms, entropy).String()
+	key.ID = keboola.RowID(newID)
 
 	// Create and save object
 	uow := projectState.LocalManager().NewUnitOfWork(ctx)

--- a/pkg/lib/operation/project/local/persist/operation.go
+++ b/pkg/lib/operation/project/local/persist/operation.go
@@ -4,13 +4,12 @@ import (
 	"context"
 	"io"
 
-	"github.com/keboola/keboola-sdk-go/v2/pkg/keboola"
-
 	"github.com/keboola/keboola-as-code/internal/pkg/log"
 	"github.com/keboola/keboola-as-code/internal/pkg/plan/persist"
 	"github.com/keboola/keboola-as-code/internal/pkg/project"
 	"github.com/keboola/keboola-as-code/internal/pkg/telemetry"
 	"github.com/keboola/keboola-as-code/internal/pkg/utils/errors"
+	"github.com/keboola/keboola-as-code/internal/pkg/utils/ulid"
 	saveManifest "github.com/keboola/keboola-as-code/pkg/lib/operation/project/local/manifest/save"
 	"github.com/keboola/keboola-as-code/pkg/lib/operation/project/local/rename"
 )
@@ -21,7 +20,6 @@ type Options struct {
 }
 
 type dependencies interface {
-	KeboolaProjectAPI() *keboola.AuthorizedAPI
 	Logger() log.Logger
 	Telemetry() telemetry.Telemetry
 	Stdout() io.Writer
@@ -32,9 +30,6 @@ func Run(ctx context.Context, projectState *project.State, o Options, d dependen
 	defer span.End(&err)
 
 	logger := d.Logger()
-
-	// Get Storage API
-	api := d.KeboolaProjectAPI()
 
 	// Get plan
 	plan, err := persist.NewPlan(ctx, projectState.State())
@@ -53,7 +48,7 @@ func Run(ctx context.Context, projectState *project.State, o Options, d dependen
 		}
 
 		// Invoke
-		if err := plan.Invoke(ctx, logger, api, projectState.State()); err != nil {
+		if err := plan.Invoke(ctx, logger, projectState.State(), ulid.NewDefaultGenerator()); err != nil {
 			return errors.PrefixError(err, "cannot persist objects")
 		}
 

--- a/pkg/lib/operation/project/local/persist/operation.go
+++ b/pkg/lib/operation/project/local/persist/operation.go
@@ -23,6 +23,7 @@ type dependencies interface {
 	Logger() log.Logger
 	Telemetry() telemetry.Telemetry
 	Stdout() io.Writer
+	NewIDGenerator() ulid.Generator
 }
 
 func Run(ctx context.Context, projectState *project.State, o Options, d dependencies) (err error) {
@@ -48,7 +49,7 @@ func Run(ctx context.Context, projectState *project.State, o Options, d dependen
 		}
 
 		// Invoke
-		if err := plan.Invoke(ctx, logger, projectState.State(), ulid.NewDefaultGenerator()); err != nil {
+		if err := plan.Invoke(ctx, logger, projectState.State(), d.NewIDGenerator()); err != nil {
 			return errors.PrefixError(err, "cannot persist objects")
 		}
 

--- a/pkg/lib/operation/project/local/template/upgrade/operation.go
+++ b/pkg/lib/operation/project/local/template/upgrade/operation.go
@@ -12,6 +12,7 @@ import (
 	"github.com/keboola/keboola-as-code/internal/pkg/telemetry"
 	"github.com/keboola/keboola-as-code/internal/pkg/template"
 	"github.com/keboola/keboola-as-code/internal/pkg/template/context/upgrade"
+	"github.com/keboola/keboola-as-code/internal/pkg/utils/ulid"
 	"github.com/keboola/keboola-as-code/pkg/lib/operation/project/local/template/use"
 )
 
@@ -51,6 +52,7 @@ func Run(ctx context.Context, projectState *project.State, tmpl *template.Templa
 		d.Components(),
 		projectState.State(),
 		d.ProjectBackends(),
+		ulid.NewDefaultGenerator(),
 	)
 	plan, err := use.PrepareTemplate(ctx, d, use.ExtendedOptions{
 		TargetBranch:          o.Branch,

--- a/pkg/lib/operation/project/local/template/upgrade/operation.go
+++ b/pkg/lib/operation/project/local/template/upgrade/operation.go
@@ -34,6 +34,7 @@ type dependencies interface {
 	StorageAPITokenID() string
 	Telemetry() telemetry.Telemetry
 	Stdout() io.Writer
+	NewIDGenerator() ulid.Generator
 }
 
 func Run(ctx context.Context, projectState *project.State, tmpl *template.Template, o Options, d dependencies) (result *use.Result, err error) {
@@ -52,7 +53,7 @@ func Run(ctx context.Context, projectState *project.State, tmpl *template.Templa
 		d.Components(),
 		projectState.State(),
 		d.ProjectBackends(),
-		ulid.NewDefaultGenerator(),
+		d.NewIDGenerator(),
 	)
 	plan, err := use.PrepareTemplate(ctx, d, use.ExtendedOptions{
 		TargetBranch:          o.Branch,

--- a/pkg/lib/operation/project/local/template/use/operation.go
+++ b/pkg/lib/operation/project/local/template/use/operation.go
@@ -21,6 +21,7 @@ import (
 	"github.com/keboola/keboola-as-code/internal/pkg/template"
 	"github.com/keboola/keboola-as-code/internal/pkg/template/context/use"
 	"github.com/keboola/keboola-as-code/internal/pkg/utils/errors"
+	"github.com/keboola/keboola-as-code/internal/pkg/utils/ulid"
 	"github.com/keboola/keboola-as-code/pkg/lib/operation/project/local/encrypt"
 	saveProjectManifest "github.com/keboola/keboola-as-code/pkg/lib/operation/project/local/manifest/save"
 	"github.com/keboola/keboola-as-code/pkg/lib/operation/project/local/rename"
@@ -79,6 +80,7 @@ func Run(ctx context.Context, projectState *project.State, tmpl *template.Templa
 		d.Components(),
 		projectState.State(),
 		d.ProjectBackends(),
+		ulid.NewDefaultGenerator(),
 	)
 	plan, err := PrepareTemplate(ctx, d, ExtendedOptions{
 		TargetBranch:          o.TargetBranch,

--- a/pkg/lib/operation/project/local/template/use/operation.go
+++ b/pkg/lib/operation/project/local/template/use/operation.go
@@ -48,6 +48,7 @@ type dependencies interface {
 	ProjectBackends() []string
 	Telemetry() telemetry.Telemetry
 	Stdout() io.Writer
+	NewIDGenerator() ulid.Generator
 }
 
 func LoadTemplateOptions() loadState.Options {
@@ -80,7 +81,7 @@ func Run(ctx context.Context, projectState *project.State, tmpl *template.Templa
 		d.Components(),
 		projectState.State(),
 		d.ProjectBackends(),
-		ulid.NewDefaultGenerator(),
+		d.NewIDGenerator(),
 	)
 	plan, err := PrepareTemplate(ctx, d, ExtendedOptions{
 		TargetBranch:          o.TargetBranch,


### PR DESCRIPTION
Jira: [PAT-387](https://keboola.atlassian.net/browse/PAT-387)

**Changes:**
- Use ulid generator and resolve the ID at the moment of calling instead of on the moment of resolving.
- The ulid generator should generate lexicographically ordered unique IDs in incremental order.

-----------


[PAT-387]: https://keboola.atlassian.net/browse/PAT-387?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ