### PR TITLE
fix: Add missing GPG tool in linux release step

### DIFF
--- a/.github/workflows/release-cli.yml
+++ b/.github/workflows/release-cli.yml
@@ -278,6 +278,9 @@ jobs:
       - name: Check out the repo
         uses: actions/checkout@v4
 
+      - name: Install GPG
+        run: sudo apt-get update && sudo apt-get install -y gnupg
+
       - name: Setup Docker Buildx
         uses: docker/setup-buildx-action@v3
 

--- a/build/package/linux/index.sh
+++ b/build/package/linux/index.sh
@@ -1,5 +1,13 @@
 #!/bin/bash
 
+set -e  # Exit immediately if a command exits with a non-zero status
+
+# Check for gpg
+if ! command -v gpg >/dev/null 2>&1; then
+  echo "gpg is required but not installed. Aborting."
+  exit 1
+fi
+
 set -o errexit          # Exit on most errors (see the manual)
 set -o errtrace         # Make sure any error trap is inherited
 set -o nounset          # Disallow expansion of unset variables


### PR DESCRIPTION
**Changes:**
- Fix missing GPG tool, see https://github.com/keboola/keboola-as-code/actions/runs/16411004041/job/46386742990#step:12:59

# Release Notes
- Fix downloading of empty tables (0 rows)

# Plans for Customer Communication
None

# Impact Analysis
None

# Change Type
Fix

# Justification
Download command should be working for any size of table (Non negative)

# Deployment Plan
Release as new CLI version.

# Rollback Plan
None

# Post-Release Support Plan
None

-----------
