### PR TITLE
fix(appsproxy): AJDA-2896 improve suspended app message wording

### DIFF
--- a/internal/pkg/service/appsproxy/proxy/apphandler/upstream/upstream.go
+++ b/internal/pkg/service/appsproxy/proxy/apphandler/upstream/upstream.go
@@ -149,7 +149,7 @@ func (u *AppUpstream) ServeHTTPOrError(rw http.ResponseWriter, req *http.Request
 			// 503 with a plain-text message that the frontend shows in its
 			// connection modal ("went to sleep due to inactivity, refresh to
 			// resume").
-			// The user has to perform a meaningful action (reload) to wake the
+			// The user has to perform a meaningful action (refresh) to wake the
 			// app, which lands on a non-poll path (GET /) and falls into the
 			// default branch below.
 			u.manager.pageWriter.WriteSuspendedPage(rw)

--- a/internal/pkg/service/appsproxy/proxy/apphandler/upstream/upstream.go
+++ b/internal/pkg/service/appsproxy/proxy/apphandler/upstream/upstream.go
@@ -147,7 +147,8 @@ func (u *AppUpstream) ServeHTTPOrError(rw http.ResponseWriter, req *http.Request
 			// cycle while the tab stays open). Triggering a wakeup here would
 			// defeat auto-suspend on every forgotten tab, so instead we serve a
 			// 503 with a plain-text message that the frontend shows in its
-			// connection modal ("paused due to inactivity, refresh to start").
+			// connection modal ("went to sleep due to inactivity, refresh to
+			// resume").
 			// The user has to perform a meaningful action (reload) to wake the
 			// app, which lands on a non-poll path (GET /) and falls into the
 			// default branch below.

--- a/internal/pkg/service/appsproxy/proxy/pagewriter/suspended.go
+++ b/internal/pkg/service/appsproxy/proxy/pagewriter/suspended.go
@@ -14,14 +14,14 @@ import (
 // (a reload hits GET / which is treated as real activity and triggers wakeup).
 //
 // The message is plain text on purpose: data-app frontends (Streamlit) display
-// the health-check response body in a modal that does not render HTML — the
-// same reason the spinner/restart messages are plain text for these paths.
-// See IsStreamlitHealthCheck and AJDA-1935.
-// Kept short on purpose: data-app frontends (Streamlit) show this in a
-// connection modal that wraps text but has limited height, so a long message
-// ends up behind a scrollbar. The modal renders the body as plain text — it
-// does not honor newlines or HTML, so wording is the only lever for length.
-const suspendedMessage = "App paused. Reload the page to restart."
+// the health-check response body in their connection-error modal, which never
+// interprets HTML. Since Streamlit 1.51 the body is wrapped in a Markdown code
+// fence (DoInitPings.tsx), so newlines ARE preserved and a multi-line message
+// renders as multiple lines; on older Streamlit versions newlines collapse
+// into spaces, which degrades gracefully to a single line.
+// See IsStreamlitHealthCheck, AJDA-1935 and AJDA-2896.
+const suspendedMessage = "App went to sleep due to inactivity. Refresh the page to resume.\n" +
+	"To avoid this, the auto-sleep timeout can be increased or disabled in the app settings."
 
 // suspendedRetryAfter is advisory back-off for the polling client. It does not
 // cause the app to restart — only a user-initiated reload does.
@@ -29,7 +29,7 @@ const suspendedRetryAfter = 60 * time.Second
 
 // WriteSuspendedPage responds to a data-app frontend background poll for an
 // auto-suspended app. It returns 503 with a plain-text body instructing the
-// user to reload, and does NOT trigger a wakeup. See suspendedMessage for the
+// user to refresh, and does NOT trigger a wakeup. See suspendedMessage for the
 // rationale (plain text, no auto-restart from background polls).
 func (pw *Writer) WriteSuspendedPage(w http.ResponseWriter) {
 	w.Header().Set("Cache-Control", "no-cache, no-store, must-revalidate;")

--- a/internal/pkg/service/appsproxy/proxy/pagewriter/suspended.go
+++ b/internal/pkg/service/appsproxy/proxy/pagewriter/suspended.go
@@ -10,8 +10,8 @@ import (
 // has been auto-suspended for inactivity. apps-proxy deliberately does NOT
 // auto-restart the app from these background polls — doing so would defeat
 // auto-suspend for forgotten tabs, which keep polling regardless of whether a
-// user is present. The user must reload the page to start the app again
-// (a reload hits GET / which is treated as real activity and triggers wakeup).
+// user is present. The user must refresh the page to start the app again
+// (a refresh hits GET / which is treated as real activity and triggers wakeup).
 //
 // The message is plain text on purpose: data-app frontends (Streamlit) display
 // the health-check response body in their connection-error modal, which never
@@ -24,7 +24,7 @@ const suspendedMessage = "App went to sleep due to inactivity. Refresh the page 
 	"To avoid this, the auto-sleep timeout can be increased or disabled in the app settings."
 
 // suspendedRetryAfter is advisory back-off for the polling client. It does not
-// cause the app to restart — only a user-initiated reload does.
+// cause the app to restart — only a user-initiated refresh does.
 const suspendedRetryAfter = 60 * time.Second
 
 // WriteSuspendedPage responds to a data-app frontend background poll for an

--- a/internal/pkg/service/appsproxy/proxy/proxy_test.go
+++ b/internal/pkg/service/appsproxy/proxy/proxy_test.go
@@ -1992,6 +1992,8 @@ func TestAppProxyRouter(t *testing.T) {
 				require.NoError(t, err)
 				assert.Contains(t, string(body), "Refresh the page",
 					"should instruct the user to refresh")
+				assert.Contains(t, string(body), "auto-sleep timeout can be increased or disabled",
+					"should include the prevention hint about the auto-sleep timeout")
 				assert.NotContains(t, string(body), "Starting your application...")
 			},
 			expectedNotifications: map[string]int{},

--- a/internal/pkg/service/appsproxy/proxy/proxy_test.go
+++ b/internal/pkg/service/appsproxy/proxy/proxy_test.go
@@ -1957,7 +1957,7 @@ func TestAppProxyRouter(t *testing.T) {
 			// wakeup — otherwise a forgotten tab whose frontend keeps polling
 			// every WS reconnect cycle would re-wake the app indefinitely,
 			// defeating auto-suspend. Apps-proxy replies 503 with a plain-text
-			// "paused due to inactivity, refresh to start" message (shown in the
+			// "went to sleep due to inactivity, refresh to resume" message (shown in the
 			// frontend's connection modal) and leaves the app alone. Meaningful
 			// user actions (refresh → GET /) wake the app via the default branch.
 			name: "public-app-framework-background-poll-on-suspended-returns-503-no-wakeup",
@@ -1984,14 +1984,14 @@ func TestAppProxyRouter(t *testing.T) {
 				assert.Equal(t, "text/plain; charset=utf-8", response.Header.Get("Content-Type"),
 					"must be plain text — the frontend modal does not render HTML")
 
-				// Body carries the user-facing "paused, refresh to start" message
+				// Body carries the user-facing "went to sleep, refresh to resume" message
 				// that the frontend shows in its connection modal. It must NOT be
 				// the spinner page ("Starting your application...") served by the
 				// default branch, which would imply the app is auto-restarting.
 				body, err := io.ReadAll(response.Body)
 				require.NoError(t, err)
-				assert.Contains(t, string(body), "Reload the page",
-					"should instruct the user to reload")
+				assert.Contains(t, string(body), "Refresh the page",
+					"should instruct the user to refresh")
 				assert.NotContains(t, string(body), "Starting your application...")
 			},
 			expectedNotifications: map[string]int{},


### PR DESCRIPTION
[link to issue](https://linear.app/keboola/issue/AJDA-2896/apps-proxy-better-error-message-wording-when-deploying-an-application)

## Description

Changes the plain-text 503 body that apps-proxy serves to data-app frontend background polls (e.g. Streamlit `/_stcore/health`) when the app is auto-suspended.

- `pagewriter/suspended.go` — `suspendedMessage` changed from `"App paused. Reload the page to restart."` to a two-line message: `"App went to sleep due to inactivity. Refresh the page to resume.\nTo avoid this, the auto-sleep timeout can be increased or disabled in the app settings."` The doc comment was updated: since Streamlit 1.51 the frontend wraps the health-check response body in a Markdown code fence (`DoInitPings.tsx`), so newlines are preserved and the message renders on two lines; on older Streamlit versions newlines collapse into spaces, degrading gracefully to a single line. Keboola data apps currently run Streamlit 1.51.0.
- `apphandler/upstream/upstream.go` — comment updated to quote the new wording.
- `proxy_test.go` — assertion updated (`"Reload the page"` → `"Refresh the page"`) and stale comments aligned with the new wording.

No behavioral change beyond the message text — status code (503), `Retry-After`, `Content-Type` and the no-wakeup-on-background-poll logic are untouched.

## Release Notes

- **Justification**
    - The previous message "App paused. Reload the page to restart." was terse and did not tell users why the app stopped or how to prevent it.
    - Users of a sleeping data app now see a friendlier two-line explanation in the Streamlit connection dialog, including a hint that the auto-sleep timeout can be adjusted in the app settings.
- **Plans for Customer Communication**
    - No customer communication needed — wording-only change of an informational message.
- **Impact Analysis**
    - Text-only change; no API or behavioral impact. Applies to all stacks including single-tenant.
    - Data apps running Streamlit older than 1.51 render the message on a single line (newline collapses into a space) — still readable.
    - Not behind a feature flag.
- **Deployment Plan**
    - Continuous deployment, no special rollout needed.
- **Rollback Plan**
    - Fully reversible by reverting the commit and redeploying; not a one-way door.
- **Post-Release Support Plan**
    - No monitoring needed; optionally verify the new message appears in the Streamlit connection dialog after an app auto-suspends.