### PR TITLE
feat: add buffer cleanup script for ST-2610 for Azure and AWS

### DIFF
--- a/provisioning/buffer/buffer_cleanup.sh
+++ b/provisioning/buffer/buffer_cleanup.sh
@@ -57,7 +57,14 @@ esac
 
 # --- List all resources in buffer namespace ---
 echo "[INFO] Listing all resources in namespace 'buffer':"
-kubectl api-resources --verbs=list --namespaced -o name | xargs -n 1 kubectl get --ignore-not-found -n buffer
+for resource in $(kubectl api-resources --verbs=list --namespaced -o name); do
+  output=$(kubectl get "$resource" -n buffer --ignore-not-found)
+  if [[ -n "$output" && "$output" != "No resources found"* ]]; then
+    echo "===== $resource ====="
+    echo "$output"
+    echo
+  fi
+done
 
 # --- List all PersistentVolumes bound to buffer namespace ---
 echo "[INFO] Listing PersistentVolumes bound to 'buffer' namespace:"

--- a/provisioning/buffer/buffer_cleanup.sh
+++ b/provisioning/buffer/buffer_cleanup.sh
@@ -1,0 +1,116 @@
+#!/usr/bin/env bash
+set -Eeuo pipefail
+
+# =========================
+# Buffer Namespace Cleanup
+# =========================
+# This script authorizes to the Kubernetes cluster (AWS or Azure)
+# a) lists all resources that will be deleted
+# b) deletes the entire 'buffer' namespace and all PersistentVolumes bound to PVCs in this namespace
+#
+# Usage:
+#   ./buffer_cleanup.sh [--dry-run]
+#
+# Required ENV:
+#   CLOUD_PROVIDER=aws|azure
+#   (AWS)   AWS_REGION, AWS_EKS_CLUSTER_NAME
+#   (Azure) RESOURCE_GROUP
+# =========================
+
+DRY_RUN=0
+if [[ "${1:-}" == "--dry-run" ]]; then
+  DRY_RUN=1
+  echo "[INFO] Running in DRY-RUN mode. No resources will be deleted."
+fi
+
+# --- Check required ENV ---
+: ${CLOUD_PROVIDER?"Missing CLOUD_PROVIDER (aws|azure)"}
+
+# --- Go to script directory ---
+cd "$(dirname "$0")"
+
+# --- Authorize to Kubernetes cluster ---
+echo "[INFO] Authorizing to Kubernetes cluster for provider: $CLOUD_PROVIDER"
+case "$CLOUD_PROVIDER" in
+  aws)
+    : ${AWS_REGION?"Missing AWS_REGION"}
+    : ${AWS_EKS_CLUSTER_NAME?"Missing AWS_EKS_CLUSTER_NAME"}
+    echo "[INFO] Using AWS EKS: $AWS_EKS_CLUSTER_NAME in $AWS_REGION"
+    aws eks update-kubeconfig --name "$AWS_EKS_CLUSTER_NAME" --region "$AWS_REGION"
+    ;;
+  azure)
+    : ${RESOURCE_GROUP?"Missing RESOURCE_GROUP"}
+    echo "[INFO] Looking up AKS cluster name in resource group: $RESOURCE_GROUP"
+    CLUSTER_NAME=$(az deployment group show \
+      --resource-group "$RESOURCE_GROUP" \
+      --name kbc-aks \
+      --query "properties.outputs.clusterName.value" \
+      --output tsv)
+    echo "[INFO] Using Azure AKS: $CLUSTER_NAME"
+    az aks get-credentials --name "$CLUSTER_NAME" --resource-group "$RESOURCE_GROUP" --overwrite-existing
+    ;;
+  *)
+    echo "[ERROR] Unsupported CLOUD_PROVIDER: $CLOUD_PROVIDER" >&2
+    exit 1
+    ;;
+esac
+
+# --- List all resources in buffer namespace ---
+echo "[INFO] Listing all resources in namespace 'buffer':"
+kubectl api-resources --verbs=list --namespaced -o name | xargs -n 1 kubectl get --ignore-not-found -n buffer
+
+# --- List all PersistentVolumes bound to buffer namespace ---
+echo "[INFO] Listing PersistentVolumes bound to 'buffer' namespace:"
+kubectl get pv -o json | jq -r '.items[] | select(.spec.claimRef.namespace=="buffer") | .metadata.name' || true
+
+if [[ $DRY_RUN -eq 1 ]]; then
+  echo "[DRY-RUN] No resources will be deleted. Exiting."
+  exit 0
+fi
+
+# --- Delete namespace and PVs ---
+echo "[INFO] Deleting namespace 'buffer' ..."
+kubectl delete namespace buffer --ignore-not-found
+
+echo "[INFO] Waiting for namespace 'buffer' to terminate ..."
+kubectl wait --for=delete namespace/buffer --timeout=180s || true
+
+# --- Delete all PersistentVolumes that were bound to PVCs in the 'buffer' namespace ---
+echo "[INFO] Searching for PersistentVolumes bound to 'buffer' namespace ..."
+PVS_TO_DELETE=$(kubectl get pv -o jsonpath='{range .items[?(@.spec.claimRef.namespace=="buffer")]}{.metadata.name}{"\n"}{end}')
+if [[ -n "$PVS_TO_DELETE" ]]; then
+  echo "[INFO] Deleting PersistentVolumes:"
+  echo "$PVS_TO_DELETE"
+  for pv in $PVS_TO_DELETE; do
+    kubectl delete pv "$pv"
+  done
+else
+  echo "[INFO] No PersistentVolumes found for 'buffer' namespace."
+fi
+
+# --- Final check: Ensure everything is deleted ---
+ERROR=0
+
+echo "[INFO] Checking for remaining resources ..."
+REMAINING_PVS=$(kubectl get pv --no-headers | grep -w buffer || true)
+if [[ -n "$REMAINING_PVS" ]]; then
+  echo "[ERROR] Some PersistentVolumes still exist for 'buffer':"
+  echo "$REMAINING_PVS"
+  ERROR=1
+else
+  echo "[INFO] No PersistentVolumes for 'buffer' remain."
+fi
+
+if kubectl get namespace buffer &>/dev/null; then
+  echo "[ERROR] Namespace 'buffer' still exists!"
+  ERROR=1
+else
+  echo "[INFO] Namespace 'buffer' is deleted."
+fi
+
+if [[ $ERROR -eq 0 ]]; then
+  echo "[SUCCESS] All resources for 'buffer' have been deleted."
+else
+  echo "[FAIL] Some resources for 'buffer' remain. Please check manually."
+  exit 1
+fi 

--- a/provisioning/buffer/buffer_cleanup.sh
+++ b/provisioning/buffer/buffer_cleanup.sh
@@ -47,6 +47,8 @@ case "$CLOUD_PROVIDER" in
       --query "properties.outputs.clusterName.value" \
       --output tsv)
     echo "[INFO] Using Azure AKS: $CLUSTER_NAME"
+    
+    export AAD_LOGIN_METHOD=azurecli
     az aks get-credentials --name "$CLUSTER_NAME" --resource-group "$RESOURCE_GROUP" --overwrite-existing
     ;;
   *)


### PR DESCRIPTION
Jira: part of https://keboola.atlassian.net/browse/ST-2610

## Changes
- Added cleanup script for buffer namespace
- Includes dry-run mode for safe testing
- Implements safe removal of all resources and check PV

## Testing
- AWS dry run: https://dev.azure.com/keboola-prod/Keboola%20Connection%20AWS/_releaseProgress?_a=release-environment-logs&releaseId=54102&environmentId=161687
- AWS execution: https://dev.azure.com/keboola-prod/Keboola%20Connection%20AWS/_releaseProgress?_a=release-environment-logs&releaseId=54103&environmentId=161688
- Azure execution: https://dev.azure.com/keboola-prod/Keboola%20Connection%20Azure/_releaseProgress?_a=release-environment-logs&releaseId=65723&environmentId=273391

## Overview of deleted resources

```bash
2025-06-17T19:10:17.6451761Z ===== configmaps =====
2025-06-17T19:10:17.6454513Z NAME               DATA   AGE
2025-06-17T19:10:17.6455494Z buffer-api         4      2y209d
2025-06-17T19:10:17.6458279Z buffer-worker      3      2y209d
2025-06-17T19:10:17.6458876Z kube-root-ca.crt   1      2y214d
2025-06-17T19:10:17.6459280Z 
2025-06-17T19:10:18.6891347Z ===== endpoints =====
2025-06-17T19:10:18.6892132Z NAME                   ENDPOINTS                                                             AGE
2025-06-17T19:10:18.6892666Z buffer-api             100.64.93.79:8000                                                     2y209d
2025-06-17T19:10:18.6893467Z buffer-etcd            100.64.237.88:2380,100.64.237.94:2380,100.64.49.79:2380 + 3 more...   677d
2025-06-17T19:10:18.6894088Z buffer-etcd-headless   100.64.237.88:2380,100.64.237.94:2380,100.64.49.79:2380 + 3 more...   677d
2025-06-17T19:10:18.6894327Z 
2025-06-17T19:10:22.0576826Z ===== persistentvolumeclaims =====
2025-06-17T19:10:22.0581125Z NAME                 STATUS   VOLUME                                     CAPACITY   ACCESS MODES   STORAGECLASS   VOLUMEATTRIBUTESCLASS   AGE
2025-06-17T19:10:22.0581902Z data-buffer-etcd-0   Bound    pvc-fe53e7c9-fbe3-4b04-876a-11d4ae304a81   50Gi       RWO            etcd-gp3       <unset>                 677d
2025-06-17T19:10:22.0582447Z data-buffer-etcd-1   Bound    pvc-184c06fe-948b-48a5-8033-cea4a0ce99d0   50Gi       RWO            etcd-gp3       <unset>                 677d
2025-06-17T19:10:22.0583416Z data-buffer-etcd-2   Bound    pvc-e9a8585d-1af0-4278-975a-d4c1616ad356   50Gi       RWO            etcd-gp3       <unset>                 677d
2025-06-17T19:10:22.0583800Z 
2025-06-17T19:10:23.1307222Z ===== pods =====
2025-06-17T19:10:23.1308388Z NAME                                READY   STATUS      RESTARTS      AGE
2025-06-17T19:10:23.1309617Z buffer-api-775f6bdd88-p7gs6         1/1     Running     1 (12d ago)   12d
2025-06-17T19:10:23.1310029Z buffer-etcd-0                       1/1     Running     0             12d
2025-06-17T19:10:23.1310416Z buffer-etcd-1                       1/1     Running     0             12d
2025-06-17T19:10:23.1310800Z buffer-etcd-2                       1/1     Running     0             12d
2025-06-17T19:10:23.1312091Z buffer-etcd-defrag-29169720-sjxwn   0/1     Completed   0             70m
2025-06-17T19:10:23.1312572Z buffer-worker-5d44bbb6b9-qltv6      1/1     Running     1 (12d ago)   12d
2025-06-17T19:10:23.1312748Z 
2025-06-17T19:10:27.3926949Z ===== secrets =====
2025-06-17T19:10:27.3928134Z NAME                                TYPE                                  DATA   AGE
2025-06-17T19:10:27.3935578Z buffer-etcd                         Opaque                                1      677d
2025-06-17T19:10:27.3936206Z buffer-etcd-jwt-token               Opaque                                1      677d
2025-06-17T19:10:27.3936655Z default-token-crfbd                 kubernetes.io/service-account-token   3      2y214d
2025-06-17T19:10:27.3937268Z sh.helm.release.v1.buffer-etcd.v1   helm.sh/release.v1                    1      677d
2025-06-17T19:10:27.3938056Z sh.helm.release.v1.buffer-etcd.v2   helm.sh/release.v1                    1      669d
2025-06-17T19:10:27.3938467Z sh.helm.release.v1.buffer-etcd.v3   helm.sh/release.v1                    1      666d
2025-06-17T19:10:27.3939099Z sh.helm.release.v1.buffer-etcd.v4   helm.sh/release.v1                    1      361d
2025-06-17T19:10:27.3939519Z sh.helm.release.v1.buffer-etcd.v5   helm.sh/release.v1                    1      308d
2025-06-17T19:10:27.3939713Z 
2025-06-17T19:10:28.4609359Z ===== serviceaccounts =====
2025-06-17T19:10:28.4612857Z NAME      SECRETS   AGE
2025-06-17T19:10:28.4613314Z default   1         2y214d
2025-06-17T19:10:28.4613574Z 
2025-06-17T19:10:29.4893749Z ===== services =====
2025-06-17T19:10:29.4895358Z NAME                   TYPE        CLUSTER-IP       EXTERNAL-IP   PORT(S)             AGE
2025-06-17T19:10:29.4895832Z buffer-api             ClusterIP   172.20.145.224   <none>        80/TCP              2y209d
2025-06-17T19:10:29.4896451Z buffer-etcd            ClusterIP   None             <none>        2379/TCP,2380/TCP   677d
2025-06-17T19:10:29.4897803Z buffer-etcd-headless   ClusterIP   None             <none>        2379/TCP,2380/TCP   677d
2025-06-17T19:10:29.4897971Z 
2025-06-17T19:10:32.6977706Z ===== controllerrevisions.apps =====
2025-06-17T19:10:32.6982574Z NAME                     CONTROLLER                     REVISION   AGE
2025-06-17T19:10:32.6983065Z buffer-etcd-5b878788bf   statefulset.apps/buffer-etcd   2          673d
2025-06-17T19:10:32.6983661Z buffer-etcd-5df996589d   statefulset.apps/buffer-etcd   5          669d
2025-06-17T19:10:32.6984431Z buffer-etcd-7889bfdbb8   statefulset.apps/buffer-etcd   1          677d
2025-06-17T19:10:32.6984840Z buffer-etcd-7db87bf958   statefulset.apps/buffer-etcd   4          361d
2025-06-17T19:10:32.6984997Z 
2025-06-17T19:10:34.8527701Z ===== deployments.apps =====
2025-06-17T19:10:34.8530979Z NAME            READY   UP-TO-DATE   AVAILABLE   AGE
2025-06-17T19:10:34.8531975Z buffer-api      1/1     1            1           2y162d
2025-06-17T19:10:34.8534499Z buffer-worker   1/1     1            1           2y162d
2025-06-17T19:10:34.8534958Z 
2025-06-17T19:10:35.9630538Z ===== replicasets.apps =====
2025-06-17T19:10:35.9632545Z NAME                       DESIRED   CURRENT   READY   AGE
2025-06-17T19:10:35.9632948Z buffer-api-585f5949f8      0         0         0       678d
2025-06-17T19:10:35.9633736Z buffer-api-5b55b79874      0         0         0       361d
2025-06-17T19:10:35.9634115Z buffer-api-5fdb9778cc      0         0         0       677d
2025-06-17T19:10:35.9634612Z buffer-api-66d44d5f95      0         0         0       677d
2025-06-17T19:10:35.9634984Z buffer-api-6cc8d76859      0         0         0       678d
2025-06-17T19:10:35.9635553Z buffer-api-6dc8669bb9      0         0         0       677d
2025-06-17T19:10:35.9636142Z buffer-api-74ff554cdb      0         0         0       677d
2025-06-17T19:10:35.9636867Z buffer-api-775f6bdd88      1         1         1       666d
2025-06-17T19:10:35.9637260Z buffer-api-7f8f4d4757      0         0         0       677d
2025-06-17T19:10:35.9637661Z buffer-api-866f7bd6d8      0         0         0       678d
2025-06-17T19:10:35.9638037Z buffer-api-d4746595b       0         0         0       669d
2025-06-17T19:10:35.9638414Z buffer-worker-556976794    0         0         0       678d
2025-06-17T19:10:35.9638787Z buffer-worker-567d6bdffc   0         0         0       678d
2025-06-17T19:10:35.9639170Z buffer-worker-57969d746c   0         0         0       677d
2025-06-17T19:10:35.9639564Z buffer-worker-5d44bbb6b9   1         1         1       666d
2025-06-17T19:10:35.9639948Z buffer-worker-69cdbc45d7   0         0         0       677d
2025-06-17T19:10:35.9640325Z buffer-worker-6df4b976fc   0         0         0       669d
2025-06-17T19:10:35.9640703Z buffer-worker-747b6d6665   0         0         0       678d
2025-06-17T19:10:35.9641078Z buffer-worker-74957d76fc   0         0         0       361d
2025-06-17T19:10:35.9641454Z buffer-worker-75d4995c8c   0         0         0       677d
2025-06-17T19:10:35.9641831Z buffer-worker-7dc4cb77b9   0         0         0       677d
2025-06-17T19:10:35.9642377Z buffer-worker-86dd5fbc55   0         0         0       677d
2025-06-17T19:10:35.9642711Z 
2025-06-17T19:10:37.0494050Z ===== statefulsets.apps =====
2025-06-17T19:10:37.0495958Z NAME          READY   AGE
2025-06-17T19:10:37.0496771Z buffer-etcd   3/3     673d
2025-06-17T19:10:37.0497315Z 
2025-06-17T19:10:40.2794182Z ===== cronjobs.batch =====
2025-06-17T19:10:40.2795483Z NAME                 SCHEDULE      TIMEZONE   SUSPEND   ACTIVE   LAST SCHEDULE   AGE
2025-06-17T19:10:40.2800952Z buffer-etcd-defrag   0 */2 * * *   <none>     False     0        70m             677d
2025-06-17T19:10:40.2801142Z 
2025-06-17T19:10:41.3223483Z ===== jobs.batch =====
2025-06-17T19:10:41.3226728Z NAME                          STATUS     COMPLETIONS   DURATION   AGE
2025-06-17T19:10:41.3227172Z buffer-etcd-defrag-29169720   Complete   1/1           10s        70m
2025-06-17T19:10:41.3227347Z 
2025-06-17T19:10:49.0704391Z ===== endpointslices.discovery.k8s.io =====
2025-06-17T19:10:49.0705318Z NAME                         ADDRESSTYPE   PORTS       ENDPOINTS                                  AGE
2025-06-17T19:10:49.0706760Z buffer-api-z7lg6             IPv4          8000        100.64.93.79                               2y209d
2025-06-17T19:10:49.0717672Z buffer-etcd-headless-f4b4c   IPv4          2379,2380   100.64.237.88,100.64.49.79,100.64.237.94   677d
2025-06-17T19:10:49.0720912Z buffer-etcd-ztphj            IPv4          2379,2380   100.64.237.88,100.64.49.79,100.64.237.94   677d
2025-06-17T19:10:49.0723109Z 
2025-06-17T19:10:58.1024509Z ===== pods.metrics.k8s.io =====
2025-06-17T19:10:58.1027291Z NAME                             CPU         MEMORY    WINDOW
2025-06-17T19:10:58.1029963Z buffer-api-775f6bdd88-p7gs6      4381064n    28436Ki   30s
2025-06-17T19:10:58.1031124Z buffer-etcd-0                    60283998n   75248Ki   30s
2025-06-17T19:10:58.1031534Z buffer-etcd-1                    60459708n   87080Ki   30s
2025-06-17T19:10:58.1031908Z buffer-etcd-2                    57126820n   88424Ki   30s
2025-06-17T19:10:58.1032282Z buffer-worker-5d44bbb6b9-qltv6   4420296n    27316Ki   30s
2025-06-17T19:10:58.1032427Z 
2025-06-17T19:11:00.3399203Z ===== ingresses.networking.k8s.io =====
2025-06-17T19:11:00.3404460Z NAME         CLASS    HOSTS                              ADDRESS          PORTS   AGE
2025-06-17T19:11:00.3405879Z buffer-api   <none>   buffer.eu-west-1.aws.keboola.dev   172.20.187.126   80      2y209d
2025-06-17T19:11:00.3406139Z 
2025-06-17T19:11:01.4600957Z ===== networkpolicies.networking.k8s.io =====
2025-06-17T19:11:01.4601486Z NAME            POD-SELECTOR                                                                                                                                    AGE
2025-06-17T19:11:01.4601918Z buffer-api      app=buffer-api                                                                                                                                  2y26d
2025-06-17T19:11:01.4602414Z buffer-etcd     app=buffer-etcd,app.kubernetes.io/instance=buffer-etcd,app.kubernetes.io/managed-by=Helm,app.kubernetes.io/name=etcd,helm.sh/chart=etcd-8.5.8   677d
2025-06-17T19:11:01.4602930Z buffer-worker   app=buffer-worker                                                                                                                               2y26d
2025-06-17T19:11:01.4603123Z 
2025-06-17T19:11:02.5746670Z ===== poddisruptionbudgets.policy =====
2025-06-17T19:11:02.5749985Z NAME                MIN AVAILABLE   MAX UNAVAILABLE   ALLOWED DISRUPTIONS   AGE
2025-06-17T19:11:02.5753000Z buffer-api-pdb      N/A             1                 1                     679d
2025-06-17T19:11:02.5756485Z buffer-etcd         51%             N/A               1                     677d
2025-06-17T19:11:02.5759712Z buffer-worker-pdb   N/A             1                 1                     679d
2025-06-17T19:11:02.5763322Z 
2025-06-17T19:11:08.1793988Z [INFO] Listing PersistentVolumes bound to 'buffer' namespace:
2025-06-17T19:11:09.3109235Z pvc-184c06fe-948b-48a5-8033-cea4a0ce99d0
2025-06-17T19:11:09.3110003Z pvc-e9a8585d-1af0-4278-975a-d4c1616ad356
2025-06-17T19:11:09.3110770Z pvc-fe53e7c9-fbe3-4b04-876a-11d4ae304a81
```

### Release proses
- [x]  merge https://github.com/keboola/infrastructure/pull/2620
- [ ] merge this PR
- [ ] edit Azure and AWS DevOps pipeline and manual trigger with dry run
- [ ]  run DevOps pipeline withnout dry run
- [ ]  revert this PR
