### PR TITLE
Fix ENV variable reference for Storage API token error

### DIFF
--- a/internal/pkg/service/cli/cmd/cmd.go
+++ b/internal/pkg/service/cli/cmd/cmd.go
@@ -373,7 +373,7 @@ func (root *RootCommand) printError(errRaw error) {
 		case errors.Is(err, dependencies.ErrMissingStorageAPIHost), errors.Is(err, dialog.ErrMissingStorageAPIHost):
 			modifiedErrs.Append(errors.Wrapf(err, `missing Storage Api host, please use "--%s" flag or ENV variable "%s"`, StorageAPIHostOpt, env.NewNamingConvention(cmdconfig.ENVPrefix).FlagToEnv(StorageAPIHostOpt)))
 		case errors.Is(err, dependencies.ErrMissingStorageAPIToken), errors.Is(err, dialog.ErrMissingStorageAPIToken):
-			modifiedErrs.Append(errors.Wrapf(err, `missing Storage Api token, please use "--%s" flag or ENV variable "%s"`, StorageAPITokenOpt, env.NewNamingConvention(cmdconfig.ENVPrefix).FlagToEnv(StorageAPIHostOpt)))
+			modifiedErrs.Append(errors.Wrapf(err, `missing Storage Api token, please use "--%s" flag or ENV variable "%s"`, StorageAPITokenOpt, env.NewNamingConvention(cmdconfig.ENVPrefix).FlagToEnv(StorageAPITokenOpt)))
 		default:
 			modifiedErrs.Append(err)
 		}


### PR DESCRIPTION
## Release Notes

## Plans for customer communication
None.

## Impact analysis

## Change type

Bugfix

## Justification

The error message shown to users in CLI is misleading, which confuses both users and agents…

```
Error:
- Missing Storage Api token, please use "--storage-api-token" flag or ENV variable "KBC_STORAGE_API_HOST".
```

## Deployment
Merge & automatic deploy.

## Rollback plan
Revert of this PR.

## Post release support plan
None.
