### PR TITLE
fix: Report user error when wrong data were pushed on HTTP source

### DIFF
--- a/internal/pkg/service/stream/sink/router/router.go
+++ b/internal/pkg/service/stream/sink/router/router.go
@@ -265,7 +265,7 @@ func (r *Router) DispatchToSource(sourceKey key.SourceKey, c recordctx.Context) 
 	r.metrics.sourceDuration.Record(finalizationCtx, durationMs, metric.WithAttributes(attrs...))
 	r.metrics.sourceBytes.Add(finalizationCtx, int64(c.BodyLength()), metric.WithAttributes(attrs...))
 
-	// Log errors when has_error is true
+	// Log errors when has_error is true.
 	// This ensures that when the metric has_error:true is reported, there is a corresponding log entry in Datadog.
 	// This is important because some errors (e.g., 400 Bad Request) are not logged at the sink level,
 	// but they still set has_error:true in the metric.
@@ -298,7 +298,7 @@ func (r *Router) DispatchToSource(sourceKey key.SourceKey, c recordctx.Context) 
 		).Error()
 
 		// Log with appropriate level based on status code
-		// Use Warn level for client errors (4xx), Error level for server errors (5xx)
+		// Use Error level for server errors (5xx), Warn level for client errors (4xx)
 		if result.StatusCode >= http.StatusInternalServerError {
 			r.logger.Errorf(finalizationCtx, logMsg)
 		} else {


### PR DESCRIPTION
## Release Notes
Report user error when wrong data were pushed on HTTP source

## Plans for customer communication
None.

## Impact analysis
none

## Change type
fix

## Justification
We need more logs to see what happend with user data, we see only metric that something is wrong

## Deployment
Merge & automatic deploy.

## Rollback plan
Revert of this PR.

## Post release support plan
None.
