### PR TITLE
PAT-1782 Disable auto-resume in DEV mode

### DIFF
--- a/internal/pkg/service/appsproxy/dataapps/k8sapp/appinfo.go
+++ b/internal/pkg/service/appsproxy/dataapps/k8sapp/appinfo.go
@@ -42,9 +42,18 @@ type appObject struct {
 }
 
 type appSpec struct {
-	AppID              string     `json:"appId"`
-	AutoRestartEnabled *bool      `json:"autoRestartEnabled,omitempty"`
-	Runtime            appRuntime `json:"runtime"`
+	AppID              string          `json:"appId"`
+	AutoRestartEnabled *bool           `json:"autoRestartEnabled,omitempty"`
+	DevMode            *appDevModeSpec `json:"devMode,omitempty"`
+	Runtime            appRuntime      `json:"runtime"`
+}
+
+// appDevModeSpec mirrors the App CRD's spec.devMode block. The proxy only
+// cares about the Enabled toggle; the remaining knobs (gitPollInterval,
+// autoRunSetupOnDepChange) are interpreted by the operator and the in-pod
+// runtime, not by apps-proxy.
+type appDevModeSpec struct {
+	Enabled bool `json:"enabled"`
 }
 
 type appRuntime struct {
@@ -59,6 +68,10 @@ type appBackend struct {
 type AppInfo struct {
 	ActualState        AppActualState
 	AutoRestartEnabled bool
+	// DevMode mirrors spec.devMode.enabled from the App CRD. When true the
+	// proxy does not auto-resume a Stopped app — only the owner of the
+	// dev/prod switch may trigger a restart.
+	DevMode bool
 	// UpstreamTarget is the pre-parsed URL from .status.appsProxy.upstreamUrl.
 	// Nil when the field is absent or unparseable.
 	UpstreamTarget *url.URL

--- a/internal/pkg/service/appsproxy/dataapps/k8sapp/watcher.go
+++ b/internal/pkg/service/appsproxy/dataapps/k8sapp/watcher.go
@@ -29,6 +29,7 @@ type entry struct {
 	k8sName            string
 	state              AppActualState
 	autoRestartEnabled bool
+	devMode            bool
 	upstreamTarget     *url.URL // pre-parsed; nil when appsProxy.upstreamUrl absent/invalid
 	e2bAccessToken     string   // loaded from K8s Secret; empty for non-E2B apps
 	e2bSecretName      string   // Secret name for lazy token loading; empty for non-E2B apps
@@ -146,6 +147,7 @@ func (w *StateWatcher) GetState(ctx context.Context, appID api.AppID) (AppInfo, 
 	return AppInfo{
 		ActualState:        e.state,
 		AutoRestartEnabled: e.autoRestartEnabled,
+		DevMode:            e.devMode,
 		UpstreamTarget:     e.upstreamTarget,
 		E2BAccessToken:     e.e2bAccessToken,
 	}, true
@@ -209,6 +211,8 @@ func (w *StateWatcher) handleUpsert(ctx context.Context, obj any) {
 		autoRestartEnabled = *appObj.Spec.AutoRestartEnabled
 	}
 
+	devMode := appObj.Spec.DevMode != nil && appObj.Spec.DevMode.Enabled
+
 	var upstreamTarget *url.URL
 	if rawURL := appObj.Status.AppsProxy.UpstreamURL; rawURL != "" {
 		if t, err := url.Parse(rawURL); err == nil {
@@ -235,11 +239,12 @@ func (w *StateWatcher) handleUpsert(ctx context.Context, obj any) {
 		k8sName:            k8sName,
 		state:              appObj.Status.CurrentState,
 		autoRestartEnabled: autoRestartEnabled,
+		devMode:            devMode,
 		upstreamTarget:     upstreamTarget,
 		e2bAccessToken:     e2bAccessToken,
 		e2bSecretName:      e2bSecretName,
 	})
-	w.logger.Debugf(ctx, "App CRD %q (appID=%s) state updated: actualState=%q autoRestartEnabled=%v upstreamTarget=%v", k8sName, appID, appObj.Status.CurrentState, autoRestartEnabled, upstreamTarget != nil)
+	w.logger.Debugf(ctx, "App CRD %q (appID=%s) state updated: actualState=%q autoRestartEnabled=%v devMode=%v upstreamTarget=%v", k8sName, appID, appObj.Status.CurrentState, autoRestartEnabled, devMode, upstreamTarget != nil)
 }
 
 func (w *StateWatcher) handleDelete(ctx context.Context, obj any) {

--- a/internal/pkg/service/appsproxy/proxy/apphandler/upstream/upstream.go
+++ b/internal/pkg/service/appsproxy/proxy/apphandler/upstream/upstream.go
@@ -150,7 +150,10 @@ func (u *AppUpstream) ServeHTTPOrError(rw http.ResponseWriter, req *http.Request
 		switch {
 		case appInfo.ActualState == k8sapp.AppActualStateStarting:
 			u.manager.pageWriter.WriteSpinnerPage(rw, req, u.app)
-		case !appInfo.AutoRestartEnabled:
+		case appInfo.DevMode, !appInfo.AutoRestartEnabled:
+			// In DEV mode (per App CRD spec.devMode.enabled) auto-resume is
+			// disabled — only the owner of the dev/prod switch may bring
+			// the app back to Running.
 			u.manager.pageWriter.WriteRestartDisabledPage(rw, req, u.app)
 		default:
 			u.wakeup(ctx, errors.Errorf("app state is %s", appInfo.ActualState))

--- a/internal/pkg/service/appsproxy/proxy/proxy_test.go
+++ b/internal/pkg/service/appsproxy/proxy/proxy_test.go
@@ -2397,6 +2397,38 @@ func TestAppProxyRouter(t *testing.T) {
 			},
 			expectedNotifications: map[string]int{},
 		},
+		{
+			// DEV mode app that is Stopped — proxy must not auto-resume it
+			// and must show the "Application Disabled" page.
+			name: "dev-mode-no-wakeup",
+			setupK8s: func(t *testing.T, fakeClient *k8sfake.FakeDynamicClient, watcher *k8sapp.StateWatcher) {
+				patch := []byte(`{"spec":{"devMode":{"enabled":true}},"status":{"currentState":"Stopped"}}`)
+				_, err := fakeClient.Resource(k8sapp.AppGVR()).Namespace("keboola").Patch(
+					t.Context(), "app-devmode", k8stypes.MergePatchType, patch, metav1.PatchOptions{},
+				)
+				require.NoError(t, err)
+				require.Eventually(t, func() bool {
+					info, ok := watcher.GetState(t.Context(), api.AppID("devmode"))
+					return ok && info.DevMode && info.ActualState == k8sapp.AppActualStateStopped
+				}, 5*time.Second, 50*time.Millisecond)
+			},
+			run: func(t *testing.T, client *http.Client, m []*mockoidc.MockOIDC, appServer *testutil.AppServer, service *testutil.DataAppsAPI, fakeClient *k8sfake.FakeDynamicClient, watcher *k8sapp.StateWatcher) {
+				request, err := http.NewRequestWithContext(t.Context(), http.MethodGet, "https://dev-devmode.hub.keboola.local/", nil)
+				require.NoError(t, err)
+				response, err := client.Do(request)
+				require.NoError(t, err)
+				require.Equal(t, http.StatusServiceUnavailable, response.StatusCode)
+				body, err := io.ReadAll(response.Body)
+				require.NoError(t, err)
+				assert.Contains(t, string(body), "Application Disabled")
+
+				// Confirm the app was not auto-resumed: state remains Stopped.
+				info, ok := watcher.GetState(t.Context(), api.AppID("devmode"))
+				require.True(t, ok)
+				assert.Equal(t, k8sapp.AppActualStateStopped, info.ActualState)
+			},
+			expectedNotifications: map[string]int{},
+		},
 	}
 
 	publicAppTestCaseFactory := func(method string) testCase {
@@ -2926,6 +2958,22 @@ func testDataApps(upstream *url.URL, m []*mockoidc.MockOIDC) []api.AppConfig {
 					Type:  api.RulePathPrefix,
 					Value: "/",
 					Auth:  []provider.ID{"basic"},
+				},
+			},
+		},
+		{
+			// DEV mode test fixture: public app; spec.devMode.enabled is
+			// flipped on the App CRD by the test setupK8s.
+			ID:             "devmode",
+			ProjectID:      "123",
+			Name:           "dev-mode-app",
+			AppSlug:        new("dev"), // dev-devmode.hub.keboola.local
+			UpstreamAppURL: upstream.String(),
+			AuthRules: []api.Rule{
+				{
+					Type:         api.RulePathPrefix,
+					Value:        "/",
+					AuthRequired: new(false),
 				},
 			},
 		},


### PR DESCRIPTION
## Release Notes
https://linear.app/keboola/issue/PAT-1782/disable-auto-resume-and-auth-in-dev-mode

When the App CRD has `spec.devMode.enabled: true` (per the [Data Apps Dev Mode design](https://github.com/keboola/platform-architecture-and-concepts/blob/main/concepts/data-apps-dev-mode.md)), the proxy must not auto-resume the app. The App CRD is the source of truth for dev mode regardless of how it got set there — only the owner of the dev/prod switch may trigger a restart.

Implementation:
* The k8sapp watcher parses `spec.devMode.enabled` and exposes it as a flat `AppInfo.DevMode` alongside the existing `AutoRestartEnabled`.
* `upstream.ServeHTTPOrError` takes the existing `RestartDisabledPage` branch when a stopped app has `DevMode=true`; no wakeup is triggered. Same code path the proxy already uses for `!AutoRestartEnabled`.

## Plans for customer communication
None.

## Impact analysis
No end-user impact for prod apps. For dev-mode apps that are Stopped, an incoming request renders the "Application Disabled" page (HTTP 503) instead of triggering a K8s `WakeupApp` patch.

## Change type
New feature

## Justification
Dev-mode apps should require explicit start.

## Deployment
Merge & automatic deploy.

## Rollback plan
Revert of this PR.

## Post release support plan
None.