### PR TITLE
Fix: enforce default encryption and simplify validation logic

### DIFF
--- a/pkg/lib/operation/project/local/template/use/operation.go
+++ b/pkg/lib/operation/project/local/template/use/operation.go
@@ -277,7 +277,7 @@ func (p *TemplatePlan) Invoke(ctx context.Context) (*Result, error) {
 		return nil, err
 	}
 
-	// Encrypt values
+	// Encrypt values - ALWAYS, except when creating template tests (SkipEncrypt flag)
 	if !p.options.SkipEncrypt {
 		if err := encrypt.Run(ctx, p.options.ProjectState, encrypt.Options{DryRun: false, LogEmpty: false}, p.deps); err != nil {
 			return nil, err
@@ -298,7 +298,8 @@ func (p *TemplatePlan) Invoke(ctx context.Context) (*Result, error) {
 	}
 
 	// Validate schemas and encryption
-	if err := validate.Run(ctx, p.options.ProjectState, validate.Options{ValidateSecrets: !p.options.SkipSecretsValidation, ValidateJSONSchema: true}, p.deps); err != nil {
+	validateSecrets := p.options.SkipEncrypt && !p.options.SkipSecretsValidation
+	if err := validate.Run(ctx, p.options.ProjectState, validate.Options{ValidateSecrets: validateSecrets, ValidateJSONSchema: true}, p.deps); err != nil {
 		logger.Warn(ctx, errors.Format(errors.PrefixError(err, "warning"), errors.FormatAsSentences()))
 		logger.Warn(ctx, "")
 		logger.Warn(ctx, `Please correct the problems listed above.`)

--- a/pkg/lib/operation/project/sync/push/operation.go
+++ b/pkg/lib/operation/project/sync/push/operation.go
@@ -40,11 +40,9 @@ func Run(ctx context.Context, projectState *project.State, o Options, d dependen
 
 	logger := d.Logger()
 
-	// Encrypt before push?
-	if o.Encrypt {
-		if err := encrypt.Run(ctx, projectState, encrypt.Options{DryRun: o.DryRun, LogEmpty: true}, d); err != nil {
-			return err
-		}
+	// Encrypt before push - ALWAYS (--encrypt flag kept for backwards compatibility)
+	if err := encrypt.Run(ctx, projectState, encrypt.Options{DryRun: o.DryRun, LogEmpty: false}, d); err != nil {
+		return err
 	}
 
 	// Change description - optional arg
@@ -58,7 +56,7 @@ func Run(ctx context.Context, projectState *project.State, o Options, d dependen
 	// Validate
 	if !o.SkipValidation {
 		validateOptions := validate.Options{
-			ValidateSecrets:    !o.Encrypt || !o.DryRun,
+			ValidateSecrets:    false, // Already encrypted above
 			ValidateJSONSchema: true,
 		}
 		if err := validate.Run(ctx, projectState, validateOptions, d); err != nil {


### PR DESCRIPTION
## Release Notes
Updated to enforce encryption as the default setting and refactored validation logic for simplicity and reliability.

## Plans for customer communication
None.

## Impact analysis
This change ensures stronger security defaults and reduces complexity in the validation process. Should have minimal to no impact on existing customers.

## Change type
Security improvement and code refactor.

## Justification
Addresses the need for improved default security measures and makes validation code easier to maintain.

## Deployment
Merge & automatic deploy.

## Rollback plan
Revert of this PR.

## Post release support plan
None.