### PR TITLE
fix(docker): bump golang base image to 1.26.3 to match go.mod

### DIFF
--- a/provisioning/apps-proxy/docker/Dockerfile
+++ b/provisioning/apps-proxy/docker/Dockerfile
@@ -1,5 +1,5 @@
 # Build container
-FROM golang:1.26.2-alpine3.23 AS buildContainer
+FROM golang:1.26.3-alpine3.23 AS buildContainer
 RUN apk add -U --no-cache bash curl
 
 # Install Task

--- a/provisioning/dev/docker/Dockerfile
+++ b/provisioning/dev/docker/Dockerfile
@@ -1,4 +1,4 @@
-FROM golang:1.26.2
+FROM golang:1.26.3
 
 ENV HOME=/my-home
 ENV GOCACHE=/tmp/cache/go

--- a/provisioning/stream/docker/service/Dockerfile
+++ b/provisioning/stream/docker/service/Dockerfile
@@ -1,5 +1,5 @@
 # Build container
-FROM golang:1.26.2-alpine3.23 AS buildContainer
+FROM golang:1.26.3-alpine3.23 AS buildContainer
 RUN apk add -U --no-cache bash curl
 
 # Install Task

--- a/provisioning/stream/docker/service/race/Dockerfile
+++ b/provisioning/stream/docker/service/race/Dockerfile
@@ -1,5 +1,5 @@
 # Build container
-FROM golang:1.26.2-alpine3.23 AS buildContainer
+FROM golang:1.26.3-alpine3.23 AS buildContainer
 # gcc and g++ are needed for CGO_ENABLED racer
 RUN apk add --update --no-cache bash curl gcc g++ binutils-gold
 

--- a/provisioning/templates-api/docker/Dockerfile
+++ b/provisioning/templates-api/docker/Dockerfile
@@ -1,5 +1,5 @@
 # Build container
-FROM golang:1.26.2-alpine3.23 AS buildContainer
+FROM golang:1.26.3-alpine3.23 AS buildContainer
 RUN apk add -U --no-cache bash curl
 
 # Install Task


### PR DESCRIPTION
## Problem

The release build of `apps-proxy` (`production-apps-proxy-v1.14.0`, [run 27269724776](https://github.com/keboola/keboola-as-code/actions/runs/27269724776)) failed at the Docker image build step:

```
#18 [buildcontainer 9/11] RUN go mod download
go: go.mod requires go >= 1.26.3 (running go 1.26.2; GOTOOLCHAIN=local)
ERROR: process "/bin/sh -c go mod download" did not complete successfully: exit code: 1
```

## Root cause

Commit [`abce533a`](https://github.com/keboola/keboola-as-code/commit/abce533a) (`fix(cli): pin keboola-sdk-go with empty-array column definition fix`) bumped `keboola-sdk-go` to `v2.20.1`, which raised the `go` directive in `go.mod` to `1.26.3`. The build Dockerfiles, however, stayed pinned to `golang:1.26.2`, so `go mod download` aborts inside the image with `GOTOOLCHAIN=local`.

Unit-test CI jobs passed because they resolve Go from `go.mod` — only the Docker-based release builds are affected.

## Fix

Bump all pinned `1.26.2` base images to `1.26.3`:

- `provisioning/apps-proxy/docker/Dockerfile`
- `provisioning/stream/docker/service/Dockerfile`
- `provisioning/stream/docker/service/race/Dockerfile`
- `provisioning/templates-api/docker/Dockerfile`
- `provisioning/dev/docker/Dockerfile`

`provisioning/stream/docker/k6/Dockerfile` uses the floating `golang:1.26-alpine` tag and already resolves to a compatible patch, so it is left unchanged. Both `golang:1.26.3-alpine3.23` and `golang:1.26.3` tags are confirmed published on Docker Hub.

## Impact

Unblocks the apps-proxy production release and prevents the same failure on the next stream / templates-api release builds. No application code changes.