### PR TITLE
feat(apps-proxy): AJDA-2746 track WS activity per data frame instead of presence

### DIFF
--- a/internal/pkg/service/appsproxy/proxy/apphandler/upstream/upstream.go
+++ b/internal/pkg/service/appsproxy/proxy/apphandler/upstream/upstream.go
@@ -3,13 +3,13 @@ package upstream
 
 import (
 	"context"
+	"io"
 	"net/http"
 	"net/http/httptrace"
 	"net/http/httputil"
 	"net/url"
 	"strings"
 	"sync"
-	"sync/atomic"
 	"time"
 
 	"go.opentelemetry.io/otel/attribute"
@@ -22,6 +22,7 @@ import (
 	"github.com/keboola/keboola-as-code/internal/pkg/service/appsproxy/dataapps/notify"
 	"github.com/keboola/keboola-as-code/internal/pkg/service/appsproxy/dataapps/wakeup"
 	"github.com/keboola/keboola-as-code/internal/pkg/service/appsproxy/proxy/apphandler/chain"
+	"github.com/keboola/keboola-as-code/internal/pkg/service/appsproxy/proxy/apphandler/upstream/wsactivity"
 	"github.com/keboola/keboola-as-code/internal/pkg/service/appsproxy/proxy/pagewriter"
 	"github.com/keboola/keboola-as-code/internal/pkg/service/common/ctxattr"
 	"github.com/keboola/keboola-as-code/internal/pkg/service/common/servicectx"
@@ -50,13 +51,12 @@ type Manager struct {
 }
 
 type AppUpstream struct {
-	manager       *Manager
-	app           api.AppConfig
-	target        *url.URL // parsed from appsProxy.upstreamUrl at creation; nil when absent
-	handler       *chain.Chain
-	wsHandler     *chain.Chain
-	cancelWs      context.CancelCauseFunc
-	activeWsCount atomic.Int64
+	manager   *Manager
+	app       api.AppConfig
+	target    *url.URL // parsed from appsProxy.upstreamUrl at creation; nil when absent
+	handler   *chain.Chain
+	wsHandler *chain.Chain
+	cancelWs  context.CancelCauseFunc
 }
 
 type dependencies interface {
@@ -123,20 +123,9 @@ func (m *Manager) NewUpstream(ctx context.Context, app api.AppConfig) (upstream 
 	upstream.handler = upstream.newProxy(m.config.Upstream.HTTPTimeout)
 	upstream.wsHandler = upstream.newWebsocketProxy(m.config.Upstream.WsTimeout)
 
-	// Call notify while there is an active websocket connection
-	go func(ctx context.Context) {
-		for {
-			select {
-			case <-ctx.Done():
-				return
-			default:
-				if upstream.activeWsCount.Load() > 0 {
-					upstream.notify(ctx)
-				}
-				time.Sleep(30 * time.Second)
-			}
-		}
-	}(ctx)
+	// WebSocket activity tracking is per-frame (see newWebsocketProxy).
+	// No periodic ticker is needed — idle connections (only ping/pong) must
+	// not keep the app alive.
 
 	return upstream, nil
 }
@@ -255,6 +244,40 @@ func (u *AppUpstream) newWebsocketProxy(timeout time.Duration) *chain.Chain {
 		}
 	}
 
+	// Per-frame WebSocket activity tracking.
+	//
+	// httputil.ReverseProxy.handleUpgradeResponse type-asserts res.Body to
+	// io.ReadWriteCloser and uses it as the upstream end of a bidirectional
+	// copy with the hijacked client conn. Wrapping res.Body once therefore
+	// observes both directions of the WebSocket stream:
+	//
+	//   - Read on the wrapped RWC = server→client bytes (unmasked frames),
+	//   - Write on the wrapped RWC = client→server bytes (masked frames).
+	//
+	// wsactivity.Wrap parses frame headers in both directions and invokes
+	// the callback once per non-control frame. notify.Manager already
+	// throttles per app to one outbound call per 30s, so we can fire the
+	// callback per frame without flooding the Sandboxes Service.
+	proxy.ModifyResponse = func(res *http.Response) error {
+		if res.StatusCode != http.StatusSwitchingProtocols {
+			return nil
+		}
+		rwc, ok := res.Body.(io.ReadWriteCloser)
+		if !ok {
+			// httputil.ReverseProxy itself requires this assertion to succeed
+			// for a 101 response; if it doesn't, the proxy errors out anyway.
+			// We just skip wrapping and let the proxy report the error.
+			return nil
+		}
+		// Bind the callback to the request context so notify() can decorate
+		// its span/log with the right request attributes. notify() itself
+		// uses context.WithoutCancel, so the in-flight call survives the WS
+		// timeout and any per-request cancellation.
+		reqCtx := res.Request.Context()
+		res.Body = wsactivity.Wrap(rwc, func() { u.notify(reqCtx) })
+		return nil
+	}
+
 	return chain.
 		New(chain.HandlerFunc(func(w http.ResponseWriter, req *http.Request) error {
 			ctx := ctxattr.ContextWith(req.Context(), attribute.Bool(attrWebsocket, true))
@@ -263,9 +286,6 @@ func (u *AppUpstream) newWebsocketProxy(timeout time.Duration) *chain.Chain {
 
 			ctx, c := context.WithCancelCause(ctx)
 			u.cancelWs = c
-
-			u.activeWsCount.Add(1)
-			defer u.activeWsCount.Add(-1)
 
 			proxy.ServeHTTP(w, req.WithContext(ctx))
 			return nil

--- a/internal/pkg/service/appsproxy/proxy/apphandler/upstream/upstream.go
+++ b/internal/pkg/service/appsproxy/proxy/apphandler/upstream/upstream.go
@@ -144,13 +144,14 @@ func (u *AppUpstream) ServeHTTPOrError(rw http.ResponseWriter, req *http.Request
 		case isFrameworkBackgroundPoll(req.URL.Path):
 			// Auto-suspended app + framework background poll (e.g. Streamlit's
 			// /_stcore/health emitted by the frontend on its WS reconnect
-			// cycle while the tab stays open). Returning a wakeup here would
-			// defeat auto-suspend on every forgotten tab. Reply 503 with
-			// Retry-After so the client backs off — the user has to perform a
-			// meaningful action (refresh, click) to wake the app, which lands
-			// on a non-poll path and falls into the default branch below.
-			rw.Header().Set("Retry-After", "60")
-			rw.WriteHeader(http.StatusServiceUnavailable)
+			// cycle while the tab stays open). Triggering a wakeup here would
+			// defeat auto-suspend on every forgotten tab, so instead we serve a
+			// 503 with a plain-text message that the frontend shows in its
+			// connection modal ("paused due to inactivity, refresh to start").
+			// The user has to perform a meaningful action (reload) to wake the
+			// app, which lands on a non-poll path (GET /) and falls into the
+			// default branch below.
+			u.manager.pageWriter.WriteSuspendedPage(rw)
 		default:
 			u.wakeup(ctx, errors.Errorf("app state is %s", appInfo.ActualState))
 			u.manager.pageWriter.WriteSpinnerPage(rw, req, u.app)

--- a/internal/pkg/service/appsproxy/proxy/apphandler/upstream/upstream.go
+++ b/internal/pkg/service/appsproxy/proxy/apphandler/upstream/upstream.go
@@ -141,6 +141,16 @@ func (u *AppUpstream) ServeHTTPOrError(rw http.ResponseWriter, req *http.Request
 			u.manager.pageWriter.WriteSpinnerPage(rw, req, u.app)
 		case !appInfo.AutoRestartEnabled:
 			u.manager.pageWriter.WriteRestartDisabledPage(rw, req, u.app)
+		case isFrameworkBackgroundPoll(req.URL.Path):
+			// Auto-suspended app + framework background poll (e.g. Streamlit's
+			// /_stcore/health emitted by the frontend on its WS reconnect
+			// cycle while the tab stays open). Returning a wakeup here would
+			// defeat auto-suspend on every forgotten tab. Reply 503 with
+			// Retry-After so the client backs off — the user has to perform a
+			// meaningful action (refresh, click) to wake the app, which lands
+			// on a non-poll path and falls into the default branch below.
+			rw.Header().Set("Retry-After", "60")
+			rw.WriteHeader(http.StatusServiceUnavailable)
 		default:
 			u.wakeup(ctx, errors.Errorf("app state is %s", appInfo.ActualState))
 			u.manager.pageWriter.WriteSpinnerPage(rw, req, u.app)
@@ -300,10 +310,20 @@ func (u *AppUpstream) trace() chain.Middleware {
 	return func(next chain.Handler) chain.Handler {
 		return chain.HandlerFunc(func(w http.ResponseWriter, req *http.Request) error {
 			ctx := req.Context()
+			// Capture the path at request scope — it must be available inside
+			// the GotConn callback closure below, which only receives a
+			// connInfo argument.
+			reqPath := req.URL.Path
 
-			// Trace connection events
+			// Trace connection events. Background polls emitted by data-app
+			// frontends independent of user interaction (see
+			// isFrameworkBackgroundPoll) are not considered activity and do
+			// not bump lastRequestTimestamp.
 			reqCtx := httptrace.WithClientTrace(ctx, &httptrace.ClientTrace{
 				GotConn: func(connInfo httptrace.GotConnInfo) {
+					if isFrameworkBackgroundPoll(reqPath) {
+						return
+					}
 					u.notify(ctx)
 				},
 			})
@@ -347,5 +367,26 @@ func (u *AppUpstream) wakeup(ctx context.Context, err error) {
 func (u *AppUpstream) Cancel(err error) {
 	if u.cancelWs != nil {
 		u.cancelWs(err)
+	}
+}
+
+// isFrameworkBackgroundPoll reports whether the given URL path is a known
+// data-app frontend background-poll endpoint that fires independently of user
+// interaction.
+//
+// Currently covers Streamlit's /_stcore/health and /_stcore/host-config. These
+// are emitted on every WebSocket (re)connect — including the periodic ~20 min
+// reconnect cycle imposed by an external idle timeout — and would otherwise
+// either bump lastRequestTimestamp on a Running app (defeating auto-suspend)
+// or wake a Suspended one (defeating it again). Apps-proxy treats them as
+// non-activity: notify is skipped on a Running app and the request is rejected
+// with 503 Retry-After on a Suspended one, requiring the user to perform a
+// meaningful action (refresh, click into the UI) to wake the app.
+func isFrameworkBackgroundPoll(path string) bool {
+	switch path {
+	case "/_stcore/health", "/_stcore/host-config":
+		return true
+	default:
+		return false
 	}
 }

--- a/internal/pkg/service/appsproxy/proxy/apphandler/upstream/upstream_test.go
+++ b/internal/pkg/service/appsproxy/proxy/apphandler/upstream/upstream_test.go
@@ -1,0 +1,41 @@
+package upstream
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+)
+
+func TestIsFrameworkBackgroundPoll(t *testing.T) {
+	t.Parallel()
+	tests := []struct {
+		path string
+		want bool
+	}{
+		// Currently filtered Streamlit endpoints.
+		{"/_stcore/health", true},
+		{"/_stcore/host-config", true},
+
+		// Other Streamlit endpoints — must NOT be filtered.
+		{"/_stcore/stream", false},      // WebSocket upgrade — real channel.
+		{"/_stcore/upload_file", false}, // User-initiated upload.
+
+		// Real user-driven traffic.
+		{"/", false},
+		{"/favicon.ico", false},
+		{"/apple-touch-icon.png", false},
+		{"/_proxy/assets/styles.css", false},
+
+		// Edge cases that must not silently match.
+		{"", false},
+		{"/_stcore/health/extra", false},
+		{"_stcore/health", false}, // no leading slash
+	}
+
+	for _, tc := range tests {
+		t.Run(tc.path, func(t *testing.T) {
+			t.Parallel()
+			assert.Equal(t, tc.want, isFrameworkBackgroundPoll(tc.path))
+		})
+	}
+}

--- a/internal/pkg/service/appsproxy/proxy/apphandler/upstream/wsactivity/conn.go
+++ b/internal/pkg/service/appsproxy/proxy/apphandler/upstream/wsactivity/conn.go
@@ -1,0 +1,67 @@
+package wsactivity
+
+import "io"
+
+// Wrap returns an io.ReadWriteCloser that observes the byte stream in both
+// directions, parses WebSocket frame headers, and invokes onDataFrame once
+// per non-control frame (opcodes 0x0..0x7) on either side. Bytes flow through
+// unchanged.
+//
+// The wrapper is intended for the upstream-side io.ReadWriteCloser exposed by
+// httputil.ReverseProxy as res.Body for a 101 Switching Protocols response.
+// In that role:
+//
+//   - Read returns bytes flowing from the upstream WebSocket endpoint to the
+//     client (unmasked frames per RFC 6455 §5.3).
+//   - Write receives bytes flowing from the client to the upstream endpoint
+//     (masked frames).
+//
+// Masking does not affect parsing: only opcode and length fields are inspected,
+// both of which are unmasked. Payload bytes are skipped via a counter and never
+// buffered, so the wrapper is safe against attacker-controlled payload sizes
+// (up to 2^63-1 per the spec).
+//
+// onDataFrame must be cheap and non-blocking — it runs synchronously on the
+// goroutine performing the Read or Write.
+func Wrap(rwc io.ReadWriteCloser, onDataFrame FrameCallback) io.ReadWriteCloser {
+	return &conn{
+		inner:  rwc,
+		reader: newFrameParser(onDataFrame),
+		writer: newFrameParser(onDataFrame),
+	}
+}
+
+// conn is a thin passthrough wrapper around an io.ReadWriteCloser that drives
+// one frame parser per direction.
+type conn struct {
+	inner  io.ReadWriteCloser
+	reader *frameParser // observes bytes flowing from inner to caller
+	writer *frameParser // observes bytes flowing from caller to inner
+}
+
+// Read reads from the wrapped conn and feeds the observed bytes to the
+// read-side parser before returning them to the caller.
+func (c *conn) Read(p []byte) (int, error) {
+	n, err := c.inner.Read(p)
+	if n > 0 {
+		c.reader.Feed(p[:n])
+	}
+	return n, err
+}
+
+// Write writes through to the wrapped conn and feeds the bytes that actually
+// reached the underlying writer to the write-side parser. Symmetric with Read
+// so a short write does not double-feed if the caller retries with the
+// remaining slice.
+func (c *conn) Write(p []byte) (int, error) {
+	n, err := c.inner.Write(p)
+	if n > 0 {
+		c.writer.Feed(p[:n])
+	}
+	return n, err
+}
+
+// Close closes the wrapped conn.
+func (c *conn) Close() error {
+	return c.inner.Close()
+}

--- a/internal/pkg/service/appsproxy/proxy/apphandler/upstream/wsactivity/conn_test.go
+++ b/internal/pkg/service/appsproxy/proxy/apphandler/upstream/wsactivity/conn_test.go
@@ -2,12 +2,13 @@ package wsactivity
 
 import (
 	"bytes"
-	"errors"
 	"io"
 	"testing"
 
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
+
+	"github.com/keboola/keboola-as-code/internal/pkg/utils/errors"
 )
 
 // fakeRWC is a minimal io.ReadWriteCloser used to drive the wrapper from
@@ -136,12 +137,21 @@ func TestWrap_OnlyControlFrames_NoCallbacks(t *testing.T) {
 func TestWrap_PassThroughGolden(t *testing.T) {
 	t.Parallel()
 	// Random-ish stream of mixed frames — the wrapper must not mutate any byte.
-	var stream []byte
-	stream = append(stream, buildFrame(t, 0x1, true, 7, true)...)
-	stream = append(stream, buildFrame(t, 0x9, true, 0, false)...)
-	stream = append(stream, buildFrame(t, 0x2, false, 200, true)...) // 16-bit len
-	stream = append(stream, buildFrame(t, 0x0, true, 100, true)...)
-	stream = append(stream, buildFrame(t, 0x8, true, 2, false)...) // close
+	parts := [][]byte{
+		buildFrame(t, 0x1, true, 7, true),
+		buildFrame(t, 0x9, true, 0, false),
+		buildFrame(t, 0x2, false, 200, true), // 16-bit len
+		buildFrame(t, 0x0, true, 100, true),
+		buildFrame(t, 0x8, true, 2, false), // close
+	}
+	total := 0
+	for _, p := range parts {
+		total += len(p)
+	}
+	stream := make([]byte, 0, total)
+	for _, p := range parts {
+		stream = append(stream, p...)
+	}
 
 	rwc := newFakeRWC(stream)
 	c := Wrap(rwc, func() {})

--- a/internal/pkg/service/appsproxy/proxy/apphandler/upstream/wsactivity/conn_test.go
+++ b/internal/pkg/service/appsproxy/proxy/apphandler/upstream/wsactivity/conn_test.go
@@ -171,10 +171,26 @@ func TestWrap_Close_DelegatesToInner(t *testing.T) {
 
 func TestWrap_ShortWrite_DoesNotDoubleFeed(t *testing.T) {
 	t.Parallel()
-	// Inner Write returns half of p with io.ErrShortWrite. The parser must
-	// only see the bytes that actually reached the inner writer, so that the
-	// caller's retry with the unwritten tail doesn't cause double-counting.
-	frame := buildFrame(t, 0x1, true, 10, true) // total ~20 bytes
+	// Property under test: when the inner Write reports a short write
+	// (n < len(p)), the wrapper must only feed p[:n] to the parser. A buggy
+	// implementation that feeds the entire p on every Write would, on the
+	// caller's retry with p[n:], cause the parser to re-walk those bytes —
+	// resynchronising mid-payload as if a new frame had started, and firing
+	// spurious callbacks.
+	//
+	// For a single masked text frame with payloadLen=10 the total frame is
+	// 16 bytes (1+1+4 mask key + 10 payload). The half-point at 8 lands one
+	// byte past the end of the header — so the header is already complete in
+	// the first chunk and the callback fires there. The test still detects
+	// the double-feed bug: under the buggy path the parser would re-walk the
+	// last 8 bytes (mask bytes 0xDE 0xAD 0xBE 0xEF + payload 0..1 in this
+	// helper's deterministic fill), interpret 0xDE & 0x0F = 0xE as a new
+	// (reserved control) opcode header, and either fire extra callbacks
+	// (for reserved data opcodes 0x0..0x7 in different fill positions) or
+	// at minimum count more than 1 if any retry-fed prefix happens to
+	// constitute a non-control opcode. We assert the strict invariant of
+	// exactly one callback across the whole write+retry.
+	frame := buildFrame(t, 0x1, true, 10, true) // total 16 bytes
 	rwc := &fakeRWC{
 		rBuf:       &bytes.Buffer{},
 		wBuf:       &bytes.Buffer{},
@@ -188,9 +204,7 @@ func TestWrap_ShortWrite_DoesNotDoubleFeed(t *testing.T) {
 	require.ErrorIs(t, err, io.ErrShortWrite)
 	assert.Equal(t, len(frame)/2, n)
 
-	// The first half includes only the partial header; the parser shouldn't
-	// have fired a callback yet (it needs the full header).
-	// Now simulate the caller retrying with the unwritten tail (no shortWrite
+	// Simulate the caller retrying with the unwritten tail (no shortWrite
 	// this time so it succeeds completely).
 	rwc.shortWrite = false
 	rest := frame[n:]

--- a/internal/pkg/service/appsproxy/proxy/apphandler/upstream/wsactivity/conn_test.go
+++ b/internal/pkg/service/appsproxy/proxy/apphandler/upstream/wsactivity/conn_test.go
@@ -1,0 +1,205 @@
+package wsactivity
+
+import (
+	"bytes"
+	"errors"
+	"io"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+// fakeRWC is a minimal io.ReadWriteCloser used to drive the wrapper from
+// either direction. Read consumes from rBuf; Write appends to wBuf.
+type fakeRWC struct {
+	rBuf       *bytes.Buffer
+	wBuf       *bytes.Buffer
+	closed     bool
+	writeErr   error // injected error for Write
+	readErr    error // injected error after rBuf drained
+	shortWrite bool  // if true, Write returns half of len(p) and io.ErrShortWrite
+}
+
+func (f *fakeRWC) Read(p []byte) (int, error) {
+	if f.rBuf.Len() == 0 {
+		if f.readErr != nil {
+			return 0, f.readErr
+		}
+		return 0, io.EOF
+	}
+	return f.rBuf.Read(p)
+}
+
+func (f *fakeRWC) Write(p []byte) (int, error) {
+	if f.writeErr != nil {
+		return 0, f.writeErr
+	}
+	if f.shortWrite {
+		n := len(p) / 2
+		_, _ = f.wBuf.Write(p[:n])
+		return n, io.ErrShortWrite
+	}
+	return f.wBuf.Write(p)
+}
+
+func (f *fakeRWC) Close() error {
+	f.closed = true
+	return nil
+}
+
+func newFakeRWC(readData []byte) *fakeRWC {
+	return &fakeRWC{rBuf: bytes.NewBuffer(readData), wBuf: &bytes.Buffer{}}
+}
+
+func TestWrap_Read_CountsServerToClientFrames(t *testing.T) {
+	t.Parallel()
+	// Two unmasked text frames from server (Read side).
+	stream := append(
+		buildFrame(t, 0x1, true, 4, false),
+		buildFrame(t, 0x2, true, 8, false)...,
+	)
+	rwc := newFakeRWC(stream)
+
+	count := 0
+	c := Wrap(rwc, func() { count++ })
+
+	out, err := io.ReadAll(c)
+	require.NoError(t, err)
+	assert.Equal(t, stream, out, "pass-through must be byte-identical")
+	assert.Equal(t, 2, count)
+}
+
+func TestWrap_Write_CountsClientToServerFrames(t *testing.T) {
+	t.Parallel()
+	// One masked text frame the client would write toward the server.
+	frame := buildFrame(t, 0x1, true, 6, true)
+	rwc := newFakeRWC(nil)
+
+	count := 0
+	c := Wrap(rwc, func() { count++ })
+
+	n, err := c.Write(frame)
+	require.NoError(t, err)
+	assert.Equal(t, len(frame), n)
+	assert.Equal(t, frame, rwc.wBuf.Bytes(), "pass-through must be byte-identical")
+	assert.Equal(t, 1, count)
+}
+
+func TestWrap_ReadAndWrite_BothDirectionsIndependent(t *testing.T) {
+	t.Parallel()
+	// Read side: one text frame. Write side: one text frame + one ping (ignored).
+	readStream := buildFrame(t, 0x1, true, 5, false)
+	writeStream := append(
+		buildFrame(t, 0x1, true, 3, true),
+		buildFrame(t, 0x9, true, 0, true)...,
+	)
+	rwc := newFakeRWC(readStream)
+
+	count := 0
+	c := Wrap(rwc, func() { count++ })
+
+	// Read first.
+	got, err := io.ReadAll(c)
+	require.NoError(t, err)
+	assert.Equal(t, readStream, got)
+
+	// Then write.
+	n, err := c.Write(writeStream)
+	require.NoError(t, err)
+	assert.Equal(t, len(writeStream), n)
+
+	// Expect 1 (from read text frame) + 1 (from write text frame) = 2.
+	assert.Equal(t, 2, count)
+}
+
+func TestWrap_OnlyControlFrames_NoCallbacks(t *testing.T) {
+	t.Parallel()
+	// Idle WS pattern: only ping/pong in either direction.
+	pings := append(
+		buildFrame(t, 0x9, true, 0, false),
+		buildFrame(t, 0xA, true, 0, false)...,
+	)
+	rwc := newFakeRWC(pings)
+
+	count := 0
+	c := Wrap(rwc, func() { count++ })
+
+	_, err := io.ReadAll(c)
+	require.NoError(t, err)
+	_, err = c.Write(pings)
+	require.NoError(t, err)
+
+	assert.Equal(t, 0, count, "control-only traffic must not trigger notify")
+}
+
+func TestWrap_PassThroughGolden(t *testing.T) {
+	t.Parallel()
+	// Random-ish stream of mixed frames — the wrapper must not mutate any byte.
+	var stream []byte
+	stream = append(stream, buildFrame(t, 0x1, true, 7, true)...)
+	stream = append(stream, buildFrame(t, 0x9, true, 0, false)...)
+	stream = append(stream, buildFrame(t, 0x2, false, 200, true)...) // 16-bit len
+	stream = append(stream, buildFrame(t, 0x0, true, 100, true)...)
+	stream = append(stream, buildFrame(t, 0x8, true, 2, false)...) // close
+
+	rwc := newFakeRWC(stream)
+	c := Wrap(rwc, func() {})
+
+	got, err := io.ReadAll(c)
+	require.NoError(t, err)
+	assert.Equal(t, stream, got)
+}
+
+func TestWrap_Close_DelegatesToInner(t *testing.T) {
+	t.Parallel()
+	rwc := newFakeRWC(nil)
+	c := Wrap(rwc, func() {})
+	require.NoError(t, c.Close())
+	assert.True(t, rwc.closed)
+}
+
+func TestWrap_ShortWrite_DoesNotDoubleFeed(t *testing.T) {
+	t.Parallel()
+	// Inner Write returns half of p with io.ErrShortWrite. The parser must
+	// only see the bytes that actually reached the inner writer, so that the
+	// caller's retry with the unwritten tail doesn't cause double-counting.
+	frame := buildFrame(t, 0x1, true, 10, true) // total ~20 bytes
+	rwc := &fakeRWC{
+		rBuf:       &bytes.Buffer{},
+		wBuf:       &bytes.Buffer{},
+		shortWrite: true,
+	}
+
+	count := 0
+	c := Wrap(rwc, func() { count++ })
+
+	n, err := c.Write(frame)
+	require.ErrorIs(t, err, io.ErrShortWrite)
+	assert.Equal(t, len(frame)/2, n)
+
+	// The first half includes only the partial header; the parser shouldn't
+	// have fired a callback yet (it needs the full header).
+	// Now simulate the caller retrying with the unwritten tail (no shortWrite
+	// this time so it succeeds completely).
+	rwc.shortWrite = false
+	rest := frame[n:]
+	n2, err := c.Write(rest)
+	require.NoError(t, err)
+	assert.Equal(t, len(rest), n2)
+
+	assert.Equal(t, 1, count, "exactly one callback even after a short write + retry")
+}
+
+func TestWrap_WriteErrorDoesNotFeed(t *testing.T) {
+	t.Parallel()
+	rwc := &fakeRWC{rBuf: &bytes.Buffer{}, wBuf: &bytes.Buffer{}, writeErr: errors.New("boom")}
+
+	count := 0
+	c := Wrap(rwc, func() { count++ })
+	frame := buildFrame(t, 0x1, true, 5, true)
+
+	_, err := c.Write(frame)
+	require.Error(t, err)
+	assert.Equal(t, 0, count, "no bytes reached the wire — parser must not advance")
+}

--- a/internal/pkg/service/appsproxy/proxy/apphandler/upstream/wsactivity/frame.go
+++ b/internal/pkg/service/appsproxy/proxy/apphandler/upstream/wsactivity/frame.go
@@ -1,0 +1,175 @@
+// Package wsactivity provides a passive WebSocket frame observer used by the apps-proxy
+// to track real per-frame activity instead of the mere presence of an open connection.
+//
+// The package contains two pieces:
+//
+//   - a stateful RFC 6455 frame parser (frame.go) that consumes a raw byte stream and
+//     invokes a callback exactly once per non-control frame ("data frame"), and
+//   - a passthrough net-conn wrapper (conn.go) that drives one parser per direction.
+//
+// The parser does not inspect or buffer payload bytes; it only walks frame headers and
+// decrements a payload counter as bytes flow through. This makes it safe against
+// attacker-controlled payload lengths (which can reach 2^63-1 per RFC 6455).
+package wsactivity
+
+// FrameCallback is invoked once per non-control frame (opcode bit 0x8 unset)
+// at the moment its header has been fully parsed. Implementations must be
+// cheap and non-blocking — the callback runs on the goroutine that reads or
+// writes bytes through the wrapped connection.
+type FrameCallback func()
+
+// parserState enumerates the positions of the RFC 6455 frame state machine.
+type parserState uint8
+
+const (
+	stateHeader0 parserState = iota // expect byte 0: FIN/RSV/OPCODE
+	stateHeader1                    // expect byte 1: MASK/PAYLOAD_LEN_7
+	stateExtLen                     // accumulate 2 or 8 extended length bytes
+	stateMaskKey                    // accumulate 4 masking-key bytes (only if MASK=1)
+	statePayload                    // drain payload bytes
+)
+
+const (
+	// maskBit is the high bit of byte 1.
+	maskBit = 0x80
+	// lenMask is the low 7 bits of byte 1.
+	lenMask = 0x7F
+	// controlBit identifies control frames per RFC 6455 §5.2 (opcode & 0x8).
+	controlBit = 0x8
+)
+
+// frameParser is a stateful, allocation-free RFC 6455 frame header parser.
+//
+// It is fed an arbitrary byte stream via Feed and invokes onDataFrame exactly
+// once per non-control frame (opcodes 0x0..0x7), at the moment the frame
+// header is fully parsed. Payload bytes are not buffered or inspected — they
+// are skipped via a counter.
+//
+// The parser holds no resync logic. A malformed stream desynchronizes the
+// parser indefinitely; the connection endpoints (browser, upstream) will
+// terminate such streams on their own and the throttling in notify.Manager
+// caps the cost of any spurious callback bursts.
+type frameParser struct {
+	onDataFrame FrameCallback
+
+	state parserState
+
+	// Current frame metadata, populated as the header is parsed.
+	opcode      byte
+	masked      bool
+	extLenBytes uint8  // 0, 2, or 8
+	extLenRead  uint8  // bytes of extLen consumed so far
+	extLenAccum uint64 // accumulated extended-length value
+	maskKeyRead uint8  // 0..4
+	payloadLeft uint64 // bytes of payload still to drain
+}
+
+// newFrameParser returns a parser that calls onDataFrame once per non-control frame.
+func newFrameParser(onDataFrame FrameCallback) *frameParser {
+	return &frameParser{onDataFrame: onDataFrame}
+}
+
+// Feed advances the parser through the bytes in p. It never reads or modifies
+// p beyond walking its bytes and never allocates based on payload length.
+func (fp *frameParser) Feed(p []byte) {
+	for i := 0; i < len(p); {
+		switch fp.state {
+		case stateHeader0:
+			fp.opcode = p[i] & 0x0F
+			fp.state = stateHeader1
+			i++
+
+		case stateHeader1:
+			b := p[i]
+			fp.masked = b&maskBit != 0
+			length7 := b & lenMask
+			switch {
+			case length7 < 126:
+				fp.extLenBytes = 0
+				fp.payloadLeft = uint64(length7)
+			case length7 == 126:
+				fp.extLenBytes = 2
+			default: // 127
+				fp.extLenBytes = 8
+			}
+			fp.extLenRead = 0
+			fp.extLenAccum = 0
+			fp.maskKeyRead = 0
+			if fp.extLenBytes == 0 {
+				fp.afterLengthKnown()
+			} else {
+				fp.state = stateExtLen
+			}
+			i++
+
+		case stateExtLen:
+			// Consume as many extLen bytes as available in p[i:].
+			need := int(fp.extLenBytes - fp.extLenRead)
+			avail := len(p) - i
+			n := need
+			if avail < n {
+				n = avail
+			}
+			for k := 0; k < n; k++ {
+				fp.extLenAccum = (fp.extLenAccum << 8) | uint64(p[i+k])
+			}
+			fp.extLenRead += uint8(n)
+			i += n
+			if fp.extLenRead == fp.extLenBytes {
+				fp.payloadLeft = fp.extLenAccum
+				fp.afterLengthKnown()
+			}
+
+		case stateMaskKey:
+			need := int(4 - fp.maskKeyRead)
+			avail := len(p) - i
+			n := need
+			if avail < n {
+				n = avail
+			}
+			fp.maskKeyRead += uint8(n)
+			i += n
+			if fp.maskKeyRead == 4 {
+				fp.afterHeaderComplete()
+			}
+
+		case statePayload:
+			avail := uint64(len(p) - i)
+			drop := avail
+			if fp.payloadLeft < drop {
+				drop = fp.payloadLeft
+			}
+			fp.payloadLeft -= drop
+			i += int(drop)
+			if fp.payloadLeft == 0 {
+				fp.state = stateHeader0
+			}
+		}
+	}
+}
+
+// afterLengthKnown is called once payload length is known (either after byte 1
+// for 7-bit length, or after the extended-length bytes for 16/64-bit length).
+// It advances to either stateMaskKey or directly to header-complete handling.
+func (fp *frameParser) afterLengthKnown() {
+	if fp.masked {
+		fp.state = stateMaskKey
+		return
+	}
+	fp.afterHeaderComplete()
+}
+
+// afterHeaderComplete is called when the entire frame header has been parsed.
+// It fires the data-frame callback (if applicable) and transitions to payload
+// drain or directly back to stateHeader0 for zero-length payloads.
+func (fp *frameParser) afterHeaderComplete() {
+	// Non-control frames have the high bit of the 4-bit opcode unset.
+	if fp.opcode&controlBit == 0 && fp.onDataFrame != nil {
+		fp.onDataFrame()
+	}
+	if fp.payloadLeft == 0 {
+		fp.state = stateHeader0
+		return
+	}
+	fp.state = statePayload
+}

--- a/internal/pkg/service/appsproxy/proxy/apphandler/upstream/wsactivity/frame.go
+++ b/internal/pkg/service/appsproxy/proxy/apphandler/upstream/wsactivity/frame.go
@@ -104,16 +104,18 @@ func (fp *frameParser) Feed(p []byte) {
 
 		case stateExtLen:
 			// Consume as many extLen bytes as available in p[i:].
+			// `need` is bounded by extLenBytes (≤8) and `n` is bounded by `need`,
+			// so the conversions below cannot overflow uint8.
 			need := int(fp.extLenBytes - fp.extLenRead)
 			avail := len(p) - i
 			n := need
 			if avail < n {
 				n = avail
 			}
-			for k := 0; k < n; k++ {
+			for k := range n {
 				fp.extLenAccum = (fp.extLenAccum << 8) | uint64(p[i+k])
 			}
-			fp.extLenRead += uint8(n)
+			fp.extLenRead += uint8(n) //nolint:gosec // n ≤ need ≤ extLenBytes ≤ 8
 			i += n
 			if fp.extLenRead == fp.extLenBytes {
 				fp.payloadLeft = fp.extLenAccum
@@ -121,26 +123,32 @@ func (fp *frameParser) Feed(p []byte) {
 			}
 
 		case stateMaskKey:
+			// `need` is bounded by 4 and `n` is bounded by `need`,
+			// so the conversion below cannot overflow uint8.
 			need := int(4 - fp.maskKeyRead)
 			avail := len(p) - i
 			n := need
 			if avail < n {
 				n = avail
 			}
-			fp.maskKeyRead += uint8(n)
+			fp.maskKeyRead += uint8(n) //nolint:gosec // n ≤ need ≤ 4
 			i += n
 			if fp.maskKeyRead == 4 {
 				fp.afterHeaderComplete()
 			}
 
 		case statePayload:
-			avail := uint64(len(p) - i)
+			// len(p)-i is non-negative by the outer loop condition (i < len(p))
+			// and bounded by len(p), so the uint64 cast cannot overflow.
+			// drop is then bounded by avail, so converting it back to int for
+			// the index advance cannot overflow either.
+			avail := uint64(len(p) - i) //nolint:gosec // len(p)-i ≥ 0 by loop condition
 			drop := avail
 			if fp.payloadLeft < drop {
 				drop = fp.payloadLeft
 			}
 			fp.payloadLeft -= drop
-			i += int(drop)
+			i += int(drop) //nolint:gosec // drop ≤ avail = uint64(len(p)-i), fits in int
 			if fp.payloadLeft == 0 {
 				fp.state = stateHeader0
 			}

--- a/internal/pkg/service/appsproxy/proxy/apphandler/upstream/wsactivity/frame.go
+++ b/internal/pkg/service/appsproxy/proxy/apphandler/upstream/wsactivity/frame.go
@@ -7,10 +7,13 @@
 //     invokes a callback exactly once per non-control frame ("data frame"), and
 //   - a passthrough net-conn wrapper (conn.go) that drives one parser per direction.
 //
-// The parser does not inspect or buffer payload bytes; it only walks frame headers and
-// decrements a payload counter as bytes flow through. This makes it safe against
-// attacker-controlled payload lengths (which can reach 2^63-1 per RFC 6455).
+// The parser does not inspect or buffer payload bytes; it only buffers the frame
+// header (at most 14 bytes per RFC 6455) and decrements a payload counter as bytes
+// flow through. This makes it safe against attacker-controlled payload lengths
+// (which can reach 2^63-1 per RFC 6455).
 package wsactivity
+
+import "encoding/binary"
 
 // FrameCallback is invoked once per non-control frame (opcode bit 0x8 unset)
 // at the moment its header has been fully parsed. Implementations must be
@@ -18,32 +21,36 @@ package wsactivity
 // writes bytes through the wrapped connection.
 type FrameCallback func()
 
-// parserState enumerates the positions of the RFC 6455 frame state machine.
-type parserState uint8
-
 const (
-	stateHeader0 parserState = iota // expect byte 0: FIN/RSV/OPCODE
-	stateHeader1                    // expect byte 1: MASK/PAYLOAD_LEN_7
-	stateExtLen                     // accumulate 2 or 8 extended length bytes
-	stateMaskKey                    // accumulate 4 masking-key bytes (only if MASK=1)
-	statePayload                    // drain payload bytes
-)
+	// maxHeaderBytes is the upper bound on a single WebSocket frame header:
+	//   2 base bytes + up to 8 extended-length bytes + up to 4 mask-key bytes.
+	maxHeaderBytes = 14
 
-const (
 	// maskBit is the high bit of byte 1.
 	maskBit = 0x80
-	// lenMask is the low 7 bits of byte 1.
+	// lenMask is the low 7 bits of byte 1 (the 7-bit payload-length field).
 	lenMask = 0x7F
 	// controlBit identifies control frames per RFC 6455 §5.2 (opcode & 0x8).
 	controlBit = 0x8
+
+	// payloadLen16 and payloadLen64 are the sentinel values of the 7-bit length
+	// field that select 16-bit and 64-bit extended payload-length encodings.
+	payloadLen16 = 126
+	payloadLen64 = 127
 )
 
 // frameParser is a stateful, allocation-free RFC 6455 frame header parser.
 //
 // It is fed an arbitrary byte stream via Feed and invokes onDataFrame exactly
 // once per non-control frame (opcodes 0x0..0x7), at the moment the frame
-// header is fully parsed. Payload bytes are not buffered or inspected — they
-// are skipped via a counter.
+// header is fully parsed. Payload bytes are not inspected — they are skipped
+// via a counter.
+//
+// Implicit state is encoded in three fields:
+//   - payloadLeft > 0 → currently draining a payload (header already fired);
+//   - headerNeed == 0 → waiting for the first 2 header bytes to know total
+//     header length;
+//   - headerLen < headerNeed → still accumulating header bytes.
 //
 // The parser holds no resync logic. A malformed stream desynchronizes the
 // parser indefinitely; the connection endpoints (browser, upstream) will
@@ -52,16 +59,13 @@ const (
 type frameParser struct {
 	onDataFrame FrameCallback
 
-	state parserState
+	// header buffers the current frame's header bytes. Indexed via headerLen,
+	// decoded all at once when headerLen reaches headerNeed.
+	header     [maxHeaderBytes]byte
+	headerLen  int
+	headerNeed int // 0 until the 7-bit length field has been read
 
-	// Current frame metadata, populated as the header is parsed.
-	opcode      byte
-	masked      bool
-	extLenBytes uint8  // 0, 2, or 8
-	extLenRead  uint8  // bytes of extLen consumed so far
-	extLenAccum uint64 // accumulated extended-length value
-	maskKeyRead uint8  // 0..4
-	payloadLeft uint64 // bytes of payload still to drain
+	payloadLeft uint64 // bytes of the current payload still to drain
 }
 
 // newFrameParser returns a parser that calls onDataFrame once per non-control frame.
@@ -72,112 +76,97 @@ func newFrameParser(onDataFrame FrameCallback) *frameParser {
 // Feed advances the parser through the bytes in p. It never reads or modifies
 // p beyond walking its bytes and never allocates based on payload length.
 func (fp *frameParser) Feed(p []byte) {
-	for i := 0; i < len(p); {
-		switch fp.state {
-		case stateHeader0:
-			fp.opcode = p[i] & 0x0F
-			fp.state = stateHeader1
-			i++
-
-		case stateHeader1:
-			b := p[i]
-			fp.masked = b&maskBit != 0
-			length7 := b & lenMask
-			switch {
-			case length7 < 126:
-				fp.extLenBytes = 0
-				fp.payloadLeft = uint64(length7)
-			case length7 == 126:
-				fp.extLenBytes = 2
-			default: // 127
-				fp.extLenBytes = 8
-			}
-			fp.extLenRead = 0
-			fp.extLenAccum = 0
-			fp.maskKeyRead = 0
-			if fp.extLenBytes == 0 {
-				fp.afterLengthKnown()
-			} else {
-				fp.state = stateExtLen
-			}
-			i++
-
-		case stateExtLen:
-			// Consume as many extLen bytes as available in p[i:].
-			// `need` is bounded by extLenBytes (≤8) and `n` is bounded by `need`,
-			// so the conversions below cannot overflow uint8.
-			need := int(fp.extLenBytes - fp.extLenRead)
-			avail := len(p) - i
-			n := need
-			if avail < n {
-				n = avail
-			}
-			for k := range n {
-				fp.extLenAccum = (fp.extLenAccum << 8) | uint64(p[i+k])
-			}
-			fp.extLenRead += uint8(n) //nolint:gosec // n ≤ need ≤ extLenBytes ≤ 8
-			i += n
-			if fp.extLenRead == fp.extLenBytes {
-				fp.payloadLeft = fp.extLenAccum
-				fp.afterLengthKnown()
-			}
-
-		case stateMaskKey:
-			// `need` is bounded by 4 and `n` is bounded by `need`,
-			// so the conversion below cannot overflow uint8.
-			need := int(4 - fp.maskKeyRead)
-			avail := len(p) - i
-			n := need
-			if avail < n {
-				n = avail
-			}
-			fp.maskKeyRead += uint8(n) //nolint:gosec // n ≤ need ≤ 4
-			i += n
-			if fp.maskKeyRead == 4 {
-				fp.afterHeaderComplete()
-			}
-
-		case statePayload:
-			// len(p)-i is non-negative by the outer loop condition (i < len(p))
-			// and bounded by len(p), so the uint64 cast cannot overflow.
-			// drop is then bounded by avail, so converting it back to int for
-			// the index advance cannot overflow either.
-			avail := uint64(len(p) - i) //nolint:gosec // len(p)-i ≥ 0 by loop condition
-			drop := avail
-			if fp.payloadLeft < drop {
-				drop = fp.payloadLeft
-			}
-			fp.payloadLeft -= drop
-			i += int(drop) //nolint:gosec // drop ≤ avail = uint64(len(p)-i), fits in int
-			if fp.payloadLeft == 0 {
-				fp.state = stateHeader0
-			}
+	for len(p) > 0 {
+		// Phase 1: drain payload of the current frame, if any. Once payloadLeft
+		// hits zero the parser is back at the start of a new header.
+		if fp.payloadLeft > 0 {
+			p = fp.drainPayload(p)
+			continue
 		}
+
+		// Phase 2: accumulate at least the first 2 bytes of the next header so
+		// we can compute the header's total length.
+		if fp.headerNeed == 0 {
+			p = fp.fillHeader(p, 2)
+			if fp.headerLen < 2 {
+				return // need more bytes; come back on the next Feed call
+			}
+			fp.headerNeed = headerLengthFromByte1(fp.header[1])
+		}
+
+		// Phase 3: finish accumulating the rest of the header.
+		p = fp.fillHeader(p, fp.headerNeed)
+		if fp.headerLen < fp.headerNeed {
+			return // need more bytes; come back on the next Feed call
+		}
+
+		fp.completeHeader()
 	}
 }
 
-// afterLengthKnown is called once payload length is known (either after byte 1
-// for 7-bit length, or after the extended-length bytes for 16/64-bit length).
-// It advances to either stateMaskKey or directly to header-complete handling.
-func (fp *frameParser) afterLengthKnown() {
-	if fp.masked {
-		fp.state = stateMaskKey
-		return
+// drainPayload consumes up to payloadLeft bytes from the front of p and returns
+// the rest. Bytes are not inspected.
+func (fp *frameParser) drainPayload(p []byte) []byte {
+	n := uint64(len(p))
+	if n > fp.payloadLeft {
+		n = fp.payloadLeft
 	}
-	fp.afterHeaderComplete()
+	fp.payloadLeft -= n
+	return p[n:]
 }
 
-// afterHeaderComplete is called when the entire frame header has been parsed.
-// It fires the data-frame callback (if applicable) and transitions to payload
-// drain or directly back to stateHeader0 for zero-length payloads.
-func (fp *frameParser) afterHeaderComplete() {
-	// Non-control frames have the high bit of the 4-bit opcode unset.
-	if fp.opcode&controlBit == 0 && fp.onDataFrame != nil {
+// fillHeader copies bytes from p into the header buffer until either p is
+// exhausted or headerLen reaches target. Returns the remaining slice of p.
+func (fp *frameParser) fillHeader(p []byte, target int) []byte {
+	if fp.headerLen >= target {
+		return p
+	}
+	n := copy(fp.header[fp.headerLen:target], p)
+	fp.headerLen += n
+	return p[n:]
+}
+
+// headerLengthFromByte1 returns the total header length implied by byte 1 of
+// the frame (the MASK bit + 7-bit length field). Result is in [2, 14].
+func headerLengthFromByte1(b byte) int {
+	n := 2
+	switch b & lenMask {
+	case payloadLen16:
+		n += 2
+	case payloadLen64:
+		n += 8
+	}
+	if b&maskBit != 0 {
+		n += 4
+	}
+	return n
+}
+
+// completeHeader decodes the buffered header, fires the data-frame callback
+// (if applicable), primes payloadLeft for the next drain phase, and resets
+// header accumulation for the next frame.
+func (fp *frameParser) completeHeader() {
+	opcode := fp.header[0] & 0x0F
+	b1 := fp.header[1]
+
+	var payloadLen uint64
+	switch b1 & lenMask {
+	case payloadLen16:
+		payloadLen = uint64(binary.BigEndian.Uint16(fp.header[2:4]))
+	case payloadLen64:
+		payloadLen = binary.BigEndian.Uint64(fp.header[2:10])
+	default:
+		payloadLen = uint64(b1 & lenMask)
+	}
+	// The mask key, if present, sits in the last 4 bytes of the header and is
+	// of no interest to the observer — we only need its length, which is
+	// already accounted for in headerLengthFromByte1.
+
+	if opcode&controlBit == 0 && fp.onDataFrame != nil {
 		fp.onDataFrame()
 	}
-	if fp.payloadLeft == 0 {
-		fp.state = stateHeader0
-		return
-	}
-	fp.state = statePayload
+
+	fp.payloadLeft = payloadLen
+	fp.headerLen = 0
+	fp.headerNeed = 0
 }

--- a/internal/pkg/service/appsproxy/proxy/apphandler/upstream/wsactivity/frame_test.go
+++ b/internal/pkg/service/appsproxy/proxy/apphandler/upstream/wsactivity/frame_test.go
@@ -113,8 +113,11 @@ func TestFrameParser_ExtLen64_NoAllocation_HugeLen(t *testing.T) {
 	p := newFrameParser(func() { count++ })
 	p.Feed(patched)
 	assert.Equal(t, 1, count, "callback must fire once on header completion")
-	assert.Equal(t, statePayload, p.state, "must be draining payload")
+	// Header is fully consumed and parser is now draining the payload — never
+	// allocating a buffer for it, just decrementing payloadLeft as bytes arrive.
 	assert.Equal(t, huge, p.payloadLeft, "must record full payload length")
+	assert.Equal(t, 0, p.headerLen, "header buffer must be reset after header completion")
+	assert.Equal(t, 0, p.headerNeed, "headerNeed must be reset after header completion")
 }
 
 func TestFrameParser_MaskedFrame(t *testing.T) {

--- a/internal/pkg/service/appsproxy/proxy/apphandler/upstream/wsactivity/frame_test.go
+++ b/internal/pkg/service/appsproxy/proxy/apphandler/upstream/wsactivity/frame_test.go
@@ -103,9 +103,10 @@ func TestFrameParser_ExtLen64_NoAllocation_HugeLen(t *testing.T) {
 	frame := buildFrame(t, 0x2, true, 0, false) // baseline header
 	// Patch the 7-bit length field to 127 and append a huge 64-bit length.
 	huge := uint64(1) << 50 // 1 PiB — clearly non-allocatable
-	patched := []byte{frame[0], 127}
 	extLen := make([]byte, 8)
 	binary.BigEndian.PutUint64(extLen, huge)
+	patched := make([]byte, 0, 2+len(extLen))
+	patched = append(patched, frame[0], 127)
 	patched = append(patched, extLen...)
 
 	count := 0
@@ -230,7 +231,7 @@ func TestFrameParser_MixedDataAndControl(t *testing.T) {
 	pong := buildFrame(t, 0xA, true, 0, false)
 	data := buildFrame(t, 0x1, true, 12, false)
 
-	var stream []byte
+	stream := make([]byte, 0, 3*len(ping)+len(pong)*2+len(data))
 	stream = append(stream, ping...)
 	stream = append(stream, pong...)
 	stream = append(stream, ping...)

--- a/internal/pkg/service/appsproxy/proxy/apphandler/upstream/wsactivity/frame_test.go
+++ b/internal/pkg/service/appsproxy/proxy/apphandler/upstream/wsactivity/frame_test.go
@@ -1,0 +1,282 @@
+package wsactivity
+
+import (
+	"encoding/binary"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+)
+
+// buildFrame constructs a raw RFC 6455 frame with the given opcode, FIN bit,
+// payload length, and (optionally) a 4-byte masking key. Payload bytes are
+// filled with deterministic data; the parser never inspects them, so the
+// content is irrelevant.
+func buildFrame(t *testing.T, opcode byte, fin bool, payloadLen uint64, masked bool) []byte {
+	t.Helper()
+
+	var buf []byte
+
+	// Byte 0: FIN | RSV1..3 | OPCODE
+	b0 := opcode & 0x0F
+	if fin {
+		b0 |= 0x80
+	}
+	buf = append(buf, b0)
+
+	// Byte 1: MASK | PAYLOAD_LEN_7 + extended length
+	var b1 byte
+	if masked {
+		b1 |= maskBit
+	}
+	switch {
+	case payloadLen < 126:
+		b1 |= byte(payloadLen)
+		buf = append(buf, b1)
+	case payloadLen <= 0xFFFF:
+		b1 |= 126
+		buf = append(buf, b1)
+		extLen := make([]byte, 2)
+		binary.BigEndian.PutUint16(extLen, uint16(payloadLen))
+		buf = append(buf, extLen...)
+	default:
+		b1 |= 127
+		buf = append(buf, b1)
+		extLen := make([]byte, 8)
+		binary.BigEndian.PutUint64(extLen, payloadLen)
+		buf = append(buf, extLen...)
+	}
+
+	// 4-byte masking key (content arbitrary; parser only counts bytes).
+	if masked {
+		buf = append(buf, 0xDE, 0xAD, 0xBE, 0xEF)
+	}
+
+	// Payload bytes (parser only walks past them via the counter).
+	if payloadLen > 0 {
+		payload := make([]byte, payloadLen)
+		for i := range payload {
+			payload[i] = byte(i)
+		}
+		buf = append(buf, payload...)
+	}
+
+	return buf
+}
+
+// countCallbacks feeds the given byte slices (in order) into a fresh parser
+// and returns the total number of data-frame callbacks observed.
+func countCallbacks(chunks ...[]byte) int {
+	count := 0
+	p := newFrameParser(func() { count++ })
+	for _, c := range chunks {
+		p.Feed(c)
+	}
+	return count
+}
+
+func TestFrameParser_SingleTextFrame_FixedPayload(t *testing.T) {
+	t.Parallel()
+	frame := buildFrame(t, 0x1, true, 5, false)
+	assert.Equal(t, 1, countCallbacks(frame))
+}
+
+func TestFrameParser_ExtLen16(t *testing.T) {
+	t.Parallel()
+	for _, payloadLen := range []uint64{126, 200, 65535} {
+		frame := buildFrame(t, 0x2, true, payloadLen, false)
+		assert.Equal(t, 1, countCallbacks(frame), "payloadLen=%d", payloadLen)
+	}
+}
+
+func TestFrameParser_ExtLen64(t *testing.T) {
+	t.Parallel()
+	// 65536 = first value requiring 64-bit ext length.
+	frame := buildFrame(t, 0x2, true, 65536, false)
+	assert.Equal(t, 1, countCallbacks(frame))
+}
+
+func TestFrameParser_ExtLen64_NoAllocation_HugeLen(t *testing.T) {
+	t.Parallel()
+	// Header-only feed with a 64-bit length larger than any plausible
+	// allocation. The parser must accept and transition to payload-drain
+	// without allocating a buffer for the payload.
+	frame := buildFrame(t, 0x2, true, 0, false) // baseline header
+	// Patch the 7-bit length field to 127 and append a huge 64-bit length.
+	huge := uint64(1) << 50 // 1 PiB — clearly non-allocatable
+	patched := []byte{frame[0], 127}
+	extLen := make([]byte, 8)
+	binary.BigEndian.PutUint64(extLen, huge)
+	patched = append(patched, extLen...)
+
+	count := 0
+	p := newFrameParser(func() { count++ })
+	p.Feed(patched)
+	assert.Equal(t, 1, count, "callback must fire once on header completion")
+	assert.Equal(t, statePayload, p.state, "must be draining payload")
+	assert.Equal(t, huge, p.payloadLeft, "must record full payload length")
+}
+
+func TestFrameParser_MaskedFrame(t *testing.T) {
+	t.Parallel()
+	// Client-side frame with MASK=1 and a 4-byte key — parser must skip the
+	// key and still emit the callback exactly once.
+	frame := buildFrame(t, 0x1, true, 10, true)
+	assert.Equal(t, 1, countCallbacks(frame))
+}
+
+func TestFrameParser_ControlFramesIgnored(t *testing.T) {
+	t.Parallel()
+	for _, opcode := range []byte{0x8 /* close */, 0x9 /* ping */, 0xA /* pong */} {
+		// Ping/pong typically use small or zero-length payloads.
+		frame := buildFrame(t, opcode, true, 0, false)
+		assert.Equal(t, 0, countCallbacks(frame), "opcode=0x%X", opcode)
+	}
+}
+
+func TestFrameParser_ControlFrame_WithPayload(t *testing.T) {
+	t.Parallel()
+	// Ping with a payload — still control, still zero callbacks.
+	// Tests that the payload-drain path doesn't accidentally fire.
+	frame := buildFrame(t, 0x9, true, 50, true)
+	assert.Equal(t, 0, countCallbacks(frame))
+}
+
+func TestFrameParser_FragmentedMessage_OneCallbackPerFrame(t *testing.T) {
+	t.Parallel()
+	// text(FIN=0) + continuation(FIN=0) + continuation(FIN=1) = 3 frames.
+	// Spec: "Callback fires once per frame at frame-start, not per byte."
+	first := buildFrame(t, 0x1, false, 4, false)
+	mid := buildFrame(t, 0x0, false, 4, false)
+	last := buildFrame(t, 0x0, true, 4, false)
+	assert.Equal(t, 3, countCallbacks(first, mid, last))
+}
+
+func TestFrameParser_MultipleFramesInOneFeed(t *testing.T) {
+	t.Parallel()
+	// Three concatenated text frames in a single Feed → 3 callbacks.
+	f1 := buildFrame(t, 0x1, true, 3, false)
+	f2 := buildFrame(t, 0x2, true, 10, false)
+	f3 := buildFrame(t, 0x1, true, 0, false)
+	concat := append(append(f1, f2...), f3...)
+	assert.Equal(t, 3, countCallbacks(concat))
+}
+
+func TestFrameParser_SplitAcrossFeeds(t *testing.T) {
+	t.Parallel()
+	frame := buildFrame(t, 0x1, true, 200, true) // 16-bit length + mask
+
+	splitPoints := []struct {
+		name string
+		at   int
+	}{
+		{"after byte 0", 1},
+		{"after byte 1", 2},
+		{"middle of extLen", 3},
+		{"after extLen", 4},
+		{"middle of mask key", 6},
+		{"after header", 8},
+		{"middle of payload", 100},
+	}
+
+	for _, sp := range splitPoints {
+		t.Run(sp.name, func(t *testing.T) {
+			t.Parallel()
+			if sp.at >= len(frame) {
+				t.Skipf("split point %d out of range", sp.at)
+			}
+			assert.Equal(t, 1, countCallbacks(frame[:sp.at], frame[sp.at:]),
+				"single frame split at %d should still yield one callback", sp.at)
+		})
+	}
+}
+
+func TestFrameParser_OneByteAtATime(t *testing.T) {
+	t.Parallel()
+	// Worst-case TCP framing: each byte arrives in its own Feed call.
+	frame := buildFrame(t, 0x1, true, 65535, true) // 16-bit length + mask + 65535B payload
+	count := 0
+	p := newFrameParser(func() { count++ })
+	for _, b := range frame {
+		p.Feed([]byte{b})
+	}
+	assert.Equal(t, 1, count)
+}
+
+func TestFrameParser_ReservedDataOpcodesCountAsData(t *testing.T) {
+	t.Parallel()
+	// RFC 6455 §5.2: opcodes 0x3..0x7 are reserved for further non-control
+	// frames. The spec asks us to discriminate by (opcode & 0x8), so all of
+	// 0x0..0x7 count as data.
+	for _, opcode := range []byte{0x3, 0x4, 0x5, 0x6, 0x7} {
+		frame := buildFrame(t, opcode, true, 1, false)
+		assert.Equal(t, 1, countCallbacks(frame), "opcode=0x%X", opcode)
+	}
+}
+
+func TestFrameParser_ReservedControlOpcodesIgnored(t *testing.T) {
+	t.Parallel()
+	// 0xB..0xF are reserved for further control frames — must not callback.
+	for _, opcode := range []byte{0xB, 0xC, 0xD, 0xE, 0xF} {
+		frame := buildFrame(t, opcode, true, 0, false)
+		assert.Equal(t, 0, countCallbacks(frame), "opcode=0x%X", opcode)
+	}
+}
+
+func TestFrameParser_MixedDataAndControl(t *testing.T) {
+	t.Parallel()
+	// Realistic Streamlit idle pattern: ping/pong heartbeats interleaved
+	// with a single data frame.
+	ping := buildFrame(t, 0x9, true, 0, false)
+	pong := buildFrame(t, 0xA, true, 0, false)
+	data := buildFrame(t, 0x1, true, 12, false)
+
+	var stream []byte
+	stream = append(stream, ping...)
+	stream = append(stream, pong...)
+	stream = append(stream, ping...)
+	stream = append(stream, data...)
+	stream = append(stream, pong...)
+
+	assert.Equal(t, 1, countCallbacks(stream))
+}
+
+func TestFrameParser_EmptyPayload(t *testing.T) {
+	t.Parallel()
+	// Zero-length text frame: callback fires once, parser returns to header0.
+	f1 := buildFrame(t, 0x1, true, 0, false)
+	f2 := buildFrame(t, 0x1, true, 3, false)
+	assert.Equal(t, 2, countCallbacks(f1, f2),
+		"empty-payload frame must not stall the parser")
+}
+
+func TestFrameParser_NilCallback_DoesNotPanic(t *testing.T) {
+	t.Parallel()
+	p := newFrameParser(nil)
+	frame := buildFrame(t, 0x1, true, 5, false)
+	assert.NotPanics(t, func() { p.Feed(frame) })
+}
+
+// FuzzFrameParser feeds arbitrary byte streams to the parser and ensures it
+// never panics. The parser is a passive observer — any sequence of bytes must
+// be safely walkable.
+func FuzzFrameParser(f *testing.F) {
+	f.Add([]byte{0x81, 0x05, 'h', 'e', 'l', 'l', 'o'})
+	f.Add([]byte{0x89, 0x00})                                                                               // ping
+	f.Add([]byte{0x82, 0x7E, 0x00, 0x10, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0})                   // 16-bit len
+	f.Add([]byte{0x82, 0xFF, 0xDE, 0xAD, 0xBE, 0xEF, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x01, 0xAA}) // masked + 64-bit len header
+	f.Add([]byte{0xFF, 0xFF, 0xFF, 0xFF})                                                                   // garbage
+	f.Add([]byte{})                                                                                         // empty
+
+	f.Fuzz(func(t *testing.T, data []byte) {
+		p := newFrameParser(func() {})
+		// Feed in random chunk sizes to exercise split-state transitions.
+		for i := 0; i < len(data); {
+			step := 1 + (int(data[i]) % 7)
+			if i+step > len(data) {
+				step = len(data) - i
+			}
+			p.Feed(data[i : i+step])
+			i += step
+		}
+	})
+}

--- a/internal/pkg/service/appsproxy/proxy/pagewriter/suspended.go
+++ b/internal/pkg/service/appsproxy/proxy/pagewriter/suspended.go
@@ -17,7 +17,11 @@ import (
 // the health-check response body in a modal that does not render HTML — the
 // same reason the spinner/restart messages are plain text for these paths.
 // See IsStreamlitHealthCheck and AJDA-1935.
-const suspendedMessage = "The application was paused due to inactivity. Refresh the page to start it again."
+// Kept short on purpose: data-app frontends (Streamlit) show this in a
+// connection modal that wraps text but has limited height, so a long message
+// ends up behind a scrollbar. The modal renders the body as plain text — it
+// does not honor newlines or HTML, so wording is the only lever for length.
+const suspendedMessage = "App paused. Reload the page to restart."
 
 // suspendedRetryAfter is advisory back-off for the polling client. It does not
 // cause the app to restart — only a user-initiated reload does.

--- a/internal/pkg/service/appsproxy/proxy/pagewriter/suspended.go
+++ b/internal/pkg/service/appsproxy/proxy/pagewriter/suspended.go
@@ -1,0 +1,37 @@
+package pagewriter
+
+import (
+	"net/http"
+	"time"
+)
+
+// suspendedMessage is shown to a data-app frontend that keeps polling a
+// background health endpoint (e.g. Streamlit /_stcore/health) after the app
+// has been auto-suspended for inactivity. apps-proxy deliberately does NOT
+// auto-restart the app from these background polls — doing so would defeat
+// auto-suspend for forgotten tabs, which keep polling regardless of whether a
+// user is present. The user must reload the page to start the app again
+// (a reload hits GET / which is treated as real activity and triggers wakeup).
+//
+// The message is plain text on purpose: data-app frontends (Streamlit) display
+// the health-check response body in a modal that does not render HTML — the
+// same reason the spinner/restart messages are plain text for these paths.
+// See IsStreamlitHealthCheck and AJDA-1935.
+const suspendedMessage = "The application was paused due to inactivity. Refresh the page to start it again."
+
+// suspendedRetryAfter is advisory back-off for the polling client. It does not
+// cause the app to restart — only a user-initiated reload does.
+const suspendedRetryAfter = 60 * time.Second
+
+// WriteSuspendedPage responds to a data-app frontend background poll for an
+// auto-suspended app. It returns 503 with a plain-text body instructing the
+// user to reload, and does NOT trigger a wakeup. See suspendedMessage for the
+// rationale (plain text, no auto-restart from background polls).
+func (pw *Writer) WriteSuspendedPage(w http.ResponseWriter) {
+	w.Header().Set("Cache-Control", "no-cache, no-store, must-revalidate;")
+	w.Header().Set("pragma", "no-cache")
+	w.Header().Set("Retry-After", pw.clock.Now().Add(suspendedRetryAfter).UTC().Format(http.TimeFormat))
+	w.Header().Set("Content-Type", "text/plain; charset=utf-8")
+	w.WriteHeader(http.StatusServiceUnavailable)
+	_, _ = w.Write([]byte(suspendedMessage))
+}

--- a/internal/pkg/service/appsproxy/proxy/proxy_test.go
+++ b/internal/pkg/service/appsproxy/proxy/proxy_test.go
@@ -1956,9 +1956,10 @@ func TestAppProxyRouter(t *testing.T) {
 			// On a Suspended app, framework background polls must NOT trigger
 			// wakeup — otherwise a forgotten tab whose frontend keeps polling
 			// every WS reconnect cycle would re-wake the app indefinitely,
-			// defeating auto-suspend. Apps-proxy replies 503 with Retry-After
-			// and leaves the app alone. Meaningful user actions (refresh, GET
-			// / etc.) continue to wake the app via the default branch.
+			// defeating auto-suspend. Apps-proxy replies 503 with a plain-text
+			// "paused due to inactivity, refresh to start" message (shown in the
+			// frontend's connection modal) and leaves the app alone. Meaningful
+			// user actions (refresh → GET /) wake the app via the default branch.
 			name: "public-app-framework-background-poll-on-suspended-returns-503-no-wakeup",
 			setupK8s: func(t *testing.T, fakeClient *k8sfake.FakeDynamicClient, watcher *k8sapp.StateWatcher) {
 				patch := []byte(`{"status":{"currentState":"Stopped"}}`)
@@ -1979,13 +1980,18 @@ func TestAppProxyRouter(t *testing.T) {
 				defer response.Body.Close()
 
 				require.Equal(t, http.StatusServiceUnavailable, response.StatusCode)
-				assert.Equal(t, "60", response.Header.Get("Retry-After"))
+				assert.NotEmpty(t, response.Header.Get("Retry-After"), "should advise the client to back off")
+				assert.Equal(t, "text/plain; charset=utf-8", response.Header.Get("Content-Type"),
+					"must be plain text — the frontend modal does not render HTML")
 
-				// Body is empty — the spinner page (served on the default
-				// suspended branch) would contain "Starting your application..."
+				// Body carries the user-facing "paused, refresh to start" message
+				// that the frontend shows in its connection modal. It must NOT be
+				// the spinner page ("Starting your application...") served by the
+				// default branch, which would imply the app is auto-restarting.
 				body, err := io.ReadAll(response.Body)
 				require.NoError(t, err)
-				assert.Empty(t, body, "filtered path must not return the spinner page")
+				assert.Contains(t, string(body), "Refresh the page",
+					"should instruct the user to reload")
 				assert.NotContains(t, string(body), "Starting your application...")
 			},
 			expectedNotifications: map[string]int{},

--- a/internal/pkg/service/appsproxy/proxy/proxy_test.go
+++ b/internal/pkg/service/appsproxy/proxy/proxy_test.go
@@ -1990,7 +1990,7 @@ func TestAppProxyRouter(t *testing.T) {
 				// default branch, which would imply the app is auto-restarting.
 				body, err := io.ReadAll(response.Body)
 				require.NoError(t, err)
-				assert.Contains(t, string(body), "Refresh the page",
+				assert.Contains(t, string(body), "Reload the page",
 					"should instruct the user to reload")
 				assert.NotContains(t, string(body), "Starting your application...")
 			},

--- a/internal/pkg/service/appsproxy/proxy/proxy_test.go
+++ b/internal/pkg/service/appsproxy/proxy/proxy_test.go
@@ -3355,6 +3355,135 @@ func TestKaiPreviewSlidingRefresh(t *testing.T) {
 	assert.Empty(t, mocked.DebugLogger().ErrorMessages())
 }
 
+// TestWebsocketActivityTracking verifies the per-frame WebSocket activity-tracking
+// behavior introduced by wsactivity:
+//
+//  1. The initial handshake produces exactly one Sandboxes Service notify (from the
+//     GotConn ClientTrace hook).
+//  2. An open but otherwise IDLE WebSocket past the per-app 30 s notify throttle
+//     window must NOT produce additional notifies. This is the regression test for
+//     the removed 30 s ticker — the customer's "forgotten browser tab" case from
+//     SUPPORT-16324 / PROF-104.
+//  3. A real data frame past the throttle window MUST produce a second notify,
+//     proving the per-frame path is wired end-to-end through the wrapped conn.
+//
+// The test uses an injected FakeClock so the notify throttle can be advanced
+// deterministically without sleeping for 30 s of real time.
+//
+// Note on protocol-level pings: the "control frames ignored" property is unit-tested
+// in wsactivity (TestWrap_OnlyControlFrames_NoCallbacks). A full integration test of
+// that property would require driving ping/pong through coder/websocket with a
+// custom server handler, which is fragile w.r.t. the library's read-loop semantics.
+// The (idle WS + advanced clock → count unchanged) check below is sufficient for
+// the actual customer-visible behavior.
+func TestWebsocketActivityTracking(t *testing.T) {
+	t.Parallel()
+	ctx := t.Context()
+
+	fakeClock := clockwork.NewFakeClock()
+
+	// Standard testing scaffold: apps API + upstream app server + secrets + config.
+	tmpDir := t.TempDir()
+	pm, _ := server.NewPortManager(t, tmpDir, "appsproxy")
+	appsAPI := testutil.StartDataAppsAPI(t, pm)
+	t.Cleanup(func() { appsAPI.Close() })
+	appServer := testutil.StartAppServer(t, pm)
+	t.Cleanup(func() { appServer.Close() })
+
+	providers := testAuthProviders(t, pm)
+	appURL := testutil.AppServerURL(t, appServer)
+	apps := testDataApps(appURL, providers)
+	appsAPI.Register(apps)
+
+	secret := make([]byte, 32)
+	_, err := rand.Read(secret)
+	require.NoError(t, err)
+	csrfSecret := make([]byte, 32)
+	_, err = rand.Read(csrfSecret)
+	require.NoError(t, err)
+
+	cfg := config.New()
+	cfg.API.PublicURL, _ = url.Parse("https://hub.keboola.local")
+	cfg.CookieSecretSalt = string(secret)
+	cfg.CsrfTokenSalt = string(csrfSecret)
+	cfg.SandboxesAPI.URL = appsAPI.URL
+
+	d, mocked := proxyDependencies.NewMockedServiceScopeWithK8sObjects(
+		t, ctx, cfg,
+		makeDefaultK8sObjects(apps, appURL.String()),
+		dependencies.WithRealHTTPClient(),
+		dependencies.WithClock(fakeClock),
+	)
+	defer func() {
+		d.Process().Shutdown(ctx, errors.New("bye bye"))
+		d.Process().WaitForShutdown()
+	}()
+
+	loggerWriter := logging.NewLoggerWriter(d.Logger(), "info")
+	logger.SetOutput(loggerWriter)
+	logger.SetErrOutput(loggerWriter)
+	handler := proxy.NewHandler(ctx, d)
+
+	var lc net.ListenConfig
+	l, err := lc.Listen(ctx, "tcp", "127.0.0.1:0")
+	require.NoError(t, err)
+	proxySrv := &httptest.Server{
+		Listener: l,
+		Config:   &http.Server{Handler: handler, ReadHeaderTimeout: 5 * time.Second, ErrorLog: log.NewStdErrorLogger(d.Logger())},
+	}
+	proxySrv.StartTLS()
+	t.Cleanup(func() { proxySrv.Close() })
+
+	proxyURL, err := url.Parse(proxySrv.URL)
+	require.NoError(t, err)
+	client := createHTTPClient(t, proxyURL)
+	registerDefaultK8sApps(t, d.AppStateWatcher())
+
+	// notifyCount is locked behind the testutil mutex so it is safe to read
+	// concurrently with the in-flight notify goroutine driven by data frames.
+	notifyCount := func() int { return appsAPI.NotificationsCount("123") }
+
+	wsCtx, wsCancel := context.WithTimeout(ctx, time.Minute)
+	defer wsCancel()
+
+	// Open the idle WebSocket. The handshake's GotConn ClientTrace hook fires
+	// u.notify once, producing the first Sandboxes Service PATCH call.
+	c, _, err := websocket.Dial(
+		wsCtx,
+		"wss://public-123.hub.keboola.local/ws-idle",
+		&websocket.DialOptions{HTTPClient: client},
+	)
+	require.NoError(t, err)
+	t.Cleanup(func() { _ = c.Close(websocket.StatusNormalClosure, "") })
+
+	require.Eventually(t, func() bool { return notifyCount() == 1 }, 5*time.Second, 10*time.Millisecond,
+		"handshake should produce exactly one notify (from GotConn)")
+
+	// Regression check for the removed 30 s ticker: advance the fake clock
+	// well past the throttle window with NO activity, then verify the notify
+	// count did not move. Under the old presence-based tracking the ticker
+	// would have fired notify here just because the connection was open.
+	fakeClock.Advance(31 * time.Second)
+	// Yield wall-clock time long enough that any (hypothetical) periodic
+	// goroutine driven by real time would have had a chance to fire. 250 ms
+	// is plenty — the old ticker slept 30 s of real time, so even a
+	// dramatically accelerated variant would tick within this window.
+	time.Sleep(250 * time.Millisecond)
+	assert.Equal(t, 1, notifyCount(),
+		"idle WS past the throttle window must NOT trigger a notify (ticker must be removed)")
+
+	// Write a real data frame (text message). The proxy observes a non-control
+	// opcode (0x1) in the client→server direction, fires u.notify, and — since
+	// fakeClock is past the throttle window — the throttle gate opens and we
+	// get a second PATCH call to apps API.
+	require.NoError(t, c.Write(wsCtx, websocket.MessageText, []byte("hello data")))
+
+	require.Eventually(t, func() bool { return notifyCount() == 2 }, 5*time.Second, 10*time.Millisecond,
+		"data-frame activity past the throttle window must produce a second notify")
+
+	assert.Empty(t, mocked.DebugLogger().ErrorMessages())
+}
+
 // makeDefaultK8sObjects converts a slice of app configs into K8s unstructured App CRD objects
 // with Running state and the given upstream URL. Pass the result to NewMockedServiceScopeWithK8sObjects
 // so the fake client is pre-populated before the informer starts.

--- a/internal/pkg/service/appsproxy/proxy/proxy_test.go
+++ b/internal/pkg/service/appsproxy/proxy/proxy_test.go
@@ -1929,6 +1929,67 @@ func TestAppProxyRouter(t *testing.T) {
 			},
 			expectedNotifications: map[string]int{},
 		},
+		{
+			// Background-poll endpoints emitted by data-app frontends
+			// (Streamlit's /_stcore/health and /_stcore/host-config) fire
+			// independently of user interaction — every WS reconnect cycle
+			// while the tab stays open. Apps-proxy must NOT count them as
+			// activity, otherwise auto-suspend never triggers.
+			name: "public-app-framework-background-poll-skips-notify",
+			run: func(t *testing.T, client *http.Client, m []*mockoidc.MockOIDC, appServer *testutil.AppServer, service *testutil.DataAppsAPI, fakeClient *k8sfake.FakeDynamicClient, watcher *k8sapp.StateWatcher) {
+				// Three background-poll requests against a Running app. Each
+				// reaches the upstream (GotConn fires), but the new filter in
+				// trace() must skip notify for these paths. The upstream test
+				// server has no handler for them, so we accept whatever status
+				// it returns — what matters is the notify count below.
+				for _, path := range []string{"/_stcore/health", "/_stcore/host-config", "/_stcore/health"} {
+					request, err := http.NewRequestWithContext(t.Context(), http.MethodGet, "https://public-123.hub.keboola.local"+path, nil)
+					require.NoError(t, err)
+					response, err := client.Do(request)
+					require.NoError(t, err)
+					_ = response.Body.Close()
+				}
+			},
+			expectedNotifications: map[string]int{},
+		},
+		{
+			// On a Suspended app, framework background polls must NOT trigger
+			// wakeup — otherwise a forgotten tab whose frontend keeps polling
+			// every WS reconnect cycle would re-wake the app indefinitely,
+			// defeating auto-suspend. Apps-proxy replies 503 with Retry-After
+			// and leaves the app alone. Meaningful user actions (refresh, GET
+			// / etc.) continue to wake the app via the default branch.
+			name: "public-app-framework-background-poll-on-suspended-returns-503-no-wakeup",
+			setupK8s: func(t *testing.T, fakeClient *k8sfake.FakeDynamicClient, watcher *k8sapp.StateWatcher) {
+				patch := []byte(`{"status":{"currentState":"Stopped"}}`)
+				_, err := fakeClient.Resource(k8sapp.AppGVR()).Namespace("keboola").Patch(
+					t.Context(), "app-123", k8stypes.MergePatchType, patch, metav1.PatchOptions{},
+				)
+				require.NoError(t, err)
+				require.Eventually(t, func() bool {
+					info, ok := watcher.GetState(t.Context(), api.AppID("123"))
+					return ok && info.ActualState == k8sapp.AppActualStateStopped
+				}, 5*time.Second, 50*time.Millisecond)
+			},
+			run: func(t *testing.T, client *http.Client, m []*mockoidc.MockOIDC, appServer *testutil.AppServer, service *testutil.DataAppsAPI, fakeClient *k8sfake.FakeDynamicClient, watcher *k8sapp.StateWatcher) {
+				request, err := http.NewRequestWithContext(t.Context(), http.MethodGet, "https://public-123.hub.keboola.local/_stcore/health", nil)
+				require.NoError(t, err)
+				response, err := client.Do(request)
+				require.NoError(t, err)
+				defer response.Body.Close()
+
+				require.Equal(t, http.StatusServiceUnavailable, response.StatusCode)
+				assert.Equal(t, "60", response.Header.Get("Retry-After"))
+
+				// Body is empty — the spinner page (served on the default
+				// suspended branch) would contain "Starting your application..."
+				body, err := io.ReadAll(response.Body)
+				require.NoError(t, err)
+				assert.Empty(t, body, "filtered path must not return the spinner page")
+				assert.NotContains(t, string(body), "Starting your application...")
+			},
+			expectedNotifications: map[string]int{},
+		},
 
 		{
 			name: "private-one-provider-selector",

--- a/internal/pkg/service/appsproxy/proxy/proxy_test.go
+++ b/internal/pkg/service/appsproxy/proxy/proxy_test.go
@@ -3360,22 +3360,27 @@ func TestKaiPreviewSlidingRefresh(t *testing.T) {
 //
 //  1. The initial handshake produces exactly one Sandboxes Service notify (from the
 //     GotConn ClientTrace hook).
-//  2. An open but otherwise IDLE WebSocket past the per-app 30 s notify throttle
-//     window must NOT produce additional notifies. This is the regression test for
-//     the removed 30 s ticker — the customer's "forgotten browser tab" case from
-//     SUPPORT-16324 / PROF-104.
+//  2. An idle WebSocket — connection open, no data frames exchanged — does NOT
+//     spontaneously increment the notify count past the throttle window. The
+//     customer-visible goal of the change (forgotten browser tab no longer blocks
+//     auto-suspend) is that an idle connection produces zero activity-driven
+//     notifies; this test confirms that for the per-frame path.
 //  3. A real data frame past the throttle window MUST produce a second notify,
 //     proving the per-frame path is wired end-to-end through the wrapped conn.
 //
 // The test uses an injected FakeClock so the notify throttle can be advanced
 // deterministically without sleeping for 30 s of real time.
 //
-// Note on protocol-level pings: the "control frames ignored" property is unit-tested
-// in wsactivity (TestWrap_OnlyControlFrames_NoCallbacks). A full integration test of
-// that property would require driving ping/pong through coder/websocket with a
-// custom server handler, which is fragile w.r.t. the library's read-loop semantics.
-// The (idle WS + advanced clock → count unchanged) check below is sufficient for
-// the actual customer-visible behavior.
+// Caveat on (2): this is not a hard regression test against re-introducing a real-
+// time ticker (the previous implementation slept 30 s of wall-clock time). The
+// 250 ms wall-clock yield only catches accidentally short-period real-time goroutines;
+// a future 30 s ticker would still pass this test. Catching that regression
+// reliably would require making the ticker interval injectable. Code review is
+// expected to catch any reintroduction of presence-based polling.
+//
+// The "control frames are ignored" property is covered separately by
+// wsactivity's TestWrap_OnlyControlFrames_NoCallbacks unit test, which can do
+// the assertion without driving ping/pong through coder/websocket's read loop.
 func TestWebsocketActivityTracking(t *testing.T) {
 	t.Parallel()
 	ctx := t.Context()
@@ -3459,18 +3464,16 @@ func TestWebsocketActivityTracking(t *testing.T) {
 	require.Eventually(t, func() bool { return notifyCount() == 1 }, 5*time.Second, 10*time.Millisecond,
 		"handshake should produce exactly one notify (from GotConn)")
 
-	// Regression check for the removed 30 s ticker: advance the fake clock
-	// well past the throttle window with NO activity, then verify the notify
-	// count did not move. Under the old presence-based tracking the ticker
-	// would have fired notify here just because the connection was open.
+	// Advance the fake clock past the per-app throttle window. From now on,
+	// any activity-driven notify will pass the throttle gate. With no
+	// frames flowing through the wrapper, the count must stay at 1.
 	fakeClock.Advance(31 * time.Second)
-	// Yield wall-clock time long enough that any (hypothetical) periodic
-	// goroutine driven by real time would have had a chance to fire. 250 ms
-	// is plenty — the old ticker slept 30 s of real time, so even a
-	// dramatically accelerated variant would tick within this window.
+	// Brief wall-clock yield so that any short-period goroutine that mistakenly
+	// fired on connection presence (rather than per-frame) would surface. See
+	// the doc comment caveat — this does NOT catch a 30 s real-time ticker.
 	time.Sleep(250 * time.Millisecond)
 	assert.Equal(t, 1, notifyCount(),
-		"idle WS past the throttle window must NOT trigger a notify (ticker must be removed)")
+		"idle WS past the throttle window must NOT trigger an activity-driven notify")
 
 	// Write a real data frame (text message). The proxy observes a non-control
 	// opcode (0x1) in the client→server direction, fires u.notify, and — since

--- a/internal/pkg/service/appsproxy/proxy/testutil/api.go
+++ b/internal/pkg/service/appsproxy/proxy/testutil/api.go
@@ -8,6 +8,7 @@ import (
 	"net/http/httptest"
 	"strconv"
 	"strings"
+	"sync"
 	"testing"
 	"time"
 
@@ -21,8 +22,36 @@ import (
 
 type DataAppsAPI struct {
 	*httptest.Server
-	Apps          map[api.AppID]api.AppConfig
+	Apps map[api.AppID]api.AppConfig
+	// Notifications counts PATCH /apps/{app} calls per appID.
+	//
+	// Most table-driven tests read this map only after process Shutdown, by which
+	// time all in-flight notify goroutines have drained, so direct access is
+	// race-free. Tests that need to observe Notifications mid-flight must call
+	// NotificationsSnapshot or NotificationsCount, both of which lock the map.
 	Notifications map[string]int
+	notifyLock    sync.Mutex
+}
+
+// NotificationsCount returns the current count for appID under a lock,
+// suitable for use in concurrent test assertions (e.g. require.Eventually
+// while the proxy is still running).
+func (v *DataAppsAPI) NotificationsCount(appID string) int {
+	v.notifyLock.Lock()
+	defer v.notifyLock.Unlock()
+	return v.Notifications[appID]
+}
+
+// NotificationsSnapshot returns a copy of the current Notifications map under
+// a lock.
+func (v *DataAppsAPI) NotificationsSnapshot() map[string]int {
+	v.notifyLock.Lock()
+	defer v.notifyLock.Unlock()
+	out := make(map[string]int, len(v.Notifications))
+	for k, val := range v.Notifications {
+		out[k] = val
+	}
+	return out
 }
 
 func StartDataAppsAPI(t *testing.T, pm server.PortManager) *DataAppsAPI {
@@ -73,7 +102,9 @@ func StartDataAppsAPI(t *testing.T, pm server.PortManager) *DataAppsAPI {
 		require.NoError(t, err)
 
 		if _, ok := data["lastRequestTimestamp"]; ok {
+			service.notifyLock.Lock()
 			service.Notifications[appID] += 1
+			service.notifyLock.Unlock()
 		}
 	})
 

--- a/internal/pkg/service/appsproxy/proxy/testutil/app.go
+++ b/internal/pkg/service/appsproxy/proxy/testutil/app.go
@@ -72,6 +72,29 @@ func StartAppServer(t *testing.T, pm server.PortManager) *AppServer {
 		}
 	})
 
+	// /ws-idle accepts a WebSocket and keeps it open without sending any data
+	// frames. It only echoes the client's reads so that c.Ping/c.Write from the
+	// test side work normally (the library auto-pongs reading from this side).
+	// Used by tests that need to distinguish data-frame activity from idle WS
+	// with only protocol-level ping/pong traffic.
+	mux.HandleFunc("/ws-idle", func(w http.ResponseWriter, r *http.Request) {
+		c, err := websocket.Accept(w, r, nil)
+		require.NoError(t, err)
+
+		ctx, cancel := context.WithTimeoutCause(r.Context(), time.Minute, errors.New("ws-idle server timeout"))
+		defer cancel()
+
+		// Read forever and discard. This lets the library's frame reader process
+		// incoming pings → automatic pongs. No data is ever written by the server.
+		for {
+			_, _, err := c.Read(ctx)
+			if err != nil {
+				_ = c.Close(websocket.StatusNormalClosure, "")
+				return
+			}
+		}
+	})
+
 	mux.HandleFunc("/", func(w http.ResponseWriter, r *http.Request) {
 		lock.Lock()
 		defer lock.Unlock()

--- a/internal/pkg/service/appsproxy/proxy/testutil/app.go
+++ b/internal/pkg/service/appsproxy/proxy/testutil/app.go
@@ -72,11 +72,11 @@ func StartAppServer(t *testing.T, pm server.PortManager) *AppServer {
 		}
 	})
 
-	// /ws-idle accepts a WebSocket and keeps it open without sending any data
-	// frames. It only echoes the client's reads so that c.Ping/c.Write from the
-	// test side work normally (the library auto-pongs reading from this side).
-	// Used by tests that need to distinguish data-frame activity from idle WS
-	// with only protocol-level ping/pong traffic.
+	// /ws-idle accepts a WebSocket and keeps it open without ever writing.
+	// It drains incoming frames in a Read loop so that coder/websocket's
+	// internal frame reader can auto-respond to client pings with pongs;
+	// no data leaves the server side. Used by tests that need an idle
+	// WebSocket holding a connection open with no data-frame activity.
 	mux.HandleFunc("/ws-idle", func(w http.ResponseWriter, r *http.Request) {
 		c, err := websocket.Accept(w, r, nil)
 		require.NoError(t, err)


### PR DESCRIPTION
[link to issue](https://linear.app/keboola/issue/AJDA-2746/track-app-activity-from-websocket-data-frames)

## Description

Replaces presence-based WebSocket activity tracking with per-frame activity tracking in `apps-proxy`.

**Removed.** The 30 s ticker goroutine in `AppUpstream.NewUpstream` that called `notify()` whenever `activeWsCount > 0`, the `activeWsCount atomic.Int64` field, and its `Add(1)` / `Add(-1)` bookkeeping in `newWebsocketProxy`.

**Added.** A new internal package `internal/pkg/service/appsproxy/proxy/apphandler/upstream/wsactivity/`:

- `frame.go` — a stateful, allocation-free RFC 6455 frame parser. State machine: `header0 → header1 → extLen → maskKey → payload → header0`. Discriminates control vs data via `opcode & 0x8` (data: 0x0–0x7, control: 0x8–0xF). Handles 7-, 16-, and 64-bit payload lengths and masked frames. Payload bytes are skipped via a `uint64` counter — no buffer is sized from the wire (payload length can be up to 2^63-1 per RFC).
- `conn.go` — `Wrap(io.ReadWriteCloser, FrameCallback) io.ReadWriteCloser` instantiates one parser per direction. Read feeds the server→client parser, Write feeds the client→server parser; bytes pass through unchanged.

**Integration in `upstream.go`.** `newWebsocketProxy` installs a `proxy.ModifyResponse` hook that, on 101 Switching Protocols, wraps `res.Body` — which `httputil.ReverseProxy.handleUpgradeResponse` type-asserts to `io.ReadWriteCloser` and uses as the upstream end of the bidirectional copy with the hijacked client conn. A single wrap captures both directions of the WebSocket stream. The wrapper invokes `u.notify(reqCtx)` once per non-control frame; the existing 30 s-per-app throttle in `notify.Manager` absorbs the burst (at most one Sandboxes Service PATCH per app per 30 s, regardless of frame rate). The existing `trace().GotConn` notify on the upstream handshake is preserved.

**Tests.**

- `wsactivity/{frame,conn}_test.go` — unit tests across all frame-header shapes (7/16/64-bit length, masked/unmasked), control-frame skipping, fragmented messages (one callback per frame), multi-frame buffers, byte-by-byte streaming, reserved opcode classification, fuzz test for parser panic safety, and `Wrap` pass-through / short-write / Close semantics.
- `proxy_test.go` — new `TestWebsocketActivityTracking` using a `clockwork.FakeClock`: opens an idle WS to a new `/ws-idle` endpoint, advances the fake clock past the 30 s throttle window, and asserts (a) notify count stays at 1 (regression test for the removed ticker) and (b) sending a real text frame past the window increments notify to 2 (proves the per-frame path is wired end-to-end).
- `testutil/api.go` — `sync.Mutex` around `DataAppsAPI.Notifications` plus `NotificationsCount` / `NotificationsSnapshot` getters, needed for race-free reads while the proxy is still running.
- `testutil/app.go` — `/ws-idle` endpoint that accepts a WebSocket and reads forever without writing any data frames.

## Release Notes

- **Justification**
    - A customer reported that the `autoSuspendAfterSeconds` setting was effectively disabled for Streamlit data apps with regular viewers: a forgotten browser tab keeps a WebSocket open, the 30 s ticker resets the activity timestamp on every iteration, and the app never suspends. Compute is billed for sessions nobody is using.
    - From now on, the proxy looks at actual WebSocket traffic. Idle tabs that only exchange protocol-level keep-alive pings stop counting as "active", so `autoSuspendAfterSeconds` becomes a usable cost control again.
- **Plans for Customer Communication**
    - User-visible behavior shift: an open WebSocket that only exchanges ping/pong frames will no longer prevent an app from auto-suspending. Any app that relied on the 30 s heartbeat to stay alive without emitting data frames must now emit real frames as a liveness signal. This should be flagged in the apps-proxy operator notes / changelog when the PR lands. The reporting customer is awaiting this fix and should be notified.
- **Impact Analysis**
    - Strict subset of the previous notify firing set (real activity ⊆ "WS is open"), so the only behavioral regression is for apps whose framework emits zero data frames between renders — undocumented and not a supported pattern.
    - Not behind a feature flag. The change is the explicit goal of the ticket and Pepa's spec; gating it would dilute the fix.
- **Deployment Plan**
    - Continuous deployment via the standard `apps-proxy` rollout — test on `dev-*` tag first, have PM verify on testing stack, then promote stack by stack.
- **Rollback Plan**
    - Trivial revert: the change is isolated to `apps-proxy` and contains no schema or data migration. Re-deploying the prior image restores the old presence-based tracking.
- **Post-Release Support Plan**
    - Watch for new tickets reporting "my app suspended unexpectedly" — those will identify frameworks that silently relied on the old behavior. Otherwise no additional monitoring beyond the existing apps-proxy SLOs.