### PR TITLE
fix(cli): tolerate empty-array column definition in table download

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -1,6 +1,6 @@
 module github.com/keboola/keboola-as-code
 
-go 1.26.2
+go 1.26.3
 
 replace github.com/google/go-jsonnet => github.com/keboola/go-jsonnet v0.22.1-0.20260427095904-b7e5c35127af
 
@@ -44,7 +44,7 @@ require (
 	github.com/json-iterator/go v1.1.12
 	github.com/keboola/go-cloud-encrypt v0.0.0-20250422071622-41a5d5547c43
 	github.com/keboola/go-utils v1.4.0
-	github.com/keboola/keboola-sdk-go/v2 v2.19.0
+	github.com/keboola/keboola-sdk-go/v2 v2.20.1
 	github.com/keboola/keboola-sdk-go/v2/transfer v1.1.0
 	github.com/klauspost/compress v1.18.5
 	github.com/klauspost/pgzip v1.2.6

--- a/go.sum
+++ b/go.sum
@@ -601,8 +601,8 @@ github.com/keboola/go-oauth2-proxy/v7 v7.15.3-0.20260427095909-2cab86bcf028 h1:s
 github.com/keboola/go-oauth2-proxy/v7 v7.15.3-0.20260427095909-2cab86bcf028/go.mod h1:+YPrVbsB1rdZx5K45/ealm94rx9PwzSGK/uT5YwTKmU=
 github.com/keboola/go-utils v1.4.0 h1:WTyj95yrr8O8HxtC8TSTyUcElZiRGDeEdVvDpFo6HUo=
 github.com/keboola/go-utils v1.4.0/go.mod h1:IopwJzFz2gh0Yj3fUbIe2eamRoDKzbXvjqFjQyw3ZdQ=
-github.com/keboola/keboola-sdk-go/v2 v2.19.0 h1:HGFmt21TE4o7A9mNNCboF8pn4iZE/5wIlHr+cTgDETg=
-github.com/keboola/keboola-sdk-go/v2 v2.19.0/go.mod h1:I7NF3SGE44X+yKakw5cnsZws9KzWJU1Ohjmiakz5Jkw=
+github.com/keboola/keboola-sdk-go/v2 v2.20.1 h1:R1qoJHZBXjuHyzlOorykJPtwJQ1yRbkxuL30hi7TOeY=
+github.com/keboola/keboola-sdk-go/v2 v2.20.1/go.mod h1:zpTnNSewMw0zlo7lHEdUKoFBocPOf05eq1sp0wGookU=
 github.com/keboola/keboola-sdk-go/v2/transfer v1.1.0 h1:q+Ux+EOOqDIeDol3sce90pzC5jh3RdKMwfsWAjFgKWI=
 github.com/keboola/keboola-sdk-go/v2/transfer v1.1.0/go.mod h1:FHJQSxvveci565IVjBqQHMFMiYMVX3sA98z+xWu5fCY=
 github.com/keybase/go-keychain v0.0.1 h1:way+bWYa6lDppZoZcgMbYsvC7GxljxrskdNInRtuthU=

--- a/test/cli/remote-create/table-columns-flag/expected-state.json
+++ b/test/cli/remote-create/table-columns-flag/expected-state.json
@@ -22,6 +22,20 @@
           "name": "table1",
           "displayName": "table1",
           "primaryKey": [],
+          "definition": {
+            "primaryKeysNames": [],
+            "columns": [
+              {
+                "name": "col1"
+              },
+              {
+                "name": "col2"
+              },
+              {
+                "name": "col3"
+              }
+            ]
+          },
           "columns": [
             "col1",
             "col2",

--- a/test/cli/remote-create/table-interactive/expected-state.json
+++ b/test/cli/remote-create/table-interactive/expected-state.json
@@ -25,6 +25,23 @@
             "col1",
             "col2"
           ],
+          "definition": {
+            "primaryKeysNames": [
+              "col1",
+              "col2"
+            ],
+            "columns": [
+              {
+                "name": "col1"
+              },
+              {
+                "name": "col2"
+              },
+              {
+                "name": "col3"
+              }
+            ]
+          },
           "columns": [
             "col1",
             "col2",

--- a/test/cli/remote-table-download/run-0-rows/expected-state.json
+++ b/test/cli/remote-table-download/run-0-rows/expected-state.json
@@ -25,6 +25,29 @@
             "Id",
             "Name"
           ],
+          "definition": {
+            "primaryKeysNames": [
+              "Id",
+              "Name"
+            ],
+            "columns": [
+              {
+                "name": "Id"
+              },
+              {
+                "name": "Name"
+              },
+              {
+                "name": "Region"
+              },
+              {
+                "name": "Status"
+              },
+              {
+                "name": "First_Order"
+              }
+            ]
+          },
           "columns": [
             "Id",
             "Name",

--- a/test/cli/remote-table-download/run-ok/expected-state.json
+++ b/test/cli/remote-table-download/run-ok/expected-state.json
@@ -25,6 +25,29 @@
             "Id",
             "Name"
           ],
+          "definition": {
+            "primaryKeysNames": [
+              "Id",
+              "Name"
+            ],
+            "columns": [
+              {
+                "name": "Id"
+              },
+              {
+                "name": "Name"
+              },
+              {
+                "name": "Region"
+              },
+              {
+                "name": "Status"
+              },
+              {
+                "name": "First_Order"
+              }
+            ]
+          },
           "columns": [
             "Id",
             "Name",

--- a/test/cli/remote-table-download/with-columns/expected-state.json
+++ b/test/cli/remote-table-download/with-columns/expected-state.json
@@ -25,6 +25,29 @@
             "Id",
             "Name"
           ],
+          "definition": {
+            "primaryKeysNames": [
+              "Id",
+              "Name"
+            ],
+            "columns": [
+              {
+                "name": "Id"
+              },
+              {
+                "name": "Name"
+              },
+              {
+                "name": "Region"
+              },
+              {
+                "name": "Status"
+              },
+              {
+                "name": "First_Order"
+              }
+            ]
+          },
           "columns": [
             "Id",
             "Name",

--- a/test/cli/remote-table-download/with-header-columns-order/expected-state.json
+++ b/test/cli/remote-table-download/with-header-columns-order/expected-state.json
@@ -25,6 +25,29 @@
             "Id",
             "Name"
           ],
+          "definition": {
+            "primaryKeysNames": [
+              "Id",
+              "Name"
+            ],
+            "columns": [
+              {
+                "name": "Id"
+              },
+              {
+                "name": "Name"
+              },
+              {
+                "name": "Region"
+              },
+              {
+                "name": "Status"
+              },
+              {
+                "name": "First_Order"
+              }
+            ]
+          },
           "columns": [
             "Id",
             "Name",

--- a/test/cli/remote-table-download/with-header-columns-where/expected-state.json
+++ b/test/cli/remote-table-download/with-header-columns-where/expected-state.json
@@ -25,6 +25,29 @@
             "Id",
             "Name"
           ],
+          "definition": {
+            "primaryKeysNames": [
+              "Id",
+              "Name"
+            ],
+            "columns": [
+              {
+                "name": "Id"
+              },
+              {
+                "name": "Name"
+              },
+              {
+                "name": "Region"
+              },
+              {
+                "name": "Status"
+              },
+              {
+                "name": "First_Order"
+              }
+            ]
+          },
           "columns": [
             "Id",
             "Name",

--- a/test/cli/remote-table-download/with-header-columns/expected-state.json
+++ b/test/cli/remote-table-download/with-header-columns/expected-state.json
@@ -25,6 +25,29 @@
             "Id",
             "Name"
           ],
+          "definition": {
+            "primaryKeysNames": [
+              "Id",
+              "Name"
+            ],
+            "columns": [
+              {
+                "name": "Id"
+              },
+              {
+                "name": "Name"
+              },
+              {
+                "name": "Region"
+              },
+              {
+                "name": "Status"
+              },
+              {
+                "name": "First_Order"
+              }
+            ]
+          },
           "columns": [
             "Id",
             "Name",

--- a/test/cli/remote-table-download/with-header/expected-state.json
+++ b/test/cli/remote-table-download/with-header/expected-state.json
@@ -25,6 +25,29 @@
             "Id",
             "Name"
           ],
+          "definition": {
+            "primaryKeysNames": [
+              "Id",
+              "Name"
+            ],
+            "columns": [
+              {
+                "name": "Id"
+              },
+              {
+                "name": "Name"
+              },
+              {
+                "name": "Region"
+              },
+              {
+                "name": "Status"
+              },
+              {
+                "name": "First_Order"
+              }
+            ]
+          },
           "columns": [
             "Id",
             "Name",

--- a/test/cli/remote-table-download/with-where/expected-state.json
+++ b/test/cli/remote-table-download/with-where/expected-state.json
@@ -25,6 +25,29 @@
             "Id",
             "Name"
           ],
+          "definition": {
+            "primaryKeysNames": [
+              "Id",
+              "Name"
+            ],
+            "columns": [
+              {
+                "name": "Id"
+              },
+              {
+                "name": "Name"
+              },
+              {
+                "name": "Region"
+              },
+              {
+                "name": "Status"
+              },
+              {
+                "name": "First_Order"
+              }
+            ]
+          },
           "columns": [
             "Id",
             "Name",

--- a/test/cli/remote-table-import/import/expected-state.json
+++ b/test/cli/remote-table-import/import/expected-state.json
@@ -25,6 +25,29 @@
             "Id",
             "Name"
           ],
+          "definition": {
+            "primaryKeysNames": [
+              "Id",
+              "Name"
+            ],
+            "columns": [
+              {
+                "name": "Id"
+              },
+              {
+                "name": "Name"
+              },
+              {
+                "name": "Region"
+              },
+              {
+                "name": "Status"
+              },
+              {
+                "name": "First_Order"
+              }
+            ]
+          },
           "columns": [
             "Id",
             "Name",

--- a/test/cli/remote-table-unload/run-ok/expected-state.json
+++ b/test/cli/remote-table-unload/run-ok/expected-state.json
@@ -25,6 +25,29 @@
             "Id",
             "Name"
           ],
+          "definition": {
+            "primaryKeysNames": [
+              "Id",
+              "Name"
+            ],
+            "columns": [
+              {
+                "name": "Id"
+              },
+              {
+                "name": "Name"
+              },
+              {
+                "name": "Region"
+              },
+              {
+                "name": "Status"
+              },
+              {
+                "name": "First_Order"
+              }
+            ]
+          },
           "columns": [
             "Id",
             "Name",

--- a/test/cli/remote-table-upload/table-create-columns-flag-file-without-headers/expected-state.json
+++ b/test/cli/remote-table-upload/table-create-columns-flag-file-without-headers/expected-state.json
@@ -22,6 +22,26 @@
           "name": "data",
           "displayName": "data",
           "primaryKey": [],
+          "definition": {
+            "primaryKeysNames": [],
+            "columns": [
+              {
+                "name": "Id"
+              },
+              {
+                "name": "Name"
+              },
+              {
+                "name": "Region"
+              },
+              {
+                "name": "Status"
+              },
+              {
+                "name": "First_Order"
+              }
+            ]
+          },
           "columns": [
             "Id",
             "Name",

--- a/test/cli/remote-table-upload/table-create-columns-flag/expected-state.json
+++ b/test/cli/remote-table-upload/table-create-columns-flag/expected-state.json
@@ -22,6 +22,26 @@
           "name": "data",
           "displayName": "data",
           "primaryKey": [],
+          "definition": {
+            "primaryKeysNames": [],
+            "columns": [
+              {
+                "name": "Id"
+              },
+              {
+                "name": "Name"
+              },
+              {
+                "name": "Region"
+              },
+              {
+                "name": "Status"
+              },
+              {
+                "name": "First_Order"
+              }
+            ]
+          },
           "columns": [
             "Id",
             "Name",

--- a/test/cli/remote-table-upload/table-create-csv-columns/expected-state.json
+++ b/test/cli/remote-table-upload/table-create-csv-columns/expected-state.json
@@ -22,6 +22,26 @@
           "name": "data",
           "displayName": "data",
           "primaryKey": [],
+          "definition": {
+            "primaryKeysNames": [],
+            "columns": [
+              {
+                "name": "Id"
+              },
+              {
+                "name": "Name"
+              },
+              {
+                "name": "Region"
+              },
+              {
+                "name": "Status"
+              },
+              {
+                "name": "First_Order"
+              }
+            ]
+          },
           "columns": [
             "Id",
             "Name",

--- a/test/cli/remote-table-upload/table-exist-columns-flag-diff-order/expected-state.json
+++ b/test/cli/remote-table-upload/table-exist-columns-flag-diff-order/expected-state.json
@@ -22,6 +22,26 @@
           "name": "data",
           "displayName": "data",
           "primaryKey": [],
+          "definition": {
+            "primaryKeysNames": [],
+            "columns": [
+              {
+                "name": "Id"
+              },
+              {
+                "name": "Name"
+              },
+              {
+                "name": "Region"
+              },
+              {
+                "name": "Status"
+              },
+              {
+                "name": "First_Order"
+              }
+            ]
+          },
           "columns": [
             "Id",
             "Name",

--- a/test/cli/remote-table-upload/table-exist-columns-flag-file-without-headers/expected-state.json
+++ b/test/cli/remote-table-upload/table-exist-columns-flag-file-without-headers/expected-state.json
@@ -22,6 +22,26 @@
           "name": "data",
           "displayName": "data",
           "primaryKey": [],
+          "definition": {
+            "primaryKeysNames": [],
+            "columns": [
+              {
+                "name": "Id"
+              },
+              {
+                "name": "Name"
+              },
+              {
+                "name": "Region"
+              },
+              {
+                "name": "Status"
+              },
+              {
+                "name": "First_Order"
+              }
+            ]
+          },
           "columns": [
             "Id",
             "Name",

--- a/test/cli/remote-table-upload/table-exist-columns-flag/expected-state.json
+++ b/test/cli/remote-table-upload/table-exist-columns-flag/expected-state.json
@@ -22,6 +22,26 @@
           "name": "data",
           "displayName": "data",
           "primaryKey": [],
+          "definition": {
+            "primaryKeysNames": [],
+            "columns": [
+              {
+                "name": "Id"
+              },
+              {
+                "name": "Name"
+              },
+              {
+                "name": "Region"
+              },
+              {
+                "name": "Status"
+              },
+              {
+                "name": "First_Order"
+              }
+            ]
+          },
           "columns": [
             "Id",
             "Name",

--- a/test/cli/remote-table-upload/table-exist-file-without-headers/expected-state.json
+++ b/test/cli/remote-table-upload/table-exist-file-without-headers/expected-state.json
@@ -22,6 +22,26 @@
           "name": "data",
           "displayName": "data",
           "primaryKey": [],
+          "definition": {
+            "primaryKeysNames": [],
+            "columns": [
+              {
+                "name": "Id"
+              },
+              {
+                "name": "Name"
+              },
+              {
+                "name": "Region"
+              },
+              {
+                "name": "Status"
+              },
+              {
+                "name": "First_Order"
+              }
+            ]
+          },
           "columns": [
             "Id",
             "Name",

--- a/test/cli/remote-table-upload/table-exist-same-csv-columns-diff-order/expected-state.json
+++ b/test/cli/remote-table-upload/table-exist-same-csv-columns-diff-order/expected-state.json
@@ -22,6 +22,26 @@
           "name": "data",
           "displayName": "data",
           "primaryKey": [],
+          "definition": {
+            "primaryKeysNames": [],
+            "columns": [
+              {
+                "name": "Status"
+              },
+              {
+                "name": "Region"
+              },
+              {
+                "name": "Name"
+              },
+              {
+                "name": "Id"
+              },
+              {
+                "name": "First_Order"
+              }
+            ]
+          },
           "columns": [
             "Status",
             "Region",

--- a/test/cli/remote-table-upload/table-exist-same-csv-columns/expected-state.json
+++ b/test/cli/remote-table-upload/table-exist-same-csv-columns/expected-state.json
@@ -22,6 +22,26 @@
           "name": "data",
           "displayName": "data",
           "primaryKey": [],
+          "definition": {
+            "primaryKeysNames": [],
+            "columns": [
+              {
+                "name": "Id"
+              },
+              {
+                "name": "Name"
+              },
+              {
+                "name": "Region"
+              },
+              {
+                "name": "Status"
+              },
+              {
+                "name": "First_Order"
+              }
+            ]
+          },
           "columns": [
             "Id",
             "Name",

--- a/test/cli/remote-table-upload/table-exist-same-csv-file-withtout-headers/expected-state.json
+++ b/test/cli/remote-table-upload/table-exist-same-csv-file-withtout-headers/expected-state.json
@@ -22,6 +22,26 @@
           "name": "data",
           "displayName": "data",
           "primaryKey": [],
+          "definition": {
+            "primaryKeysNames": [],
+            "columns": [
+              {
+                "name": "Id"
+              },
+              {
+                "name": "Name"
+              },
+              {
+                "name": "Region"
+              },
+              {
+                "name": "Status"
+              },
+              {
+                "name": "First_Order"
+              }
+            ]
+          },
           "columns": [
             "Id",
             "Name",


### PR DESCRIPTION
## Release Notes
- Fixes `kbc remote table download` (and other commands that fetch table metadata) failing with `cannot decode JSON result: ... readObjectStart: expect { or n, but found [` after the table was already unloaded.
- Root cause is server-side: the Storage API now returns `"definition":[]` (an empty array) for columns of **untyped** tables instead of omitting the field. The fix is entirely client-side — no PHP/server change required.
- Bumps `github.com/keboola/keboola-sdk-go/v2` to the commit adding `Column.UnmarshalJSON`, which treats any non-object `definition` shape (null, empty, array) as "no definition" and decodes objects as before.

## Plans for customer communication
None.

## Impact analysis
- `go.mod` / `go.sum`: `keboola-sdk-go/v2` `v2.19.0` → `v2.20.1-0.20260609143011-f51d570a7be4` (commit pin; pseudo-version pending the SDK release).
- `go` directive raised `1.26.2` → `1.26.3` (required by the SDK module).
- Affects any CLI command that decodes table metadata (`remote table download`, table detail flows). Fully backwards-compatible: typed-column definitions decode exactly as before; only the previously-fatal empty-array shape is now tolerated.
- No API, schema, or runtime-config changes. Vendor dir is gitignored, so only `go.mod`/`go.sum` are tracked.

## Change type
Bug fix — robust parsing of untyped-table column definitions from the Storage API.

## Justification
A Storage API change started returning `"definition":[]` for untyped-table columns. The SDK type is `*ColumnDefinition` and the jsoniter decoder expected an object or null, so it aborted after the table had already been unloaded — leaving the command broken through no fault of the user. Per request, the fix belongs in the client (SDK) for robust parsing rather than reverting the server. SDK fix: https://github.com/keboola/keboola-sdk-go/pull/91

## Deployment
Merge & automatic deploy.

## Rollback plan
Revert of this PR.

## Post release support plan
None. Follow-up: once the SDK PR (https://github.com/keboola/keboola-sdk-go/pull/91) merges and is tagged, replace the commit pin with the tagged release to satisfy the no-pseudo-version policy.

🤖 Generated with [Claude Code](https://claude.com/claude-code)