### PR TITLE
fix(AI-3278): bound etcd transaction size for branch delete & stats rollup

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -131,7 +131,9 @@ services:
       ETCD_LISTEN_CLIENT_URLS: "http://0.0.0.0:2379"
       ETCD_LISTEN_PEER_URLS: "http://0.0.0.0:2380"
       ETCD_DISABLE_STORE_MEMBER_ID: "true"
-      ETCD_MAX_TXN_OPS: "128"
+      # Match the production limit (provisioning/common/etcd/values.yaml) so the dev/compose
+      # environment does not false-fail (or mask) transaction-size issues differently than prod.
+      ETCD_MAX_TXN_OPS: "1024"
 
   k6:
     volumes:

--- a/internal/pkg/service/common/etcdop/op/batch.go
+++ b/internal/pkg/service/common/etcdop/op/batch.go
@@ -1,0 +1,60 @@
+package op
+
+import (
+	"context"
+	"sync"
+
+	etcd "go.etcd.io/etcd/client/v3"
+
+	"github.com/keboola/keboola-as-code/internal/pkg/utils/errors"
+)
+
+// MaxOpsPerTxn is the safe upper bound of operations in a single etcd transaction.
+//
+// It is kept well under the ETCD_MAX_TXN_OPS limit (1024 in both production and dev/compose),
+// leaving headroom for IF conditions and nested operations. Callers that write more than one
+// operation per item must divide this by the ops-per-item to derive the batch size
+// (see RunWriteTxnsInBatches).
+const MaxOpsPerTxn = 100
+
+// RunWriteTxnsInBatches splits items into batches of at most maxItemsPerTxn, builds one
+// transaction per batch via addToTxn, and executes the transactions in parallel.
+//
+// Unlike AtomicOp, there is NO cross-batch atomicity and no read-revision guard: each
+// batch is an independent transaction. Use this only for bulk writes/deletes that
+// tolerate partial progress, where a partially applied result is never user-visibly
+// inconsistent (e.g. cascade soft-deletes, statistics rollup/reset).
+//
+// The op count of each transaction is bounded by maxItemsPerTxn * (ops added per item),
+// independent of len(items), so it cannot exceed the etcd per-transaction limit.
+//
+// Note: one goroutine per batch with no concurrency cap, matching the original stats_put
+// behaviour. Add a bounded worker pool if batch counts ever grow large enough to overload etcd.
+func RunWriteTxnsInBatches[T any](ctx context.Context, client etcd.KV, items []T, maxItemsPerTxn int, addToTxn func(txn *TxnOp[NoResult], item T)) error {
+	if maxItemsPerTxn < 1 {
+		maxItemsPerTxn = 1
+	}
+
+	// Group items into per-batch transactions
+	var batches []*TxnOp[NoResult]
+	for i, item := range items {
+		if i%maxItemsPerTxn == 0 {
+			batches = append(batches, Txn(client))
+		}
+		addToTxn(batches[len(batches)-1], item)
+	}
+
+	// Run batches in parallel, collect all errors
+	wg := &sync.WaitGroup{}
+	errs := errors.NewMultiError()
+	for _, txn := range batches {
+		wg.Go(func() {
+			if err := txn.Do(ctx).Err(); err != nil {
+				errs.Append(err)
+			}
+		})
+	}
+	wg.Wait()
+
+	return errs.ErrorOrNil()
+}

--- a/internal/pkg/service/common/etcdop/op/batch_test.go
+++ b/internal/pkg/service/common/etcdop/op/batch_test.go
@@ -1,0 +1,66 @@
+package op_test
+
+import (
+	"context"
+	"fmt"
+	"sync/atomic"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	etcd "go.etcd.io/etcd/client/v3"
+
+	"github.com/keboola/keboola-as-code/internal/pkg/service/common/etcdop"
+	. "github.com/keboola/keboola-as-code/internal/pkg/service/common/etcdop/op"
+	"github.com/keboola/keboola-as-code/internal/pkg/utils/etcdhelper"
+)
+
+// txnCountingKV counts how many low-level operations (one per executed transaction) are sent to etcd.
+type txnCountingKV struct {
+	etcd.KV
+	count atomic.Int64
+}
+
+func (kv *txnCountingKV) Do(ctx context.Context, op etcd.Op) (etcd.OpResponse, error) {
+	kv.count.Add(1)
+	return kv.KV.Do(ctx, op)
+}
+
+// TestRunWriteTxnsInBatches verifies that the helper splits items into the expected number of
+// transactions, independent of the etcd ETCD_MAX_TXN_OPS limit (it asserts the transaction COUNT,
+// not whether a single big transaction would be rejected).
+func TestRunWriteTxnsInBatches(t *testing.T) {
+	t.Parallel()
+	ctx := t.Context()
+	client := etcdhelper.ClientForTest(t, etcdhelper.TmpNamespace(t))
+
+	cases := []struct {
+		items     int
+		maxPerTxn int
+		wantTxns  int64
+	}{
+		{items: 0, maxPerTxn: 50, wantTxns: 0},   // nothing to do, no transaction
+		{items: 1, maxPerTxn: 50, wantTxns: 1},   // single partial batch
+		{items: 50, maxPerTxn: 50, wantTxns: 1},  // exactly one full batch
+		{items: 51, maxPerTxn: 50, wantTxns: 2},  // one full + one partial batch
+		{items: 70, maxPerTxn: 50, wantTxns: 2},  // matches the slice-delete cascade scenario
+		{items: 150, maxPerTxn: 50, wantTxns: 3}, // three full batches
+		{items: 10, maxPerTxn: 1, wantTxns: 10},  // one transaction per item
+	}
+
+	for _, tc := range cases {
+		counter := &txnCountingKV{KV: client.KV}
+
+		items := make([]int, tc.items)
+		for i := range items {
+			items[i] = i
+		}
+
+		err := RunWriteTxnsInBatches(ctx, counter, items, tc.maxPerTxn, func(txn *TxnOp[NoResult], item int) {
+			txn.Then(etcdop.Key(fmt.Sprintf("batch-test/%d-%d/%d", tc.items, tc.maxPerTxn, item)).Put(counter, "v"))
+		})
+		require.NoError(t, err, "items=%d maxPerTxn=%d", tc.items, tc.maxPerTxn)
+
+		assert.Equal(t, tc.wantTxns, counter.count.Load(), "items=%d maxPerTxn=%d", tc.items, tc.maxPerTxn)
+	}
+}

--- a/internal/pkg/service/stream/api/service/source.go
+++ b/internal/pkg/service/stream/api/service/source.go
@@ -511,10 +511,12 @@ func (s *service) SourceStatisticsClear(ctx context.Context, d dependencies.Sour
 		sinkKeys = append(sinkKeys, sink.SinkKey)
 	}
 
-	result := d.StatisticsRepository().ResetAllSinksStats(sinkKeys).Do(ctx)
-	s.logger.Infof(ctx, `Statistics clear for source "%s" used %d operations`, d.SourceKey().String(), result.MaxOps())
+	if err := d.StatisticsRepository().ResetAllSinksStats(ctx, sinkKeys); err != nil {
+		return err
+	}
 
-	return result.Err()
+	s.logger.Infof(ctx, `Statistics clear for source "%s" reset %d sinks`, d.SourceKey().String(), len(sinkKeys))
+	return nil
 }
 
 func (s *service) DisableSource(ctx context.Context, d dependencies.SourceRequestScope, payload *api.DisableSourcePayload) (*api.Task, error) {

--- a/internal/pkg/service/stream/definition/repository/sink/sink_delete_test.go
+++ b/internal/pkg/service/stream/definition/repository/sink/sink_delete_test.go
@@ -1,6 +1,7 @@
 package sink_test
 
 import (
+	"fmt"
 	"net/http"
 	"testing"
 	"time"
@@ -161,6 +162,62 @@ func TestSinkRepository_DeleteSinksOnSourceDelete_DeleteSource(t *testing.T) {
 		require.NoError(t, err)
 		assert.True(t, sink3.IsDeleted())
 		assert.False(t, sink3.IsDeletedDirectly())
+	}
+}
+
+// TestSinkRepository_DeleteBranch_BoundedTxnSize verifies that deleting a branch with many sources and
+// sinks stays within the etcd per-transaction operation limit. The cascade is decoupled so each source
+// (with its sinks) is deleted in its own transaction; previously the whole subtree was one transaction,
+// which exceeded the limit. Success against the test etcd proves each per-source transaction is bounded.
+func TestSinkRepository_DeleteBranch_BoundedTxnSize(t *testing.T) {
+	t.Parallel()
+
+	ctx := t.Context()
+	now := utctime.MustParse("2000-01-01T01:00:00.000Z").Time()
+	by := test.ByUser()
+
+	// The total sink count across all sources (sourcesCount * sinksPerSource * 2 ops) is large enough
+	// that deleting the whole subtree in one transaction would exceed the etcd per-transaction limit,
+	// while each per-source cascade stays comfortably under it.
+	const sourcesCount = 4
+	const sinksPerSource = 25
+
+	d, _ := dependencies.NewMockedServiceScope(t, ctx)
+	defRepo := d.DefinitionRepository()
+	branchRepo := defRepo.Branch()
+	sourceRepo := defRepo.Source()
+	sinkRepo := defRepo.Sink()
+
+	// Fixtures
+	projectID := keboola.ProjectID(123)
+	branchKey := key.BranchKey{ProjectID: projectID, BranchID: 567}
+
+	// Create branch, sources and sinks
+	branch := test.NewBranch(branchKey)
+	require.NoError(t, branchRepo.Create(&branch, now, by).Do(ctx).Err())
+	sinkKeys := make([]key.SinkKey, 0, sourcesCount*sinksPerSource)
+	for s := range sourcesCount {
+		sourceKey := key.SourceKey{BranchKey: branchKey, SourceID: key.SourceID(fmt.Sprintf("my-source-%d", s))}
+		source := test.NewSource(sourceKey)
+		require.NoError(t, sourceRepo.Create(&source, now, by, "Create source").Do(ctx).Err())
+		for k := range sinksPerSource {
+			sinkKey := key.SinkKey{SourceKey: sourceKey, SinkID: key.SinkID(fmt.Sprintf("my-sink-%d", k))}
+			sink := dummy.NewSink(sinkKey)
+			require.NoError(t, sinkRepo.Create(&sink, now, by, "Create sink").Do(ctx).Err())
+			sinkKeys = append(sinkKeys, sinkKey)
+		}
+	}
+
+	// Delete the branch - must succeed despite the large subtree
+	now = now.Add(time.Hour)
+	require.NoError(t, branchRepo.SoftDelete(branchKey, now, by).Do(ctx).Err())
+
+	// All sinks must be soft-deleted as part of the cascade
+	for _, sinkKey := range sinkKeys {
+		deleted, err := sinkRepo.GetDeleted(sinkKey).Do(ctx).ResultOrErr()
+		require.NoError(t, err)
+		assert.True(t, deleted.IsDeleted())
+		assert.False(t, deleted.IsDeletedDirectly())
 	}
 }
 

--- a/internal/pkg/service/stream/definition/repository/source/source_delete.go
+++ b/internal/pkg/service/stream/definition/repository/source/source_delete.go
@@ -26,7 +26,28 @@ func (r *Repository) SoftDelete(k key.SourceKey, now time.Time, by definition.By
 
 func (r *Repository) deleteSourcesOnBranchDelete() {
 	r.plugins.Collection().OnBranchDelete(func(ctx context.Context, now time.Time, by definition.By, original, deleted *definition.Branch) error {
-		op.AtomicOpCtxFrom(ctx).AddFrom(r.softDeleteAllFrom(deleted.BranchKey, now, by, false))
+		// Decoupled cascade: delete each source in its own transaction, independent of the branch
+		// delete transaction. A branch may have up to MaxSourcesPerBranch sources, each cascading to
+		// up to MaxSinksPerSource sinks; keeping the whole subtree in one atomic transaction exceeds
+		// the etcd per-transaction operation limit. Each per-source delete (source + its sinks) stays
+		// within the limit.
+		//
+		// These per-source deletes commit BEFORE the branch delete transaction (this callback runs
+		// during its generation) - deliberately "children first". If the branch delete then collides,
+		// is retried, or fails, the branch stays ACTIVE with a subset of its sources deleted: an
+		// incomplete delete that the next delete attempt completes (the branch is still deletable, and
+		// soft-delete is monotonic and idempotent, so only the remaining active sources are deleted).
+		// It never leaves active sources orphaned under an already-deleted branch, which the reverse
+		// ordering (cascade after commit) would. The incomplete state is observable but not corrupt.
+		var sources []definition.Source
+		if err := r.List(deleted.BranchKey).WithAllTo(&sources).Do(ctx).Err(); err != nil {
+			return err
+		}
+		for i := range sources {
+			if err := r.softDeleteAllFrom(sources[i].SourceKey, now, by, false).Do(ctx).Err(); err != nil {
+				return err
+			}
+		}
 		return nil
 	})
 }

--- a/internal/pkg/service/stream/definition/repository/source/source_undelete.go
+++ b/internal/pkg/service/stream/definition/repository/source/source_undelete.go
@@ -37,7 +37,25 @@ func (r *Repository) Undelete(k key.SourceKey, now time.Time, by definition.By) 
 
 func (r *Repository) undeleteSourcesOnBranchUndelete() {
 	r.plugins.Collection().OnBranchUndelete(func(ctx context.Context, now time.Time, by definition.By, old, updated *definition.Branch) error {
-		op.AtomicOpCtxFrom(ctx).AddFrom(r.undeleteAllFrom(updated.BranchKey, now, by, false))
+		// Decoupled cascade, mirroring deleteSourcesOnBranchDelete: undelete each source in its own
+		// transaction to keep the per-transaction operation count within the etcd limit for large
+		// branches. undeleteAllFrom(sourceKey, false) skips sources that were deleted directly (not as
+		// part of this branch's cascade), preserving the original undelete semantics.
+		//
+		// Like the delete cascade, these per-source undeletes commit before the branch undelete
+		// transaction. If the branch undelete collides/retries/fails, the branch stays DELETED with a
+		// subset of its sources undeleted: an incomplete undelete that the next undelete attempt
+		// completes (the branch is still undeletable). The undelete is idempotent (sources already
+		// active are skipped via the directly flag), so the state is observable but not corrupt.
+		var sources []definition.Source
+		if err := r.ListDeleted(updated.BranchKey).WithAllTo(&sources).Do(ctx).Err(); err != nil {
+			return err
+		}
+		for i := range sources {
+			if err := r.undeleteAllFrom(sources[i].SourceKey, now, by, false).Do(ctx).Err(); err != nil {
+				return err
+			}
+		}
 		return nil
 	})
 }

--- a/internal/pkg/service/stream/sink/type/tablesink/keboola/bridge/fixtures/delete_files_ops.txt
+++ b/internal/pkg/service/stream/sink/type/tablesink/keboola/bridge/fixtures/delete_files_ops.txt
@@ -4,36 +4,42 @@
   001 ➡️  GET "storage/file/all/123/456/my-source/my-sink/2000-01-01T01:00:00.000Z"
 ✔️  TXN | succeeded: true
 
-// READ: slices from the file to be deleted, and statistics for rollup/delete
+// Slices are deleted in their own bounded transaction(s), independent of the file delete.
+// List the slices of the file ...
+➡️  GET ["storage/slice/all/123/456/my-source/my-sink/2000-01-01T01:00:00.000Z/", "storage/slice/all/123/456/my-source/my-sink/2000-01-01T01:00:00.000Z0")
+✔️  GET ["storage/slice/all/123/456/my-source/my-sink/2000-01-01T01:00:00.000Z/", "storage/slice/all/123/456/my-source/my-sink/2000-01-01T01:00:00.000Z0") | count: 1
+
+// ... then delete them in a batch (no IF guard, deletion tolerates partial progress)
 ➡️  TXN
   ➡️  THEN:
-  001 ➡️  GET ["storage/slice/all/123/456/my-source/my-sink/2000-01-01T01:00:00.000Z/", "storage/slice/all/123/456/my-source/my-sink/2000-01-01T01:00:00.000Z0")
-  002 ➡️  GET "storage/stats/target/123/456/my-source/my-sink/_sum"
-  003 ➡️  GET ["storage/stats/target/123/456/my-source/my-sink/2000-01-01T01:00:00.000Z/", "storage/stats/target/123/456/my-source/my-sink/2000-01-01T01:00:00.000Z0")
+  001 ➡️  DEL "storage/slice/all/123/456/my-source/my-sink/2000-01-01T01:00:00.000Z/my-volume-1/2000-01-01T01:00:00.000Z"
+  002 ➡️  DEL "storage/slice/level/local/123/456/my-source/my-sink/2000-01-01T01:00:00.000Z/my-volume-1/2000-01-01T01:00:00.000Z"
 ✔️  TXN | succeeded: true
 
+// READ: statistics for rollup/delete
+➡️  TXN
+  ➡️  THEN:
+  001 ➡️  GET "storage/stats/target/123/456/my-source/my-sink/_sum"
+  002 ➡️  GET ["storage/stats/target/123/456/my-source/my-sink/2000-01-01T01:00:00.000Z/", "storage/stats/target/123/456/my-source/my-sink/2000-01-01T01:00:00.000Z0")
+✔️  TXN | succeeded: true
+
+// WRITE: delete the file, its upload credentials, and roll up statistics (slices already deleted above)
 ➡️  TXN
   ➡️  IF:
   001 "storage/file/all/123/456/my-source/my-sink/2000-01-01T01:00:00.000Z" MOD GREATER 0
   002 "storage/file/all/123/456/my-source/my-sink/2000-01-01T01:00:00.000Z" MOD LESS %d
-  003 ["storage/slice/all/123/456/my-source/my-sink/2000-01-01T01:00:00.000Z/", "storage/slice/all/123/456/my-source/my-sink/2000-01-01T01:00:00.000Z0") MOD GREATER 0
-  004 ["storage/slice/all/123/456/my-source/my-sink/2000-01-01T01:00:00.000Z/", "storage/slice/all/123/456/my-source/my-sink/2000-01-01T01:00:00.000Z0") MOD LESS %d
-  005 "storage/slice/all/123/456/my-source/my-sink/2000-01-01T01:00:00.000Z/my-volume-1/2000-01-01T01:00:00.000Z" MOD GREATER 0
-  006 "storage/stats/target/123/456/my-source/my-sink/_sum" MOD EQUAL 0
-  007 ["storage/stats/target/123/456/my-source/my-sink/2000-01-01T01:00:00.000Z/", "storage/stats/target/123/456/my-source/my-sink/2000-01-01T01:00:00.000Z0") MOD EQUAL 0
+  003 "storage/stats/target/123/456/my-source/my-sink/_sum" MOD EQUAL 0
+  004 ["storage/stats/target/123/456/my-source/my-sink/2000-01-01T01:00:00.000Z/", "storage/stats/target/123/456/my-source/my-sink/2000-01-01T01:00:00.000Z0") MOD EQUAL 0
   ➡️  THEN:
   // Delete file
   001 ➡️  DEL "storage/file/all/123/456/my-source/my-sink/2000-01-01T01:00:00.000Z"
   002 ➡️  DEL "storage/file/level/local/123/456/my-source/my-sink/2000-01-01T01:00:00.000Z"
-  // Delete slice
-  003 ➡️  DEL "storage/slice/all/123/456/my-source/my-sink/2000-01-01T01:00:00.000Z/my-volume-1/2000-01-01T01:00:00.000Z"
-  004 ➡️  DEL "storage/slice/level/local/123/456/my-source/my-sink/2000-01-01T01:00:00.000Z/my-volume-1/2000-01-01T01:00:00.000Z"
   // Delete file upload credentials
-  005 ➡️  DEL "storage/keboola/file/123/456/my-source/my-sink/2000-01-01T01:00:00.000Z"
+  003 ➡️  DEL "storage/keboola/file/123/456/my-source/my-sink/2000-01-01T01:00:00.000Z"
   // Delete statistics (there is no PUT _sum, because statistics are empty)
-  006 ➡️  DEL ["storage/stats/local/123/456/my-source/my-sink/2000-01-01T01:00:00.000Z/", "storage/stats/local/123/456/my-source/my-sink/2000-01-01T01:00:00.000Z0")
-  007 ➡️  DEL ["storage/stats/staging/123/456/my-source/my-sink/2000-01-01T01:00:00.000Z/", "storage/stats/staging/123/456/my-source/my-sink/2000-01-01T01:00:00.000Z0")
-  008 ➡️  DEL ["storage/stats/target/123/456/my-source/my-sink/2000-01-01T01:00:00.000Z/", "storage/stats/target/123/456/my-source/my-sink/2000-01-01T01:00:00.000Z0")
+  004 ➡️  DEL ["storage/stats/local/123/456/my-source/my-sink/2000-01-01T01:00:00.000Z/", "storage/stats/local/123/456/my-source/my-sink/2000-01-01T01:00:00.000Z0")
+  005 ➡️  DEL ["storage/stats/staging/123/456/my-source/my-sink/2000-01-01T01:00:00.000Z/", "storage/stats/staging/123/456/my-source/my-sink/2000-01-01T01:00:00.000Z0")
+  006 ➡️  DEL ["storage/stats/target/123/456/my-source/my-sink/2000-01-01T01:00:00.000Z/", "storage/stats/target/123/456/my-source/my-sink/2000-01-01T01:00:00.000Z0")
 ✔️  TXN | succeeded: true
 
 // Bellow are the same operations for the second file
@@ -43,11 +49,19 @@
   001 ➡️  GET "storage/file/all/123/456/my-source/my-sink/2000-01-01T03:00:00.000Z"
 ✔️  TXN | succeeded: true
 
+➡️  GET ["storage/slice/all/123/456/my-source/my-sink/2000-01-01T03:00:00.000Z/", "storage/slice/all/123/456/my-source/my-sink/2000-01-01T03:00:00.000Z0")
+✔️  GET ["storage/slice/all/123/456/my-source/my-sink/2000-01-01T03:00:00.000Z/", "storage/slice/all/123/456/my-source/my-sink/2000-01-01T03:00:00.000Z0") | count: 1
+
 ➡️  TXN
   ➡️  THEN:
-  001 ➡️  GET ["storage/slice/all/123/456/my-source/my-sink/2000-01-01T03:00:00.000Z/", "storage/slice/all/123/456/my-source/my-sink/2000-01-01T03:00:00.000Z0")
-  002 ➡️  GET "storage/stats/target/123/456/my-source/my-sink/_sum"
-  003 ➡️  GET ["storage/stats/target/123/456/my-source/my-sink/2000-01-01T03:00:00.000Z/", "storage/stats/target/123/456/my-source/my-sink/2000-01-01T03:00:00.000Z0")
+  001 ➡️  DEL "storage/slice/all/123/456/my-source/my-sink/2000-01-01T03:00:00.000Z/my-volume-1/2000-01-01T03:00:00.000Z"
+  002 ➡️  DEL "storage/slice/level/local/123/456/my-source/my-sink/2000-01-01T03:00:00.000Z/my-volume-1/2000-01-01T03:00:00.000Z"
+✔️  TXN | succeeded: true
+
+➡️  TXN
+  ➡️  THEN:
+  001 ➡️  GET "storage/stats/target/123/456/my-source/my-sink/_sum"
+  002 ➡️  GET ["storage/stats/target/123/456/my-source/my-sink/2000-01-01T03:00:00.000Z/", "storage/stats/target/123/456/my-source/my-sink/2000-01-01T03:00:00.000Z0")
 ✔️  TXN | succeeded: true
 
 ➡️  TXN
@@ -55,19 +69,13 @@
   // Objects from the READ phase must be unchanged
   001 "storage/file/all/123/456/my-source/my-sink/2000-01-01T03:00:00.000Z" MOD GREATER 0
   002 "storage/file/all/123/456/my-source/my-sink/2000-01-01T03:00:00.000Z" MOD LESS %d
-  003 ["storage/slice/all/123/456/my-source/my-sink/2000-01-01T03:00:00.000Z/", "storage/slice/all/123/456/my-source/my-sink/2000-01-01T03:00:00.000Z0") MOD GREATER 0
-  004 ["storage/slice/all/123/456/my-source/my-sink/2000-01-01T03:00:00.000Z/", "storage/slice/all/123/456/my-source/my-sink/2000-01-01T03:00:00.000Z0") MOD LESS %d
-  005 "storage/slice/all/123/456/my-source/my-sink/2000-01-01T03:00:00.000Z/my-volume-1/2000-01-01T03:00:00.000Z" MOD GREATER 0
-  006 "storage/stats/target/123/456/my-source/my-sink/_sum" MOD EQUAL 0
-  007 ["storage/stats/target/123/456/my-source/my-sink/2000-01-01T03:00:00.000Z/", "storage/stats/target/123/456/my-source/my-sink/2000-01-01T03:00:00.000Z0") MOD EQUAL 0
+  003 "storage/stats/target/123/456/my-source/my-sink/_sum" MOD EQUAL 0
+  004 ["storage/stats/target/123/456/my-source/my-sink/2000-01-01T03:00:00.000Z/", "storage/stats/target/123/456/my-source/my-sink/2000-01-01T03:00:00.000Z0") MOD EQUAL 0
   ➡️  THEN:
   001 ➡️  DEL "storage/file/all/123/456/my-source/my-sink/2000-01-01T03:00:00.000Z"
   002 ➡️  DEL "storage/file/level/local/123/456/my-source/my-sink/2000-01-01T03:00:00.000Z"
-  003 ➡️  DEL "storage/slice/all/123/456/my-source/my-sink/2000-01-01T03:00:00.000Z/my-volume-1/2000-01-01T03:00:00.000Z"
-  004 ➡️  DEL "storage/slice/level/local/123/456/my-source/my-sink/2000-01-01T03:00:00.000Z/my-volume-1/2000-01-01T03:00:00.000Z"
-  005 ➡️  DEL "storage/keboola/file/123/456/my-source/my-sink/2000-01-01T03:00:00.000Z"
-  006 ➡️  DEL ["storage/stats/local/123/456/my-source/my-sink/2000-01-01T03:00:00.000Z/", "storage/stats/local/123/456/my-source/my-sink/2000-01-01T03:00:00.000Z0")
-  007 ➡️  DEL ["storage/stats/staging/123/456/my-source/my-sink/2000-01-01T03:00:00.000Z/", "storage/stats/staging/123/456/my-source/my-sink/2000-01-01T03:00:00.000Z0")
-  008 ➡️  DEL ["storage/stats/target/123/456/my-source/my-sink/2000-01-01T03:00:00.000Z/", "storage/stats/target/123/456/my-source/my-sink/2000-01-01T03:00:00.000Z0")
+  003 ➡️  DEL "storage/keboola/file/123/456/my-source/my-sink/2000-01-01T03:00:00.000Z"
+  004 ➡️  DEL ["storage/stats/local/123/456/my-source/my-sink/2000-01-01T03:00:00.000Z/", "storage/stats/local/123/456/my-source/my-sink/2000-01-01T03:00:00.000Z0")
+  005 ➡️  DEL ["storage/stats/staging/123/456/my-source/my-sink/2000-01-01T03:00:00.000Z/", "storage/stats/staging/123/456/my-source/my-sink/2000-01-01T03:00:00.000Z0")
+  006 ➡️  DEL ["storage/stats/target/123/456/my-source/my-sink/2000-01-01T03:00:00.000Z/", "storage/stats/target/123/456/my-source/my-sink/2000-01-01T03:00:00.000Z0")
 ✔️  TXN | succeeded: true
-

--- a/internal/pkg/service/stream/storage/model/repository/file/file_repo.go
+++ b/internal/pkg/service/stream/storage/model/repository/file/file_repo.go
@@ -115,6 +115,13 @@ func (r *Repository) save(ctx context.Context, now time.Time, old, updated *mode
 func (r *Repository) update(k model.FileKey, now time.Time, updateFn func(model.File) (model.File, error)) *op.AtomicOp[model.File] {
 	var old, updated model.File
 	return op.Atomic(r.client, &updated).
+		// SkipPrefixKeysCheck: on file delete the statistics rollup plugin reads all per-slice stats
+		// under the file (a prefix GetAll). With the per-key check enabled, one IF condition would be
+		// generated per slice, growing the write transaction op count with the slice count and risking
+		// the etcd per-transaction limit. The file is locked during the update, so the per-key guards
+		// (which only detect concurrent deletion of an individual key) are unnecessary; modifications
+		// to the prefix are still detected.
+		SkipPrefixKeysCheck().
 		// Read entity for modification
 		Read(func(ctx context.Context) op.Op {
 			return r.Get(k).WithResultTo(&old)

--- a/internal/pkg/service/stream/storage/model/repository/file/fixtures/file_delete_ops_001.txt
+++ b/internal/pkg/service/stream/storage/model/repository/file/fixtures/file_delete_ops_001.txt
@@ -4,35 +4,39 @@
   001 ➡️  GET "storage/file/all/123/456/my-source/my-sink/2000-01-01T02:00:00.000Z"
 ✔️  TXN | succeeded: true
 
-// READ
+// Slices are deleted in their own bounded transaction(s), independent of the file delete.
+// List the slices of the file ...
+➡️  GET ["storage/slice/all/123/456/my-source/my-sink/2000-01-01T02:00:00.000Z/", "storage/slice/all/123/456/my-source/my-sink/2000-01-01T02:00:00.000Z0")
+✔️  GET ["storage/slice/all/123/456/my-source/my-sink/2000-01-01T02:00:00.000Z/", "storage/slice/all/123/456/my-source/my-sink/2000-01-01T02:00:00.000Z0") | count: 1
+
+// ... then delete them in a batch (no IF guard, deletion tolerates partial progress)
 ➡️  TXN
   ➡️  THEN:
-  // Get slices from the file for deletion
-  001 ➡️  GET ["storage/slice/all/123/456/my-source/my-sink/2000-01-01T02:00:00.000Z/", "storage/slice/all/123/456/my-source/my-sink/2000-01-01T02:00:00.000Z0")
-  // Get statistics for aggregation
-  002 ➡️  GET "storage/stats/target/123/456/my-source/my-sink/_sum"
-  003 ➡️  GET ["storage/stats/target/123/456/my-source/my-sink/2000-01-01T02:00:00.000Z/", "storage/stats/target/123/456/my-source/my-sink/2000-01-01T02:00:00.000Z0")
+  001 ➡️  DEL "storage/slice/all/123/456/my-source/my-sink/2000-01-01T02:00:00.000Z/my-volume-1/2000-01-01T02:00:00.000Z"
+  002 ➡️  DEL "storage/slice/level/local/123/456/my-source/my-sink/2000-01-01T02:00:00.000Z/my-volume-1/2000-01-01T02:00:00.000Z"
 ✔️  TXN | succeeded: true
 
-// WRITE
+// READ - statistics for aggregation (rollup on file delete)
+➡️  TXN
+  ➡️  THEN:
+  001 ➡️  GET "storage/stats/target/123/456/my-source/my-sink/_sum"
+  002 ➡️  GET ["storage/stats/target/123/456/my-source/my-sink/2000-01-01T02:00:00.000Z/", "storage/stats/target/123/456/my-source/my-sink/2000-01-01T02:00:00.000Z0")
+✔️  TXN | succeeded: true
+
+// WRITE - delete the file and roll up its statistics (slices already deleted above)
 ➡️  TXN
   // Objects from the READ phase must be unchanged
   ➡️  IF:
   001 "storage/file/all/123/456/my-source/my-sink/2000-01-01T02:00:00.000Z" MOD GREATER 0
   002 "storage/file/all/123/456/my-source/my-sink/2000-01-01T02:00:00.000Z" MOD LESS %d
-  003 ["storage/slice/all/123/456/my-source/my-sink/2000-01-01T02:00:00.000Z/", "storage/slice/all/123/456/my-source/my-sink/2000-01-01T02:00:00.000Z0") MOD GREATER 0
-  004 ["storage/slice/all/123/456/my-source/my-sink/2000-01-01T02:00:00.000Z/", "storage/slice/all/123/456/my-source/my-sink/2000-01-01T02:00:00.000Z0") MOD LESS %d
-  005 "storage/slice/all/123/456/my-source/my-sink/2000-01-01T02:00:00.000Z/my-volume-1/2000-01-01T02:00:00.000Z" MOD GREATER 0
-  006 "storage/stats/target/123/456/my-source/my-sink/_sum" MOD EQUAL 0
-  007 ["storage/stats/target/123/456/my-source/my-sink/2000-01-01T02:00:00.000Z/", "storage/stats/target/123/456/my-source/my-sink/2000-01-01T02:00:00.000Z0") MOD EQUAL 0
+  003 "storage/stats/target/123/456/my-source/my-sink/_sum" MOD EQUAL 0
+  004 ["storage/stats/target/123/456/my-source/my-sink/2000-01-01T02:00:00.000Z/", "storage/stats/target/123/456/my-source/my-sink/2000-01-01T02:00:00.000Z0") MOD EQUAL 0
   ➡️  THEN:
-  // Delete file, slices, stats
+  // Delete the file
   001 ➡️  DEL "storage/file/all/123/456/my-source/my-sink/2000-01-01T02:00:00.000Z"
   002 ➡️  DEL "storage/file/level/local/123/456/my-source/my-sink/2000-01-01T02:00:00.000Z"
-  003 ➡️  DEL "storage/slice/all/123/456/my-source/my-sink/2000-01-01T02:00:00.000Z/my-volume-1/2000-01-01T02:00:00.000Z"
-  004 ➡️  DEL "storage/slice/level/local/123/456/my-source/my-sink/2000-01-01T02:00:00.000Z/my-volume-1/2000-01-01T02:00:00.000Z"
-  005 ➡️  DEL ["storage/stats/local/123/456/my-source/my-sink/2000-01-01T02:00:00.000Z/", "storage/stats/local/123/456/my-source/my-sink/2000-01-01T02:00:00.000Z0")
-  006 ➡️  DEL ["storage/stats/staging/123/456/my-source/my-sink/2000-01-01T02:00:00.000Z/", "storage/stats/staging/123/456/my-source/my-sink/2000-01-01T02:00:00.000Z0")
-  007 ➡️  DEL ["storage/stats/target/123/456/my-source/my-sink/2000-01-01T02:00:00.000Z/", "storage/stats/target/123/456/my-source/my-sink/2000-01-01T02:00:00.000Z0")
+  // Roll up statistics
+  003 ➡️  DEL ["storage/stats/local/123/456/my-source/my-sink/2000-01-01T02:00:00.000Z/", "storage/stats/local/123/456/my-source/my-sink/2000-01-01T02:00:00.000Z0")
+  004 ➡️  DEL ["storage/stats/staging/123/456/my-source/my-sink/2000-01-01T02:00:00.000Z/", "storage/stats/staging/123/456/my-source/my-sink/2000-01-01T02:00:00.000Z0")
+  005 ➡️  DEL ["storage/stats/target/123/456/my-source/my-sink/2000-01-01T02:00:00.000Z/", "storage/stats/target/123/456/my-source/my-sink/2000-01-01T02:00:00.000Z0")
 ✔️  TXN | succeeded: true
-

--- a/internal/pkg/service/stream/storage/model/repository/slice/fixtures/slice_delete_ops_001.txt
+++ b/internal/pkg/service/stream/storage/model/repository/slice/fixtures/slice_delete_ops_001.txt
@@ -4,38 +4,41 @@
   001 ➡️  GET "storage/file/all/123/456/my-source/my-sink/2000-01-01T01:00:00.000Z"
 ✔️  TXN | succeeded: true
 
-// READ
+// Slices are deleted in their own bounded transaction(s), independent of the file delete.
+// List the slices of the file ...
+➡️  GET ["storage/slice/all/123/456/my-source/my-sink/2000-01-01T01:00:00.000Z/", "storage/slice/all/123/456/my-source/my-sink/2000-01-01T01:00:00.000Z0")
+✔️  GET ["storage/slice/all/123/456/my-source/my-sink/2000-01-01T01:00:00.000Z/", "storage/slice/all/123/456/my-source/my-sink/2000-01-01T01:00:00.000Z0") | count: 2
+
+// ... then delete them in a batch (no IF guard, deletion tolerates partial progress)
 ➡️  TXN
   ➡️  THEN:
-  // Get slices from the file for deletion
-  001 ➡️  GET ["storage/slice/all/123/456/my-source/my-sink/2000-01-01T01:00:00.000Z/", "storage/slice/all/123/456/my-source/my-sink/2000-01-01T01:00:00.000Z0")
-  // Get statistics for aggregation
-  002 ➡️  GET "storage/stats/target/123/456/my-source/my-sink/_sum"
-  003 ➡️  GET ["storage/stats/target/123/456/my-source/my-sink/2000-01-01T01:00:00.000Z/", "storage/stats/target/123/456/my-source/my-sink/2000-01-01T01:00:00.000Z0")
+  001 ➡️  DEL "storage/slice/all/123/456/my-source/my-sink/2000-01-01T01:00:00.000Z/my-volume-1/2000-01-01T01:00:00.000Z"
+  002 ➡️  DEL "storage/slice/level/local/123/456/my-source/my-sink/2000-01-01T01:00:00.000Z/my-volume-1/2000-01-01T01:00:00.000Z"
+  003 ➡️  DEL "storage/slice/all/123/456/my-source/my-sink/2000-01-01T01:00:00.000Z/my-volume-1/2000-01-01T02:00:00.000Z"
+  004 ➡️  DEL "storage/slice/level/local/123/456/my-source/my-sink/2000-01-01T01:00:00.000Z/my-volume-1/2000-01-01T02:00:00.000Z"
 ✔️  TXN | succeeded: true
 
-// WRITE
+// READ - statistics for aggregation (rollup on file delete)
+➡️  TXN
+  ➡️  THEN:
+  001 ➡️  GET "storage/stats/target/123/456/my-source/my-sink/_sum"
+  002 ➡️  GET ["storage/stats/target/123/456/my-source/my-sink/2000-01-01T01:00:00.000Z/", "storage/stats/target/123/456/my-source/my-sink/2000-01-01T01:00:00.000Z0")
+✔️  TXN | succeeded: true
+
+// WRITE - delete the file and roll up its statistics (slices already deleted above)
 ➡️  TXN
   ➡️  IF:
   // Objects from the READ phase must be unchanged
   001 "storage/file/all/123/456/my-source/my-sink/2000-01-01T01:00:00.000Z" MOD GREATER 0
   002 "storage/file/all/123/456/my-source/my-sink/2000-01-01T01:00:00.000Z" MOD LESS %d
-  003 ["storage/slice/all/123/456/my-source/my-sink/2000-01-01T01:00:00.000Z/", "storage/slice/all/123/456/my-source/my-sink/2000-01-01T01:00:00.000Z0") MOD GREATER 0
-  004 ["storage/slice/all/123/456/my-source/my-sink/2000-01-01T01:00:00.000Z/", "storage/slice/all/123/456/my-source/my-sink/2000-01-01T01:00:00.000Z0") MOD LESS %d
-  005 "storage/slice/all/123/456/my-source/my-sink/2000-01-01T01:00:00.000Z/my-volume-1/2000-01-01T01:00:00.000Z" MOD GREATER 0
-  006 "storage/slice/all/123/456/my-source/my-sink/2000-01-01T01:00:00.000Z/my-volume-1/2000-01-01T02:00:00.000Z" MOD GREATER 0
-  007 "storage/stats/target/123/456/my-source/my-sink/_sum" MOD EQUAL 0
-  008 ["storage/stats/target/123/456/my-source/my-sink/2000-01-01T01:00:00.000Z/", "storage/stats/target/123/456/my-source/my-sink/2000-01-01T01:00:00.000Z0") MOD EQUAL 0
+  003 "storage/stats/target/123/456/my-source/my-sink/_sum" MOD EQUAL 0
+  004 ["storage/stats/target/123/456/my-source/my-sink/2000-01-01T01:00:00.000Z/", "storage/stats/target/123/456/my-source/my-sink/2000-01-01T01:00:00.000Z0") MOD EQUAL 0
   ➡️  THEN:
-  // Delete file and both slices
+  // Delete the file
   001 ➡️  DEL "storage/file/all/123/456/my-source/my-sink/2000-01-01T01:00:00.000Z"
   002 ➡️  DEL "storage/file/level/local/123/456/my-source/my-sink/2000-01-01T01:00:00.000Z"
-  003 ➡️  DEL "storage/slice/all/123/456/my-source/my-sink/2000-01-01T01:00:00.000Z/my-volume-1/2000-01-01T01:00:00.000Z"
-  004 ➡️  DEL "storage/slice/level/local/123/456/my-source/my-sink/2000-01-01T01:00:00.000Z/my-volume-1/2000-01-01T01:00:00.000Z"
-  005 ➡️  DEL "storage/slice/all/123/456/my-source/my-sink/2000-01-01T01:00:00.000Z/my-volume-1/2000-01-01T02:00:00.000Z"
-  006 ➡️  DEL "storage/slice/level/local/123/456/my-source/my-sink/2000-01-01T01:00:00.000Z/my-volume-1/2000-01-01T02:00:00.000Z"
-  007 ➡️  DEL ["storage/stats/local/123/456/my-source/my-sink/2000-01-01T01:00:00.000Z/", "storage/stats/local/123/456/my-source/my-sink/2000-01-01T01:00:00.000Z0")
-  008 ➡️  DEL ["storage/stats/staging/123/456/my-source/my-sink/2000-01-01T01:00:00.000Z/", "storage/stats/staging/123/456/my-source/my-sink/2000-01-01T01:00:00.000Z0")
-  009 ➡️  DEL ["storage/stats/target/123/456/my-source/my-sink/2000-01-01T01:00:00.000Z/", "storage/stats/target/123/456/my-source/my-sink/2000-01-01T01:00:00.000Z0")
+  // Roll up statistics
+  003 ➡️  DEL ["storage/stats/local/123/456/my-source/my-sink/2000-01-01T01:00:00.000Z/", "storage/stats/local/123/456/my-source/my-sink/2000-01-01T01:00:00.000Z0")
+  004 ➡️  DEL ["storage/stats/staging/123/456/my-source/my-sink/2000-01-01T01:00:00.000Z/", "storage/stats/staging/123/456/my-source/my-sink/2000-01-01T01:00:00.000Z0")
+  005 ➡️  DEL ["storage/stats/target/123/456/my-source/my-sink/2000-01-01T01:00:00.000Z/", "storage/stats/target/123/456/my-source/my-sink/2000-01-01T01:00:00.000Z0")
 ✔️  TXN | succeeded: true
-

--- a/internal/pkg/service/stream/storage/model/repository/slice/slice_delete.go
+++ b/internal/pkg/service/stream/storage/model/repository/slice/slice_delete.go
@@ -10,23 +10,53 @@ import (
 
 func (r *Repository) deleteSlicesOnFileDelete() {
 	r.plugins.Collection().OnFileDelete(func(ctx context.Context, now time.Time, original, file *model.File) error {
-		op.AtomicOpCtxFrom(ctx).AddFrom(r.deleteAll(file.FileKey, now))
-		return nil
+		return r.deleteAllInBatches(ctx, file.FileKey, now)
 	})
 }
 
-// deleteAll slices from the file.
-// This operation deletes only the metadata, the file resources in the local or staging storage are unaffected.
-func (r *Repository) deleteAll(k model.FileKey, now time.Time) *op.AtomicOp[[]model.Slice] {
-	var slices, deleted []model.Slice
-	return op.Atomic(r.client, &deleted).
-		Read(func(ctx context.Context) op.Op {
-			return r.ListIn(k).WithAllTo(&slices)
-		}).
-		Write(func(ctx context.Context) op.Op {
-			return r.updateAll(ctx, now, slices, func(slice model.Slice) (model.Slice, error) {
-				slice.Deleted = true
-				return slice, nil
-			})
-		})
+// deleteAllInBatches soft-deletes all slices of the file in bounded transactions.
+//
+// A file can accumulate many slices (e.g. a throttled file that keeps getting new slices), and
+// deleting them all in a single transaction would exceed the etcd per-transaction operation limit.
+// The slices are therefore deleted in batches, each batch in its own transaction.
+//
+// This callback runs during generation of the file delete transaction, so the slice batches commit
+// BEFORE the file delete commits - deliberately "children first". If the file delete then
+// collides/retries/fails, the file stays present with a subset of its slices deleted: an incomplete
+// delete that the cleanup node retries (the file is still present and still expired), re-listing and
+// deleting only the remaining slices. Slice deletion is monotonic and idempotent, the file is locked
+// by the cleanup node during the delete, and the data is old (no cross-batch strong consistency is
+// required), so the intermediate state is observable but not corrupt.
+//
+// This operation deletes only the metadata; the file resources in the local or staging storage are
+// unaffected.
+func (r *Repository) deleteAllInBatches(ctx context.Context, k model.FileKey, now time.Time) error {
+	var slices []model.Slice
+	if err := r.ListIn(k).WithAllTo(&slices).Do(ctx).Err(); err != nil {
+		return err
+	}
+
+	// Each slice delete is 2 ops (removal from the All and InLevel prefixes), so size the batch to
+	// stay under the per-transaction limit.
+	batchSize := op.MaxOpsPerTxn / 2
+	for start := 0; start < len(slices); start += batchSize {
+		batch := slices[start:min(start+batchSize, len(slices))]
+
+		// Each batch runs in its own AtomicOp so the slice save plugins (which require the atomic
+		// operation context) are satisfied; the write phase generates no extra operations because a
+		// delete-save has no IF condition and no plugin reacts to a slice deletion.
+		err := op.Atomic(r.client, &op.NoResult{}).
+			Write(func(ctx context.Context) op.Op {
+				return r.updateAll(ctx, now, batch, func(slice model.Slice) (model.Slice, error) {
+					slice.Deleted = true
+					return slice, nil
+				})
+			}).
+			Do(ctx).Err()
+		if err != nil {
+			return err
+		}
+	}
+
+	return nil
 }

--- a/internal/pkg/service/stream/storage/model/repository/slice/slice_delete_test.go
+++ b/internal/pkg/service/stream/storage/model/repository/slice/slice_delete_test.go
@@ -99,3 +99,79 @@ func TestSliceRepository_DeleteSliceOnFileDelete(t *testing.T) {
 	// -----------------------------------------------------------------------------------------------------------------
 	etcdhelper.AssertKVsString(t, client, ``, etcdhelper.WithIgnoredKeyPattern("^definition/|storage/secret/|storage/volume"))
 }
+
+// TestSliceRepository_DeleteSliceOnFileDelete_BoundedTxnSize exercises end-to-end that a file with
+// many slices can be deleted: the slices are deleted in bounded batches (op.RunWriteTxnsInBatches)
+// rather than a single transaction. The batch-sizing itself is verified limit-independently in the
+// op package (TestRunWriteTxnsInBatches); this test confirms the file-delete cascade uses it.
+func TestSliceRepository_DeleteSliceOnFileDelete_BoundedTxnSize(t *testing.T) {
+	t.Parallel()
+
+	ctx := t.Context()
+	clk := clockwork.NewFakeClockAt(utctime.MustParse("2000-01-01T01:00:00.000Z").Time())
+	by := test.ByUser()
+
+	// More slices than fit in a single batch, so the delete must span multiple transactions.
+	const sliceCount = 70
+
+	// Fixtures
+	projectID := keboola.ProjectID(123)
+	branchKey := key.BranchKey{ProjectID: projectID, BranchID: 456}
+	sourceKey := key.SourceKey{BranchKey: branchKey, SourceID: "my-source"}
+	sinkKey := key.SinkKey{SourceKey: sourceKey, SinkID: "my-sink"}
+
+	d, mocked := dependencies.NewMockedStorageScope(t, ctx, commonDeps.WithClock(clk))
+	client := mocked.TestEtcdClient()
+	defRepo := d.DefinitionRepository()
+	storageRepo := d.StorageRepository()
+	fileRepo := storageRepo.File()
+	sliceRepo := storageRepo.Slice()
+	volumeRepo := storageRepo.Volume()
+
+	// Register active volumes
+	{
+		session, err := concurrency.NewSession(client)
+		require.NoError(t, err)
+		defer func() { require.NoError(t, session.Close()) }()
+		test.RegisterWriterVolumes(t, ctx, volumeRepo, session, 1)
+	}
+
+	// Create branch, source, sink (opens the file with one slice)
+	var fileKey model.FileKey
+	{
+		branch := test.NewBranch(branchKey)
+		require.NoError(t, defRepo.Branch().Create(&branch, clk.Now(), by).Do(ctx).Err())
+		source := test.NewSource(sourceKey)
+		require.NoError(t, defRepo.Source().Create(&source, clk.Now(), by, "Create source").Do(ctx).Err())
+		sink := dummy.NewSinkWithLocalStorage(sinkKey)
+		require.NoError(t, defRepo.Sink().Create(&sink, clk.Now(), by, "Create sink").Do(ctx).Err())
+		fileKey = model.FileKey{SinkKey: sinkKey, FileID: model.FileID{OpenedAt: utctime.From(clk.Now())}}
+	}
+
+	// Rotate slices to grow the file up to sliceCount slices
+	{
+		slices, err := sliceRepo.ListIn(fileKey).Do(ctx).All()
+		require.NoError(t, err)
+		require.Len(t, slices, 1)
+		current := slices[0].SliceKey
+		for range sliceCount - 1 {
+			clk.Advance(time.Hour)
+			require.NoError(t, sliceRepo.Rotate(current, clk.Now()).Do(ctx).Err())
+			latest, err := sliceRepo.ListIn(fileKey).Do(ctx).All()
+			require.NoError(t, err)
+			current = latest[len(latest)-1].SliceKey
+		}
+		all, err := sliceRepo.ListIn(fileKey).Do(ctx).All()
+		require.NoError(t, err)
+		require.Len(t, all, sliceCount)
+	}
+
+	// Delete the file - must succeed despite the large number of slices
+	clk.Advance(time.Hour)
+	require.NoError(t, fileRepo.Delete(fileKey, clk.Now()).Do(ctx).Err())
+
+	// All slices must be gone
+	remaining, err := sliceRepo.ListIn(fileKey).Do(ctx).All()
+	require.NoError(t, err)
+	require.Empty(t, remaining)
+}

--- a/internal/pkg/service/stream/storage/statistics/repository/stats_delete_test.go
+++ b/internal/pkg/service/stream/storage/statistics/repository/stats_delete_test.go
@@ -531,7 +531,7 @@ func TestRepository_RollupStatisticsOnFileDelete_NearTxnLimit(t *testing.T) {
 	// -----------------------------------------------------------------------------------------------------------------
 	{
 		clk.Advance(time.Hour)
-		require.NoError(t, statsRepo.ResetAllSinksStats([]key.SinkKey{sinkKey}).Do(ctx).Err())
+		require.NoError(t, statsRepo.ResetAllSinksStats(ctx, []key.SinkKey{sinkKey}))
 
 		stats, err := statsRepo.SinkStats(ctx, sinkKey)
 		require.NoError(t, err)
@@ -545,8 +545,9 @@ func TestRepository_RollupStatisticsOnFileDelete_NearTxnLimit(t *testing.T) {
 	}
 }
 
-// TestRepository_RollupStatisticsOnFileDelete_LevelTarget_TxnLimit tests statistics reset above the transaction limit.
-func TestRepository_RollupStatisticsOnFileDelete_AboveTxnLimit(t *testing.T) {
+// TestRepository_ResetAllSinksStats_BoundedTxnSize verifies that resetting statistics for a sink with
+// many slices stays within the etcd per-transaction operation limit (regression: it previously exceeded it).
+func TestRepository_ResetAllSinksStats_BoundedTxnSize(t *testing.T) {
 	t.Parallel()
 
 	// How many files and slices to create
@@ -670,7 +671,8 @@ func TestRepository_RollupStatisticsOnFileDelete_AboveTxnLimit(t *testing.T) {
 	// -----------------------------------------------------------------------------------------------------------------
 	{
 		clk.Advance(time.Hour)
-		err := statsRepo.ResetAllSinksStats([]key.SinkKey{sinkKey}).Do(ctx).Err()
-		require.Error(t, err, "Received unexpected error:\netcdserver: too many operations in txn request")
+		// Previously this exceeded the etcd per-transaction operation limit. The reset is now bounded
+		// (SkipPrefixKeysCheck + per-sink transactions), so it must succeed within the limit.
+		require.NoError(t, statsRepo.ResetAllSinksStats(ctx, []key.SinkKey{sinkKey}))
 	}
 }

--- a/internal/pkg/service/stream/storage/statistics/repository/stats_delete_test.go
+++ b/internal/pkg/service/stream/storage/statistics/repository/stats_delete_test.go
@@ -676,3 +676,132 @@ func TestRepository_ResetAllSinksStats_BoundedTxnSize(t *testing.T) {
 		require.NoError(t, statsRepo.ResetAllSinksStats(ctx, []key.SinkKey{sinkKey}))
 	}
 }
+
+// TestRepository_RollupStatisticsOnFileDelete_ManySlices_BoundedTxnSize verifies that deleting a file
+// whose slices each have target-level statistics stays within the etcd per-transaction limit. The
+// statistics rollup reads all per-slice stats under the file (a prefix GetAll); without
+// SkipPrefixKeysCheck on the file delete this emits one IF condition per slice, so the file delete
+// transaction would exceed the limit for a file with many slices.
+func TestRepository_RollupStatisticsOnFileDelete_ManySlices_BoundedTxnSize(t *testing.T) {
+	t.Parallel()
+
+	// Number of slices in one file. Each slice gets a target-level statistics record, so the rollup on
+	// file delete reads sliceCount keys. Without SkipPrefixKeysCheck that would add one IF condition per
+	// slice to the file delete transaction; the test asserts the op count does not scale with sliceCount.
+	// (The count is kept modest because moving this many slices to the target level is itself a separate,
+	// not-yet-bounded batch - see the deferred file rotation / slice close path.)
+	const sliceCount = 10
+
+	ctx, cancel := context.WithTimeout(t.Context(), 60*time.Second)
+	defer cancel()
+
+	clk := clockwork.NewFakeClockAt(utctime.MustParse("2000-01-01T01:00:00.000Z").Time())
+	by := test.ByUser()
+
+	// Fixtures
+	projectID := keboola.ProjectID(123)
+	branchKey := key.BranchKey{ProjectID: projectID, BranchID: 456}
+	sourceKey := key.SourceKey{BranchKey: branchKey, SourceID: "my-source"}
+	sinkKey := key.SinkKey{SourceKey: sourceKey, SinkID: "my-sink"}
+
+	d, mocked := dependencies.NewMockedStorageScope(t, ctx, commonDeps.WithClock(clk))
+	client := mocked.TestEtcdClient()
+	defRepo := d.DefinitionRepository()
+	storageRepo := d.StorageRepository()
+	fileRepo := storageRepo.File()
+	sliceRepo := storageRepo.Slice()
+	volumeRepo := storageRepo.Volume()
+	statsRepo := d.StatisticsRepository()
+
+	// Register active volume
+	{
+		session, err := concurrency.NewSession(client)
+		require.NoError(t, err)
+		defer func() { require.NoError(t, session.Close()) }()
+		test.RegisterWriterVolumes(t, ctx, volumeRepo, session, 1)
+	}
+
+	// Create branch, source, sink (opens the file with one slice)
+	var fileKey model.FileKey
+	{
+		branch := test.NewBranch(branchKey)
+		require.NoError(t, defRepo.Branch().Create(&branch, clk.Now(), by).Do(ctx).Err())
+		source := test.NewSource(sourceKey)
+		require.NoError(t, defRepo.Source().Create(&source, clk.Now(), by, "Create source").Do(ctx).Err())
+		sink := dummy.NewSinkWithLocalStorage(sinkKey)
+		require.NoError(t, defRepo.Sink().Create(&sink, clk.Now(), by, "Create sink").Do(ctx).Err())
+		files, err := fileRepo.ListIn(sinkKey).Do(ctx).All()
+		require.NoError(t, err)
+		require.Len(t, files, 1)
+		fileKey = files[0].FileKey
+	}
+
+	// Grow the file up to sliceCount slices
+	var sliceKeys []model.SliceKey
+	{
+		slices, err := sliceRepo.ListIn(fileKey).Do(ctx).All()
+		require.NoError(t, err)
+		require.Len(t, slices, 1)
+		current := slices[0].SliceKey
+		for range sliceCount - 1 {
+			clk.Advance(time.Hour)
+			require.NoError(t, sliceRepo.Rotate(current, clk.Now()).Do(ctx).Err())
+			latest, err := sliceRepo.ListIn(fileKey).Do(ctx).All()
+			require.NoError(t, err)
+			current = latest[len(latest)-1].SliceKey
+		}
+		all, err := sliceRepo.ListIn(fileKey).Do(ctx).All()
+		require.NoError(t, err)
+		require.Len(t, all, sliceCount)
+		for _, s := range all {
+			sliceKeys = append(sliceKeys, s.SliceKey)
+		}
+	}
+
+	// Write statistics for each slice
+	{
+		stats := make([]statistics.PerSlice, 0, len(sliceKeys))
+		for _, sliceKey := range sliceKeys {
+			stats = append(stats, statistics.PerSlice{
+				SliceKey:         sliceKey,
+				FirstRecordAt:    utctime.MustParse("2000-01-01T01:00:00.000Z"),
+				LastRecordAt:     utctime.MustParse("2000-01-01T02:00:00.000Z"),
+				RecordsCount:     1,
+				UncompressedSize: 1,
+				CompressedSize:   1,
+			})
+		}
+		require.NoError(t, statsRepo.Put(ctx, "test-node", stats))
+	}
+
+	// Move all statistics to the target level
+	{
+		require.NoError(t, defRepo.Sink().Disable(sinkKey, clk.Now(), by, "some reason").Do(ctx).Err())
+		clk.Advance(time.Hour)
+		for _, sliceKey := range sliceKeys {
+			require.NoError(t, sliceRepo.SwitchToUploading(sliceKey, clk.Now(), false).Do(ctx).Err())
+		}
+		clk.Advance(time.Hour)
+		for _, sliceKey := range sliceKeys {
+			require.NoError(t, sliceRepo.SwitchToUploaded(sliceKey, clk.Now()).Do(ctx).Err())
+		}
+		clk.Advance(time.Hour)
+		require.NoError(t, fileRepo.SwitchToImporting(fileKey, clk.Now(), false).Do(ctx).Err())
+		clk.Advance(time.Hour)
+		require.NoError(t, fileRepo.SwitchToImported(fileKey, clk.Now()).Do(ctx).Err())
+	}
+
+	// Delete the file - the rollup reads all target-level per-slice stats; the op count must stay bounded
+	clk.Advance(time.Hour)
+	result := fileRepo.Delete(fileKey, clk.Now()).Do(ctx)
+	require.NoError(t, result.Err())
+
+	// The file delete transaction op count must not scale with the number of slices/stats under the file.
+	// Without SkipPrefixKeysCheck it would be ~sliceCount (one IF condition per target stat key).
+	require.Less(t, result.MaxOps(), sliceCount, "file delete op count must not scale with slice count")
+
+	// The file is gone
+	files, err := fileRepo.ListIn(sinkKey).Do(ctx).All()
+	require.NoError(t, err)
+	require.Empty(t, files)
+}

--- a/internal/pkg/service/stream/storage/statistics/repository/stats_put.go
+++ b/internal/pkg/service/stream/storage/statistics/repository/stats_put.go
@@ -2,14 +2,12 @@ package repository
 
 import (
 	"context"
-	"sync"
 
 	"go.opentelemetry.io/otel/attribute"
 
 	"github.com/keboola/keboola-as-code/internal/pkg/service/common/etcdop/op"
 	"github.com/keboola/keboola-as-code/internal/pkg/service/stream/storage/model"
 	"github.com/keboola/keboola-as-code/internal/pkg/service/stream/storage/statistics"
-	"github.com/keboola/keboola-as-code/internal/pkg/utils/errors"
 )
 
 // Put creates or updates slices statistics records in the level.LevelLocal.
@@ -17,19 +15,14 @@ func (r *Repository) Put(ctx context.Context, nodeID string, stats []statistics.
 	ctx, span := r.telemetry.Tracer().Start(ctx, "keboola.go.stream.storage.statistics.Repository.Put")
 	defer span.End(&err)
 
-	var currentTxn *op.TxnOp[op.NoResult]
-	var allTxn []*op.TxnOp[op.NoResult]
-	addTxn := func() {
-		currentTxn = op.Txn(r.client)
-		allTxn = append(allTxn, currentTxn)
-	}
+	// Trace records and transactions count
+	span.SetAttributes(
+		attribute.Int("put.records_count", len(stats)),
+		attribute.Int("put.txn_count", (len(stats)+putMaxStatsPerTxn-1)/putMaxStatsPerTxn),
+	)
 
-	// Merge multiple put operations into one transaction
-	for i, v := range stats {
-		if i%putMaxStatsPerTxn == 0 {
-			addTxn()
-		}
-
+	// Each Put is a single op, so batch by putMaxStatsPerTxn keys per transaction, run in parallel.
+	return op.RunWriteTxnsInBatches(ctx, r.client, stats, putMaxStatsPerTxn, func(txn *op.TxnOp[op.NoResult], v statistics.PerSlice) {
 		value := statistics.Value{
 			FirstRecordAt:    v.FirstRecordAt,
 			LastRecordAt:     v.LastRecordAt,
@@ -37,28 +30,6 @@ func (r *Repository) Put(ctx context.Context, nodeID string, stats []statistics.
 			UncompressedSize: v.UncompressedSize,
 			CompressedSize:   v.CompressedSize,
 		}
-
-		currentTxn.Then(r.schema.InLevel(model.LevelLocal).InSliceSourceNode(v.SliceKey, nodeID).Put(r.client, value))
-	}
-
-	// Trace records and transactions count
-	span.SetAttributes(
-		attribute.Int("put.records_count", len(stats)),
-		attribute.Int("put.txn_count", len(allTxn)),
-	)
-
-	// Run transactions in parallel
-	wg := &sync.WaitGroup{}
-	errs := errors.NewMultiError()
-	for _, txn := range allTxn {
-		wg.Go(func() {
-			if err := txn.Do(ctx).Err(); err != nil {
-				errs.Append(err)
-			}
-		})
-	}
-
-	// Wait for all transactions
-	wg.Wait()
-	return errs.ErrorOrNil()
+		txn.Then(r.schema.InLevel(model.LevelLocal).InSliceSourceNode(v.SliceKey, nodeID).Put(r.client, value))
+	})
 }

--- a/internal/pkg/service/stream/storage/statistics/repository/stats_reset.go
+++ b/internal/pkg/service/stream/storage/statistics/repository/stats_reset.go
@@ -2,6 +2,7 @@ package repository
 
 import (
 	"context"
+	"sync"
 
 	"github.com/keboola/keboola-as-code/internal/pkg/service/common/etcdop/iterator"
 	"github.com/keboola/keboola-as-code/internal/pkg/service/common/etcdop/op"
@@ -9,22 +10,40 @@ import (
 	"github.com/keboola/keboola-as-code/internal/pkg/service/stream/definition/key"
 	"github.com/keboola/keboola-as-code/internal/pkg/service/stream/storage/model"
 	"github.com/keboola/keboola-as-code/internal/pkg/service/stream/storage/statistics"
+	"github.com/keboola/keboola-as-code/internal/pkg/utils/errors"
 )
 
-func (r *Repository) ResetAllSinksStats(sinkKeys []key.SinkKey) *op.AtomicOp[op.NoResult] {
-	ops := op.Atomic(r.client, &op.NoResult{})
-
+// ResetAllSinksStats resets statistics of each sink in its own bounded transaction, run in parallel.
+//
+// Each sink reset is an independent atomic operation, so the per-transaction op count stays bounded
+// regardless of the number of sinks (previously all sinks were merged into one transaction, which
+// exceeded the etcd per-transaction operation limit). There is no cross-sink atomicity, which is
+// acceptable: a partially reset set of sinks is never user-visibly inconsistent and re-running
+// completes it.
+func (r *Repository) ResetAllSinksStats(ctx context.Context, sinkKeys []key.SinkKey) error {
+	wg := &sync.WaitGroup{}
+	errs := errors.NewMultiError()
 	for _, sinkKey := range sinkKeys {
-		ops.AddFrom(r.ResetSinkStats(sinkKey))
+		wg.Go(func() {
+			if err := r.ResetSinkStats(sinkKey).Do(ctx).Err(); err != nil {
+				// Prefix with the sink key so a failure can be attributed when multiple sinks reset concurrently.
+				errs.Append(errors.PrefixErrorf(err, `sink "%s"`, sinkKey.String()))
+			}
+		})
 	}
+	wg.Wait()
 
-	return ops
+	return errs.ErrorOrNil()
 }
 
 // ResetSinkStats sums all statistics for data in target level and saves the sum in _reset key.
 // Local and staging levels are unaffected because those data will be moved to target later.
 func (r *Repository) ResetSinkStats(sinkKey key.SinkKey) *op.AtomicOp[op.NoResult] {
-	ops := op.Atomic(r.client, &op.NoResult{})
+	// SkipPrefixKeysCheck: the read sums all statistics under the sink prefix, which may contain
+	// many per-slice keys. Without this, one IF condition is generated per key, exploding the
+	// transaction op count. Modifications to the prefix are still detected; only concurrent
+	// deletion of an individual key is not — harmless for a reset that just re-sums the prefix.
+	ops := op.Atomic(r.client, &op.NoResult{}).SkipPrefixKeysCheck()
 
 	// Object prefix contains all statistics related to the object
 	objectPfx := r.schema.InLevel(model.LevelTarget).InObject(sinkKey)

--- a/test/stream/api/sink/statistics-clear-001-ok/expected-server-stdout
+++ b/test/stream/api/sink/statistics-clear-001-ok/expected-server-stdout
@@ -1,1 +1,1 @@
-{"level":"info","message":"Statistics clear for sink \"%s/my-source/my-sink\" used 4 operations","nodeId":"test-node","component":"api"}
+{"level":"info","message":"Statistics clear for sink \"%s/my-source/my-sink\" used 2 operations","nodeId":"test-node","component":"api"}

--- a/test/stream/api/source/statistics-clear-001-ok/expected-server-stdout
+++ b/test/stream/api/source/statistics-clear-001-ok/expected-server-stdout
@@ -1,1 +1,1 @@
-{"level":"info","message":"Statistics clear for source \"%s/my-source\" used 4 operations","nodeId":"test-node","component":"api"}
+{"level":"info","message":"Statistics clear for source \"%s/my-source\" reset 1 sinks","nodeId":"test-node","component":"api"}


### PR DESCRIPTION
## Release Notes
- Branch deletion no longer builds a single etcd transaction covering every source and sink in the branch; each source (with its sinks) is now deleted in its own transaction, so deletion succeeds for large branches that previously failed with `etcdserver: too many operations in txn request`.
- File deletion no longer deletes the file and all of its slices in one transaction; the slices are deleted in bounded batches.
- File deletion no longer generates one IF condition per slice for the statistics rollup read (`SkipPrefixKeysCheck`), so the file delete transaction op count stays bounded regardless of how many per-slice statistics exist.
- Statistics reset (`Source statistics clear`) is now bounded: each sink is reset in its own transaction and the per-sink read no longer emits one IF condition per slice.
- Adds `op.RunWriteTxnsInBatches`, a shared helper that splits bulk writes into independent, parallel, size-bounded transactions (`MaxOpsPerTxn = 100`).
- Dev/compose etcd `ETCD_MAX_TXN_OPS` raised 128 → 1024 to match production.

Linear: https://linear.app/keboola/issue/AI-3278/stream-bound-etcd-transaction-size-cascading-deletes-and-stats-rollup

## Plans for customer communication
None.

## Impact analysis
- `stream/definition/repository/source`: `deleteSourcesOnBranchDelete` / `undeleteSourcesOnBranchUndelete` now iterate sources and delete/undelete each in its own `.Do(ctx)` transaction instead of merging the whole subtree into the branch's AtomicOp. The `source → sink` hook is unchanged; final etcd state is identical (existing KV-snapshot tests pass unmodified).
- `stream/storage/model/repository/slice`: `deleteSlicesOnFileDelete` lists the file's slices and soft-deletes them in batches of `MaxOpsPerTxn/2`, each batch in its own transaction, instead of merging all slices into the file delete transaction. File/slice delete op-log fixtures updated accordingly.
- `stream/storage/model/repository/file`: the file `update` AtomicOp uses `SkipPrefixKeysCheck()` so the statistics rollup's prefix `GetAll` on file delete no longer emits one IF condition per slice. The file is locked during the update, so the per-key guards are unnecessary and the rollup math is unchanged; file retry has no prefix reads and is unaffected.
- `stream/storage/statistics/repository`: `ResetSinkStats` adds `SkipPrefixKeysCheck()`; `ResetAllSinksStats` signature changed from `(...) *op.AtomicOp[op.NoResult]` to `(ctx, sinkKeys) error` (runs per-sink resets in parallel). Sole caller `stream/api/service/source.go` (`SourceStatisticsClear`) updated.
- `etcdop/op`: new `batch.go` (`RunWriteTxnsInBatches`, `MaxOpsPerTxn`); `statistics Put` refactored onto it with no behaviour change.
- `docker-compose.yml`: `ETCD_MAX_TXN_OPS` 128 → 1024.
- Behavioural trade-off: cascade deletes now run as multiple transactions, so they are no longer atomic across the whole subtree. This is safe — soft/metadata deletion is monotonic and idempotent; a partially-cascaded delete is never user-visibly inconsistent and re-running completes it. Branch undelete still restores only cascade-deleted children (the per-entity `Deleted.Directly` flag is preserved). File slice deletes run while the file is locked by the cleanup node.
- No public API contract change; `SourceStatisticsClear` behaviour is unchanged for callers.
- Not changed (separate follow-up): slice **state transitions** — file close / import (`slice_state.go switchStateInBatch`, `switchSlicesToImported`, and the per-slice statistics `moveAll`) still transition all of a file's slices in one transaction. This is the binding limit for a file with very many slices (it fails before delete is ever reached) and is a state-machine transition, not a deletion, so it is deferred to a dedicated change.

## Change type
Bug fix — bound unbounded etcd transactions in cascading deletes (branch, file/slice) and statistics rollup/reset.

## Justification
The stream service built etcd transactions whose operation count grew with the number of child entities. The branch delete cascade (up to `MaxSourcesPerBranch` × `MaxSinksPerSource` ≈ 20,000 ops), file delete with many slices, and statistics rollup/reset exceeded the production `ETCD_MAX_TXN_OPS=1024` and failed intermittently in production/staging. Raising the limit is not a real fix (the largest cascades exceed any reasonable ceiling). This PR bounds the transaction size independently of how many sources/sinks/slices exist. Surfaced during AI-3191.

## Deployment
Merge & automatic deploy.

## Rollback plan
Revert of this PR.

## Post release support plan
Watch stream-service error logs for `etcdserver: too many operations in txn request` on branch/source delete, file cleanup, and `Source statistics clear`; the rate should drop to zero. No data migration involved.