### PR TITLE
feat(stream): add native OTLP/HTTP endpoints (logs, metrics, traces)

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -382,11 +382,11 @@ require (
 	go.opencensus.io v0.24.0 // indirect
 	go.opentelemetry.io/auto/sdk v1.2.1 // indirect
 	go.opentelemetry.io/collector/component v1.51.1-0.20260205185216-81bc641f26c0 // indirect
-	go.opentelemetry.io/collector/pdata v1.51.1-0.20260205185216-81bc641f26c0 // indirect
+	go.opentelemetry.io/collector/pdata v1.51.1-0.20260205185216-81bc641f26c0
 	go.opentelemetry.io/contrib/detectors/gcp v1.39.0 // indirect
 	go.opentelemetry.io/otel/exporters/otlp/otlptrace v1.39.0 // indirect
 	go.opentelemetry.io/otel/exporters/otlp/otlptrace/otlptracegrpc v1.39.0 // indirect
-	go.opentelemetry.io/proto/otlp v1.9.0 // indirect
+	go.opentelemetry.io/proto/otlp v1.9.0
 	gocloud.dev v0.45.0 // indirect
 	golang.org/x/image v0.39.0 // indirect
 	golang.org/x/oauth2 v0.36.0 // indirect

--- a/internal/pkg/service/stream/mapping/recordctx/otlp.go
+++ b/internal/pkg/service/stream/mapping/recordctx/otlp.go
@@ -1,0 +1,169 @@
+package recordctx
+
+import (
+	"context"
+	"net"
+	"net/http"
+	"sort"
+	"strings"
+	"sync"
+	"time"
+
+	"github.com/keboola/go-utils/pkg/orderedmap"
+	"github.com/valyala/fastjson"
+
+	"github.com/keboola/keboola-as-code/internal/pkg/utils/errors"
+)
+
+type otlpContext struct {
+	ctx       context.Context
+	timestamp time.Time
+	clientIP  net.IP
+	headers   *orderedmap.OrderedMap
+	bodyMap   *orderedmap.OrderedMap
+
+	lock          sync.Mutex
+	headersString *string
+	bodyBytes     []byte
+	bodyBytesErr  error
+	jsonValue     *fastjson.Value
+	jsonValueErr  error
+}
+
+// FromOTLP builds a Context from a single pre-flattened OTLP record body.
+//
+// timestamp is the request arrival time — the OTLP record's own timestamp
+// stays inside bodyMap under "timestamp" so the column renderer can promote
+// it to a dedicated column independently of the datetime column.
+//
+// headers is the original HTTP request headers map (pass through), since the
+// OTLP transport rides on HTTP and downstream column mappings may extract
+// values like User-Agent.
+func FromOTLP(
+	ctx context.Context,
+	timestamp time.Time,
+	clientIP net.IP,
+	headers *orderedmap.OrderedMap,
+	bodyMap *orderedmap.OrderedMap,
+) Context {
+	return &otlpContext{
+		ctx:       ctx,
+		timestamp: timestamp,
+		clientIP:  clientIP,
+		headers:   headers,
+		bodyMap:   bodyMap,
+	}
+}
+
+func (c *otlpContext) Ctx() context.Context {
+	return c.ctx
+}
+
+func (c *otlpContext) Timestamp() time.Time {
+	return c.timestamp
+}
+
+func (c *otlpContext) ClientIP() net.IP {
+	return c.clientIP
+}
+
+func (c *otlpContext) HeadersString() string {
+	c.lock.Lock()
+	defer c.lock.Unlock()
+
+	if c.headersString != nil {
+		return *c.headersString
+	}
+
+	var s string
+	if c.headers == nil {
+		s = ""
+	} else {
+		keys := c.headers.Keys()
+		lines := make([]string, 0, len(keys))
+		for _, k := range keys {
+			v, _ := c.headers.Get(k)
+			if str, ok := v.(string); ok {
+				lines = append(lines, http.CanonicalHeaderKey(k)+": "+str+"\n")
+			}
+		}
+		sort.Strings(lines)
+		s = strings.Join(lines, "")
+	}
+	c.headersString = &s
+	return s
+}
+
+func (c *otlpContext) HeadersMap() *orderedmap.OrderedMap {
+	if c.headers == nil {
+		return orderedmap.New()
+	}
+	return c.headers
+}
+
+func (c *otlpContext) ReleaseBuffers() {
+	c.lock.Lock()
+	defer c.lock.Unlock()
+	c.bodyBytes = nil
+	c.jsonValue = nil
+}
+
+func (c *otlpContext) BodyBytes() ([]byte, error) {
+	c.lock.Lock()
+	defer c.lock.Unlock()
+	return c.bodyBytesWithoutLock()
+}
+
+func (c *otlpContext) BodyLength() int {
+	b, err := c.BodyBytes()
+	if err != nil {
+		return 0
+	}
+	return len(b)
+}
+
+func (c *otlpContext) BodyMap() (*orderedmap.OrderedMap, error) {
+	return c.bodyMap, nil
+}
+
+func (c *otlpContext) JSONValue(parserPool *fastjson.ParserPool) (*fastjson.Value, error) {
+	c.lock.Lock()
+	defer c.lock.Unlock()
+
+	if c.jsonValue != nil || c.jsonValueErr != nil {
+		return c.jsonValue, c.jsonValueErr
+	}
+
+	body, err := c.bodyBytesWithoutLock()
+	if err != nil {
+		c.jsonValueErr = err
+		return nil, err
+	}
+
+	parser := parserPool.Get()
+	defer parserPool.Put(parser)
+
+	if v, err := parser.ParseBytes(body); err != nil {
+		c.jsonValueErr = errors.PrefixError(err, "cannot parse OTLP record JSON")
+	} else {
+		c.jsonValue = v
+	}
+	return c.jsonValue, c.jsonValueErr
+}
+
+func (c *otlpContext) bodyBytesWithoutLock() ([]byte, error) {
+	if c.bodyBytes != nil || c.bodyBytesErr != nil {
+		return c.bodyBytes, c.bodyBytesErr
+	}
+	if c.bodyMap == nil {
+		c.bodyBytes = []byte("{}")
+		return c.bodyBytes, nil
+	}
+	b, err := json.Marshal(c.bodyMap)
+	if err != nil {
+		c.bodyBytesErr = errors.PrefixError(err, "cannot serialize OTLP record body to JSON")
+		return nil, c.bodyBytesErr
+	}
+	c.bodyBytes = b
+	return c.bodyBytes, nil
+}

--- a/internal/pkg/service/stream/mapping/recordctx/otlp_test.go
+++ b/internal/pkg/service/stream/mapping/recordctx/otlp_test.go
@@ -1,0 +1,130 @@
+package recordctx
+
+import (
+	"context"
+	stdjson "encoding/json"
+	"net"
+	"testing"
+	"time"
+
+	"github.com/keboola/go-utils/pkg/orderedmap"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	"github.com/valyala/fastjson"
+)
+
+func TestOTLPContext_BodyMap_PassesThroughWithoutParsing(t *testing.T) {
+	t.Parallel()
+
+	body := orderedmap.New()
+	body.Set("severity_text", "INFO")
+	body.Set("body", "hello")
+
+	c := FromOTLP(context.Background(), time.Now(), net.IPv4(127, 0, 0, 1), nil, body)
+
+	gotMap, err := c.BodyMap()
+	require.NoError(t, err)
+	assert.Same(t, body, gotMap, "BodyMap should return the pre-flattened map without copying")
+}
+
+func TestOTLPContext_BodyBytes_LazyJSONMarshal(t *testing.T) {
+	t.Parallel()
+
+	body := orderedmap.New()
+	body.Set("severity_text", "WARN")
+	body.Set("count", 42)
+
+	c := FromOTLP(context.Background(), time.Now(), net.IPv4(10, 0, 0, 1), nil, body)
+
+	bytesA, err := c.BodyBytes()
+	require.NoError(t, err)
+
+	// Decoding the result must yield the same fields.
+	decoded := map[string]any{}
+	require.NoError(t, stdjson.Unmarshal(bytesA, &decoded))
+	assert.Equal(t, "WARN", decoded["severity_text"])
+	assert.InDelta(t, 42.0, decoded["count"], 0)
+
+	// Subsequent calls must return the cached slice (same pointer).
+	bytesB, err := c.BodyBytes()
+	require.NoError(t, err)
+	assert.Equal(t, &bytesA[0], &bytesB[0], "BodyBytes should cache the marshaled body")
+}
+
+func TestOTLPContext_BodyLength(t *testing.T) {
+	t.Parallel()
+
+	body := orderedmap.New()
+	body.Set("k", "v")
+	c := FromOTLP(context.Background(), time.Now(), nil, nil, body)
+
+	expected, err := c.BodyBytes()
+	require.NoError(t, err)
+	assert.Equal(t, len(expected), c.BodyLength())
+}
+
+func TestOTLPContext_JSONValue(t *testing.T) {
+	t.Parallel()
+
+	body := orderedmap.New()
+	body.Set("severity_text", "ERROR")
+	c := FromOTLP(context.Background(), time.Now(), nil, nil, body)
+
+	pool := &fastjson.ParserPool{}
+	v, err := c.JSONValue(pool)
+	require.NoError(t, err)
+	require.NotNil(t, v)
+	assert.Equal(t, "ERROR", string(v.GetStringBytes("severity_text")))
+}
+
+func TestOTLPContext_TimestampAndClientIP(t *testing.T) {
+	t.Parallel()
+
+	now := time.Date(2024, 5, 11, 12, 0, 0, 0, time.UTC)
+	ip := net.IPv4(192, 168, 1, 100)
+	c := FromOTLP(context.Background(), now, ip, nil, orderedmap.New())
+
+	assert.Equal(t, now, c.Timestamp())
+	assert.True(t, c.ClientIP().Equal(ip))
+}
+
+func TestOTLPContext_HeadersMap_NilSafe(t *testing.T) {
+	t.Parallel()
+
+	c := FromOTLP(context.Background(), time.Now(), nil, nil, orderedmap.New())
+	m := c.HeadersMap()
+	require.NotNil(t, m)
+	assert.Equal(t, 0, m.Len())
+}
+
+func TestOTLPContext_HeadersString(t *testing.T) {
+	t.Parallel()
+
+	headers := orderedmap.New()
+	headers.Set("Content-Type", "application/x-protobuf")
+	headers.Set("User-Agent", "otel-go/1.0")
+
+	c := FromOTLP(context.Background(), time.Now(), nil, headers, orderedmap.New())
+	s := c.HeadersString()
+
+	// Canonical header names, sorted, newline-terminated.
+	expected := "Content-Type: application/x-protobuf\nUser-Agent: otel-go/1.0\n"
+	assert.Equal(t, expected, s)
+}
+
+func TestOTLPContext_ReleaseBuffers(t *testing.T) {
+	t.Parallel()
+
+	body := orderedmap.New()
+	body.Set("k", "v")
+	c := FromOTLP(context.Background(), time.Now(), nil, nil, body)
+
+	_, err := c.BodyBytes()
+	require.NoError(t, err)
+	c.ReleaseBuffers()
+
+	// BodyMap survives — that's the source of truth.
+	got, err := c.BodyMap()
+	require.NoError(t, err)
+	assert.Same(t, body, got)
+}

--- a/internal/pkg/service/stream/source/type/httpsource/httpsource.go
+++ b/internal/pkg/service/stream/source/type/httpsource/httpsource.go
@@ -152,11 +152,14 @@ func Start(ctx context.Context, d dependencies, cfg Config) error {
 	// Native OTLP/HTTP endpoints. The OTLP transport rides on the existing
 	// HTTP source (same server, same dispatcher) — the only new pieces are
 	// route registration, OTLP decoding, record flattening, and OTLP-conformant
-	// response construction. Phase 1 ships /v1/logs only; metrics and traces
-	// will follow once logs are proven end-to-end.
+	// response construction.
 	otlpHandler := otlpsource.New(ctx, logger, d.Clock(), dp, errorHandler)
 	router.Options("/otlp/<projectID>/<sourceID>/<secret>/v1/logs", otlpHandler.HandleOptions)
 	router.Post("/otlp/<projectID>/<sourceID>/<secret>/v1/logs", otlpHandler.HandleLogs)
+	router.Options("/otlp/<projectID>/<sourceID>/<secret>/v1/metrics", otlpHandler.HandleOptions)
+	router.Post("/otlp/<projectID>/<sourceID>/<secret>/v1/metrics", otlpHandler.HandleMetrics)
+	router.Options("/otlp/<projectID>/<sourceID>/<secret>/v1/traces", otlpHandler.HandleOptions)
+	router.Post("/otlp/<projectID>/<sourceID>/<secret>/v1/traces", otlpHandler.HandleTraces)
 
 	// Prepare HTTP server
 	readBufferSize, err := safecast.Convert[int](cfg.ReadBufferSize.Bytes())

--- a/internal/pkg/service/stream/source/type/httpsource/httpsource.go
+++ b/internal/pkg/service/stream/source/type/httpsource/httpsource.go
@@ -25,6 +25,7 @@ import (
 	"github.com/keboola/keboola-as-code/internal/pkg/service/stream/mapping/recordctx"
 	sinkRouter "github.com/keboola/keboola-as-code/internal/pkg/service/stream/sink/router"
 	"github.com/keboola/keboola-as-code/internal/pkg/service/stream/source/dispatcher"
+	"github.com/keboola/keboola-as-code/internal/pkg/service/stream/source/type/otlpsource"
 	"github.com/keboola/keboola-as-code/internal/pkg/telemetry"
 	"github.com/keboola/keboola-as-code/internal/pkg/utils/errors"
 )
@@ -147,6 +148,15 @@ func Start(ctx context.Context, d dependencies, cfg Config) error {
 
 		return nil
 	})
+
+	// Native OTLP/HTTP endpoints. The OTLP transport rides on the existing
+	// HTTP source (same server, same dispatcher) — the only new pieces are
+	// route registration, OTLP decoding, record flattening, and OTLP-conformant
+	// response construction. Phase 1 ships /v1/logs only; metrics and traces
+	// will follow once logs are proven end-to-end.
+	otlpHandler := otlpsource.New(ctx, logger, d.Clock(), dp, errorHandler)
+	router.Options("/otlp/<projectID>/<sourceID>/<secret>/v1/logs", otlpHandler.HandleOptions)
+	router.Post("/otlp/<projectID>/<sourceID>/<secret>/v1/logs", otlpHandler.HandleLogs)
 
 	// Prepare HTTP server
 	readBufferSize, err := safecast.Convert[int](cfg.ReadBufferSize.Bytes())

--- a/internal/pkg/service/stream/source/type/otlpsource/config.go
+++ b/internal/pkg/service/stream/source/type/otlpsource/config.go
@@ -1,0 +1,16 @@
+// Package otlpsource adds native OTLP/HTTP endpoints to the Stream HTTP source.
+//
+// It decodes OpenTelemetry signals (logs in Phase 1, metrics and traces later),
+// flattens each nested record into an ordered JSON map, and dispatches every
+// record through the standard sink pipeline via a recordctx.Context.
+package otlpsource
+
+type Config struct {
+	Enabled bool `configKey:"enabled" configUsage:"Enable native OTLP/HTTP endpoints on the HTTP source."`
+}
+
+func NewConfig() Config {
+	return Config{
+		Enabled: true,
+	}
+}

--- a/internal/pkg/service/stream/source/type/otlpsource/decode.go
+++ b/internal/pkg/service/stream/source/type/otlpsource/decode.go
@@ -1,0 +1,93 @@
+package otlpsource
+
+import (
+	"bytes"
+	"compress/gzip"
+	"io"
+	"strings"
+
+	"go.opentelemetry.io/collector/pdata/plog"
+
+	"github.com/keboola/keboola-as-code/internal/pkg/utils/errors"
+)
+
+// Encoding identifies the OTLP wire format negotiated from Content-Type.
+type Encoding int
+
+const (
+	EncodingUnsupported Encoding = iota
+	EncodingProtobuf
+	EncodingJSON
+)
+
+const (
+	contentTypeProtobuf = "application/x-protobuf"
+	contentTypeJSON     = "application/json"
+)
+
+// DetectEncoding parses the Content-Type header value and returns the matching
+// OTLP wire format. Unknown values yield EncodingUnsupported.
+func DetectEncoding(contentType string) Encoding {
+	contentType = strings.TrimSpace(contentType)
+	if i := strings.IndexByte(contentType, ';'); i >= 0 {
+		contentType = strings.TrimSpace(contentType[:i])
+	}
+	switch contentType {
+	case contentTypeProtobuf:
+		return EncodingProtobuf
+	case contentTypeJSON:
+		return EncodingJSON
+	default:
+		return EncodingUnsupported
+	}
+}
+
+// ContentType returns the canonical Content-Type string for an Encoding.
+// Response Content-Type must match the request, per OTLP spec.
+func (e Encoding) ContentType() string {
+	switch e {
+	case EncodingProtobuf:
+		return contentTypeProtobuf
+	case EncodingJSON:
+		return contentTypeJSON
+	default:
+		return ""
+	}
+}
+
+// DecompressIfGzip decompresses body when Content-Encoding is "gzip", otherwise
+// returns body unchanged. No other compression formats are recognized.
+func DecompressIfGzip(contentEncoding string, body []byte) ([]byte, error) {
+	if strings.TrimSpace(contentEncoding) != "gzip" {
+		return body, nil
+	}
+
+	reader, err := gzip.NewReader(bytes.NewReader(body))
+	if err != nil {
+		return nil, errors.PrefixError(err, "cannot create gzip reader")
+	}
+	defer func() { _ = reader.Close() }()
+
+	decompressed, err := io.ReadAll(reader)
+	if err != nil {
+		return nil, errors.PrefixError(err, "cannot decompress gzip body")
+	}
+	return decompressed, nil
+}
+
+var (
+	logsProtoUnmarshaler = &plog.ProtoUnmarshaler{} //nolint:gochecknoglobals
+	logsJSONUnmarshaler  = &plog.JSONUnmarshaler{}  //nolint:gochecknoglobals
+)
+
+// DecodeLogs unmarshals an ExportLogsServiceRequest body into plog.Logs.
+func DecodeLogs(body []byte, enc Encoding) (plog.Logs, error) {
+	switch enc {
+	case EncodingProtobuf:
+		return logsProtoUnmarshaler.UnmarshalLogs(body)
+	case EncodingJSON:
+		return logsJSONUnmarshaler.UnmarshalLogs(body)
+	default:
+		return plog.Logs{}, errors.New("unsupported OTLP encoding")
+	}
+}

--- a/internal/pkg/service/stream/source/type/otlpsource/decode.go
+++ b/internal/pkg/service/stream/source/type/otlpsource/decode.go
@@ -7,6 +7,8 @@ import (
 	"strings"
 
 	"go.opentelemetry.io/collector/pdata/plog"
+	"go.opentelemetry.io/collector/pdata/pmetric"
+	"go.opentelemetry.io/collector/pdata/ptrace"
 
 	"github.com/keboola/keboola-as-code/internal/pkg/utils/errors"
 )
@@ -76,8 +78,12 @@ func DecompressIfGzip(contentEncoding string, body []byte) ([]byte, error) {
 }
 
 var (
-	logsProtoUnmarshaler = &plog.ProtoUnmarshaler{} //nolint:gochecknoglobals
-	logsJSONUnmarshaler  = &plog.JSONUnmarshaler{}  //nolint:gochecknoglobals
+	logsProtoUnmarshaler    = &plog.ProtoUnmarshaler{}    //nolint:gochecknoglobals
+	logsJSONUnmarshaler     = &plog.JSONUnmarshaler{}     //nolint:gochecknoglobals
+	metricsProtoUnmarshaler = &pmetric.ProtoUnmarshaler{} //nolint:gochecknoglobals
+	metricsJSONUnmarshaler  = &pmetric.JSONUnmarshaler{}  //nolint:gochecknoglobals
+	tracesProtoUnmarshaler  = &ptrace.ProtoUnmarshaler{}  //nolint:gochecknoglobals
+	tracesJSONUnmarshaler   = &ptrace.JSONUnmarshaler{}   //nolint:gochecknoglobals
 )
 
 // DecodeLogs unmarshals an ExportLogsServiceRequest body into plog.Logs.
@@ -89,5 +95,29 @@ func DecodeLogs(body []byte, enc Encoding) (plog.Logs, error) {
 		return logsJSONUnmarshaler.UnmarshalLogs(body)
 	default:
 		return plog.Logs{}, errors.New("unsupported OTLP encoding")
+	}
+}
+
+// DecodeMetrics unmarshals an ExportMetricsServiceRequest body into pmetric.Metrics.
+func DecodeMetrics(body []byte, enc Encoding) (pmetric.Metrics, error) {
+	switch enc {
+	case EncodingProtobuf:
+		return metricsProtoUnmarshaler.UnmarshalMetrics(body)
+	case EncodingJSON:
+		return metricsJSONUnmarshaler.UnmarshalMetrics(body)
+	default:
+		return pmetric.Metrics{}, errors.New("unsupported OTLP encoding")
+	}
+}
+
+// DecodeTraces unmarshals an ExportTraceServiceRequest body into ptrace.Traces.
+func DecodeTraces(body []byte, enc Encoding) (ptrace.Traces, error) {
+	switch enc {
+	case EncodingProtobuf:
+		return tracesProtoUnmarshaler.UnmarshalTraces(body)
+	case EncodingJSON:
+		return tracesJSONUnmarshaler.UnmarshalTraces(body)
+	default:
+		return ptrace.Traces{}, errors.New("unsupported OTLP encoding")
 	}
 }

--- a/internal/pkg/service/stream/source/type/otlpsource/decode_test.go
+++ b/internal/pkg/service/stream/source/type/otlpsource/decode_test.go
@@ -8,6 +8,8 @@ import (
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 	"go.opentelemetry.io/collector/pdata/plog"
+	"go.opentelemetry.io/collector/pdata/pmetric"
+	"go.opentelemetry.io/collector/pdata/ptrace"
 )
 
 func TestDetectEncoding(t *testing.T) {
@@ -117,5 +119,77 @@ func TestDecodeLogs_Unsupported(t *testing.T) {
 	t.Parallel()
 
 	_, err := DecodeLogs([]byte("{}"), EncodingUnsupported)
+	require.Error(t, err)
+}
+
+func TestDecodeMetrics_Protobuf(t *testing.T) {
+	t.Parallel()
+
+	metrics := pmetric.NewMetrics()
+	m := metrics.ResourceMetrics().AppendEmpty().ScopeMetrics().AppendEmpty().Metrics().AppendEmpty()
+	m.SetName("requests")
+	m.SetEmptyGauge().DataPoints().AppendEmpty().SetIntValue(7)
+
+	protoBytes, err := (&pmetric.ProtoMarshaler{}).MarshalMetrics(metrics)
+	require.NoError(t, err)
+
+	decoded, err := DecodeMetrics(protoBytes, EncodingProtobuf)
+	require.NoError(t, err)
+	assert.Equal(t, "requests", decoded.ResourceMetrics().At(0).ScopeMetrics().At(0).Metrics().At(0).Name())
+}
+
+func TestDecodeMetrics_JSON(t *testing.T) {
+	t.Parallel()
+
+	metrics := pmetric.NewMetrics()
+	metrics.ResourceMetrics().AppendEmpty().ScopeMetrics().AppendEmpty().Metrics().AppendEmpty().SetName("requests")
+
+	jsonBytes, err := (&pmetric.JSONMarshaler{}).MarshalMetrics(metrics)
+	require.NoError(t, err)
+
+	decoded, err := DecodeMetrics(jsonBytes, EncodingJSON)
+	require.NoError(t, err)
+	assert.Equal(t, "requests", decoded.ResourceMetrics().At(0).ScopeMetrics().At(0).Metrics().At(0).Name())
+}
+
+func TestDecodeMetrics_Unsupported(t *testing.T) {
+	t.Parallel()
+
+	_, err := DecodeMetrics([]byte("{}"), EncodingUnsupported)
+	require.Error(t, err)
+}
+
+func TestDecodeTraces_Protobuf(t *testing.T) {
+	t.Parallel()
+
+	traces := ptrace.NewTraces()
+	traces.ResourceSpans().AppendEmpty().ScopeSpans().AppendEmpty().Spans().AppendEmpty().SetName("GET /")
+
+	protoBytes, err := (&ptrace.ProtoMarshaler{}).MarshalTraces(traces)
+	require.NoError(t, err)
+
+	decoded, err := DecodeTraces(protoBytes, EncodingProtobuf)
+	require.NoError(t, err)
+	assert.Equal(t, "GET /", decoded.ResourceSpans().At(0).ScopeSpans().At(0).Spans().At(0).Name())
+}
+
+func TestDecodeTraces_JSON(t *testing.T) {
+	t.Parallel()
+
+	traces := ptrace.NewTraces()
+	traces.ResourceSpans().AppendEmpty().ScopeSpans().AppendEmpty().Spans().AppendEmpty().SetName("GET /")
+
+	jsonBytes, err := (&ptrace.JSONMarshaler{}).MarshalTraces(traces)
+	require.NoError(t, err)
+
+	decoded, err := DecodeTraces(jsonBytes, EncodingJSON)
+	require.NoError(t, err)
+	assert.Equal(t, "GET /", decoded.ResourceSpans().At(0).ScopeSpans().At(0).Spans().At(0).Name())
+}
+
+func TestDecodeTraces_Unsupported(t *testing.T) {
+	t.Parallel()
+
+	_, err := DecodeTraces([]byte("{}"), EncodingUnsupported)
 	require.Error(t, err)
 }

--- a/internal/pkg/service/stream/source/type/otlpsource/decode_test.go
+++ b/internal/pkg/service/stream/source/type/otlpsource/decode_test.go
@@ -1,0 +1,121 @@
+package otlpsource
+
+import (
+	"bytes"
+	"compress/gzip"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	"go.opentelemetry.io/collector/pdata/plog"
+)
+
+func TestDetectEncoding(t *testing.T) {
+	t.Parallel()
+
+	cases := []struct {
+		in   string
+		want Encoding
+	}{
+		{"application/x-protobuf", EncodingProtobuf},
+		{"application/x-protobuf; charset=utf-8", EncodingProtobuf},
+		{"  application/x-protobuf  ", EncodingProtobuf},
+		{"application/json", EncodingJSON},
+		{"application/json; charset=utf-8", EncodingJSON},
+		{"text/plain", EncodingUnsupported},
+		{"", EncodingUnsupported},
+	}
+	for _, c := range cases {
+		assert.Equal(t, c.want, DetectEncoding(c.in), "input=%q", c.in)
+	}
+}
+
+func TestEncodingContentType(t *testing.T) {
+	t.Parallel()
+
+	assert.Equal(t, "application/x-protobuf", EncodingProtobuf.ContentType())
+	assert.Equal(t, "application/json", EncodingJSON.ContentType())
+	assert.Empty(t, EncodingUnsupported.ContentType())
+}
+
+func TestDecompressIfGzip_NoCompression(t *testing.T) {
+	t.Parallel()
+
+	body := []byte("hello")
+	out, err := DecompressIfGzip("", body)
+	require.NoError(t, err)
+	assert.Equal(t, body, out)
+}
+
+func TestDecompressIfGzip_Gzip(t *testing.T) {
+	t.Parallel()
+
+	original := []byte("the quick brown fox jumps over the lazy dog")
+	var buf bytes.Buffer
+	gz := gzip.NewWriter(&buf)
+	_, err := gz.Write(original)
+	require.NoError(t, err)
+	require.NoError(t, gz.Close())
+
+	out, err := DecompressIfGzip("gzip", buf.Bytes())
+	require.NoError(t, err)
+	assert.Equal(t, original, out)
+}
+
+func TestDecompressIfGzip_InvalidGzip(t *testing.T) {
+	t.Parallel()
+
+	_, err := DecompressIfGzip("gzip", []byte("not gzip"))
+	require.Error(t, err)
+}
+
+func TestDecodeLogs_JSON(t *testing.T) {
+	t.Parallel()
+
+	// Build a minimal logs payload via pdata, then marshal as JSON and
+	// round-trip through DecodeLogs.
+	logs := plog.NewLogs()
+	rl := logs.ResourceLogs().AppendEmpty()
+	sl := rl.ScopeLogs().AppendEmpty()
+	lr := sl.LogRecords().AppendEmpty()
+	lr.Body().SetStr("hello world")
+
+	jsonBytes, err := (&plog.JSONMarshaler{}).MarshalLogs(logs)
+	require.NoError(t, err)
+
+	decoded, err := DecodeLogs(jsonBytes, EncodingJSON)
+	require.NoError(t, err)
+	assert.Equal(t, 1, decoded.LogRecordCount())
+	assert.Equal(t, "hello world", decoded.ResourceLogs().At(0).ScopeLogs().At(0).LogRecords().At(0).Body().Str())
+}
+
+func TestDecodeLogs_Protobuf(t *testing.T) {
+	t.Parallel()
+
+	logs := plog.NewLogs()
+	rl := logs.ResourceLogs().AppendEmpty()
+	sl := rl.ScopeLogs().AppendEmpty()
+	lr := sl.LogRecords().AppendEmpty()
+	lr.SetSeverityText("WARN")
+
+	protoBytes, err := (&plog.ProtoMarshaler{}).MarshalLogs(logs)
+	require.NoError(t, err)
+
+	decoded, err := DecodeLogs(protoBytes, EncodingProtobuf)
+	require.NoError(t, err)
+	assert.Equal(t, "WARN", decoded.ResourceLogs().At(0).ScopeLogs().At(0).LogRecords().At(0).SeverityText())
+}
+
+func TestDecodeLogs_InvalidProtobuf(t *testing.T) {
+	t.Parallel()
+
+	_, err := DecodeLogs([]byte("not a protobuf"), EncodingProtobuf)
+	require.Error(t, err)
+}
+
+func TestDecodeLogs_Unsupported(t *testing.T) {
+	t.Parallel()
+
+	_, err := DecodeLogs([]byte("{}"), EncodingUnsupported)
+	require.Error(t, err)
+}

--- a/internal/pkg/service/stream/source/type/otlpsource/dispatch.go
+++ b/internal/pkg/service/stream/source/type/otlpsource/dispatch.go
@@ -1,0 +1,78 @@
+package otlpsource
+
+import (
+	"context"
+	"net"
+	"time"
+
+	"github.com/keboola/go-utils/pkg/orderedmap"
+	"github.com/keboola/keboola-sdk-go/v2/pkg/keboola"
+
+	svcerrors "github.com/keboola/keboola-as-code/internal/pkg/service/common/errors"
+	"github.com/keboola/keboola-as-code/internal/pkg/service/stream/definition/key"
+	"github.com/keboola/keboola-as-code/internal/pkg/service/stream/mapping/recordctx"
+	"github.com/keboola/keboola-as-code/internal/pkg/service/stream/source/dispatcher"
+	"github.com/keboola/keboola-as-code/internal/pkg/utils/errors"
+)
+
+// DispatchResult aggregates the outcome of dispatching N flattened records
+// from a single OTLP request. It feeds the OTLP partial_success response.
+type DispatchResult struct {
+	Total           int
+	Rejected        int
+	WorstStatusCode int
+	FirstError      error
+}
+
+// DispatchRecords dispatches every record through the Stream pipeline and
+// aggregates per-record outcomes. Each record's failure is counted; the worst
+// HTTP status code observed is retained so the handler can decide between
+// 200 (partial_success) and a 4xx/5xx top-level error.
+//
+// Records share the same arrival timestamp and HTTP headers — the per-record
+// OTLP timestamp lives inside the body map for the column renderer to extract.
+//
+// Dispatch is sequential. The plan defers parallel dispatch to Phase 2;
+// typical OTLP batches (≤100 records) are dominated by sink-pipeline writes,
+// not per-record dispatcher overhead.
+func DispatchRecords(
+	ctx context.Context,
+	dp *dispatcher.Dispatcher,
+	now time.Time,
+	clientIP net.IP,
+	headers *orderedmap.OrderedMap,
+	projectID keboola.ProjectID,
+	sourceID key.SourceID,
+	secret string,
+	records []FlatRecord,
+) DispatchResult {
+	result := DispatchResult{Total: len(records)}
+
+	for _, rec := range records {
+		recordCtx := recordctx.FromOTLP(ctx, now, clientIP, headers, rec.Body)
+		_, err := dp.Dispatch(projectID, sourceID, secret, recordCtx)
+		recordCtx.ReleaseBuffers()
+		if err == nil {
+			continue
+		}
+
+		result.Rejected++
+		if result.FirstError == nil {
+			result.FirstError = err
+		}
+		statusCode := statusCodeFromError(err)
+		if statusCode > result.WorstStatusCode {
+			result.WorstStatusCode = statusCode
+		}
+	}
+
+	return result
+}
+
+func statusCodeFromError(err error) int {
+	var withStatus svcerrors.WithStatusCode
+	if errors.As(err, &withStatus) {
+		return withStatus.StatusCode()
+	}
+	return 500
+}

--- a/internal/pkg/service/stream/source/type/otlpsource/flatten_common.go
+++ b/internal/pkg/service/stream/source/type/otlpsource/flatten_common.go
@@ -1,0 +1,79 @@
+package otlpsource
+
+import (
+	"encoding/base64"
+	"time"
+
+	"github.com/keboola/go-utils/pkg/orderedmap"
+	"go.opentelemetry.io/collector/pdata/pcommon"
+)
+
+// FlatRecord is a single flattened OTLP record (one log record, one metric data
+// point, or one span) ready to be wrapped in a recordctx.Context.
+type FlatRecord struct {
+	Body *orderedmap.OrderedMap
+}
+
+// attributesToMap converts pcommon.Map of attributes to an ordered map. Keys
+// preserve their dotted form (e.g. "http.method") so they remain addressable
+// via Path column GetNested with proper escaping at the column level.
+func attributesToMap(attrs pcommon.Map) *orderedmap.OrderedMap {
+	m := orderedmap.New()
+	attrs.Range(func(k string, v pcommon.Value) bool {
+		m.Set(k, anyValueToInterface(v))
+		return true
+	})
+	return m
+}
+
+// anyValueToInterface converts pcommon.Value (OTel AnyValue) into a Go value
+// that can survive JSON round-trip — string, int64, float64, bool, []byte
+// (base64-encoded string), nested ordered map, or []any.
+func anyValueToInterface(v pcommon.Value) any {
+	switch v.Type() {
+	case pcommon.ValueTypeStr:
+		return v.Str()
+	case pcommon.ValueTypeInt:
+		return v.Int()
+	case pcommon.ValueTypeDouble:
+		return v.Double()
+	case pcommon.ValueTypeBool:
+		return v.Bool()
+	case pcommon.ValueTypeBytes:
+		return base64.StdEncoding.EncodeToString(v.Bytes().AsRaw())
+	case pcommon.ValueTypeMap:
+		return attributesToMap(v.Map())
+	case pcommon.ValueTypeSlice:
+		slice := v.Slice()
+		result := make([]any, slice.Len())
+		for i := 0; i < slice.Len(); i++ {
+			result[i] = anyValueToInterface(slice.At(i))
+		}
+		return result
+	case pcommon.ValueTypeEmpty:
+		return nil
+	default:
+		return nil
+	}
+}
+
+// formatTimestamp returns the RFC3339Nano UTC string for a pcommon.Timestamp,
+// or an empty string for the zero timestamp. Empty timestamps are common in
+// OTLP (optional fields), and emitting "" lets the column renderer apply its
+// own defaultValue logic.
+func formatTimestamp(ts pcommon.Timestamp) string {
+	if ts == 0 {
+		return ""
+	}
+	return ts.AsTime().UTC().Format(time.RFC3339Nano)
+}
+
+// makeScopeMap returns an ordered map with name/version of an instrumentation
+// scope. Always populated, even when the scope is empty — downstream column
+// mappings expect the keys to exist.
+func makeScopeMap(scope pcommon.InstrumentationScope) *orderedmap.OrderedMap {
+	m := orderedmap.New()
+	m.Set("name", scope.Name())
+	m.Set("version", scope.Version())
+	return m
+}

--- a/internal/pkg/service/stream/source/type/otlpsource/flatten_logs.go
+++ b/internal/pkg/service/stream/source/type/otlpsource/flatten_logs.go
@@ -1,0 +1,62 @@
+package otlpsource
+
+import (
+	"github.com/keboola/go-utils/pkg/orderedmap"
+	"go.opentelemetry.io/collector/pdata/plog"
+)
+
+// FlattenLogs explodes plog.Logs into one FlatRecord per LogRecord, denormalizing
+// resource and scope attributes onto each record so column mappings can extract
+// them without joining across nesting levels.
+//
+// Optional fields (trace_id, span_id) are omitted when empty so the renderer's
+// defaultValue applies. attributes/resource/scope are always emitted, possibly
+// as empty maps.
+func FlattenLogs(logs plog.Logs) []FlatRecord {
+	records := make([]FlatRecord, 0, logs.LogRecordCount())
+
+	for i := 0; i < logs.ResourceLogs().Len(); i++ {
+		rl := logs.ResourceLogs().At(i)
+		resourceAttrs := attributesToMap(rl.Resource().Attributes())
+
+		for j := 0; j < rl.ScopeLogs().Len(); j++ {
+			sl := rl.ScopeLogs().At(j)
+			scopeMap := makeScopeMap(sl.Scope())
+
+			for k := 0; k < sl.LogRecords().Len(); k++ {
+				lr := sl.LogRecords().At(k)
+				records = append(records, FlatRecord{Body: flattenLogRecord(lr, resourceAttrs, scopeMap)})
+			}
+		}
+	}
+
+	return records
+}
+
+func flattenLogRecord(
+	lr plog.LogRecord,
+	resourceAttrs *orderedmap.OrderedMap,
+	scopeMap *orderedmap.OrderedMap,
+) *orderedmap.OrderedMap {
+	rec := orderedmap.New()
+	rec.Set("timestamp", formatTimestamp(lr.Timestamp()))
+	rec.Set("observed_timestamp", formatTimestamp(lr.ObservedTimestamp()))
+	rec.Set("severity_number", int32(lr.SeverityNumber()))
+	rec.Set("severity_text", lr.SeverityText())
+	rec.Set("body", anyValueToInterface(lr.Body()))
+	rec.Set("flags", uint32(lr.Flags()))
+
+	// trace_id and span_id are omitted (not "") when empty — the Path column
+	// will fall back to its defaultValue. Emitting "" would mask the absence.
+	if traceID := lr.TraceID(); !traceID.IsEmpty() {
+		rec.Set("trace_id", traceID.String())
+	}
+	if spanID := lr.SpanID(); !spanID.IsEmpty() {
+		rec.Set("span_id", spanID.String())
+	}
+
+	rec.Set("attributes", attributesToMap(lr.Attributes()))
+	rec.Set("resource", resourceAttrs)
+	rec.Set("scope", scopeMap)
+	return rec
+}

--- a/internal/pkg/service/stream/source/type/otlpsource/flatten_logs_test.go
+++ b/internal/pkg/service/stream/source/type/otlpsource/flatten_logs_test.go
@@ -1,0 +1,186 @@
+package otlpsource
+
+import (
+	"testing"
+	"time"
+
+	"github.com/keboola/go-utils/pkg/orderedmap"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	"go.opentelemetry.io/collector/pdata/pcommon"
+	"go.opentelemetry.io/collector/pdata/plog"
+)
+
+func TestFlattenLogs_Empty(t *testing.T) {
+	t.Parallel()
+
+	records := FlattenLogs(plog.NewLogs())
+	assert.Empty(t, records)
+}
+
+func TestFlattenLogs_SingleRecord(t *testing.T) {
+	t.Parallel()
+
+	logs := plog.NewLogs()
+	rl := logs.ResourceLogs().AppendEmpty()
+	rl.Resource().Attributes().PutStr("service.name", "auth-service")
+
+	sl := rl.ScopeLogs().AppendEmpty()
+	sl.Scope().SetName("github.com/my/lib")
+	sl.Scope().SetVersion("0.1.0")
+
+	lr := sl.LogRecords().AppendEmpty()
+	ts := pcommon.NewTimestampFromTime(time.Date(2024, 1, 15, 10, 30, 0, 0, time.UTC))
+	lr.SetTimestamp(ts)
+	lr.SetSeverityNumber(plog.SeverityNumberInfo)
+	lr.SetSeverityText("INFO")
+	lr.Body().SetStr("User logged in")
+	lr.Attributes().PutStr("user.id", "12345")
+
+	records := FlattenLogs(logs)
+	require.Len(t, records, 1)
+
+	rec := records[0].Body
+	assert.Equal(t, "2024-01-15T10:30:00Z", getString(t, rec, "timestamp"))
+	assert.Equal(t, "INFO", getString(t, rec, "severity_text"))
+	assert.Equal(t, "User logged in", getValue(t, rec, "body"))
+	assert.Equal(t, int32(plog.SeverityNumberInfo), getValue(t, rec, "severity_number"))
+
+	// attributes / resource / scope are nested ordered maps
+	attrs, _ := rec.Get("attributes")
+	attrsMap, ok := attrs.(*orderedmap.OrderedMap)
+	require.True(t, ok, "attributes should be an *OrderedMap")
+	userID, _ := attrsMap.Get("user.id")
+	assert.Equal(t, "12345", userID)
+
+	resource, _ := rec.Get("resource")
+	resourceMap, ok := resource.(*orderedmap.OrderedMap)
+	require.True(t, ok)
+	svcName, _ := resourceMap.Get("service.name")
+	assert.Equal(t, "auth-service", svcName)
+
+	scope, _ := rec.Get("scope")
+	scopeMap, ok := scope.(*orderedmap.OrderedMap)
+	require.True(t, ok)
+	scopeName, _ := scopeMap.Get("name")
+	assert.Equal(t, "github.com/my/lib", scopeName)
+}
+
+func TestFlattenLogs_CombinatorialExplosion(t *testing.T) {
+	t.Parallel()
+
+	// 2 resources × 2 scopes × 3 records = 12 flat records.
+	logs := plog.NewLogs()
+	for r := 0; r < 2; r++ {
+		rl := logs.ResourceLogs().AppendEmpty()
+		rl.Resource().Attributes().PutInt("resource.idx", int64(r))
+		for s := 0; s < 2; s++ {
+			sl := rl.ScopeLogs().AppendEmpty()
+			sl.Scope().SetName("scope-" + string(rune('a'+s)))
+			for k := 0; k < 3; k++ {
+				lr := sl.LogRecords().AppendEmpty()
+				lr.Body().SetStr("rec")
+				lr.Attributes().PutInt("k", int64(k))
+			}
+		}
+	}
+
+	records := FlattenLogs(logs)
+	assert.Len(t, records, 12)
+}
+
+func TestFlattenLogs_OmitsEmptyTraceAndSpanIDs(t *testing.T) {
+	t.Parallel()
+
+	logs := plog.NewLogs()
+	lr := logs.ResourceLogs().AppendEmpty().ScopeLogs().AppendEmpty().LogRecords().AppendEmpty()
+	lr.Body().SetStr("no trace")
+
+	records := FlattenLogs(logs)
+	require.Len(t, records, 1)
+
+	_, ok := records[0].Body.Get("trace_id")
+	assert.False(t, ok, "trace_id should be absent when empty so Path defaultValue applies")
+	_, ok = records[0].Body.Get("span_id")
+	assert.False(t, ok, "span_id should be absent when empty")
+}
+
+func TestFlattenLogs_IncludesNonEmptyTraceAndSpanIDs(t *testing.T) {
+	t.Parallel()
+
+	logs := plog.NewLogs()
+	lr := logs.ResourceLogs().AppendEmpty().ScopeLogs().AppendEmpty().LogRecords().AppendEmpty()
+	lr.SetTraceID(pcommon.TraceID([16]byte{1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15, 16}))
+	lr.SetSpanID(pcommon.SpanID([8]byte{1, 2, 3, 4, 5, 6, 7, 8}))
+
+	records := FlattenLogs(logs)
+	require.Len(t, records, 1)
+
+	traceID, ok := records[0].Body.Get("trace_id")
+	assert.True(t, ok)
+	assert.Equal(t, "0102030405060708090a0b0c0d0e0f10", traceID)
+}
+
+func TestFlattenLogs_AttributeValueTypes(t *testing.T) {
+	t.Parallel()
+
+	logs := plog.NewLogs()
+	lr := logs.ResourceLogs().AppendEmpty().ScopeLogs().AppendEmpty().LogRecords().AppendEmpty()
+	lr.Attributes().PutStr("s", "x")
+	lr.Attributes().PutInt("i", 42)
+	lr.Attributes().PutDouble("d", 3.14)
+	lr.Attributes().PutBool("b", true)
+	bytesVal := lr.Attributes().PutEmptyBytes("by")
+	bytesVal.FromRaw([]byte{0xde, 0xad})
+	mapVal := lr.Attributes().PutEmptyMap("m")
+	mapVal.PutStr("nested", "v")
+	sliceVal := lr.Attributes().PutEmptySlice("sl")
+	sliceVal.AppendEmpty().SetStr("a")
+	sliceVal.AppendEmpty().SetInt(1)
+
+	records := FlattenLogs(logs)
+	require.Len(t, records, 1)
+	attrs := mustMap(t, records[0].Body, "attributes")
+
+	assert.Equal(t, "x", mustGet(t, attrs, "s"))
+	assert.Equal(t, int64(42), mustGet(t, attrs, "i"))
+	assert.InDelta(t, 3.14, mustGet(t, attrs, "d"), 1e-9)
+	assert.Equal(t, true, mustGet(t, attrs, "b"))
+	assert.Equal(t, "3q0=", mustGet(t, attrs, "by")) // base64 of 0xde 0xad
+	nested := mustMap(t, attrs, "m")
+	assert.Equal(t, "v", mustGet(t, nested, "nested"))
+	slice, ok := mustGet(t, attrs, "sl").([]any)
+	require.True(t, ok)
+	assert.Equal(t, []any{"a", int64(1)}, slice)
+}
+
+func getString(t *testing.T, m *orderedmap.OrderedMap, key string) string {
+	t.Helper()
+	v, _ := m.Get(key)
+	s, ok := v.(string)
+	require.True(t, ok, "key %q is not a string", key)
+	return s
+}
+
+func getValue(t *testing.T, m *orderedmap.OrderedMap, key string) any {
+	t.Helper()
+	v, ok := m.Get(key)
+	require.True(t, ok, "key %q missing", key)
+	return v
+}
+
+func mustMap(t *testing.T, m *orderedmap.OrderedMap, key string) *orderedmap.OrderedMap {
+	t.Helper()
+	v, ok := m.Get(key)
+	require.True(t, ok, "key %q missing", key)
+	sub, ok := v.(*orderedmap.OrderedMap)
+	require.True(t, ok, "key %q is not *OrderedMap", key)
+	return sub
+}
+
+func mustGet(t *testing.T, m *orderedmap.OrderedMap, key string) any {
+	t.Helper()
+	v, ok := m.Get(key)
+	require.True(t, ok, "key %q missing", key)
+	return v
+}

--- a/internal/pkg/service/stream/source/type/otlpsource/flatten_metrics.go
+++ b/internal/pkg/service/stream/source/type/otlpsource/flatten_metrics.go
@@ -1,0 +1,207 @@
+package otlpsource
+
+import (
+	"github.com/keboola/go-utils/pkg/orderedmap"
+	"go.opentelemetry.io/collector/pdata/pcommon"
+	"go.opentelemetry.io/collector/pdata/pmetric"
+)
+
+// FlattenMetrics explodes pmetric.Metrics into one FlatRecord per data point.
+//
+// Each metric type contributes type-specific fields (value for gauge/sum,
+// count/sum/bucket_counts/explicit_bounds for histogram, etc.). Fields that
+// don't apply to a given type are simply omitted from that record so the
+// column renderer's defaultValue applies — schemas can therefore include
+// every possible field and let unused ones fall back to defaults.
+func FlattenMetrics(metrics pmetric.Metrics) []FlatRecord {
+	records := make([]FlatRecord, 0, metrics.DataPointCount())
+
+	for i := 0; i < metrics.ResourceMetrics().Len(); i++ {
+		rm := metrics.ResourceMetrics().At(i)
+		resourceAttrs := attributesToMap(rm.Resource().Attributes())
+
+		for j := 0; j < rm.ScopeMetrics().Len(); j++ {
+			sm := rm.ScopeMetrics().At(j)
+			scopeMap := makeScopeMap(sm.Scope())
+
+			for k := 0; k < sm.Metrics().Len(); k++ {
+				m := sm.Metrics().At(k)
+				records = append(records, flattenMetric(m, resourceAttrs, scopeMap)...)
+			}
+		}
+	}
+
+	return records
+}
+
+func flattenMetric(
+	m pmetric.Metric,
+	resourceAttrs *orderedmap.OrderedMap,
+	scopeMap *orderedmap.OrderedMap,
+) []FlatRecord {
+	name, desc, unit := m.Name(), m.Description(), m.Unit()
+
+	switch m.Type() {
+	case pmetric.MetricTypeGauge:
+		return flattenNumberPoints(m.Gauge().DataPoints(), name, desc, unit, "gauge", resourceAttrs, scopeMap, nil)
+	case pmetric.MetricTypeSum:
+		sum := m.Sum()
+		sumExtras := func(rec *orderedmap.OrderedMap) {
+			rec.Set("is_monotonic", sum.IsMonotonic())
+			rec.Set("aggregation_temporality", sum.AggregationTemporality().String())
+		}
+		return flattenNumberPoints(sum.DataPoints(), name, desc, unit, "sum", resourceAttrs, scopeMap, sumExtras)
+	case pmetric.MetricTypeHistogram:
+		return flattenHistogramPoints(m.Histogram(), name, desc, unit, resourceAttrs, scopeMap)
+	case pmetric.MetricTypeExponentialHistogram:
+		return flattenExpHistogramPoints(m.ExponentialHistogram(), name, desc, unit, resourceAttrs, scopeMap)
+	case pmetric.MetricTypeSummary:
+		return flattenSummaryPoints(m.Summary(), name, desc, unit, resourceAttrs, scopeMap)
+	default:
+		return nil
+	}
+}
+
+func flattenNumberPoints(
+	dps pmetric.NumberDataPointSlice,
+	name, desc, unit, metricType string,
+	resourceAttrs, scopeMap *orderedmap.OrderedMap,
+	extras func(rec *orderedmap.OrderedMap),
+) []FlatRecord {
+	out := make([]FlatRecord, 0, dps.Len())
+	for i := 0; i < dps.Len(); i++ {
+		pt := dps.At(i)
+		rec := newMetricBase(name, desc, unit, metricType, resourceAttrs, scopeMap)
+		setDPTimestamps(rec, pt.StartTimestamp(), pt.Timestamp())
+		rec.Set("attributes", attributesToMap(pt.Attributes()))
+		rec.Set("value", numberDataPointValue(pt))
+		if extras != nil {
+			extras(rec)
+		}
+		out = append(out, FlatRecord{Body: rec})
+	}
+	return out
+}
+
+func flattenHistogramPoints(
+	h pmetric.Histogram,
+	name, desc, unit string,
+	resourceAttrs, scopeMap *orderedmap.OrderedMap,
+) []FlatRecord {
+	dps := h.DataPoints()
+	out := make([]FlatRecord, 0, dps.Len())
+	for i := 0; i < dps.Len(); i++ {
+		pt := dps.At(i)
+		rec := newMetricBase(name, desc, unit, "histogram", resourceAttrs, scopeMap)
+		setDPTimestamps(rec, pt.StartTimestamp(), pt.Timestamp())
+		rec.Set("attributes", attributesToMap(pt.Attributes()))
+		rec.Set("count", pt.Count())
+		if pt.HasSum() {
+			rec.Set("sum", pt.Sum())
+		}
+		if pt.HasMin() {
+			rec.Set("min", pt.Min())
+		}
+		if pt.HasMax() {
+			rec.Set("max", pt.Max())
+		}
+		rec.Set("bucket_counts", pt.BucketCounts().AsRaw())
+		rec.Set("explicit_bounds", pt.ExplicitBounds().AsRaw())
+		rec.Set("aggregation_temporality", h.AggregationTemporality().String())
+		out = append(out, FlatRecord{Body: rec})
+	}
+	return out
+}
+
+func flattenExpHistogramPoints(
+	h pmetric.ExponentialHistogram,
+	name, desc, unit string,
+	resourceAttrs, scopeMap *orderedmap.OrderedMap,
+) []FlatRecord {
+	dps := h.DataPoints()
+	out := make([]FlatRecord, 0, dps.Len())
+	for i := 0; i < dps.Len(); i++ {
+		pt := dps.At(i)
+		rec := newMetricBase(name, desc, unit, "exponential_histogram", resourceAttrs, scopeMap)
+		setDPTimestamps(rec, pt.StartTimestamp(), pt.Timestamp())
+		rec.Set("attributes", attributesToMap(pt.Attributes()))
+		rec.Set("count", pt.Count())
+		if pt.HasSum() {
+			rec.Set("sum", pt.Sum())
+		}
+		if pt.HasMin() {
+			rec.Set("min", pt.Min())
+		}
+		if pt.HasMax() {
+			rec.Set("max", pt.Max())
+		}
+		rec.Set("scale", pt.Scale())
+		rec.Set("zero_count", pt.ZeroCount())
+		rec.Set("aggregation_temporality", h.AggregationTemporality().String())
+		out = append(out, FlatRecord{Body: rec})
+	}
+	return out
+}
+
+func flattenSummaryPoints(
+	s pmetric.Summary,
+	name, desc, unit string,
+	resourceAttrs, scopeMap *orderedmap.OrderedMap,
+) []FlatRecord {
+	dps := s.DataPoints()
+	out := make([]FlatRecord, 0, dps.Len())
+	for i := 0; i < dps.Len(); i++ {
+		pt := dps.At(i)
+		rec := newMetricBase(name, desc, unit, "summary", resourceAttrs, scopeMap)
+		setDPTimestamps(rec, pt.StartTimestamp(), pt.Timestamp())
+		rec.Set("attributes", attributesToMap(pt.Attributes()))
+		rec.Set("count", pt.Count())
+		rec.Set("sum", pt.Sum())
+
+		qvSlice := pt.QuantileValues()
+		quantiles := make([]any, 0, qvSlice.Len())
+		for q := 0; q < qvSlice.Len(); q++ {
+			qp := qvSlice.At(q)
+			entry := orderedmap.New()
+			entry.Set("quantile", qp.Quantile())
+			entry.Set("value", qp.Value())
+			quantiles = append(quantiles, entry)
+		}
+		rec.Set("quantile_values", quantiles)
+		out = append(out, FlatRecord{Body: rec})
+	}
+	return out
+}
+
+func newMetricBase(
+	name, desc, unit, metricType string,
+	resourceAttrs, scopeMap *orderedmap.OrderedMap,
+) *orderedmap.OrderedMap {
+	rec := orderedmap.New()
+	rec.Set("metric_name", name)
+	rec.Set("metric_description", desc)
+	rec.Set("metric_unit", unit)
+	rec.Set("metric_type", metricType)
+	rec.Set("resource", resourceAttrs)
+	rec.Set("scope", scopeMap)
+	return rec
+}
+
+func setDPTimestamps(rec *orderedmap.OrderedMap, start, ts pcommon.Timestamp) {
+	rec.Set("start_timestamp", formatTimestamp(start))
+	rec.Set("timestamp", formatTimestamp(ts))
+}
+
+// numberDataPointValue returns the int or double payload of a number data
+// point, or nil for the empty value type. Returning nil rather than 0 lets
+// downstream consumers distinguish "no value reported" from "0".
+func numberDataPointValue(pt pmetric.NumberDataPoint) any {
+	switch pt.ValueType() {
+	case pmetric.NumberDataPointValueTypeInt:
+		return pt.IntValue()
+	case pmetric.NumberDataPointValueTypeDouble:
+		return pt.DoubleValue()
+	default:
+		return nil
+	}
+}

--- a/internal/pkg/service/stream/source/type/otlpsource/flatten_metrics_test.go
+++ b/internal/pkg/service/stream/source/type/otlpsource/flatten_metrics_test.go
@@ -1,0 +1,222 @@
+package otlpsource
+
+import (
+	"testing"
+	"time"
+
+	"github.com/keboola/go-utils/pkg/orderedmap"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	"go.opentelemetry.io/collector/pdata/pcommon"
+	"go.opentelemetry.io/collector/pdata/pmetric"
+)
+
+func TestFlattenMetrics_Empty(t *testing.T) {
+	t.Parallel()
+
+	assert.Empty(t, FlattenMetrics(pmetric.NewMetrics()))
+}
+
+func TestFlattenMetrics_Gauge_IntAndDouble(t *testing.T) {
+	t.Parallel()
+
+	metrics := pmetric.NewMetrics()
+	m := metrics.ResourceMetrics().AppendEmpty().ScopeMetrics().AppendEmpty().Metrics().AppendEmpty()
+	m.SetName("temperature")
+	m.SetUnit("C")
+	gauge := m.SetEmptyGauge()
+	gauge.DataPoints().AppendEmpty().SetIntValue(42)
+	gauge.DataPoints().AppendEmpty().SetDoubleValue(98.6)
+
+	records := FlattenMetrics(metrics)
+	require.Len(t, records, 2)
+
+	assert.Equal(t, "gauge", mustGet(t, records[0].Body, "metric_type"))
+	assert.Equal(t, "temperature", mustGet(t, records[0].Body, "metric_name"))
+	assert.Equal(t, "C", mustGet(t, records[0].Body, "metric_unit"))
+	assert.Equal(t, int64(42), mustGet(t, records[0].Body, "value"))
+	assert.InDelta(t, 98.6, mustGet(t, records[1].Body, "value"), 1e-9)
+}
+
+func TestFlattenMetrics_Gauge_EmptyValue(t *testing.T) {
+	t.Parallel()
+
+	metrics := pmetric.NewMetrics()
+	m := metrics.ResourceMetrics().AppendEmpty().ScopeMetrics().AppendEmpty().Metrics().AppendEmpty()
+	m.SetEmptyGauge().DataPoints().AppendEmpty() // no value set
+
+	records := FlattenMetrics(metrics)
+	require.Len(t, records, 1)
+	assert.Nil(t, mustGet(t, records[0].Body, "value"), "empty value type yields nil so consumers can distinguish from 0")
+}
+
+func TestFlattenMetrics_Sum_Discriminators(t *testing.T) {
+	t.Parallel()
+
+	metrics := pmetric.NewMetrics()
+	m := metrics.ResourceMetrics().AppendEmpty().ScopeMetrics().AppendEmpty().Metrics().AppendEmpty()
+	sum := m.SetEmptySum()
+	sum.SetIsMonotonic(true)
+	sum.SetAggregationTemporality(pmetric.AggregationTemporalityCumulative)
+	sum.DataPoints().AppendEmpty().SetIntValue(100)
+
+	records := FlattenMetrics(metrics)
+	require.Len(t, records, 1)
+	assert.Equal(t, "sum", mustGet(t, records[0].Body, "metric_type"))
+	assert.Equal(t, true, mustGet(t, records[0].Body, "is_monotonic"))
+	assert.Equal(t, "Cumulative", mustGet(t, records[0].Body, "aggregation_temporality"))
+}
+
+func TestFlattenMetrics_Histogram_AllFields(t *testing.T) {
+	t.Parallel()
+
+	metrics := pmetric.NewMetrics()
+	m := metrics.ResourceMetrics().AppendEmpty().ScopeMetrics().AppendEmpty().Metrics().AppendEmpty()
+	h := m.SetEmptyHistogram()
+	h.SetAggregationTemporality(pmetric.AggregationTemporalityDelta)
+	dp := h.DataPoints().AppendEmpty()
+	dp.SetCount(150)
+	dp.SetSum(4523.7)
+	dp.SetMin(1.2)
+	dp.SetMax(892.1)
+	dp.BucketCounts().FromRaw([]uint64{10, 50, 60, 20, 10})
+	dp.ExplicitBounds().FromRaw([]float64{5, 25, 50, 100})
+
+	records := FlattenMetrics(metrics)
+	require.Len(t, records, 1)
+	body := records[0].Body
+	assert.Equal(t, "histogram", mustGet(t, body, "metric_type"))
+	assert.Equal(t, uint64(150), mustGet(t, body, "count"))
+	assert.InDelta(t, 4523.7, mustGet(t, body, "sum"), 1e-9)
+	assert.InDelta(t, 1.2, mustGet(t, body, "min"), 1e-9)
+	assert.InDelta(t, 892.1, mustGet(t, body, "max"), 1e-9)
+	assert.Equal(t, []uint64{10, 50, 60, 20, 10}, mustGet(t, body, "bucket_counts"))
+	assert.Equal(t, []float64{5, 25, 50, 100}, mustGet(t, body, "explicit_bounds"))
+	assert.Equal(t, "Delta", mustGet(t, body, "aggregation_temporality"))
+}
+
+func TestFlattenMetrics_Histogram_OmitsOptionalSumMinMax(t *testing.T) {
+	t.Parallel()
+
+	metrics := pmetric.NewMetrics()
+	m := metrics.ResourceMetrics().AppendEmpty().ScopeMetrics().AppendEmpty().Metrics().AppendEmpty()
+	dp := m.SetEmptyHistogram().DataPoints().AppendEmpty()
+	dp.SetCount(10) // no sum/min/max
+	dp.BucketCounts().FromRaw([]uint64{10})
+
+	records := FlattenMetrics(metrics)
+	require.Len(t, records, 1)
+
+	_, hasSum := records[0].Body.Get("sum")
+	_, hasMin := records[0].Body.Get("min")
+	_, hasMax := records[0].Body.Get("max")
+	assert.False(t, hasSum, "sum absent when HasSum is false")
+	assert.False(t, hasMin)
+	assert.False(t, hasMax)
+}
+
+func TestFlattenMetrics_ExponentialHistogram(t *testing.T) {
+	t.Parallel()
+
+	metrics := pmetric.NewMetrics()
+	m := metrics.ResourceMetrics().AppendEmpty().ScopeMetrics().AppendEmpty().Metrics().AppendEmpty()
+	eh := m.SetEmptyExponentialHistogram()
+	eh.SetAggregationTemporality(pmetric.AggregationTemporalityCumulative)
+	dp := eh.DataPoints().AppendEmpty()
+	dp.SetCount(200)
+	dp.SetSum(123.4)
+	dp.SetScale(3)
+	dp.SetZeroCount(5)
+
+	records := FlattenMetrics(metrics)
+	require.Len(t, records, 1)
+	body := records[0].Body
+	assert.Equal(t, "exponential_histogram", mustGet(t, body, "metric_type"))
+	assert.Equal(t, uint64(200), mustGet(t, body, "count"))
+	assert.InDelta(t, 123.4, mustGet(t, body, "sum"), 1e-9)
+	assert.Equal(t, int32(3), mustGet(t, body, "scale"))
+	assert.Equal(t, uint64(5), mustGet(t, body, "zero_count"))
+}
+
+func TestFlattenMetrics_Summary_Quantiles(t *testing.T) {
+	t.Parallel()
+
+	metrics := pmetric.NewMetrics()
+	m := metrics.ResourceMetrics().AppendEmpty().ScopeMetrics().AppendEmpty().Metrics().AppendEmpty()
+	dp := m.SetEmptySummary().DataPoints().AppendEmpty()
+	dp.SetCount(1000)
+	dp.SetSum(50000)
+	q1 := dp.QuantileValues().AppendEmpty()
+	q1.SetQuantile(0.5)
+	q1.SetValue(40)
+	q2 := dp.QuantileValues().AppendEmpty()
+	q2.SetQuantile(0.99)
+	q2.SetValue(120)
+
+	records := FlattenMetrics(metrics)
+	require.Len(t, records, 1)
+	body := records[0].Body
+	assert.Equal(t, "summary", mustGet(t, body, "metric_type"))
+
+	qvs, ok := mustGet(t, body, "quantile_values").([]any)
+	require.True(t, ok)
+	require.Len(t, qvs, 2)
+
+	first, ok := qvs[0].(*orderedmap.OrderedMap)
+	require.True(t, ok)
+	assert.InDelta(t, 0.5, mustGet(t, first, "quantile"), 1e-9)
+	assert.InDelta(t, 40.0, mustGet(t, first, "value"), 1e-9)
+}
+
+func TestFlattenMetrics_TimestampsAndAttributes(t *testing.T) {
+	t.Parallel()
+
+	metrics := pmetric.NewMetrics()
+	rm := metrics.ResourceMetrics().AppendEmpty()
+	rm.Resource().Attributes().PutStr("service.name", "api")
+
+	sm := rm.ScopeMetrics().AppendEmpty()
+	sm.Scope().SetName("otel-sdk")
+
+	m := sm.Metrics().AppendEmpty()
+	m.SetName("latency")
+	dp := m.SetEmptyGauge().DataPoints().AppendEmpty()
+	dp.SetStartTimestamp(pcommon.NewTimestampFromTime(time.Date(2024, 1, 15, 10, 29, 0, 0, time.UTC)))
+	dp.SetTimestamp(pcommon.NewTimestampFromTime(time.Date(2024, 1, 15, 10, 30, 0, 0, time.UTC)))
+	dp.Attributes().PutStr("http.method", "GET")
+	dp.SetDoubleValue(1.5)
+
+	records := FlattenMetrics(metrics)
+	require.Len(t, records, 1)
+	body := records[0].Body
+
+	assert.Equal(t, "2024-01-15T10:29:00Z", mustGet(t, body, "start_timestamp"))
+	assert.Equal(t, "2024-01-15T10:30:00Z", mustGet(t, body, "timestamp"))
+	attrs := mustMap(t, body, "attributes")
+	assert.Equal(t, "GET", mustGet(t, attrs, "http.method"))
+	resource := mustMap(t, body, "resource")
+	assert.Equal(t, "api", mustGet(t, resource, "service.name"))
+	scope := mustMap(t, body, "scope")
+	assert.Equal(t, "otel-sdk", mustGet(t, scope, "name"))
+}
+
+func TestFlattenMetrics_MixedTypes_OneRecordPerDataPoint(t *testing.T) {
+	t.Parallel()
+
+	metrics := pmetric.NewMetrics()
+	sm := metrics.ResourceMetrics().AppendEmpty().ScopeMetrics().AppendEmpty()
+
+	g := sm.Metrics().AppendEmpty()
+	g.SetEmptyGauge().DataPoints().AppendEmpty().SetIntValue(1)
+	g.Gauge().DataPoints().AppendEmpty().SetIntValue(2)
+
+	s := sm.Metrics().AppendEmpty()
+	s.SetEmptySum().DataPoints().AppendEmpty().SetIntValue(3)
+
+	h := sm.Metrics().AppendEmpty()
+	h.SetEmptyHistogram().DataPoints().AppendEmpty().SetCount(4)
+
+	records := FlattenMetrics(metrics)
+	// 2 gauge + 1 sum + 1 histogram = 4 records
+	assert.Len(t, records, 4)
+}

--- a/internal/pkg/service/stream/source/type/otlpsource/flatten_traces.go
+++ b/internal/pkg/service/stream/source/type/otlpsource/flatten_traces.go
@@ -1,0 +1,92 @@
+package otlpsource
+
+import (
+	"github.com/keboola/go-utils/pkg/orderedmap"
+	"go.opentelemetry.io/collector/pdata/ptrace"
+)
+
+// FlattenTraces explodes ptrace.Traces into one FlatRecord per span. Span
+// events and links are kept nested under "events" / "links" rather than
+// exploded into separate records — they are intrinsically attached to their
+// parent span and would lose meaning if dispatched independently.
+//
+// parent_span_id is omitted when empty so the column renderer's defaultValue
+// applies; trace_state is always emitted (empty string is the common case
+// and the column may want to distinguish "present but empty" from "absent").
+func FlattenTraces(traces ptrace.Traces) []FlatRecord {
+	records := make([]FlatRecord, 0, traces.SpanCount())
+
+	for i := 0; i < traces.ResourceSpans().Len(); i++ {
+		rs := traces.ResourceSpans().At(i)
+		resourceAttrs := attributesToMap(rs.Resource().Attributes())
+
+		for j := 0; j < rs.ScopeSpans().Len(); j++ {
+			ss := rs.ScopeSpans().At(j)
+			scopeMap := makeScopeMap(ss.Scope())
+
+			for k := 0; k < ss.Spans().Len(); k++ {
+				span := ss.Spans().At(k)
+				records = append(records, FlatRecord{Body: flattenSpan(span, resourceAttrs, scopeMap)})
+			}
+		}
+	}
+
+	return records
+}
+
+func flattenSpan(
+	span ptrace.Span,
+	resourceAttrs *orderedmap.OrderedMap,
+	scopeMap *orderedmap.OrderedMap,
+) *orderedmap.OrderedMap {
+	rec := orderedmap.New()
+	rec.Set("timestamp", formatTimestamp(span.StartTimestamp()))
+	rec.Set("end_timestamp", formatTimestamp(span.EndTimestamp()))
+	rec.Set("trace_id", span.TraceID().String())
+	rec.Set("span_id", span.SpanID().String())
+
+	if parentSpanID := span.ParentSpanID(); !parentSpanID.IsEmpty() {
+		rec.Set("parent_span_id", parentSpanID.String())
+	}
+
+	rec.Set("trace_state", span.TraceState().AsRaw())
+	rec.Set("name", span.Name())
+	rec.Set("kind", span.Kind().String())
+	rec.Set("flags", span.Flags())
+	rec.Set("status_code", span.Status().Code().String())
+	rec.Set("status_message", span.Status().Message())
+	rec.Set("attributes", attributesToMap(span.Attributes()))
+	rec.Set("events", flattenSpanEvents(span.Events()))
+	rec.Set("links", flattenSpanLinks(span.Links()))
+	rec.Set("resource", resourceAttrs)
+	rec.Set("scope", scopeMap)
+	return rec
+}
+
+func flattenSpanEvents(events ptrace.SpanEventSlice) []any {
+	out := make([]any, 0, events.Len())
+	for i := 0; i < events.Len(); i++ {
+		e := events.At(i)
+		entry := orderedmap.New()
+		entry.Set("timestamp", formatTimestamp(e.Timestamp()))
+		entry.Set("name", e.Name())
+		entry.Set("attributes", attributesToMap(e.Attributes()))
+		out = append(out, entry)
+	}
+	return out
+}
+
+func flattenSpanLinks(links ptrace.SpanLinkSlice) []any {
+	out := make([]any, 0, links.Len())
+	for i := 0; i < links.Len(); i++ {
+		l := links.At(i)
+		entry := orderedmap.New()
+		entry.Set("trace_id", l.TraceID().String())
+		entry.Set("span_id", l.SpanID().String())
+		entry.Set("trace_state", l.TraceState().AsRaw())
+		entry.Set("attributes", attributesToMap(l.Attributes()))
+		entry.Set("flags", l.Flags())
+		out = append(out, entry)
+	}
+	return out
+}

--- a/internal/pkg/service/stream/source/type/otlpsource/flatten_traces_test.go
+++ b/internal/pkg/service/stream/source/type/otlpsource/flatten_traces_test.go
@@ -1,0 +1,159 @@
+package otlpsource
+
+import (
+	"testing"
+	"time"
+
+	"github.com/keboola/go-utils/pkg/orderedmap"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	"go.opentelemetry.io/collector/pdata/pcommon"
+	"go.opentelemetry.io/collector/pdata/ptrace"
+)
+
+func TestFlattenTraces_Empty(t *testing.T) {
+	t.Parallel()
+
+	assert.Empty(t, FlattenTraces(ptrace.NewTraces()))
+}
+
+func TestFlattenTraces_SingleSpan_AllFields(t *testing.T) {
+	t.Parallel()
+
+	traces := ptrace.NewTraces()
+	rs := traces.ResourceSpans().AppendEmpty()
+	rs.Resource().Attributes().PutStr("service.name", "api-gateway")
+	ss := rs.ScopeSpans().AppendEmpty()
+	ss.Scope().SetName("otel-sdk")
+
+	span := ss.Spans().AppendEmpty()
+	span.SetTraceID(pcommon.TraceID([16]byte{1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15, 16}))
+	span.SetSpanID(pcommon.SpanID([8]byte{1, 2, 3, 4, 5, 6, 7, 8}))
+	span.SetParentSpanID(pcommon.SpanID([8]byte{8, 7, 6, 5, 4, 3, 2, 1}))
+	span.SetName("GET /api/users")
+	span.SetKind(ptrace.SpanKindServer)
+	span.SetStartTimestamp(pcommon.NewTimestampFromTime(time.Date(2024, 1, 15, 10, 30, 0, 0, time.UTC)))
+	span.SetEndTimestamp(pcommon.NewTimestampFromTime(time.Date(2024, 1, 15, 10, 30, 0, 200000000, time.UTC)))
+	span.TraceState().FromRaw("vendor1=v1")
+	span.Status().SetCode(ptrace.StatusCodeOk)
+	span.Status().SetMessage("ok")
+	span.Attributes().PutStr("http.method", "GET")
+
+	records := FlattenTraces(traces)
+	require.Len(t, records, 1)
+	body := records[0].Body
+
+	assert.Equal(t, "0102030405060708090a0b0c0d0e0f10", mustGet(t, body, "trace_id"))
+	assert.Equal(t, "0102030405060708", mustGet(t, body, "span_id"))
+	assert.Equal(t, "0807060504030201", mustGet(t, body, "parent_span_id"))
+	assert.Equal(t, "GET /api/users", mustGet(t, body, "name"))
+	assert.Equal(t, "Server", mustGet(t, body, "kind"))
+	assert.Equal(t, "2024-01-15T10:30:00Z", mustGet(t, body, "timestamp"))
+	assert.Equal(t, "2024-01-15T10:30:00.2Z", mustGet(t, body, "end_timestamp"))
+	assert.Equal(t, "vendor1=v1", mustGet(t, body, "trace_state"))
+	assert.Equal(t, "Ok", mustGet(t, body, "status_code"))
+	assert.Equal(t, "ok", mustGet(t, body, "status_message"))
+
+	attrs := mustMap(t, body, "attributes")
+	assert.Equal(t, "GET", mustGet(t, attrs, "http.method"))
+	resource := mustMap(t, body, "resource")
+	assert.Equal(t, "api-gateway", mustGet(t, resource, "service.name"))
+}
+
+func TestFlattenTraces_OmitsEmptyParentSpanID(t *testing.T) {
+	t.Parallel()
+
+	traces := ptrace.NewTraces()
+	traces.ResourceSpans().AppendEmpty().ScopeSpans().AppendEmpty().Spans().AppendEmpty().SetName("root")
+
+	records := FlattenTraces(traces)
+	require.Len(t, records, 1)
+
+	_, ok := records[0].Body.Get("parent_span_id")
+	assert.False(t, ok, "parent_span_id should be absent for root spans so defaultValue applies")
+}
+
+func TestFlattenTraces_Events(t *testing.T) {
+	t.Parallel()
+
+	traces := ptrace.NewTraces()
+	span := traces.ResourceSpans().AppendEmpty().ScopeSpans().AppendEmpty().Spans().AppendEmpty()
+	ev := span.Events().AppendEmpty()
+	ev.SetName("cache.hit")
+	ev.SetTimestamp(pcommon.NewTimestampFromTime(time.Date(2024, 1, 15, 10, 30, 0, 100000000, time.UTC)))
+	ev.Attributes().PutStr("cache.key", "users-list")
+
+	records := FlattenTraces(traces)
+	require.Len(t, records, 1)
+
+	events, ok := mustGet(t, records[0].Body, "events").([]any)
+	require.True(t, ok)
+	require.Len(t, events, 1)
+
+	first, ok := events[0].(*orderedmap.OrderedMap)
+	require.True(t, ok)
+	assert.Equal(t, "cache.hit", mustGet(t, first, "name"))
+	assert.Equal(t, "2024-01-15T10:30:00.1Z", mustGet(t, first, "timestamp"))
+	eventAttrs := mustMap(t, first, "attributes")
+	assert.Equal(t, "users-list", mustGet(t, eventAttrs, "cache.key"))
+}
+
+func TestFlattenTraces_Links(t *testing.T) {
+	t.Parallel()
+
+	traces := ptrace.NewTraces()
+	span := traces.ResourceSpans().AppendEmpty().ScopeSpans().AppendEmpty().Spans().AppendEmpty()
+	link := span.Links().AppendEmpty()
+	link.SetTraceID(pcommon.TraceID([16]byte{0xa, 0xb, 0xc, 0xd, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0}))
+	link.SetSpanID(pcommon.SpanID([8]byte{0xa, 0xb, 0xc, 0xd, 0, 0, 0, 0}))
+	link.TraceState().FromRaw("vendor=x")
+	link.Attributes().PutStr("relation", "follows-from")
+
+	records := FlattenTraces(traces)
+	require.Len(t, records, 1)
+
+	links, ok := mustGet(t, records[0].Body, "links").([]any)
+	require.True(t, ok)
+	require.Len(t, links, 1)
+
+	first, ok := links[0].(*orderedmap.OrderedMap)
+	require.True(t, ok)
+	assert.Equal(t, "0a0b0c0d000000000000000000000000", mustGet(t, first, "trace_id"))
+	assert.Equal(t, "0a0b0c0d00000000", mustGet(t, first, "span_id"))
+	assert.Equal(t, "vendor=x", mustGet(t, first, "trace_state"))
+	linkAttrs := mustMap(t, first, "attributes")
+	assert.Equal(t, "follows-from", mustGet(t, linkAttrs, "relation"))
+}
+
+func TestFlattenTraces_CombinatorialExplosion(t *testing.T) {
+	t.Parallel()
+
+	traces := ptrace.NewTraces()
+	for r := 0; r < 2; r++ {
+		rs := traces.ResourceSpans().AppendEmpty()
+		for s := 0; s < 3; s++ {
+			ss := rs.ScopeSpans().AppendEmpty()
+			for k := 0; k < 4; k++ {
+				ss.Spans().AppendEmpty().SetName("span")
+			}
+		}
+	}
+
+	records := FlattenTraces(traces)
+	assert.Len(t, records, 2*3*4)
+}
+
+func TestFlattenTraces_EmptyEventsAndLinks(t *testing.T) {
+	t.Parallel()
+
+	traces := ptrace.NewTraces()
+	traces.ResourceSpans().AppendEmpty().ScopeSpans().AppendEmpty().Spans().AppendEmpty().SetName("simple")
+
+	records := FlattenTraces(traces)
+	require.Len(t, records, 1)
+
+	events, _ := records[0].Body.Get("events")
+	links, _ := records[0].Body.Get("links")
+	assert.Equal(t, []any{}, events, "empty events should be present as []any{}")
+	assert.Equal(t, []any{}, links, "empty links should be present as []any{}")
+}

--- a/internal/pkg/service/stream/source/type/otlpsource/handler.go
+++ b/internal/pkg/service/stream/source/type/otlpsource/handler.go
@@ -1,0 +1,172 @@
+package otlpsource
+
+import (
+	"context"
+	"net/http"
+	"sort"
+	"strconv"
+
+	"github.com/jonboulle/clockwork"
+	"github.com/keboola/go-utils/pkg/orderedmap"
+	"github.com/keboola/keboola-sdk-go/v2/pkg/keboola"
+	routing "github.com/qiangxue/fasthttp-routing"
+	"github.com/valyala/fasthttp"
+
+	"github.com/keboola/keboola-as-code/internal/pkg/log"
+	svcerrors "github.com/keboola/keboola-as-code/internal/pkg/service/common/errors"
+	"github.com/keboola/keboola-as-code/internal/pkg/service/stream/definition/key"
+	"github.com/keboola/keboola-as-code/internal/pkg/service/stream/source/dispatcher"
+	"github.com/keboola/keboola-as-code/internal/pkg/telemetry"
+	"github.com/keboola/keboola-as-code/internal/pkg/utils/errors"
+)
+
+// ErrorHandler is the function signature used by httpsource to write errors.
+// Re-typed here to avoid a cyclic import.
+type ErrorHandler func(c *fasthttp.RequestCtx, err error)
+
+// Handler implements the OTLP/HTTP endpoints. It is intentionally lightweight —
+// state-free except for its dependencies — so a single instance can serve
+// concurrent requests through the same fasthttp server as the HTTP source.
+type Handler struct {
+	ctx          context.Context
+	logger       log.Logger
+	clock        clockwork.Clock
+	dispatcher   *dispatcher.Dispatcher
+	errorHandler ErrorHandler
+}
+
+// New creates a Handler ready to serve OTLP requests.
+//
+// ctx is the long-lived service context (used to derive per-record contexts
+// with tracing disabled, matching the HTTP source hot-path optimization).
+func New(
+	ctx context.Context,
+	logger log.Logger,
+	clock clockwork.Clock,
+	dp *dispatcher.Dispatcher,
+	errorHandler ErrorHandler,
+) *Handler {
+	return &Handler{
+		ctx:          ctx,
+		logger:       logger.WithComponent("otlp-source"),
+		clock:        clock,
+		dispatcher:   dp,
+		errorHandler: errorHandler,
+	}
+}
+
+// HandleLogs serves POST /v1/logs.
+//
+// On well-formed input it always returns HTTP 200 with an OTLP-conformant
+// response body (possibly with partial_success). It only returns 4xx/5xx for
+// transport-level problems: malformed body, unsupported encoding, missing
+// source. This matches OTLP retry semantics: 4xx means "do not retry",
+// 5xx means "retry the whole batch".
+func (h *Handler) HandleLogs(c *routing.Context) error {
+	projectID, sourceID, secret, err := parseAuthParams(c)
+	if err != nil {
+		h.errorHandler(c.RequestCtx, err)
+		return nil //nolint:nilerr
+	}
+
+	enc := DetectEncoding(string(c.Request.Header.Peek("Content-Type")))
+	if enc == EncodingUnsupported {
+		h.errorHandler(c.RequestCtx, svcerrors.NewUnsupportedMediaTypeError(
+			errors.New(`unsupported OTLP content type, expected "application/x-protobuf" or "application/json"`),
+		))
+		return nil
+	}
+
+	body, err := DecompressIfGzip(string(c.Request.Header.Peek("Content-Encoding")), c.Request.Body())
+	if err != nil {
+		h.errorHandler(c.RequestCtx, svcerrors.NewBadRequestError(err))
+		return nil //nolint:nilerr
+	}
+
+	logs, err := DecodeLogs(body, enc)
+	if err != nil {
+		h.errorHandler(c.RequestCtx, svcerrors.NewBadRequestError(
+			errors.PrefixError(err, "cannot decode OTLP logs payload"),
+		))
+		return nil //nolint:nilerr
+	}
+
+	records := FlattenLogs(logs)
+
+	// Empty batches are valid per the OTLP spec — return 200 immediately.
+	if len(records) == 0 {
+		h.writeEmptySuccess(c, enc)
+		return nil
+	}
+
+	ctx := telemetry.ContextWithDisabledTracing(h.ctx)
+	headers := headersToOrderedMap(c.RequestCtx)
+	result := DispatchRecords(
+		ctx,
+		h.dispatcher,
+		h.clock.Now(),
+		c.RequestCtx.RemoteIP(),
+		headers,
+		projectID,
+		sourceID,
+		secret,
+		records,
+	)
+
+	encoded, err := BuildLogsResponse(enc, result)
+	if err != nil {
+		h.errorHandler(c.RequestCtx, err)
+		return nil //nolint:nilerr
+	}
+
+	c.Response.SetStatusCode(encoded.StatusCode)
+	if encoded.ContentType != "" {
+		c.Response.Header.Set("Content-Type", encoded.ContentType)
+	}
+	c.Response.SetBody(encoded.Body)
+	return nil
+}
+
+// HandleOptions serves OPTIONS for CORS preflight, matching the existing
+// /stream/... pattern.
+func (h *Handler) HandleOptions(c *routing.Context) error {
+	c.Response.Header.Set("Allow", "OPTIONS, POST")
+	c.Response.Header.Set("Access-Control-Allow-Methods", "OPTIONS, POST")
+	c.Response.Header.Set("Access-Control-Allow-Headers", "*")
+	c.Response.Header.Set("Access-Control-Expose-Headers", "*")
+	c.Response.Header.Set("Access-Control-Allow-Origin", "*")
+	c.Response.SetStatusCode(http.StatusOK)
+	return nil
+}
+
+func (h *Handler) writeEmptySuccess(c *routing.Context, enc Encoding) {
+	encoded, err := BuildLogsResponse(enc, DispatchResult{})
+	if err != nil {
+		h.errorHandler(c.RequestCtx, err)
+		return
+	}
+	c.Response.SetStatusCode(encoded.StatusCode)
+	c.Response.Header.Set("Content-Type", encoded.ContentType)
+	c.Response.SetBody(encoded.Body)
+}
+
+func parseAuthParams(c *routing.Context) (keboola.ProjectID, key.SourceID, string, error) {
+	projectIDStr := c.Param("projectID")
+	projectIDInt, err := strconv.Atoi(projectIDStr)
+	if err != nil {
+		return 0, "", "", svcerrors.NewBadRequestError(errors.Errorf("invalid project ID %q", projectIDStr))
+	}
+	return keboola.ProjectID(projectIDInt), key.SourceID(c.Param("sourceID")), c.Param("secret"), nil
+}
+
+func headersToOrderedMap(reqCtx *fasthttp.RequestCtx) *orderedmap.OrderedMap {
+	out := orderedmap.New()
+	for _, k := range reqCtx.Request.Header.PeekKeys() {
+		key := string(k)
+		out.Set(http.CanonicalHeaderKey(key), string(reqCtx.Request.Header.Peek(key)))
+	}
+	out.SortKeys(func(keys []string) {
+		sort.Strings(keys)
+	})
+	return out
+}

--- a/internal/pkg/service/stream/source/type/otlpsource/handler.go
+++ b/internal/pkg/service/stream/source/type/otlpsource/handler.go
@@ -55,6 +55,14 @@ func New(
 	}
 }
 
+// signalDecoder is "decode the request body into N flat records". It bundles
+// the signal-specific decode (plog/pmetric/ptrace) with its flatten so the
+// shared handle() helper does not need to know which signal it is serving.
+type signalDecoder func(body []byte, enc Encoding) ([]FlatRecord, error)
+
+// responseBuilder constructs the signal-specific OTLP response body.
+type responseBuilder func(enc Encoding, result DispatchResult) (EncodedResponse, error)
+
 // HandleLogs serves POST /v1/logs.
 //
 // On well-formed input it always returns HTTP 200 with an OTLP-conformant
@@ -63,6 +71,24 @@ func New(
 // source. This matches OTLP retry semantics: 4xx means "do not retry",
 // 5xx means "retry the whole batch".
 func (h *Handler) HandleLogs(c *routing.Context) error {
+	return h.handle(c, "logs", decodeAndFlattenLogs, BuildLogsResponse)
+}
+
+// HandleMetrics serves POST /v1/metrics. One OTLP request typically carries
+// many metrics, each with many data points; flatten emits one record per
+// data point, so a single request can dispatch hundreds.
+func (h *Handler) HandleMetrics(c *routing.Context) error {
+	return h.handle(c, "metrics", decodeAndFlattenMetrics, BuildMetricsResponse)
+}
+
+// HandleTraces serves POST /v1/traces. Span events and links are kept nested
+// under the span rather than exploded into separate records — they are
+// intrinsically attached to their parent span.
+func (h *Handler) HandleTraces(c *routing.Context) error {
+	return h.handle(c, "traces", decodeAndFlattenTraces, BuildTracesResponse)
+}
+
+func (h *Handler) handle(c *routing.Context, signal string, decode signalDecoder, build responseBuilder) error {
 	projectID, sourceID, secret, err := parseAuthParams(c)
 	if err != nil {
 		h.errorHandler(c.RequestCtx, err)
@@ -83,19 +109,17 @@ func (h *Handler) HandleLogs(c *routing.Context) error {
 		return nil //nolint:nilerr
 	}
 
-	logs, err := DecodeLogs(body, enc)
+	records, err := decode(body, enc)
 	if err != nil {
 		h.errorHandler(c.RequestCtx, svcerrors.NewBadRequestError(
-			errors.PrefixError(err, "cannot decode OTLP logs payload"),
+			errors.PrefixError(err, "cannot decode OTLP "+signal+" payload"),
 		))
 		return nil //nolint:nilerr
 	}
 
-	records := FlattenLogs(logs)
-
 	// Empty batches are valid per the OTLP spec — return 200 immediately.
 	if len(records) == 0 {
-		h.writeEmptySuccess(c, enc)
+		h.writeEmptySuccess(c, enc, build)
 		return nil
 	}
 
@@ -113,7 +137,7 @@ func (h *Handler) HandleLogs(c *routing.Context) error {
 		records,
 	)
 
-	encoded, err := BuildLogsResponse(enc, result)
+	encoded, err := build(enc, result)
 	if err != nil {
 		h.errorHandler(c.RequestCtx, err)
 		return nil //nolint:nilerr
@@ -125,6 +149,30 @@ func (h *Handler) HandleLogs(c *routing.Context) error {
 	}
 	c.Response.SetBody(encoded.Body)
 	return nil
+}
+
+func decodeAndFlattenLogs(body []byte, enc Encoding) ([]FlatRecord, error) {
+	logs, err := DecodeLogs(body, enc)
+	if err != nil {
+		return nil, err
+	}
+	return FlattenLogs(logs), nil
+}
+
+func decodeAndFlattenMetrics(body []byte, enc Encoding) ([]FlatRecord, error) {
+	metrics, err := DecodeMetrics(body, enc)
+	if err != nil {
+		return nil, err
+	}
+	return FlattenMetrics(metrics), nil
+}
+
+func decodeAndFlattenTraces(body []byte, enc Encoding) ([]FlatRecord, error) {
+	traces, err := DecodeTraces(body, enc)
+	if err != nil {
+		return nil, err
+	}
+	return FlattenTraces(traces), nil
 }
 
 // HandleOptions serves OPTIONS for CORS preflight, matching the existing
@@ -139,8 +187,8 @@ func (h *Handler) HandleOptions(c *routing.Context) error {
 	return nil
 }
 
-func (h *Handler) writeEmptySuccess(c *routing.Context, enc Encoding) {
-	encoded, err := BuildLogsResponse(enc, DispatchResult{})
+func (h *Handler) writeEmptySuccess(c *routing.Context, enc Encoding, build responseBuilder) {
+	encoded, err := build(enc, DispatchResult{})
 	if err != nil {
 		h.errorHandler(c.RequestCtx, err)
 		return

--- a/internal/pkg/service/stream/source/type/otlpsource/response.go
+++ b/internal/pkg/service/stream/source/type/otlpsource/response.go
@@ -1,0 +1,93 @@
+package otlpsource
+
+import (
+	"strconv"
+
+	logspb "go.opentelemetry.io/proto/otlp/collector/logs/v1"
+	"google.golang.org/protobuf/encoding/protojson"
+	"google.golang.org/protobuf/proto"
+
+	"github.com/keboola/keboola-as-code/internal/pkg/utils/errors"
+)
+
+// EncodedResponse holds a marshaled OTLP response body and its Content-Type.
+// The handler writes both to the HTTP response.
+type EncodedResponse struct {
+	StatusCode  int
+	ContentType string
+	Body        []byte
+}
+
+// BuildLogsResponse builds the OTLP ExportLogsServiceResponse for a dispatched
+// batch. Per OTLP spec the response Content-Type must match the request.
+//
+// Success vs partial-success vs top-level error:
+//   - All records dispatched OK: 200 with empty ExportLogsServiceResponse.
+//   - Some records rejected, no top-level failure: 200 with partial_success
+//     populated. The OTLP client SHOULD NOT retry rejected records.
+//   - All records failed with the same retryable status (5xx, 429): return
+//     that status code; the OTLP client SHOULD retry the entire batch.
+//
+// We choose top-level error when result.Rejected == result.Total AND
+// result.WorstStatusCode is retryable (5xx or 429). Otherwise we return 200
+// with partial_success so non-retryable rejections (4xx) are not retried.
+func BuildLogsResponse(enc Encoding, result DispatchResult) (EncodedResponse, error) {
+	if result.Rejected > 0 && result.Rejected == result.Total && isRetryable(result.WorstStatusCode) {
+		return EncodedResponse{StatusCode: result.WorstStatusCode}, nil
+	}
+
+	resp := &logspb.ExportLogsServiceResponse{}
+	if result.Rejected > 0 {
+		resp.PartialSuccess = &logspb.ExportLogsPartialSuccess{
+			RejectedLogRecords: int64(result.Rejected),
+			ErrorMessage:       formatRejectionMessage(result),
+		}
+	}
+
+	body, err := marshal(enc, resp)
+	if err != nil {
+		return EncodedResponse{}, err
+	}
+
+	return EncodedResponse{
+		StatusCode:  200,
+		ContentType: enc.ContentType(),
+		Body:        body,
+	}, nil
+}
+
+func marshal(enc Encoding, msg proto.Message) ([]byte, error) {
+	switch enc {
+	case EncodingProtobuf:
+		b, err := proto.Marshal(msg)
+		if err != nil {
+			return nil, errors.PrefixError(err, "cannot marshal OTLP response as protobuf")
+		}
+		return b, nil
+	case EncodingJSON:
+		b, err := protojson.Marshal(msg)
+		if err != nil {
+			return nil, errors.PrefixError(err, "cannot marshal OTLP response as JSON")
+		}
+		return b, nil
+	default:
+		return nil, errors.New("unsupported OTLP encoding for response")
+	}
+}
+
+func formatRejectionMessage(r DispatchResult) string {
+	if r.FirstError == nil {
+		return strconv.Itoa(r.Rejected) + " of " + strconv.Itoa(r.Total) + " records rejected"
+	}
+	return strconv.Itoa(r.Rejected) + " of " + strconv.Itoa(r.Total) +
+		" records rejected; first error: " + r.FirstError.Error()
+}
+
+// isRetryable maps a Stream error status code to OTLP retry semantics.
+// 5xx and 429 are retryable per the OTLP spec.
+func isRetryable(statusCode int) bool {
+	if statusCode == 429 {
+		return true
+	}
+	return statusCode >= 500 && statusCode < 600
+}

--- a/internal/pkg/service/stream/source/type/otlpsource/response.go
+++ b/internal/pkg/service/stream/source/type/otlpsource/response.go
@@ -4,6 +4,8 @@ import (
 	"strconv"
 
 	logspb "go.opentelemetry.io/proto/otlp/collector/logs/v1"
+	metricspb "go.opentelemetry.io/proto/otlp/collector/metrics/v1"
+	tracespb "go.opentelemetry.io/proto/otlp/collector/trace/v1"
 	"google.golang.org/protobuf/encoding/protojson"
 	"google.golang.org/protobuf/proto"
 
@@ -32,7 +34,7 @@ type EncodedResponse struct {
 // result.WorstStatusCode is retryable (5xx or 429). Otherwise we return 200
 // with partial_success so non-retryable rejections (4xx) are not retried.
 func BuildLogsResponse(enc Encoding, result DispatchResult) (EncodedResponse, error) {
-	if result.Rejected > 0 && result.Rejected == result.Total && isRetryable(result.WorstStatusCode) {
+	if shouldEscalateToError(result) {
 		return EncodedResponse{StatusCode: result.WorstStatusCode}, nil
 	}
 
@@ -43,12 +45,54 @@ func BuildLogsResponse(enc Encoding, result DispatchResult) (EncodedResponse, er
 			ErrorMessage:       formatRejectionMessage(result),
 		}
 	}
+	return encode(enc, resp)
+}
 
-	body, err := marshal(enc, resp)
+// BuildMetricsResponse mirrors BuildLogsResponse for metric data points.
+func BuildMetricsResponse(enc Encoding, result DispatchResult) (EncodedResponse, error) {
+	if shouldEscalateToError(result) {
+		return EncodedResponse{StatusCode: result.WorstStatusCode}, nil
+	}
+
+	resp := &metricspb.ExportMetricsServiceResponse{}
+	if result.Rejected > 0 {
+		resp.PartialSuccess = &metricspb.ExportMetricsPartialSuccess{
+			RejectedDataPoints: int64(result.Rejected),
+			ErrorMessage:       formatRejectionMessage(result),
+		}
+	}
+	return encode(enc, resp)
+}
+
+// BuildTracesResponse mirrors BuildLogsResponse for spans.
+func BuildTracesResponse(enc Encoding, result DispatchResult) (EncodedResponse, error) {
+	if shouldEscalateToError(result) {
+		return EncodedResponse{StatusCode: result.WorstStatusCode}, nil
+	}
+
+	resp := &tracespb.ExportTraceServiceResponse{}
+	if result.Rejected > 0 {
+		resp.PartialSuccess = &tracespb.ExportTracePartialSuccess{
+			RejectedSpans: int64(result.Rejected),
+			ErrorMessage:  formatRejectionMessage(result),
+		}
+	}
+	return encode(enc, resp)
+}
+
+// shouldEscalateToError returns true when every record failed AND with a
+// retryable status. That signals the client to retry the entire batch.
+// Mixed outcomes and non-retryable rejections stay at 200 with partial_success
+// so clients do not retry rejected records that will not succeed.
+func shouldEscalateToError(r DispatchResult) bool {
+	return r.Rejected > 0 && r.Rejected == r.Total && isRetryable(r.WorstStatusCode)
+}
+
+func encode(enc Encoding, msg proto.Message) (EncodedResponse, error) {
+	body, err := marshal(enc, msg)
 	if err != nil {
 		return EncodedResponse{}, err
 	}
-
 	return EncodedResponse{
 		StatusCode:  200,
 		ContentType: enc.ContentType(),


### PR DESCRIPTION
## Summary

Adds a native **OTLP/HTTP** receiver to the Stream HTTP source so any OpenTelemetry SDK can export **logs, metrics, and traces** directly to Keboola — no Collector sidecar, no Docker, just an env var:

```bash
export OTEL_EXPORTER_OTLP_ENDPOINT=https://stream.keboola.com/otlp/<projectID>/<sourceID>/<secret>
```

The handler rides on the existing fasthttp server and dispatcher. It decodes the relevant OTLP request (protobuf or JSON, optional gzip), flattens the nested `resource → scope → record` tree into one `*orderedmap.OrderedMap` per record/data-point/span, and dispatches each through the standard pipeline via a new `recordctx.Context` implementation. The sink router, column renderer, and sinks are unchanged.

### How it fits together

```
POST /otlp/<projectID>/<sourceID>/<secret>/v1/{logs|metrics|traces}
        │
        ├─ DetectEncoding (Content-Type)
        ├─ DecompressIfGzip (Content-Encoding)
        ├─ Decode{Logs|Metrics|Traces} → pdata
        ├─ Flatten{Logs|Metrics|Traces} → []FlatRecord    (1 request → N records)
        └─ DispatchRecords
              │ for each record:
              │   recordctx.FromOTLP(...)
              │   dispatcher.Dispatch(...)                  (existing pipeline)
              └─ Build{Logs|Metrics|Traces}Response          (OTLP partial_success / 5xx)
```

### Signal coverage

| Signal | Route | One record per |
|---|---|---|
| Logs | `POST /v1/logs` | LogRecord |
| Metrics | `POST /v1/metrics` | data point (any of gauge / sum / histogram / exponential_histogram / summary) |
| Traces | `POST /v1/traces` | Span (events and links nested under the span) |

Metric type-specific fields (`value`, `count`, `bucket_counts`, `quantile_values`, `is_monotonic`, `aggregation_temporality`, …) are emitted only when they apply — Path columns fall back to `defaultValue` for fields that don't apply to a given metric type.

### Response semantics (OTLP-conformant)

| Outcome | Status | Body |
|---|---|---|
| All records dispatched OK | `200` | empty service response |
| Some records rejected | `200` | `partial_success` with rejected count (client should NOT retry) |
| All records rejected, retryable | `5xx` / `429` | top-level error (client SHOULD retry the batch) |
| Malformed body / unsupported encoding | `400` / `415` | existing httpsource error shape |

Response `Content-Type` always matches the request (`application/x-protobuf` or `application/json`).

### What's new

| File | Purpose |
|---|---|
| `source/type/otlpsource/config.go` | Phase-1 Config (`Enabled` flag) |
| `source/type/otlpsource/decode.go` | Content-Type detection, gzip decompress, plog/pmetric/ptrace proto+JSON unmarshal |
| `source/type/otlpsource/flatten_common.go` | `attributesToMap`, `anyValueToInterface`, `formatTimestamp`, `makeScopeMap` |
| `source/type/otlpsource/flatten_logs.go` | `FlattenLogs`: 1 request → N records |
| `source/type/otlpsource/flatten_metrics.go` | `FlattenMetrics` for all five metric types |
| `source/type/otlpsource/flatten_traces.go` | `FlattenTraces` with nested events + links |
| `source/type/otlpsource/dispatch.go` | Sequential dispatch loop, aggregated `DispatchResult` |
| `source/type/otlpsource/response.go` | `BuildLogsResponse` / `BuildMetricsResponse` / `BuildTracesResponse` with partial-success / 5xx escalation |
| `source/type/otlpsource/handler.go` | Signal-agnostic `handle()` parameterized by decode + response-build function values |
| `mapping/recordctx/otlp.go` | New `Context` wrapping a pre-flattened bodyMap |
| `source/type/httpsource/httpsource.go` | Route registration: `POST/OPTIONS /otlp/.../v1/{logs,metrics,traces}` |
| `go.mod` | `pdata` and `proto/otlp` promoted from indirect → direct (both were already pulled in transitively) |

### Tests

- `decode_test.go` — encoding detection, gzip decompress, proto/JSON roundtrip for all three signals, invalid inputs
- `flatten_logs_test.go` — combinatorial fan-out, all `pcommon.Value` types, optional ID omission
- `flatten_metrics_test.go` — all 5 metric types, optional sum/min/max omission for histograms, quantile values for summary, mixed-type batches
- `flatten_traces_test.go` — full span shape, parent-span-ID omission for root spans, events, links, combinatorial fan-out, empty events/links
- `recordctx/otlp_test.go` — `BodyMap` pass-through, lazy `BodyBytes`, `JSONValue`, `ReleaseBuffers`

All green under `-race`.

## Test plan

- [x] `go build ./internal/pkg/service/stream/...` passes
- [x] `go vet` clean on new packages
- [x] `go test -race` green for `otlpsource` and `recordctx`
- [ ] `task lint` passes in CI
- [ ] `task tests` passes in CI (existing `TestHTTPSource` requires `UNIT_ETCD_ENDPOINT`; not exercised locally)
- [ ] End-to-end smoke test against a real source — set `OTEL_EXPORTER_OTLP_ENDPOINT` in an OTel SDK and confirm records land in storage

## Out of scope / explicit follow-ups

- **Per-signal sink routing.** The dispatcher walks by `(projectID, sourceID)`, so all three signals from one endpoint land in the same sinks. To use the three different column schemas the design proposes, the user currently needs three separate sources. Adding signal-aware routing (or documenting the three-source pattern as the recommendation) is a product/UX decision.
- **OTLP `google.rpc.Status` error body** for 4xx — currently we fall back to the existing httpsource error JSON shape. Works for clients that branch on status code; doesn't strictly conform to the OTLP error-response wire format.
- **Header-based auth** as an alternative to URL-embedded secrets (the URL form inherits the same access-log exposure as `/stream/...`).
- **Pre-built source templates** with the recommended column mappings for `otel_logs` / `otel_metrics` / `otel_traces` tables (Phase 3 in the design doc).
- **Integration test** with a real `dispatcher.Dispatcher` + etcd, mirroring `TestHTTPSource`.
- **Parallel dispatch** for high-volume batches — currently sequential; fine for typical OTel batches (<=100 records).

🤖 Generated with [Claude Code](https://claude.com/claude-code)