### PR TITLE
fix(release): exclude unsupported windows/arm and darwin/arm build targets

### DIFF
--- a/.github/actions/release/action.yml
+++ b/.github/actions/release/action.yml
@@ -65,7 +65,6 @@ runs:
           target/keboola-cli_${{ inputs.version }}_linux_armv6.zip
           target/keboola-cli_${{ inputs.version }}_linux_amd64.zip
           target/keboola-cli_${{ inputs.version }}_linux_arm64.zip
-          target/keboola-cli_${{ inputs.version }}_windows_armv6.zip
           target/keboola-cli_${{ inputs.version }}_windows_amd64.zip
           target/keboola-cli_${{ inputs.version }}_windows_arm64.zip
           target/keboola-cli_darwin_amd64_v1/kbc.zip

--- a/.github/workflows/release-cli.yml
+++ b/.github/workflows/release-cli.yml
@@ -173,7 +173,6 @@ jobs:
           ./build/package/s3/publish.sh "keboola-cli_${{ env.VERSION }}_linux_armv6.zip" "keboola-cli_${{ env.VERSION }}_linux_armv6.zip" "keboola-cli" "${{ env.VERSION }}" "linux" "armv6"
           ./build/package/s3/publish.sh "keboola-cli_${{ env.VERSION }}_linux_arm64.zip" "keboola-cli_${{ env.VERSION }}_linux_arm64.zip" "keboola-cli" "${{ env.VERSION }}" "linux" "arm64"
           ./build/package/s3/publish.sh "keboola-cli_${{ env.VERSION }}_linux_amd64.zip" "keboola-cli_${{ env.VERSION }}_linux_amd64.zip" "keboola-cli" "${{ env.VERSION }}" "linux" "amd64"
-          ./build/package/s3/publish.sh "keboola-cli_${{ env.VERSION }}_windows_armv6.zip" "keboola-cli_${{ env.VERSION }}_windows_armv6.zip" "keboola-cli" "${{ env.VERSION }}" "windows" "armv6"
           ./build/package/s3/publish.sh "keboola-cli_${{ env.VERSION }}_windows_arm64.zip" "keboola-cli_${{ env.VERSION }}_windows_arm64.zip" "keboola-cli" "${{ env.VERSION }}" "windows" "arm64"
           ./build/package/s3/publish.sh "keboola-cli_${{ env.VERSION }}_windows_amd64.zip" "keboola-cli_${{ env.VERSION }}_windows_amd64.zip" "keboola-cli" "${{ env.VERSION }}" "windows" "amd64"
           ./build/package/s3/publish.sh "keboola-cli_darwin_amd64_v1/kbc.zip" "keboola-cli_${{ env.VERSION }}_darwin_amd64.zip" "keboola-cli" "${{ env.VERSION }}" "darwin" "amd64"
@@ -228,7 +227,6 @@ jobs:
           curl --output /dev/null --silent --head --fail "https://github.com/${{ github.repository }}/releases/download/v${{ env.VERSION }}/keboola-cli_${{ env.VERSION }}_linux_armv6.zip"
           curl --output /dev/null --silent --head --fail "https://github.com/${{ github.repository }}/releases/download/v${{ env.VERSION }}/keboola-cli_${{ env.VERSION }}_windows_amd64.zip"
           curl --output /dev/null --silent --head --fail "https://github.com/${{ github.repository }}/releases/download/v${{ env.VERSION }}/keboola-cli_${{ env.VERSION }}_windows_arm64.zip"
-          curl --output /dev/null --silent --head --fail "https://github.com/${{ github.repository }}/releases/download/v${{ env.VERSION }}/keboola-cli_${{ env.VERSION }}_windows_armv6.zip"
 
   update-repositories-homebrew:
     needs:

--- a/build/ci/goreleaser.yml
+++ b/build/ci/goreleaser.yml
@@ -9,6 +9,11 @@ builds:
     goos: ["linux", "darwin", "windows"]
     goarch: ["amd64", "arm", "arm64"]
     goarm: ["6"]
+    ignore:
+      - goos: windows
+        goarch: arm
+      - goos: darwin
+        goarch: arm
     env:
       - CGO_ENABLED=0
     ldflags:


### PR DESCRIPTION
## Summary
- Add `ignore` entries in `goreleaser.yml` to skip `windows/arm` and `darwin/arm` — both are unsupported `GOOS/GOARCH` pairs in Go
- Remove `windows_armv6` artifact references from the release workflow and action (this target was never actually produced)

## Root cause
GoReleaser builds a full matrix of `goos × goarch`, producing `windows/arm` which Go doesn't support, causing the build to fail with:
```
unsupported GOOS/GOARCH pair windows/arm
```
32-bit ARM (`arm`/`armv6`) is only valid on Linux. Windows and Darwin only support `arm64`.

## Test plan
- [ ] Trigger a release build and verify it completes without `unsupported GOOS/GOARCH` errors
- [ ] Verify `linux_armv6` artifacts are still produced (Linux arm/armv6 remains valid)
- [ ] Verify `windows_arm64` and `windows_amd64` artifacts are produced as before

🤖 Generated with [Claude Code](https://claude.com/claude-code)