### PR TITLE
fix(templates): use RepositoryTypeDir in tests to avoid Linux git clone timeout

### DIFF
--- a/internal/pkg/service/templates/dependencies/mocked.go
+++ b/internal/pkg/service/templates/dependencies/mocked.go
@@ -2,9 +2,7 @@ package dependencies
 
 import (
 	"context"
-	"fmt"
 	"net/url"
-	"os"
 	"path"
 	"path/filepath"
 	"reflect"
@@ -13,8 +11,6 @@ import (
 
 	"github.com/stretchr/testify/require"
 
-	"github.com/keboola/keboola-as-code/internal/pkg/filesystem"
-	"github.com/keboola/keboola-as-code/internal/pkg/filesystem/aferofs"
 	"github.com/keboola/keboola-as-code/internal/pkg/model"
 	"github.com/keboola/keboola-as-code/internal/pkg/service/common/configmap"
 	"github.com/keboola/keboola-as-code/internal/pkg/service/common/dependencies"
@@ -37,14 +33,9 @@ func NewMockedAPIScope(tb testing.TB, ctx context.Context, cfg config.Config, op
 
 	// Prepare test repository with templates, instead of default repositories, to prevent loading of all production templates.
 	if reflect.DeepEqual(cfg.Repositories, config.DefaultRepositories()) {
-		tmpDir := tb.TempDir()
 		_, filename, _, _ := runtime.Caller(0)
-		srcFs, err := aferofs.NewLocalFs(path.Dir(filename))
-		require.NoError(tb, err)
-		require.NoError(tb, aferofs.CopyFs2Fs(srcFs, filesystem.Join("git_test", "repository"), nil, tmpDir))
-		require.NoError(tb, os.Rename(filepath.Join(tmpDir, ".gittest"), filepath.Join(tmpDir, ".git"))) // nolint:forbidigo
 		cfg.Repositories = []model.TemplateRepository{{
-			Type: model.RepositoryTypeGit, Name: "keboola", URL: fmt.Sprintf("file://%s", tmpDir), Ref: "main",
+			Type: model.RepositoryTypeDir, Name: "keboola", URL: filepath.Join(path.Dir(filename), "git_test", "repository"),
 		}}
 	}
 

--- a/internal/pkg/service/templates/dependencies/mocked.go
+++ b/internal/pkg/service/templates/dependencies/mocked.go
@@ -4,13 +4,13 @@ import (
 	"context"
 	"net/url"
 	"path"
-	"path/filepath"
 	"reflect"
 	"runtime"
 	"testing"
 
 	"github.com/stretchr/testify/require"
 
+	"github.com/keboola/keboola-as-code/internal/pkg/filesystem"
 	"github.com/keboola/keboola-as-code/internal/pkg/model"
 	"github.com/keboola/keboola-as-code/internal/pkg/service/common/configmap"
 	"github.com/keboola/keboola-as-code/internal/pkg/service/common/dependencies"
@@ -35,7 +35,7 @@ func NewMockedAPIScope(tb testing.TB, ctx context.Context, cfg config.Config, op
 	if reflect.DeepEqual(cfg.Repositories, config.DefaultRepositories()) {
 		_, filename, _, _ := runtime.Caller(0)
 		cfg.Repositories = []model.TemplateRepository{{
-			Type: model.RepositoryTypeDir, Name: "keboola", URL: filepath.Join(path.Dir(filename), "git_test", "repository"),
+			Type: model.RepositoryTypeDir, Name: "keboola", URL: filesystem.Join(path.Dir(filename), "git_test", "repository"),
 		}}
 	}
 


### PR DESCRIPTION
## Release Notes
- Template API service tests (`TestTemplatesResponse`, `TestSnowflakePlaceholders`, `Test_getTemplateVersion_Requirements`) no longer time out on Linux CI runners.

## Plans for customer communication
None.

## Impact analysis
- `internal/pkg/service/templates/dependencies/mocked.go`: test helper now uses `RepositoryTypeDir` (direct filesystem read) instead of `RepositoryTypeGit` with a `file://` URL. Only affects test setup — no production code changed.
- Removes 10 lines of boilerplate (temp dir creation, file copy, `.gittest` rename).
- No breaking changes, no API or schema changes.

## Change type
Bug fix — template API tests failing with `context deadline exceeded` on Linux CI

## Justification
`git clone file:///path` on Linux forces the git pack-object transport (copies all objects; no hardlinks allowed), unlike a plain local path. With 10+ parallel subtests each doing their own clone against a loaded Linux CI runner, they consistently exceeded the 10-second context deadline. macOS/Windows runners were fast enough to finish in time. Switching to `RepositoryTypeDir` reads templates directly from the working-tree files already present in `git_test/repository` — no git binary involved, no I/O race.

## Deployment
Merge & automatic deploy.

## Rollback plan
Revert of this PR.

## Post release support plan
None.