### PR TITLE
fix: Add backward compatiblity for old remote orchestrator configurations

### DIFF
--- a/internal/pkg/mapper/orchestrator/parse_phase.go
+++ b/internal/pkg/mapper/orchestrator/parse_phase.go
@@ -92,13 +92,18 @@ func (p *phaseParser) dependsOnPaths() ([]string, error) {
 		}
 	}
 
-	// Convert []any -> []string
+	// Convert []any -> []string, accept string or int/float64
 	value := make([]string, 0)
 	for i, item := range rawSlice {
-		if itemStr, ok := item.(string); ok {
-			value = append(value, itemStr)
-		} else {
-			return nil, errors.Errorf(`"dependsOn" key must contain only strings, found %T, index %d`, itemStr, i)
+		switch v := item.(type) {
+		case string:
+			value = append(value, v)
+		case int:
+			value = append(value, fmt.Sprintf("%d", v))
+		case float64:
+			value = append(value, fmt.Sprintf("%.0f", v))
+		default:
+			return nil, errors.Errorf(`"dependsOn" key must contain only strings or ints, found %T, index %d`, item, i)
 		}
 	}
 

--- a/internal/pkg/mapper/orchestrator/parse_phase.go
+++ b/internal/pkg/mapper/orchestrator/parse_phase.go
@@ -1,6 +1,8 @@
 package orchestrator
 
 import (
+	"fmt"
+
 	"github.com/keboola/go-utils/pkg/orderedmap"
 
 	"github.com/keboola/keboola-as-code/internal/pkg/utils/errors"
@@ -15,15 +17,23 @@ func (p *phaseParser) id() (string, error) {
 	if !found {
 		return "", errors.New(`missing "id" key`)
 	}
-	value, ok := raw.(string)
-	if !ok {
-		return "", errors.Errorf(`"id" must be string, found %v`, raw)
+	// Accept string or int/float64, always convert to string
+	switch v := raw.(type) {
+	case string:
+		if len(v) == 0 {
+			return "", errors.New(`"id" cannot be empty`)
+		}
+		p.content.Delete(`id`)
+		return v, nil
+	case int:
+		p.content.Delete(`id`)
+		return fmt.Sprintf("%d", v), nil
+	case float64:
+		p.content.Delete(`id`)
+		return fmt.Sprintf("%.0f", v), nil
+	default:
+		return "", errors.Errorf(`"id" must be string or int, found %T`, raw)
 	}
-	if len(value) == 0 {
-		return "", errors.New(`"id" cannot be empty`)
-	}
-	p.content.Delete(`id`)
-	return value, nil
 }
 
 func (p *phaseParser) name() (string, error) {
@@ -51,16 +61,21 @@ func (p *phaseParser) dependsOnIds() ([]string, error) {
 		}
 	}
 
-	// Convert []any -> []string
+	// Convert []any -> []string, accept string or int/float64
 	value := make([]string, 0)
 	for i, itemRaw := range rawSlice {
-		if item, ok := itemRaw.(string); ok {
-			if len(item) == 0 {
+		switch v := itemRaw.(type) {
+		case string:
+			if len(v) == 0 {
 				return nil, errors.Errorf(`"dependsOn" cannot contain empty strings, found empty string at index %d`, i)
 			}
-			value = append(value, item)
-		} else {
-			return nil, errors.Errorf(`"dependsOn" key must contain only strings, found %v, index %d`, itemRaw, i)
+			value = append(value, v)
+		case int:
+			value = append(value, fmt.Sprintf("%d", v))
+		case float64:
+			value = append(value, fmt.Sprintf("%.0f", v))
+		default:
+			return nil, errors.Errorf(`"dependsOn" key must contain only strings or ints, found %T, index %d`, itemRaw, i)
 		}
 	}
 

--- a/internal/pkg/mapper/orchestrator/parse_phase_test.go
+++ b/internal/pkg/mapper/orchestrator/parse_phase_test.go
@@ -23,10 +23,10 @@ func TestParsePhase(t *testing.T) {
 	}{
 		{
 			`{"id":123,"foo":"bar"}`,
-			`{"id":123,"foo":"bar"}`,
+			`{"foo":"bar"}`,
 			func(p *phaseParser) (any, error) { return p.id() },
-			"",
-			errors.New(`"id" must be string, found 123`),
+			"123",
+			nil,
 		},
 		{
 			`{"foo":"bar"}`,
@@ -37,10 +37,10 @@ func TestParsePhase(t *testing.T) {
 		},
 		{
 			`{"id":12.34,"foo":"bar"}`,
-			`{"id":12.34,"foo":"bar"}`,
+			`{"foo":"bar"}`,
 			func(p *phaseParser) (any, error) { return p.id() },
-			"",
-			errors.New(`"id" must be string, found 12.34`),
+			"12",
+			nil,
 		},
 		{
 			`{"id":"123","foo":"bar"}`,
@@ -107,10 +107,10 @@ func TestParsePhase(t *testing.T) {
 		},
 		{
 			`{"dependsOn":[1,"2","3"],"foo":"bar"}`,
-			`{"dependsOn":[1,"2","3"],"foo":"bar"}`,
+			`{"foo":"bar"}`,
 			func(p *phaseParser) (any, error) { return p.dependsOnIds() },
-			[]string(nil),
-			errors.New(`"dependsOn" key must contain only strings, found 1, index 0`),
+			[]string{"1", "2", "3"},
+			nil,
 		},
 		{
 			`{"dependsOn":["foo1", "foo2"],"foo":"bar"}`,
@@ -135,10 +135,10 @@ func TestParsePhase(t *testing.T) {
 		},
 		{
 			`{"dependsOn":["1",2,"3"],"foo":"bar"}`,
-			`{"dependsOn":["1",2,"3"],"foo":"bar"}`,
+			`{"foo":"bar"}`,
 			func(p *phaseParser) (any, error) { return p.dependsOnPaths() },
-			[]string(nil),
-			errors.New(`"dependsOn" key must contain only strings, found string, index 1`),
+			[]string{"1", "2", "3"},
+			nil,
 		},
 		{
 			`{"foo":"bar"}`,

--- a/internal/pkg/mapper/orchestrator/parse_task.go
+++ b/internal/pkg/mapper/orchestrator/parse_task.go
@@ -1,6 +1,8 @@
 package orchestrator
 
 import (
+	"fmt"
+
 	"github.com/keboola/go-utils/pkg/orderedmap"
 	"github.com/keboola/keboola-sdk-go/v2/pkg/keboola"
 
@@ -16,15 +18,23 @@ func (p *taskParser) id() (string, error) {
 	if !found {
 		return "", errors.New(`missing "id" key`)
 	}
-	value, ok := raw.(string)
-	if !ok {
-		return "", errors.Errorf(`"id" must be string, found %v`, raw)
+	// Accept string or int/float64, always convert to string
+	switch v := raw.(type) {
+	case string:
+		if len(v) == 0 {
+			return "", errors.New(`"id" cannot be empty`)
+		}
+		p.content.Delete(`id`)
+		return v, nil
+	case int:
+		p.content.Delete(`id`)
+		return fmt.Sprintf("%d", v), nil
+	case float64:
+		p.content.Delete(`id`)
+		return fmt.Sprintf("%.0f", v), nil
+	default:
+		return "", errors.Errorf(`"id" must be string or int, found %T`, raw)
 	}
-	if len(value) == 0 {
-		return "", errors.New(`"id" cannot be empty`)
-	}
-	p.content.Delete(`id`)
-	return value, nil
 }
 
 func (p *taskParser) name() (string, error) {
@@ -62,15 +72,23 @@ func (p *taskParser) phaseID() (string, error) {
 	if !found {
 		return "", errors.New(`missing "phase" key`)
 	}
-	value, ok := raw.(string)
-	if !ok {
-		return "", errors.Errorf(`"phase" must be string, found %v`, raw)
+	// Accept string or int/float64, always convert to string
+	switch v := raw.(type) {
+	case string:
+		if len(v) == 0 {
+			return "", errors.New(`"phase" cannot be empty`)
+		}
+		p.content.Delete(`phase`)
+		return v, nil
+	case int:
+		p.content.Delete(`phase`)
+		return fmt.Sprintf("%d", v), nil
+	case float64:
+		p.content.Delete(`phase`)
+		return fmt.Sprintf("%.0f", v), nil
+	default:
+		return "", errors.Errorf(`"phase" must be string or int, found %T`, raw)
 	}
-	if len(value) == 0 {
-		return "", errors.New(`"phase" cannot be empty`)
-	}
-	p.content.Delete(`phase`)
-	return value, nil
 }
 
 func (p *taskParser) componentID() (keboola.ComponentID, error) {

--- a/internal/pkg/mapper/orchestrator/parse_task_test.go
+++ b/internal/pkg/mapper/orchestrator/parse_task_test.go
@@ -24,10 +24,10 @@ func TestParseTask(t *testing.T) {
 	}{
 		{
 			`{"id":123,"foo":"bar"}`,
-			`{"id":123,"foo":"bar"}`,
+			`{"foo":"bar"}`,
 			func(p *taskParser) (any, error) { return p.id() },
-			"",
-			errors.New(`"id" must be string, found 123`),
+			"123",
+			nil,
 		},
 		{
 			`{"foo":"bar"}`,
@@ -38,10 +38,10 @@ func TestParseTask(t *testing.T) {
 		},
 		{
 			`{"id":12.34,"foo":"bar"}`,
-			`{"id":12.34,"foo":"bar"}`,
+			`{"foo":"bar"}`,
 			func(p *taskParser) (any, error) { return p.id() },
-			"",
-			errors.New(`"id" must be string, found 12.34`),
+			"12",
+			nil,
 		},
 		{
 			`{"id":"123","foo":"bar"}`,
@@ -122,10 +122,10 @@ func TestParseTask(t *testing.T) {
 		},
 		{
 			`{"phase":123,"foo":"bar"}`,
-			`{"phase":123,"foo":"bar"}`,
+			`{"foo":"bar"}`,
 			func(p *taskParser) (any, error) { return p.phaseID() },
-			"",
-			errors.New(`"phase" must be string, found 123`),
+			"123",
+			nil,
 		},
 		{
 			`{"phase":"","foo":"bar"}`,


### PR DESCRIPTION
Prevents warnings like these:
```
Warning:
- Invalid orchestrator config "branch:2307/component:keboola.orchestrator/config:6159349":
  - Invalid phase[0]: "id" must be string, found 38214.
  - Invalid phase[1]:
    - "id" must be string, found 82859.
    - "dependsOn" key must contain only strings, found 38214, index 0.
  - Invalid task[0]:
    - "id" must be string, found 78587.
    - "phase" must be string, found 38214.
  - Invalid task[1]:
    - "id" must be string, found 11462.
    - "phase" must be string, found 82859.
```

