### PR TITLE
Inject default "venv" parameter for custom Python configurations

### DIFF
--- a/internal/pkg/mapper/codemapper/local_save.go
+++ b/internal/pkg/mapper/codemapper/local_save.go
@@ -48,6 +48,10 @@ func (w *localWriter) save(ctx context.Context) error {
 		return w.errors.ErrorOrNil()
 	}
 
+	// Inject default venv if missing for custom python
+	// We do this here (and not just in Load) so it is persisted to config.json
+	w.injectDefaultVenv(w.config)
+
 	// Always save the file, even if the code is empty
 	// Path to code.py file
 	codePath := filesystem.Join(w.Path(), "code.py")

--- a/internal/pkg/mapper/codemapper/local_save_helpers.go
+++ b/internal/pkg/mapper/codemapper/local_save_helpers.go
@@ -1,0 +1,28 @@
+package codemapper
+
+import (
+	"github.com/keboola/go-utils/pkg/orderedmap"
+
+	"github.com/keboola/keboola-as-code/internal/pkg/model"
+)
+
+func (w *localWriter) injectDefaultVenv(config *model.Config) {
+	// Get parameters from configuration
+	parameters, ok := config.Content.Get("parameters")
+	if !ok {
+		// Create parameters if missing (should not happen for valid check-config but safe to add)
+		parameters = orderedmap.New()
+		config.Content.Set("parameters", parameters)
+	}
+
+	// Convert to OrderedMap
+	paramsMap, ok := parameters.(*orderedmap.OrderedMap)
+	if !ok {
+		return // Should handle error but here we just skip injection if format is unexpected
+	}
+
+	// Check if venv exists
+	if _, found := paramsMap.Get("venv"); !found {
+		paramsMap.Set("venv", "base")
+	}
+}


### PR DESCRIPTION
## Release Notes
- Added default injection of the "venv" parameter if missing in custom Python configurations.

## Plans for customer communication
None.

## Impact analysis
This change ensures that Python configurations requiring a virtual environment have a default parameter supplied, reducing potential errors in setups.

## Change type
Feature enhancement.

## Justification
Improves user experience by automating the inclusion of a necessary parameter.

## Deployment
Merge & automatic deploy.

## Rollback plan
Revert of this PR.

## Post release support plan
None.