### PR TITLE
chore: update keboola-sdk-go to v2.8.1

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -43,7 +43,7 @@ require (
 	github.com/json-iterator/go v1.1.12
 	github.com/keboola/go-cloud-encrypt v0.0.0-20250422071622-41a5d5547c43
 	github.com/keboola/go-utils v1.4.0
-	github.com/keboola/keboola-sdk-go/v2 v2.8.0
+	github.com/keboola/keboola-sdk-go/v2 v2.8.1
 	github.com/klauspost/compress v1.18.1
 	github.com/klauspost/pgzip v1.2.6
 	github.com/kylelemons/godebug v1.1.0

--- a/go.sum
+++ b/go.sum
@@ -589,8 +589,8 @@ github.com/keboola/go-oauth2-proxy/v7 v7.13.1-0.20251120082210-251fbcb18c16 h1:m
 github.com/keboola/go-oauth2-proxy/v7 v7.13.1-0.20251120082210-251fbcb18c16/go.mod h1:2KeAM0/QPbyUAoky+PXVgQDt/5m0qNcn30z9jh4ig8A=
 github.com/keboola/go-utils v1.4.0 h1:WTyj95yrr8O8HxtC8TSTyUcElZiRGDeEdVvDpFo6HUo=
 github.com/keboola/go-utils v1.4.0/go.mod h1:IopwJzFz2gh0Yj3fUbIe2eamRoDKzbXvjqFjQyw3ZdQ=
-github.com/keboola/keboola-sdk-go/v2 v2.8.0 h1:EZ+snadKHjt61i4aYXy4eBqVXmvUVrFaqSun9PA9Hdo=
-github.com/keboola/keboola-sdk-go/v2 v2.8.0/go.mod h1:N/PkJnEHcyHMbVjHPjTdQwj5b9Iajl7PEaFUVtywHKU=
+github.com/keboola/keboola-sdk-go/v2 v2.8.1 h1:pSgHG9LKUG6Us713r4NvktTHjBG7X911I0BodA6RkLU=
+github.com/keboola/keboola-sdk-go/v2 v2.8.1/go.mod h1:N/PkJnEHcyHMbVjHPjTdQwj5b9Iajl7PEaFUVtywHKU=
 github.com/keybase/go-keychain v0.0.1 h1:way+bWYa6lDppZoZcgMbYsvC7GxljxrskdNInRtuthU=
 github.com/keybase/go-keychain v0.0.1/go.mod h1:PdEILRW3i9D8JcdM+FmY6RwkHGnhHxXwkPPMeUgOK1k=
 github.com/kisielk/errcheck v1.5.0/go.mod h1:pFxgyoBC7bSaBwPgfKdkLd5X25qrDl4LWUI2bnpBCr8=


### PR DESCRIPTION
## Release Notes
Update keboola-sdk-go dependency from v2.8.0 to v2.8.1.

## Plans for customer communication
None.

## Impact analysis
This is a patch version update of the Keboola SDK. The change only affects go.mod and go.sum files with no code changes required.

## Change type
Dependency update (patch version)

## Justification
Keep SDK dependency up to date with the latest patch release.

## Deployment
Merge & automatic deploy.

## Rollback plan
Revert of this PR.

## Post release support plan
None.

---

**Link to Devin run:** https://app.devin.ai/sessions/df4d4134ee9c425ea08d4ad14216ec77
**Requested by:** Martin Vasko (martin.vasko@keboola.com) / @Matovidlo