### PR TITLE
fix: Xk6 is build using go alpine container instead of xk6 one

### DIFF
--- a/provisioning/stream/docker/k6/Dockerfile
+++ b/provisioning/stream/docker/k6/Dockerfile
@@ -1,14 +1,23 @@
-FROM grafana/xk6:latest AS build
+# Build xk6 from scratch using Go 1.24+ to ensure compatibility
+FROM golang:1.24-alpine AS build
 
+# Install necessary packages for building
+RUN apk add --no-cache git
+
+# Install xk6
+RUN go install go.k6.io/xk6/cmd/xk6@latest
+
+# Build k6 with the required extensions
 RUN xk6 build \
     --with github.com/LeonAdato/xk6-output-statsd@latest \
-    --with github.com/domsolutions/xk6-fasthttp@latest
+    --with github.com/domsolutions/xk6-fasthttp@latest \
+    --output /k6
 
 FROM golang:1.24-alpine
 
 RUN apk add --no-cache bash
 
-COPY --from=build /xk6/k6 /usr/bin/k6
+COPY --from=build /k6 /usr/bin/k6
 
 COPY scripts /scripts
 


### PR DESCRIPTION
**Changes:**
- Xk6 build ends up with issue that it want's to be compiled with go `v1.22.9`.
- It is due to wrong default of `GOTOOLCHAIN=local` that references different go version.
- Default version of go compiler within `xk6` is `1.24.7` but it is not used in xk6 build target

-----------

## Release Notes
Change building of xk6 to be working with go `1.24.7`.

## Plans for customer communication
None.

## Impact analysis
None.

## Change type
bugfix

## Justification
Not working in local development

## Deployment
Merge & automatic deploy.

## Rollback plan
Revert of this PR.

## Post release support plan
None.
