### PR TITLE
Add --skip-validation flag to kbc push

### DIFF
--- a/internal/pkg/service/cli/cmd/sync/push/cmd.go
+++ b/internal/pkg/service/cli/cmd/sync/push/cmd.go
@@ -16,6 +16,7 @@ type Flags struct {
 	Force           configmap.Value[bool]   `configKey:"force" configUsage:"enable deleting of remote objects"`
 	DryRun          configmap.Value[bool]   `configKey:"dry-run" configUsage:"print what needs to be done"`
 	Encrypt         configmap.Value[bool]   `configKey:"encrypt" configUsage:"encrypt unencrypted values before push"`
+	SkipValidation  configmap.Value[bool]   `configKey:"skip-validation" configUsage:"skip local schema validation of configurations before push"`
 }
 
 func DefaultFlags() Flags {
@@ -67,6 +68,7 @@ func Command(p dependencies.Provider) *cobra.Command {
 			options := push.Options{
 				Encrypt:           f.Encrypt.Value,
 				DryRun:            f.DryRun.Value,
+				SkipValidation:    f.SkipValidation.Value,
 				AllowRemoteDelete: f.Force.Value,
 				LogUntrackedPaths: true,
 				ChangeDescription: changeDescription,


### PR DESCRIPTION
## Summary

- Exposes the existing `SkipValidation` option as a `--skip-validation` CLI flag for `kbc push`
- Allows users to bypass local JSON schema validation when pushing changes
- Unblocks users whose projects have invalid configs in unrelated branches

## Problem

When running `kbc push`, the CLI validates **all** component configurations across **all** branches. If any branch contains an invalid config (e.g., empty required field created by another user), push is blocked for the **entire project** — even when pushing changes to a completely unrelated branch.

Full details: #2537

## Changes

**`internal/pkg/service/cli/cmd/sync/push/cmd.go`** — 2 lines added:
1. Added `SkipValidation` field to the `Flags` struct with `--skip-validation` CLI flag
2. Wired `f.SkipValidation.Value` to `options.SkipValidation` in the push options

## Why this is safe

- The `SkipValidation` field already exists in `push.Options` struct and is battle-tested
- The templates API service (`internal/pkg/service/templates/api/service/service.go`) already uses `SkipValidation: true` in 5 places in production
- Server-side validation still catches issues — this only skips **local** schema validation
- The flag is opt-in and defaults to `false` (no behavioral change without the flag)

## Usage

```bash
# Push with validation skipped (when unrelated branches have invalid configs)
kbc push --skip-validation

# Normal push (unchanged behavior)
kbc push
```

## Test plan

- [ ] Verify `kbc push --help` shows the new `--skip-validation` flag
- [ ] Verify `kbc push` without the flag behaves exactly as before (validation runs)
- [ ] Verify `kbc push --skip-validation` bypasses schema validation errors
- [ ] Verify the flag works in combination with other flags (`--dry-run`, `--force`)