### PR TITLE
fix: Log branchID instead of panicing

### DIFF
--- a/pkg/lib/operation/project/local/template/use/operation.go
+++ b/pkg/lib/operation/project/local/template/use/operation.go
@@ -170,7 +170,10 @@ func PrepareTemplate(ctx context.Context, d dependencies, o ExtendedOptions) (pl
 	}
 
 	// Update instance metadata
-	branchState := o.ProjectState.GetOrNil(o.TargetBranch).(*model.BranchState)
+	branchState, found := o.ProjectState.GetOrNil(o.TargetBranch).(*model.BranchState)
+	if !found {
+		return nil, errors.Errorf(`branch "%d" not found`, o.TargetBranch.ID)
+	}
 	if err := branchState.Local.Metadata.UpsertTemplateInstance(time.Now(), o.InstanceID, o.InstanceName, o.Template.TemplateID(), o.Template.Repository().Name, o.Template.Version(), d.StorageAPITokenID(), mainConfig); err != nil {
 		errs.Append(err)
 	}


### PR DESCRIPTION
**Changes:**
- Log instead of panic. [DD trace](https://app.datadoghq.eu/logs?query=service%3A%28stream%20OR%20templates-api%20OR%20apps-proxy%29%20status%3Aerror%20-env%3Adev-keboola-migration-cs%20-%40file.id%3A%222025-02-20T19%3A18%3A31.163Z%22%20-%40file.id%3A%222025-03-04T11%3A35%3A16.462Z%22%20-%40file.id%3A%222025-03-04T11%3A36%3A12.715Z%22%20-%40file.id%3A%222025-03-04T02%3A50%3A42.549Z%22%20-%40file.id%3A%222025-03-04T02%3A50%3A42.550Z%22%20-env%3Adev-keboola-aws-eu-west-1&agg_m=count&agg_m_source=base&agg_q=env%2Cservice&agg_q_source=base%2Cbase&agg_t=count&cols=host%2Cservice&event=AwAAAZeraKP7GWGfqAAAABhBWmVyYUtzNUFBQTRhZ1VadlhEUF9nQVQAAAAkMDE5N2FiNjgtYzBjYS00YWJlLTgzNmMtMDBmYzUzYjc4ZjRmAAAxpA&fromUser=true&messageDisplay=inline&refresh_mode=sliding&sort_m=%2C&sort_m_source=%2C&sort_t=%2C&storage=hot&stream_sort=desc&top_n=10%2C10&top_o=top%2Ctop&viz=timeseries&x_missing=true%2Ctrue&from_ts=1750927156000&to_ts=1750927456000&live=false)

-----------
