### PR TITLE
fix(registry): skip naming.Attach() for rows with unresolved parent path [PSGO-233]

### DIFF
--- a/internal/pkg/state/registry/registry.go
+++ b/internal/pkg/state/registry/registry.go
@@ -346,8 +346,16 @@ func (s *Registry) Set(objectState model.ObjectState) error {
 	}
 
 	if objectState.GetRelativePath() != "" {
-		if err := s.namingRegistry.Attach(key, objectState.GetAbsPath()); err != nil {
-			return err
+		absPath := objectState.GetAbsPath()
+		// Only register in the naming registry when the parent path has been resolved.
+		// Objects with an unresolved parent path (parentPathSet=false) have a partial
+		// Path() that equals just their RelativePath, which causes false collisions
+		// between rows from different configs that share the same row name.
+		// Such objects are registered once their path is fully generated later.
+		if absPath.IsParentPathSet() {
+			if err := s.namingRegistry.Attach(key, absPath); err != nil {
+				return err
+			}
 		}
 	}
 

--- a/internal/pkg/state/registry/registry_test.go
+++ b/internal/pkg/state/registry/registry_test.go
@@ -272,6 +272,78 @@ func TestIgnoreBranch(t *testing.T) {
 	}
 }
 
+// TestRegistrySet_RowsWithSameRelativeNameUnresolvedParent is a regression test
+// for PSGO-233: kbc pull --force crashed with a false naming collision when two
+// config rows from different configs shared the same relative path name.
+//
+// Root cause: manifest.Load(ignoreErrors=true) swallows a SetRecords() error,
+// leaving some rows with parentPathSet=false. registry.Set() then called
+// naming.Attach() with the partial Path() ("rows/besc-json-export" instead of
+// the full path), causing a spurious collision between unrelated rows.
+func TestRegistrySet_RowsWithSameRelativeNameUnresolvedParent(t *testing.T) {
+	t.Parallel()
+	ctx := t.Context()
+	reg := New(knownpaths.NewNop(ctx), naming.NewRegistry(), NewComponentsMap(nil), SortByPath)
+
+	// Neither row has its parent path set (parentPathSet=false, zero value of bool).
+	// AbsPath{RelativePath: "..."} leaves parentPath="" and parentPathSet=false.
+	row1 := &ConfigRowState{
+		ConfigRowManifest: &ConfigRowManifest{
+			ConfigRowKey: ConfigRowKey{
+				BranchID: 80, ComponentID: "keboola.wr-azure-event-hub",
+				ConfigID: "1783940", ID: "2052339",
+			},
+			Paths: Paths{AbsPath: AbsPath{RelativePath: "rows/besc-json-export"}},
+		},
+		Remote: &ConfigRow{Name: "besc-json-export"},
+	}
+	row2 := &ConfigRowState{
+		ConfigRowManifest: &ConfigRowManifest{
+			ConfigRowKey: ConfigRowKey{
+				BranchID: 80, ComponentID: "keboola.wr-azure-event-hub",
+				ConfigID: "1783960", ID: "2405343",
+			},
+			Paths: Paths{AbsPath: AbsPath{RelativePath: "rows/besc-json-export"}},
+		},
+		Remote: &ConfigRow{Name: "besc-json-export"},
+	}
+
+	require.NoError(t, reg.Set(row1), "first row with unresolved parent path should not error")
+	require.NoError(t, reg.Set(row2), "second row with same relative name but different config should not error")
+	assert.Len(t, reg.ConfigRows(), 2)
+}
+
+// TestRegistrySet_RowWithResolvedParentIsAttached verifies that rows whose
+// parent path IS resolved still get registered in the naming registry (no regression).
+func TestRegistrySet_RowWithResolvedParentIsAttached(t *testing.T) {
+	t.Parallel()
+	ctx := t.Context()
+	reg := New(knownpaths.NewNop(ctx), naming.NewRegistry(), NewComponentsMap(nil), SortByPath)
+
+	row := &ConfigRowState{
+		ConfigRowManifest: &ConfigRowManifest{
+			ConfigRowKey: ConfigRowKey{
+				BranchID: 80, ComponentID: "keboola.wr-azure-event-hub",
+				ConfigID: "1783940", ID: "2052339",
+			},
+			Paths: Paths{
+				AbsPath: NewAbsPath(
+					"80-dev/keboola.wr-azure-event-hub/config-1783940",
+					"rows/besc-json-export",
+				),
+			},
+		},
+		Remote: &ConfigRow{Name: "besc-json-export"},
+	}
+
+	require.NoError(t, reg.Set(row))
+
+	// Row with a resolved parent must be reachable via GetByPath.
+	found, ok := reg.GetByPath("80-dev/keboola.wr-azure-event-hub/config-1783940/rows/besc-json-export")
+	require.True(t, ok)
+	assert.Equal(t, row, found)
+}
+
 func newTestState(t *testing.T, paths *knownpaths.Paths) *Registry {
 	t.Helper()
 	registry := New(paths, naming.NewRegistry(), NewComponentsMap(nil), SortByPath)


### PR DESCRIPTION
## Release Notes
- Fixes `kbc pull --force` crashing with a spurious "Cannot load remote state: naming error" when two configs in the same component have rows with identical names.

## Plans for customer communication
None.

## Impact analysis
- `internal/pkg/state/registry`: `registry.Set()` now skips `naming.Attach()` for objects whose `parentPathSet=false` (parent path not yet resolved). These objects are registered by the path generator later with the correct full path.
- No API or schema changes. No breaking changes.
- Only affects the `kbc pull --force` code path where `manifest.Load(ignoreErrors=true)` can leave rows with unresolved parent paths.

## Change type
Bug fix — `kbc pull --force` naming collision for configs with same-named rows [PSGO-233]

## Justification
SLSP's DevOps pipeline runs `kbc pull --force` against a project where two configs under `keboola.wr-azure-event-hub` both have a row named `besc-json-export`. The `--force` flag causes `manifest.Load()` with `ignoreErrors=true`, silently swallowing a `SetRecords()` early-return error. This leaves config rows with `parentPathSet=false`. `registry.Set()` then called `naming.Attach()` with the partial path `"rows/besc-json-export"` instead of the full resolved path, producing a false collision that aborted the pull.

## Deployment
Merge & automatic deploy.

## Rollback plan
Revert of this PR.

## Post release support plan
None.

[PSGO-233]: https://keboola.atlassian.net/browse/PSGO-233?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ