### PR TITLE
fix(stream): correct error tolerance test assertion (PSGO-71)

### DIFF
--- a/internal/pkg/service/stream/storage/node/coordinator/jobcleanup/jobcleanup_test.go
+++ b/internal/pkg/service/stream/storage/node/coordinator/jobcleanup/jobcleanup_test.go
@@ -399,7 +399,7 @@ func TestJobCleanupProcessingJobsErrorTolerance(t *testing.T) {
 			messages := logger.AllMessages()
 			assert.True(c, strings.Contains(messages, `context canceled`) || strings.Contains(messages, `canceled after`))
 			actual := strings.Count(messages, `"message":"cannot get keboola storage job \"123/456/my-source/my-sink/job`)
-			assert.GreaterOrEqual(c, actual, 5)
+			assert.GreaterOrEqual(c, actual, 4) // ErrorTolerance(3) + 1 = minimum errors before cleanup stops
 			assert.LessOrEqual(c, actual, 6)
 		}, 2*time.Second, 100*time.Millisecond)
 	}


### PR DESCRIPTION
## Release Notes
None - test-only change.

## Plans for customer communication
None.

## Impact analysis
Fixes intermittent CI failure in `TestJobCleanupProcessingJobsErrorTolerance`. The test was asserting `>= 5` errors but with `ErrorTolerance=3`, the minimum is 4 (cleanup stops when `errCount > ErrorTolerance`, i.e., on the 4th error since 4 > 3).

## Change type
Test fix

## Justification
The test assertion was incorrect and caused intermittent CI failures. With `ErrorTolerance=3` and `Concurrency=2`:
- Minimum errors: 4 (cleanup stops immediately when 4th error triggers `4 > 3`)
- Maximum errors: 5-6 (if workers were already processing when cancellation occurred)

## Deployment
Merge & automatic deploy.

## Rollback plan
Revert of this PR.

## Post release support plan
None.

---

**Human Review Checklist:**
- [ ] Verify the error tolerance logic in `jobcleanup.go` confirms that cleanup stops when `errCount > ErrorTolerance`

**Linear Ticket:** PSGO-71

**Link to Devin run:** https://app.devin.ai/sessions/2219a85710f14f95a9d278dac712de12
**Requested by:** Martin Vasko (martin.vasko@keboola.com) / @Matovidlo