### PR TITLE
feat(stream,templates): accept programmatic tokens via storage token exchange [PAT-1838]

### DIFF
--- a/api/stream/design.go
+++ b/api/stream/design.go
@@ -114,7 +114,7 @@ var _ = Service("stream", func() {
 	Description("A service for continuously importing data to the Keboola platform.")
 	// CORS
 	cors.Origin("*", func() {
-		cors.Headers("Content-Type", "X-StorageApi-Token")
+		cors.Headers("Content-Type", "X-StorageApi-Token", "X-KBC-ProjectId")
 		cors.Methods("GET", "POST", "PATCH", "DELETE")
 	})
 

--- a/api/templates/design.go
+++ b/api/templates/design.go
@@ -88,7 +88,7 @@ var _ = Service("templates", func() {
 	Description("Service for applying templates to Keboola projects.")
 	// CORS
 	cors.Origin("*", func() {
-		cors.Headers("Content-Type", "X-StorageApi-Token")
+		cors.Headers("Content-Type", "X-StorageApi-Token", "X-KBC-ProjectId")
 		cors.Methods("GET", "POST", "PUT", "DELETE")
 	})
 

--- a/go.mod
+++ b/go.mod
@@ -44,7 +44,7 @@ require (
 	github.com/json-iterator/go v1.1.12
 	github.com/keboola/go-cloud-encrypt v0.0.0-20250422071622-41a5d5547c43
 	github.com/keboola/go-utils v1.4.0
-	github.com/keboola/keboola-sdk-go/v2 v2.20.1
+	github.com/keboola/keboola-sdk-go/v2 v2.21.0
 	github.com/keboola/keboola-sdk-go/v2/transfer v1.1.0
 	github.com/klauspost/compress v1.18.5
 	github.com/klauspost/pgzip v1.2.6

--- a/go.sum
+++ b/go.sum
@@ -601,8 +601,8 @@ github.com/keboola/go-oauth2-proxy/v7 v7.15.3-0.20260427095909-2cab86bcf028 h1:s
 github.com/keboola/go-oauth2-proxy/v7 v7.15.3-0.20260427095909-2cab86bcf028/go.mod h1:+YPrVbsB1rdZx5K45/ealm94rx9PwzSGK/uT5YwTKmU=
 github.com/keboola/go-utils v1.4.0 h1:WTyj95yrr8O8HxtC8TSTyUcElZiRGDeEdVvDpFo6HUo=
 github.com/keboola/go-utils v1.4.0/go.mod h1:IopwJzFz2gh0Yj3fUbIe2eamRoDKzbXvjqFjQyw3ZdQ=
-github.com/keboola/keboola-sdk-go/v2 v2.20.1 h1:R1qoJHZBXjuHyzlOorykJPtwJQ1yRbkxuL30hi7TOeY=
-github.com/keboola/keboola-sdk-go/v2 v2.20.1/go.mod h1:zpTnNSewMw0zlo7lHEdUKoFBocPOf05eq1sp0wGookU=
+github.com/keboola/keboola-sdk-go/v2 v2.21.0 h1:E3BARR14abNwc8rMEtNRLQNv9AloRXzMGCTSyEKUjxg=
+github.com/keboola/keboola-sdk-go/v2 v2.21.0/go.mod h1:zpTnNSewMw0zlo7lHEdUKoFBocPOf05eq1sp0wGookU=
 github.com/keboola/keboola-sdk-go/v2/transfer v1.1.0 h1:q+Ux+EOOqDIeDol3sce90pzC5jh3RdKMwfsWAjFgKWI=
 github.com/keboola/keboola-sdk-go/v2/transfer v1.1.0/go.mod h1:FHJQSxvveci565IVjBqQHMFMiYMVX3sA98z+xWu5fCY=
 github.com/keybase/go-keychain v0.0.1 h1:way+bWYa6lDppZoZcgMbYsvC7GxljxrskdNInRtuthU=

--- a/internal/pkg/service/common/dependencies/exchange.go
+++ b/internal/pkg/service/common/dependencies/exchange.go
@@ -1,0 +1,88 @@
+package dependencies
+
+import (
+	"context"
+	"net/http"
+	"strings"
+
+	"github.com/keboola/keboola-sdk-go/v2/pkg/keboola"
+	"github.com/keboola/keboola-sdk-go/v2/pkg/keboola/management"
+
+	svcerrors "github.com/keboola/keboola-as-code/internal/pkg/service/common/errors"
+	"github.com/keboola/keboola-as-code/internal/pkg/utils/errors"
+)
+
+// IsProgrammaticToken reports whether the raw token value is a Connection
+// programmatic bearer token (kbc_at_* / kbc_pat_*). It tolerates a "Bearer "
+// prefix, so both raw tokens and Authorization header values match. Thin
+// re-export so callers (auth handlers) don't import the SDK keboola package
+// directly just for this gate.
+func IsProgrammaticToken(token string) bool {
+	return keboola.IsProgrammaticToken(token)
+}
+
+// ExchangeProgrammaticToken exchanges a Connection programmatic token
+// (kbc_at_* / kbc_pat_*) for the target project's legacy Storage token via
+// Connection's auth-bridge resolver, then builds a ProjectScope from the
+// resolved token.
+//
+// saTokenPath is the projected Kubernetes ServiceAccount token the service
+// authenticates itself with (its mapping must carry the
+// internal:auth-bridge:resolve-storage-token scope); it is read per call so
+// kubelet rotation needs no restart. projectID names the target project,
+// because a programmatic token is not project-scoped on its own.
+//
+// The resolver returns the full token detail alongside the legacy token, so the
+// scope is built directly from it — no redundant tokens/verify round-trip.
+// Exchange failures carry the client-facing HTTP status (401/403/...) from the
+// resolver's ClientStatusCode(), so the error writer maps them correctly instead
+// of defaulting to 500.
+func ExchangeProgrammaticToken(ctx context.Context, prjScp projectScopeDeps, saTokenPath, subjectToken string, projectID int, opts ...ProjectScopeOption) (ProjectScope, error) {
+	if saTokenPath == "" {
+		// The service does not accept programmatic tokens; surface a 400 rather than
+		// a 500, so this client error is not logged at Error level / alerted on.
+		return nil, svcerrors.WrapWithStatusCode(
+			errors.New("programmatic token exchange is not configured (no service account token path)"),
+			http.StatusBadRequest,
+		)
+	}
+
+	// ponytail: a fresh exchanger per request — NewKeboolaServiceAccountAuth reads
+	// the SA token file per call anyway, and exchange is not on the hot path.
+	// Cache it on the scope if it ever shows up in a profile.
+	exchanger, err := keboola.NewStorageTokenExchanger(
+		connectionURL(prjScp.StorageAPIHost()),
+		management.NewKeboolaServiceAccountAuth(saTokenPath),
+	)
+	if err != nil {
+		return nil, err
+	}
+
+	res, err := exchanger.Exchange(ctx, subjectToken, projectID)
+	if err != nil {
+		// Map resolver failures (invalid token → 401, no project access → 403, ...)
+		// to the proper HTTP status; without this they fall through to 500.
+		var exErr *keboola.StorageTokenExchangeError
+		if errors.As(err, &exErr) {
+			return nil, svcerrors.WrapWithStatusCode(err, exErr.ClientStatusCode())
+		}
+		return nil, err
+	}
+
+	// Mirror the telemetry the legacy verify path sets, so programmatic-token
+	// requests get the same project/token attributes in traces.
+	token := *res.Token
+	ctx = setProjectScopeTelemetry(ctx, token)
+
+	return newProjectScope(ctx, prjScp, token, opts...)
+}
+
+// connectionURL turns a bare Storage API host into a resolver base URL with a
+// scheme. StorageAPIHost is normalized scheme-less (see strhelper.NormalizeHost),
+// so a host without a scheme defaults to https.
+func connectionURL(host string) string {
+	if strings.HasPrefix(host, "http://") || strings.HasPrefix(host, "https://") {
+		return host
+	}
+	return "https://" + host
+}

--- a/internal/pkg/service/common/dependencies/exchange_test.go
+++ b/internal/pkg/service/common/dependencies/exchange_test.go
@@ -1,0 +1,42 @@
+package dependencies
+
+import (
+	"net/http"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+
+	svcerrors "github.com/keboola/keboola-as-code/internal/pkg/service/common/errors"
+)
+
+func TestIsProgrammaticToken(t *testing.T) {
+	t.Parallel()
+	assert.True(t, IsProgrammaticToken("kbc_at_secret"))
+	assert.True(t, IsProgrammaticToken("kbc_pat_secret"))
+	assert.True(t, IsProgrammaticToken("Bearer kbc_at_secret"))
+	assert.False(t, IsProgrammaticToken("regular-storage-token"))
+	assert.False(t, IsProgrammaticToken(""))
+}
+
+func TestConnectionURL(t *testing.T) {
+	t.Parallel()
+	assert.Equal(t, "https://connection.keboola.com", connectionURL("connection.keboola.com"))
+	assert.Equal(t, "https://connection.keboola.com", connectionURL("https://connection.keboola.com"))
+	assert.Equal(t, "http://127.0.0.1:8080", connectionURL("http://127.0.0.1:8080"))
+}
+
+func TestExchangeProgrammaticToken_NoConfig(t *testing.T) {
+	t.Parallel()
+	ctx := t.Context()
+	d := NewMocked(t, ctx)
+
+	// Empty service account token path disables the feature.
+	_, err := ExchangeProgrammaticToken(ctx, d, "", "kbc_at_secret", 12345)
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "not configured")
+
+	// The failure must surface as a client error (400), not the default 500 — otherwise
+	// an unsupported-auth request gets logged at Error level and alerted on.
+	assert.Equal(t, http.StatusBadRequest, svcerrors.HTTPCodeFrom(err))
+}

--- a/internal/pkg/service/common/dependencies/project.go
+++ b/internal/pkg/service/common/dependencies/project.go
@@ -72,17 +72,26 @@ func NewProjectDeps(ctx context.Context, prjScp projectScopeDeps, tokenStr strin
 		return nil, err
 	}
 
+	ctx = setProjectScopeTelemetry(ctx, *token)
+
+	prjScp.Logger().Debugf(ctx, "Storage API token is valid.")
+	prjScp.Logger().Debugf(ctx, `Project id: "%d", project name: "%s".`, token.ProjectID(), token.ProjectName())
+
+	return newProjectScope(ctx, prjScp, *token, opts...)
+}
+
+// setProjectScopeTelemetry records project/token attributes on the context and the
+// request span once the token is known. Shared by the legacy verify path
+// (NewProjectDeps) and the programmatic-token exchange path (ExchangeProgrammaticToken)
+// so both produce identical telemetry.
+func setProjectScopeTelemetry(ctx context.Context, token keboola.Token) context.Context {
 	ctx = ctxattr.ContextWith(
 		ctx,
 		attribute.String("projectId", cast.ToString(token.Owner.ID)),
 		attribute.String("tokenId", token.ID),
 	)
 
-	prjScp.Logger().Debugf(ctx, "Storage API token is valid.")
-	prjScp.Logger().Debugf(ctx, `Project id: "%d", project name: "%s".`, token.ProjectID(), token.ProjectName())
-
-	// Set attributes after token verification
-	if reqSpan != nil {
+	if reqSpan, _ := middleware.RequestSpan(ctx); reqSpan != nil {
 		reqSpan.SetAttributes(
 			attribute.String("keboola.project.id", cast.ToString(token.Owner.ID)),
 			attribute.String("keboola.project.name", token.Owner.Name),
@@ -92,7 +101,7 @@ func NewProjectDeps(ctx context.Context, prjScp projectScopeDeps, tokenStr strin
 		)
 	}
 
-	return newProjectScope(ctx, prjScp, *token, opts...)
+	return ctx
 }
 
 func newProjectScope(ctx context.Context, prjScp projectScopeDeps, token keboola.Token, opts ...ProjectScopeOption) (*projectScope, error) {

--- a/internal/pkg/service/common/httpserver/middleware/bearertoken.go
+++ b/internal/pkg/service/common/httpserver/middleware/bearertoken.go
@@ -1,0 +1,36 @@
+package middleware
+
+import (
+	"net/http"
+	"strings"
+)
+
+// BearerToken promotes an `Authorization: Bearer <token>` value into the given
+// storage-token header when that header is not already set. This lets clients
+// authenticate with a programmatic token (kbc_at_*/kbc_pat_*) via the standard
+// Authorization header while the rest of the stack (Goa security decoder,
+// ProjectScope middleware, token exchange) keeps reading a single header.
+//
+// It must run before any middleware or decoder that reads tokenHeader.
+func BearerToken(tokenHeader string) Middleware {
+	return func(next http.Handler) http.Handler {
+		return http.HandlerFunc(func(w http.ResponseWriter, req *http.Request) {
+			if req.Header.Get(tokenHeader) == "" {
+				if token := bearerToken(req.Header.Get("Authorization")); token != "" {
+					req.Header.Set(tokenHeader, token)
+				}
+			}
+			next.ServeHTTP(w, req)
+		})
+	}
+}
+
+// bearerToken extracts the token from a "Bearer <token>" Authorization value,
+// or "" if the scheme is absent or not Bearer.
+func bearerToken(authorization string) string {
+	const prefix = "Bearer "
+	if len(authorization) > len(prefix) && strings.EqualFold(authorization[:len(prefix)], prefix) {
+		return strings.TrimSpace(authorization[len(prefix):])
+	}
+	return ""
+}

--- a/internal/pkg/service/common/httpserver/middleware/bearertoken_test.go
+++ b/internal/pkg/service/common/httpserver/middleware/bearertoken_test.go
@@ -11,7 +11,7 @@ import (
 func TestBearerToken_extract(t *testing.T) {
 	t.Parallel()
 	assert.Equal(t, "kbc_at_x", bearerToken("Bearer kbc_at_x"))
-	assert.Equal(t, "kbc_at_x", bearerToken("bearer kbc_at_x")) // case-insensitive scheme
+	assert.Equal(t, "kbc_at_x", bearerToken("bearer kbc_at_x"))   // case-insensitive scheme
 	assert.Equal(t, "kbc_at_x", bearerToken("Bearer  kbc_at_x ")) // trims surrounding spaces
 	assert.Empty(t, bearerToken(""))
 	assert.Empty(t, bearerToken("Bearer"))
@@ -27,7 +27,7 @@ func TestBearerToken_promotesToHeader(t *testing.T) {
 		h := BearerToken(tokenHeader)(http.HandlerFunc(func(_ http.ResponseWriter, r *http.Request) {
 			seen = r.Header.Get(tokenHeader)
 		}))
-		req := httptest.NewRequest(http.MethodGet, "/", nil)
+		req := httptest.NewRequestWithContext(t.Context(), http.MethodGet, "/", nil)
 		setup(req)
 		h.ServeHTTP(httptest.NewRecorder(), req)
 		return seen

--- a/internal/pkg/service/common/httpserver/middleware/bearertoken_test.go
+++ b/internal/pkg/service/common/httpserver/middleware/bearertoken_test.go
@@ -1,0 +1,49 @@
+package middleware
+
+import (
+	"net/http"
+	"net/http/httptest"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+)
+
+func TestBearerToken_extract(t *testing.T) {
+	t.Parallel()
+	assert.Equal(t, "kbc_at_x", bearerToken("Bearer kbc_at_x"))
+	assert.Equal(t, "kbc_at_x", bearerToken("bearer kbc_at_x")) // case-insensitive scheme
+	assert.Equal(t, "kbc_at_x", bearerToken("Bearer  kbc_at_x ")) // trims surrounding spaces
+	assert.Empty(t, bearerToken(""))
+	assert.Empty(t, bearerToken("Bearer"))
+	assert.Empty(t, bearerToken("Basic abc"))
+}
+
+func TestBearerToken_promotesToHeader(t *testing.T) {
+	t.Parallel()
+	const tokenHeader = "X-StorageAPI-Token"
+
+	run := func(setup func(*http.Request)) string {
+		var seen string
+		h := BearerToken(tokenHeader)(http.HandlerFunc(func(_ http.ResponseWriter, r *http.Request) {
+			seen = r.Header.Get(tokenHeader)
+		}))
+		req := httptest.NewRequest(http.MethodGet, "/", nil)
+		setup(req)
+		h.ServeHTTP(httptest.NewRecorder(), req)
+		return seen
+	}
+
+	// Bearer token is promoted into the storage-token header.
+	assert.Equal(t, "kbc_at_x", run(func(r *http.Request) {
+		r.Header.Set("Authorization", "Bearer kbc_at_x")
+	}))
+
+	// Existing storage-token header is not overwritten.
+	assert.Equal(t, "explicit", run(func(r *http.Request) {
+		r.Header.Set(tokenHeader, "explicit")
+		r.Header.Set("Authorization", "Bearer kbc_at_x")
+	}))
+
+	// No Authorization, no header -> stays empty.
+	assert.Empty(t, run(func(_ *http.Request) {}))
+}

--- a/internal/pkg/service/common/httpserver/middleware/requestinfo.go
+++ b/internal/pkg/service/common/httpserver/middleware/requestinfo.go
@@ -12,7 +12,11 @@ import (
 )
 
 const (
-	RequestIDHeader      = "X-Request-Id"
+	RequestIDHeader = "X-Request-Id"
+	// ProjectIDHeader names the target project for a programmatic-token request.
+	// Programmatic tokens (kbc_at_*/kbc_pat_*) are not project-scoped on their own,
+	// so the client must name the project to exchange them against.
+	ProjectIDHeader      = "X-KBC-ProjectId"
 	RequestCtxKey        = ctxKey("request")
 	RequestIDCtxKey      = ctxKey("request-id")
 	RequestURLCtxKey     = ctxKey("request-url")
@@ -52,6 +56,15 @@ func RequestIDFromContext(ctx context.Context) string {
 func RequestValue(ctx context.Context) (*http.Request, bool) {
 	v, ok := ctx.Value(RequestCtxKey).(*http.Request)
 	return v, ok
+}
+
+// ProjectIDFromHeader returns the target project ID from the X-KBC-ProjectId
+// header of the in-flight request, or "" if the request or header is absent.
+func ProjectIDFromHeader(ctx context.Context) string {
+	if req, ok := RequestValue(ctx); ok {
+		return req.Header.Get(ProjectIDHeader)
+	}
+	return ""
 }
 
 func ResponseWriter(ctx context.Context) http.ResponseWriter {

--- a/internal/pkg/service/stream/api/gen/http/stream/server/server.go
+++ b/internal/pkg/service/stream/api/gen/http/stream/server/server.go
@@ -2502,7 +2502,7 @@ func HandleStreamOrigin(h http.Handler) http.Handler {
 			if acrm := r.Header.Get("Access-Control-Request-Method"); acrm != "" {
 				// We are handling a preflight request
 				w.Header().Set("Access-Control-Allow-Methods", "GET, POST, PATCH, DELETE")
-				w.Header().Set("Access-Control-Allow-Headers", "Content-Type, X-StorageApi-Token")
+				w.Header().Set("Access-Control-Allow-Headers", "Content-Type, X-StorageApi-Token, X-KBC-ProjectId")
 				w.WriteHeader(204)
 				return
 			}

--- a/internal/pkg/service/stream/api/start.go
+++ b/internal/pkg/service/stream/api/start.go
@@ -46,6 +46,9 @@ func Start(ctx context.Context, d dependencies.APIScope, cfg config.Config) erro
 			}),
 		},
 		BeforeLoggerMiddlewares: []middleware.Middleware{
+			// Accept a programmatic token sent as `Authorization: Bearer <token>` by
+			// promoting it into the storage-token header before anything reads it.
+			middleware.BearerToken(StorageTokenHeader),
 			// Inject PublicRequestScope early so ProjectScope middleware can use it.
 			func(next http.Handler) http.Handler {
 				return http.HandlerFunc(func(w http.ResponseWriter, req *http.Request) {

--- a/internal/pkg/service/stream/config/config.go
+++ b/internal/pkg/service/stream/config/config.go
@@ -50,6 +50,11 @@ type API struct {
 	Listen    string          `configKey:"listen" configUsage:"Listen address of the configuration HTTP API." validate:"required,hostname_port"`
 	PublicURL *url.URL        `configKey:"publicUrl" configUsage:"Public URL of the configuration HTTP API for link generation." validate:"required"`
 	Task      task.NodeConfig `configKey:"task" configUsage:"Background tasks configuration." validate:"required"`
+	// KubernetesTokenPath points to a projected Kubernetes ServiceAccount token whose
+	// mapping carries the internal:auth-bridge:resolve-storage-token scope. When set,
+	// programmatic tokens (kbc_at_*/kbc_pat_*) are exchanged for the project's Storage
+	// token via Connection's auth-bridge; empty disables programmatic-token support.
+	KubernetesTokenPath string `configKey:"kubernetesTokenPath" configUsage:"Path to a projected Kubernetes ServiceAccount token enabling programmatic-token (kbc_at_*/kbc_pat_*) exchange; empty disables it."`
 }
 
 func New() Config {

--- a/internal/pkg/service/stream/config/config_test.go
+++ b/internal/pkg/service/stream/config/config_test.go
@@ -96,6 +96,8 @@ api:
         cleanupEnabled: true
         # How often will old tasks be deleted. Validation rules: required
         cleanupInterval: 1h0m0s
+    # Path to a projected Kubernetes ServiceAccount token enabling programmatic-token (kbc_at_*/kbc_pat_*) exchange; empty disables it.
+    kubernetesTokenPath: ""
 distribution:
     # The maximum time to wait for creating a new session. Validation rules: required,minDuration=1s,maxDuration=1m
     grantTimeout: 5s

--- a/internal/pkg/service/stream/dependencies/api.go
+++ b/internal/pkg/service/stream/dependencies/api.go
@@ -20,6 +20,7 @@ type apiScope struct {
 	logger              log.Logger
 	apiPublicURL        *url.URL
 	httpSourcePublicURL *url.URL
+	kubernetesTokenPath string
 }
 
 func NewAPIScope(serviceScp ServiceScope, distScp dependencies.DistributionScope, taskScp dependencies.TaskScope, cfg config.Config) (v APIScope, err error) {
@@ -61,6 +62,8 @@ func newAPIScope(svcScope ServiceScope, distScp dependencies.DistributionScope, 
 	d.apiPublicURL = cfg.API.PublicURL
 
 	d.httpSourcePublicURL = cfg.Source.HTTP.PublicURL
+
+	d.kubernetesTokenPath = cfg.API.KubernetesTokenPath
 	return d
 }
 
@@ -76,4 +79,8 @@ func (v *apiScope) APIPublicURL() *url.URL {
 func (v *apiScope) HTTPSourcePublicURL() *url.URL {
 	out, _ := url.Parse(v.httpSourcePublicURL.String()) // clone
 	return out
+}
+
+func (v *apiScope) KubernetesTokenPath() string {
+	return v.kubernetesTokenPath
 }

--- a/internal/pkg/service/stream/dependencies/dependencies.go
+++ b/internal/pkg/service/stream/dependencies/dependencies.go
@@ -98,6 +98,9 @@ type APIScope interface {
 	dependencies.TaskScope
 	APIPublicURL() *url.URL
 	HTTPSourcePublicURL() *url.URL
+	// KubernetesTokenPath is the projected ServiceAccount token path enabling
+	// programmatic-token exchange; empty disables it (see config.API).
+	KubernetesTokenPath() string
 }
 
 type PublicRequestScope interface {

--- a/internal/pkg/service/stream/dependencies/reqproject.go
+++ b/internal/pkg/service/stream/dependencies/reqproject.go
@@ -2,11 +2,16 @@ package dependencies
 
 import (
 	"context"
+	"net/http"
+	"strconv"
 	"testing"
 
 	"github.com/keboola/keboola-as-code/internal/pkg/log"
 	"github.com/keboola/keboola-as-code/internal/pkg/service/common/dependencies"
+	svcerrors "github.com/keboola/keboola-as-code/internal/pkg/service/common/errors"
+	"github.com/keboola/keboola-as-code/internal/pkg/service/common/httpserver/middleware"
 	"github.com/keboola/keboola-as-code/internal/pkg/service/stream/definition"
+	"github.com/keboola/keboola-as-code/internal/pkg/utils/errors"
 )
 
 // projectRequestScope implements ProjectRequestScope interface.
@@ -20,12 +25,33 @@ func NewProjectRequestScope(ctx context.Context, pubReqScp PublicRequestScope, t
 	ctx, span := pubReqScp.Telemetry().Tracer().Start(ctx, "keboola.go.stream.dependencies.NewProjectRequestScope")
 	defer span.End(&err)
 
-	prjScp, err := dependencies.NewProjectDeps(ctx, pubReqScp, tokenStr)
+	prjScp, err := resolveProjectScope(ctx, pubReqScp, tokenStr)
 	if err != nil {
 		return nil, err
 	}
 
 	return newProjectRequestScope(pubReqScp, prjScp), nil
+}
+
+// resolveProjectScope builds the project scope from the request token. A
+// programmatic token (kbc_at_*/kbc_pat_*) is exchanged for the project's Storage
+// token via Connection's auth-bridge (project named by the X-KBC-ProjectId
+// header); a legacy Storage token takes the normal verify path. The master-token
+// requirement is preserved either way.
+func resolveProjectScope(ctx context.Context, pubReqScp PublicRequestScope, tokenStr string) (dependencies.ProjectScope, error) {
+	if !dependencies.IsProgrammaticToken(tokenStr) {
+		return dependencies.NewProjectDeps(ctx, pubReqScp, tokenStr)
+	}
+
+	projectID, err := strconv.Atoi(middleware.ProjectIDFromHeader(ctx))
+	if err != nil || projectID <= 0 {
+		return nil, svcerrors.WrapWithStatusCode(
+			errors.Errorf("programmatic token request missing valid %s header", middleware.ProjectIDHeader),
+			http.StatusBadRequest,
+		)
+	}
+
+	return dependencies.ExchangeProgrammaticToken(ctx, pubReqScp, pubReqScp.KubernetesTokenPath(), tokenStr, projectID)
 }
 
 func NewMockedProjectRequestScope(tb testing.TB, ctx context.Context, opts ...dependencies.MockedOption) (ProjectRequestScope, Mocked) {

--- a/internal/pkg/service/templates/api/config/config.go
+++ b/internal/pkg/service/templates/api/config/config.go
@@ -31,6 +31,11 @@ type API struct {
 	Listen    string          `configKey:"listen" configUsage:"Listen address of the configuration HTTP API." validate:"required,hostname_port"`
 	PublicURL *url.URL        `configKey:"publicUrl" configUsage:"Public URL of the configuration HTTP API for link generation." validate:"required"`
 	Task      task.NodeConfig `configKey:"task" configUsage:"Background tasks configuration." validate:"required"`
+	// KubernetesTokenPath points to a projected Kubernetes ServiceAccount token whose
+	// mapping carries the internal:auth-bridge:resolve-storage-token scope. When set,
+	// programmatic tokens (kbc_at_*/kbc_pat_*) are exchanged for the project's Storage
+	// token via Connection's auth-bridge; empty disables programmatic-token support.
+	KubernetesTokenPath string `configKey:"kubernetesTokenPath" configUsage:"Path to a projected Kubernetes ServiceAccount token enabling programmatic-token (kbc_at_*/kbc_pat_*) exchange; empty disables it."`
 }
 
 func New() Config {

--- a/internal/pkg/service/templates/api/gen/http/templates/server/server.go
+++ b/internal/pkg/service/templates/api/gen/http/templates/server/server.go
@@ -1373,7 +1373,7 @@ func HandleTemplatesOrigin(h http.Handler) http.Handler {
 			if acrm := r.Header.Get("Access-Control-Request-Method"); acrm != "" {
 				// We are handling a preflight request
 				w.Header().Set("Access-Control-Allow-Methods", "GET, POST, PUT, DELETE")
-				w.Header().Set("Access-Control-Allow-Headers", "Content-Type, X-StorageApi-Token")
+				w.Header().Set("Access-Control-Allow-Headers", "Content-Type, X-StorageApi-Token, X-KBC-ProjectId")
 				w.WriteHeader(204)
 				return
 			}

--- a/internal/pkg/service/templates/dependencies/reqproject.go
+++ b/internal/pkg/service/templates/dependencies/reqproject.go
@@ -2,10 +2,14 @@ package dependencies
 
 import (
 	"context"
+	"net/http"
+	"strconv"
 
 	"github.com/keboola/keboola-as-code/internal/pkg/log"
 	"github.com/keboola/keboola-as-code/internal/pkg/model"
 	"github.com/keboola/keboola-as-code/internal/pkg/service/common/dependencies"
+	svcerrors "github.com/keboola/keboola-as-code/internal/pkg/service/common/errors"
+	"github.com/keboola/keboola-as-code/internal/pkg/service/common/httpserver/middleware"
 	"github.com/keboola/keboola-as-code/internal/pkg/template"
 	"github.com/keboola/keboola-as-code/internal/pkg/template/repository"
 	repositoryManager "github.com/keboola/keboola-as-code/internal/pkg/template/repository/manager"
@@ -25,12 +29,33 @@ func NewProjectRequestScope(ctx context.Context, pubScp PublicRequestScope, toke
 	ctx, span := pubScp.Telemetry().Tracer().Start(ctx, "keboola.go.templates.api.dependencies.NewProjectRequestScope")
 	defer span.End(&err)
 
-	prjScp, err := dependencies.NewProjectDeps(ctx, pubScp, tokenStr)
+	prjScp, err := resolveProjectScope(ctx, pubScp, tokenStr)
 	if err != nil {
 		return nil, err
 	}
 
 	return newProjectRequestScope(pubScp, prjScp), nil
+}
+
+// resolveProjectScope builds the project scope from the request token. A
+// programmatic token (kbc_at_*/kbc_pat_*) is exchanged for the project's Storage
+// token via Connection's auth-bridge (project named by the X-KBC-ProjectId
+// header); a legacy Storage token takes the normal verify path. The master-token
+// requirement is preserved either way.
+func resolveProjectScope(ctx context.Context, pubScp PublicRequestScope, tokenStr string) (dependencies.ProjectScope, error) {
+	if !dependencies.IsProgrammaticToken(tokenStr) {
+		return dependencies.NewProjectDeps(ctx, pubScp, tokenStr)
+	}
+
+	projectID, err := strconv.Atoi(middleware.ProjectIDFromHeader(ctx))
+	if err != nil || projectID <= 0 {
+		return nil, svcerrors.WrapWithStatusCode(
+			errors.Errorf("programmatic token request missing valid %s header", middleware.ProjectIDHeader),
+			http.StatusBadRequest,
+		)
+	}
+
+	return dependencies.ExchangeProgrammaticToken(ctx, pubScp, pubScp.APIConfig().API.KubernetesTokenPath, tokenStr, projectID)
 }
 
 func newProjectRequestScope(pubScp PublicRequestScope, prjScp dependencies.ProjectScope) *projectRequestScope {


### PR DESCRIPTION
## Release Notes
- The Templates API and Stream API now accept Connection programmatic tokens (`kbc_at_*` / `kbc_pat_*`) on endpoints that previously took only legacy Storage API tokens.
- A programmatic token is detected by prefix and exchanged for the target project's legacy Storage token via Connection's auth-bridge resolver (keboola-sdk-go `StorageTokenExchanger`), with the service authenticating itself using its projected Kubernetes ServiceAccount JWT.
- The target project is named by the new `X-KBC-ProjectId` request header, since programmatic tokens are not project-scoped on their own.
- Gated per service by the new `api.kubernetesTokenPath` config (path to the projected SA token); empty disables the feature, so existing deployments are unchanged.
- Bumps `keboola-sdk-go/v2` to `v2.21.0`.

## Plans for customer communication
None.

## Impact analysis
- `internal/pkg/service/common/dependencies`: new `IsProgrammaticToken` + `ExchangeProgrammaticToken` helpers (resolve via auth-bridge, build a `ProjectScope` directly from the resolved token detail — no redundant tokens/verify round-trip).
- `internal/pkg/service/common/httpserver/middleware`: new `ProjectIDHeader` (`X-KBC-ProjectId`) const + `ProjectIDFromHeader` accessor.
- `templates` & `stream`: `NewProjectRequestScope` branches on token kind; legacy Storage tokens keep the existing verify path unchanged. Master-token requirement is preserved on both paths.
- New config field `api.kubernetesTokenPath` on both services; defaults empty (feature disabled) — fully backwards-compatible.
- **appsproxy**: not changed — its `NewProjectRequestScope` is a no-op stub that never verifies a Storage token, so there is no project scope to exchange against.
- No DB migration, no performance impact on the legacy-token path (prefix check only).

## Change type
Feature — Accept Connection programmatic tokens via Storage token exchange (PAT-1838).

## Justification
Connection programmatic tokens (`kbc_at_*` / `kbc_pat_*`) are bearer tokens that cannot call legacy Storage-token APIs directly. This change lets the Templates and Stream APIs transparently exchange them for the project's Storage token through Connection's auth-bridge, mirroring the implementation already landed for query & metastore in the go-monorepo (PAT-1838). The feature is opt-in per service via the SA-token path config, so it is inert until the deployment provides the projected ServiceAccount token.

## Deployment
Merge & automatic deploy. Feature stays disabled until `api.kubernetesTokenPath` is configured with a projected ServiceAccount token whose mapping carries the `internal:auth-bridge:resolve-storage-token` scope.

## Rollback plan
Revert of this PR.

## Post release support plan
None. Once enabled, watch for auth-bridge resolver failures (exchange errors are logged; the SDK maps resolver status to the client HTTP status without exposing token material).