### PR TITLE
fix: stop repeated wakeup requests when app restart is disabled

### DIFF
--- a/internal/pkg/service/appsproxy/proxy/apphandler/upstream/upstream.go
+++ b/internal/pkg/service/appsproxy/proxy/apphandler/upstream/upstream.go
@@ -196,7 +196,9 @@ func (u *AppUpstream) trace() chain.Middleware {
 				},
 				DNSDone: func(info httptrace.DNSDoneInfo) {
 					if info.Err != nil {
-						u.wakeup(ctx, info.Err)
+						if !u.restartDisabled.Load() {
+							u.wakeup(ctx, info.Err)
+						}
 					} else {
 						u.restartDisabled.Store(false)
 					}


### PR DESCRIPTION
## Release Notes
Fix: apps-proxy no longer bombards sandboxes-service-api with repeated wakeup requests when an app has restart disabled. Previously, ~1 wakeup request/second was sent indefinitely, generating thousands of error logs.

## Plans for customer communication
None.

## Impact analysis
When a Data App has restartDisabled, apps-proxy now sends exactly 1 wakeup request instead of unlimited repeated calls
Recovery is unaffected — the flag resets automatically when DNS lookup succeeds
No breaking changes
## Change type
Bug fix

## Justification
PSGO-167: Apps-proxy was sending ~1 wakeup request/second to sandboxes API after receiving apps.restartDisabled response, because the DNSDone callback never checked the restartDisabled flag before calling 
wakeup().

## Deployment
Merge & automatic deploy.

## Rollback plan
Revert of this PR.

## Post release support plan
None.

