### PR TITLE
PAT-1832 Enable auto-resume for apps in dev mode

### DIFF
--- a/internal/pkg/service/appsproxy/dataapps/k8sapp/appinfo.go
+++ b/internal/pkg/service/appsproxy/dataapps/k8sapp/appinfo.go
@@ -69,8 +69,7 @@ type AppInfo struct {
 	ActualState        AppActualState
 	AutoRestartEnabled bool
 	// DevMode mirrors spec.devMode.enabled from the App CRD. When true the
-	// proxy does not auto-resume a Stopped app — only the owner of the
-	// dev/prod switch may trigger a restart.
+	// proxy enables the kai-preview iframe-auth path for the app.
 	DevMode bool
 	// UpstreamTarget is the pre-parsed URL from .status.appsProxy.upstreamUrl.
 	// Nil when the field is absent or unparseable.

--- a/internal/pkg/service/appsproxy/proxy/apphandler/upstream/upstream.go
+++ b/internal/pkg/service/appsproxy/proxy/apphandler/upstream/upstream.go
@@ -150,10 +150,7 @@ func (u *AppUpstream) ServeHTTPOrError(rw http.ResponseWriter, req *http.Request
 		switch {
 		case appInfo.ActualState == k8sapp.AppActualStateStarting:
 			u.manager.pageWriter.WriteSpinnerPage(rw, req, u.app)
-		case appInfo.DevMode, !appInfo.AutoRestartEnabled:
-			// In DEV mode (per App CRD spec.devMode.enabled) auto-resume is
-			// disabled — only the owner of the dev/prod switch may bring
-			// the app back to Running.
+		case !appInfo.AutoRestartEnabled:
 			u.manager.pageWriter.WriteRestartDisabledPage(rw, req, u.app)
 		default:
 			u.wakeup(ctx, errors.Errorf("app state is %s", appInfo.ActualState))

--- a/internal/pkg/service/appsproxy/proxy/proxy_test.go
+++ b/internal/pkg/service/appsproxy/proxy/proxy_test.go
@@ -2400,9 +2400,10 @@ func TestAppProxyRouter(t *testing.T) {
 			expectedNotifications: map[string]int{},
 		},
 		{
-			// DEV mode app that is Stopped — proxy must not auto-resume it
-			// and must show the "Application Disabled" page.
-			name: "dev-mode-no-wakeup",
+			// DEV mode app that is Stopped — the proxy must auto-resume it
+			// (trigger a wakeup and show the spinner page). autoRestartEnabled
+			// is absent here, so it defaults to true.
+			name: "dev-mode-auto-resume",
 			setupK8s: func(t *testing.T, fakeClient *k8sfake.FakeDynamicClient, watcher *k8sapp.StateWatcher) {
 				patch := []byte(`{"spec":{"devMode":{"enabled":true}},"status":{"currentState":"Stopped"}}`)
 				_, err := fakeClient.Resource(k8sapp.AppGVR()).Namespace("keboola").Patch(
@@ -2411,7 +2412,48 @@ func TestAppProxyRouter(t *testing.T) {
 				require.NoError(t, err)
 				require.Eventually(t, func() bool {
 					info, ok := watcher.GetState(t.Context(), api.AppID("devmode"))
-					return ok && info.DevMode && info.ActualState == k8sapp.AppActualStateStopped
+					// AutoRestartEnabled must default to true (spec omits it).
+					return ok && info.DevMode && info.AutoRestartEnabled && info.ActualState == k8sapp.AppActualStateStopped
+				}, 5*time.Second, 50*time.Millisecond)
+			},
+			run: func(t *testing.T, client *http.Client, m []*mockoidc.MockOIDC, appServer *testutil.AppServer, service *testutil.DataAppsAPI, fakeClient *k8sfake.FakeDynamicClient, watcher *k8sapp.StateWatcher) {
+				request, err := http.NewRequestWithContext(t.Context(), http.MethodGet, "https://dev-devmode.hub.keboola.local/", nil)
+				require.NoError(t, err)
+				response, err := client.Do(request)
+				require.NoError(t, err)
+				require.Equal(t, http.StatusServiceUnavailable, response.StatusCode)
+				body, err := io.ReadAll(response.Body)
+				require.NoError(t, err)
+				assert.Contains(t, string(body), "Starting your application...")
+				assert.NotContains(t, string(body), "Application Disabled")
+
+				// Confirm the app was auto-resumed: the wakeup patches the App
+				// CRD's spec.state to Running (asynchronously).
+				require.Eventually(t, func() bool {
+					obj, err := fakeClient.Resource(k8sapp.AppGVR()).Namespace("keboola").Get(t.Context(), "app-devmode", metav1.GetOptions{})
+					if err != nil {
+						return false
+					}
+					state, found, err := unstructured.NestedString(obj.Object, "spec", "state")
+					return err == nil && found && state == string(k8sapp.AppActualStateRunning)
+				}, 5*time.Second, 50*time.Millisecond, "expected wakeup to patch spec.state=Running")
+			},
+			expectedNotifications: map[string]int{},
+		},
+		{
+			// DEV mode app that is Stopped AND has autoRestartEnabled=false —
+			// the app must NOT be woken and must show the "Application
+			// Disabled" page.
+			name: "dev-mode-restart-disabled",
+			setupK8s: func(t *testing.T, fakeClient *k8sfake.FakeDynamicClient, watcher *k8sapp.StateWatcher) {
+				patch := []byte(`{"spec":{"devMode":{"enabled":true},"autoRestartEnabled":false},"status":{"currentState":"Stopped"}}`)
+				_, err := fakeClient.Resource(k8sapp.AppGVR()).Namespace("keboola").Patch(
+					t.Context(), "app-devmode", k8stypes.MergePatchType, patch, metav1.PatchOptions{},
+				)
+				require.NoError(t, err)
+				require.Eventually(t, func() bool {
+					info, ok := watcher.GetState(t.Context(), api.AppID("devmode"))
+					return ok && info.DevMode && !info.AutoRestartEnabled && info.ActualState == k8sapp.AppActualStateStopped
 				}, 5*time.Second, 50*time.Millisecond)
 			},
 			run: func(t *testing.T, client *http.Client, m []*mockoidc.MockOIDC, appServer *testutil.AppServer, service *testutil.DataAppsAPI, fakeClient *k8sfake.FakeDynamicClient, watcher *k8sapp.StateWatcher) {
@@ -2424,10 +2466,19 @@ func TestAppProxyRouter(t *testing.T) {
 				require.NoError(t, err)
 				assert.Contains(t, string(body), "Application Disabled")
 
-				// Confirm the app was not auto-resumed: state remains Stopped.
-				info, ok := watcher.GetState(t.Context(), api.AppID("devmode"))
-				require.True(t, ok)
-				assert.Equal(t, k8sapp.AppActualStateStopped, info.ActualState)
+				// Confirm the app was NOT auto-resumed: the wakeup must never
+				// patch the App CRD's spec.state to Running.
+				require.Never(t, func() bool {
+					obj, err := fakeClient.Resource(k8sapp.AppGVR()).Namespace("keboola").Get(t.Context(), "app-devmode", metav1.GetOptions{})
+					if err != nil {
+						return false
+					}
+					state, found, err := unstructured.NestedString(obj.Object, "spec", "state")
+					// A non-string spec.state (err != nil) could only come from
+					// an unexpected patch — treat it as "resumed" so a decode
+					// error cannot mask a real wakeup.
+					return err != nil || (found && state == string(k8sapp.AppActualStateRunning))
+				}, time.Second, 50*time.Millisecond, "app must not be auto-resumed")
 			},
 			expectedNotifications: map[string]int{},
 		},


### PR DESCRIPTION
## Release Notes
https://linear.app/keboola/issue/PAT-1832/enable-auto-resume-for-apps-in-dev-mode

Dev-mode data apps no longer stay Stopped when accessed through apps-proxy. Previously a Stopped dev-mode app served the "Application Disabled" page; now it auto-resumes on request (wakeup + spinner) exactly like a normal app, so a developer returning to a preview after some time away (e.g. the next morning) just has to refresh to bring it back.

Auto-resume is now governed solely by the App CRD's `spec.autoRestartEnabled` (default `true`); dev mode is orthogonal to it. This reverses the proxy-side behavior added in PAT-1782 — the `AppInfo.DevMode` field is retained because it still gates the kai-preview iframe-auth path. A dev-mode app with `spec.autoRestartEnabled=false` still shows the "Application Disabled" page, so an explicit operator opt-out is respected.

## Plans for customer communication
None.

## Impact analysis
Affects dev-mode data apps only: a Stopped dev-mode app now wakes up on request instead of showing the disabled page. No change for production apps or for apps with `spec.autoRestartEnabled=false`.

## Change type
Improvement

## Justification
Resuming a dev-mode preview automatically on refresh is a better developer experience than a manual redeploy button (per PAT-1832 / Slack discussion).

## Deployment
Merge & automatic deploy.

## Rollback plan
Revert of this PR.

## Post release support plan
None.