### PR TITLE
feat: Use bitnami/etcd images from our own registries

### DIFF
--- a/provisioning/common/etcd/values.yaml
+++ b/provisioning/common/etcd/values.yaml
@@ -3,6 +3,11 @@
 # Values can be overridden by Helm --set flag or by another --values files.
 # Chart default values: https://github.com/bitnami/charts/blob/master/bitnami/etcd/values.yaml
 
+# Required for using bitnamilegacy and other repositories - https://github.com/bitnami/containers/issues/83267
+global:
+  security:
+    allowInsecureImages: true
+
 # Keboola specific options
 commonLabels:
   app: "{{ tpl (.Release.Name) . }}"

--- a/provisioning/stream/aws.sh
+++ b/provisioning/stream/aws.sh
@@ -19,6 +19,8 @@ aws eks update-kubeconfig --name "$AWS_EKS_CLUSTER_NAME" --region "$AWS_REGION"
 export ETCD_STORAGE_CLASS_NAME="etcd-gp3"
 export ETCD_SNAPSHOT_STORAGE_CLASS_NAME="stream-etcd-snapshots"
 export CLOUD_ENCRYPTION_PROVIDER="aws"
+export ETCD_IMAGE_REGISTRY="968984773589.dkr.ecr.us-east-1.amazonaws.com"
+export ETCD_IMAGE_REPOSITORY="bitnami-etcd"
 . ./common.sh
 
 # AWS specific part of the deploy

--- a/provisioning/stream/azure.sh
+++ b/provisioning/stream/azure.sh
@@ -25,6 +25,9 @@ az aks get-credentials --name "$CLUSTER_NAME" --resource-group "$RESOURCE_GROUP"
 export ETCD_STORAGE_CLASS_NAME=
 export ETCD_SNAPSHOT_STORAGE_CLASS_NAME="stream-etcd-snapshots"
 export CLOUD_ENCRYPTION_PROVIDER="azure"
+export ETCD_IMAGE_REGISTRY="keboola.azurecr.io"
+export ETCD_IMAGE_REPOSITORY="bitnami-etcd"
+export ETCD_IMAGE_PULL_SECRETS="acr-secret"
 . ./common.sh
 
 # Azure specific part of the deploy

--- a/provisioning/stream/common.sh
+++ b/provisioning/stream/common.sh
@@ -108,7 +108,10 @@ helm upgrade \
   --set "extraEnvVars[3].name=GOMEMLIMIT" \
   --set "extraEnvVars[3].value=${STREAM_ETCD_MEMORY_SOFT_LIMIT}B" \
   --set "extraEnvVars[4].name=ETCD_MAX_TXN_OPS" \
-  --set-string "extraEnvVars[4].value=${STREAM_ETCD_MAX_TXN_OPS}"
+  --set-string "extraEnvVars[4].value=${STREAM_ETCD_MAX_TXN_OPS}" \
+  --set "image.registry=${ETCD_IMAGE_REGISTRY:-}" \
+  --set "image.repository=${ETCD_IMAGE_REPOSITORY:-bitnamilegacy/etcd}" \
+  ${ETCD_IMAGE_PULL_SECRETS:+--set "image.pullSecrets[0]=${ETCD_IMAGE_PULL_SECRETS}"}
 
 # Config
 kubectl apply -f ./kubernetes/deploy/config/config-map.yaml

--- a/provisioning/templates-api/aws.sh
+++ b/provisioning/templates-api/aws.sh
@@ -17,6 +17,8 @@ aws eks update-kubeconfig --name "$AWS_EKS_CLUSTER_NAME" --region "$AWS_REGION"
 
 # Common part of the deploy
 export ETCD_STORAGE_CLASS_NAME="etcd-gp3"
+export ETCD_IMAGE_REGISTRY="968984773589.dkr.ecr.us-east-1.amazonaws.com"
+export ETCD_IMAGE_REPOSITORY="bitnami-etcd"
 . ./common.sh
 
 # AWS specific part of the deploy

--- a/provisioning/templates-api/azure.sh
+++ b/provisioning/templates-api/azure.sh
@@ -23,6 +23,9 @@ az aks get-credentials --name "$CLUSTER_NAME" --resource-group "$RESOURCE_GROUP"
 
 # Common part of the deploy
 export ETCD_STORAGE_CLASS_NAME=
+export ETCD_IMAGE_REGISTRY="keboola.azurecr.io"
+export ETCD_IMAGE_REPOSITORY="bitnami-etcd"
+export ETCD_IMAGE_PULL_SECRETS="acr-secret"
 . ./common.sh
 
 # Azure specific part of the deploy

--- a/provisioning/templates-api/common.sh
+++ b/provisioning/templates-api/common.sh
@@ -51,7 +51,10 @@ helm upgrade \
   --set "resources.requests.memory=$STREAM_ETCD_MEMORY" \
   --set "resources.limits.memory=$STREAM_ETCD_MEMORY" \
   --set "extraEnvVars[3].name=GOMEMLIMIT" \
-  --set "extraEnvVars[3].value=${STREAM_ETCD_MEMORY}B"
+  --set "extraEnvVars[3].value=${STREAM_ETCD_MEMORY}B" \
+  --set "image.registry=${ETCD_IMAGE_REGISTRY:-}" \
+  --set "image.repository=${ETCD_IMAGE_REPOSITORY:-bitnamilegacy/etcd}" \
+  ${ETCD_IMAGE_PULL_SECRETS:+--set "image.pullSecrets[0]=${ETCD_IMAGE_PULL_SECRETS}"}
 
 # API
 kubectl apply -f ./kubernetes/deploy/api/config-map.yaml


### PR DESCRIPTION
Jira: [ST-3240](https://keboola.atlassian.net/browse/ST-3240)

**Changes:**
- Enables insecure images in etcd Helm chart.
- Switches to our own registries for etcd images: https://github.com/keboola/platform-core-images/pull/17
- Expands deployment magic for Azure, and AWS.

-----------

Feature-parying with https://github.com/keboola/kbc-stacks/pull/5291.

Related Slack threads:
- https://keboolaglobal.slack.com/archives/C055K9CRFDX/p1753446689510449
- https://keboolaglobal.slack.com/archives/C055WKPHYSD/p1755159899407329