### PR TITLE
ci: remove reference to nonexistent test-k8s-service-apps-proxy workflow (PAT-868)

### DIFF
--- a/.github/workflows/release-service-apps-proxy.yml
+++ b/.github/workflows/release-service-apps-proxy.yml
@@ -48,7 +48,6 @@ jobs:
     needs:
       - test-lint
       - test-unit
-      - test-k8s-service-apps-proxy
     steps:
       - name: Checkout
         uses: actions/checkout@v5


### PR DESCRIPTION
## Release Notes
Fixed Apps Proxy release workflow by removing reference to nonexistent `test-k8s-service-apps-proxy` workflow that was blocking releases.

## Plans for customer communication
None.

## Impact analysis
The Apps Proxy release workflow (`.github/workflows/release-service-apps-proxy.yml`) was referencing a nonexistent workflow `test-k8s-service-apps-proxy` in its job dependencies. This would cause the `build-and-push-proxy-image` job to wait indefinitely for a workflow that doesn't exist, effectively blocking all Apps Proxy releases.

This PR removes that reference, allowing the release workflow to proceed with the existing test dependencies (`test-lint` and `test-unit`).

## Change type
- CI/CD configuration fix
- No application code changes

## Justification
The workflow reference was blocking releases. The referenced workflow `test-k8s-service-apps-proxy` does not exist in the repository (verified by searching `.github/workflows/`).

## Deployment
Merge & automatic deploy.

## Rollback plan
Revert of this PR.

## Post release support plan
None.

---

**Human Review Checklist:**
- [ ] Verify that `test-k8s-service-apps-proxy` workflow truly doesn't exist in `.github/workflows/`
- [ ] Confirm that the remaining test dependencies (`test-lint`, `test-unit`) are sufficient for Apps Proxy releases
- [ ] Consider if K8s-specific testing should be added in the future

---

**Link to Devin run:** https://app.devin.ai/sessions/e930826639274487aca301da8e2b1751  
**Requested by:** Martin Halamíček (martin@keboola.com) / @Halama  
**Task ID:** PAT-868