### PR TITLE
PAT-1904 Fix flaky app auth config propagation

### DIFF
--- a/internal/pkg/service/appsproxy/dataapps/appconfig/appconfig.go
+++ b/internal/pkg/service/appsproxy/dataapps/appconfig/appconfig.go
@@ -21,8 +21,13 @@ import (
 // staleCacheFallbackDuration is the maximum duration for which the old configuration of an application is used if loading new configuration is not possible.
 const staleCacheFallbackDuration = time.Hour
 
+// refreshTimeout bounds how long a single config refresh may run.
+// The refresh holds the per-app lock, so this also bounds how long concurrent
+// requests for the same app wait for an in-flight refresh.
+const refreshTimeout = 30 * time.Second
+
 type Loader interface {
-	GetConfig(ctx context.Context, appID api.AppID) (config api.AppConfig, modified bool, err error)
+	GetConfig(ctx context.Context, appID api.AppID) (config api.AppConfig, err error)
 }
 
 type loader struct {
@@ -60,7 +65,7 @@ func NewLoader(d dependencies) Loader {
 
 // GetConfig gets the AppConfig by the ID from Sandboxes Service.
 // It handles local caching based on the Cache-Control and ETag headers.
-func (l *loader) GetConfig(ctx context.Context, appID api.AppID) (out api.AppConfig, modified bool, err error) {
+func (l *loader) GetConfig(ctx context.Context, appID api.AppID) (out api.AppConfig, err error) {
 	ctx, span := l.telemetry.Tracer().Start(ctx, "keboola.go.apps-proxy.appconfig.Loader.GetConfig")
 	defer span.End(&err)
 
@@ -76,24 +81,31 @@ func (l *loader) GetConfig(ctx context.Context, appID api.AppID) (out api.AppCon
 	// At first, the item.expiresAt is zero, so the condition is skipped.
 	now := l.clock.Now()
 	if now.Before(item.expiresAt) {
-		return item.config, false, nil
+		return item.config, nil
 	}
 
 	// Send API request with cached eTag.
 	// At first, the item.config.ETag() is empty string.
-	newConfig, err := l.api.GetAppConfig(appID, item.config.ETag()).Send(ctx)
+	//
+	// The refresh runs on a context detached from the incoming request: a client
+	// disconnect (common during OAuth redirects) must not abort the shared cache
+	// refresh and leave this replica serving stale config. Trace context is
+	// preserved via WithoutCancel; the timeout bounds the per-app lock hold time.
+	fetchCtx, cancel := context.WithTimeoutCause(context.WithoutCancel(ctx), refreshTimeout, errors.New("app config refresh timeout"))
+	defer cancel()
+	newConfig, err := l.api.GetAppConfig(appID, item.config.ETag()).Send(fetchCtx)
 	if err == nil {
 		// Cache the loaded configuration
 		item.config = *newConfig
 		item.ExtendExpiration(now, item.config.MaxAge())
-		return item.config, true, nil
+		return item.config, nil
 	}
 
 	// The config hasn't been modified, extend expiration, return cached version
 	notModifierErr := api.NotModifiedError{}
 	if errors.As(err, &notModifierErr) {
 		item.ExtendExpiration(now, notModifierErr.MaxAge)
-		return item.config, false, nil
+		return item.config, nil
 	}
 
 	// Only the not found error is expected
@@ -106,21 +118,21 @@ func (l *loader) GetConfig(ctx context.Context, appID api.AppID) (out api.AppCon
 		// The item.expiresAt may be zero, if there is no cached version, then the condition is skipped.
 		if now.Before(item.expiresAt.Add(staleCacheFallbackDuration)) {
 			l.logger.Warnf(ctx, `using stale cache for app "%s": %s`, appID, err.Error())
-			return item.config, false, nil
+			return item.config, nil
 		}
 	}
 
 	// Handle not found error
 	if apiErr != nil && apiErr.StatusCode() == http.StatusNotFound {
 		err = svcErrors.NewResourceNotFoundError("application", appID.String(), "stack").Wrap(err)
-		return api.AppConfig{}, false, err
+		return api.AppConfig{}, err
 	}
 
 	// Return the error if:
 	//  - It is not found error.
 	//  - There is no cached version.
 	//  - The staleCacheFallbackDuration has been exceeded.
-	return api.AppConfig{}, false, svcErrors.
+	return api.AppConfig{}, svcErrors.
 		NewServiceUnavailableError(errors.PrefixErrorf(err,
 			`unable to load configuration for application "%s"`, appID,
 		)).

--- a/internal/pkg/service/appsproxy/dataapps/appconfig/appconfig_test.go
+++ b/internal/pkg/service/appsproxy/dataapps/appconfig/appconfig_test.go
@@ -29,7 +29,6 @@ type attempt struct {
 	delay             time.Duration
 	responses         []*http.Response
 	expectedErrorCode int
-	expectedModified  bool
 }
 
 func TestLoader_LoadConfig(t *testing.T) {
@@ -80,7 +79,6 @@ func TestLoader_LoadConfig(t *testing.T) {
 						newResponse(t, 200, appPayload, `"etag-value"`, "max-age=60"),
 					},
 					expectedErrorCode: 0, // no error expected
-					expectedModified:  true,
 				},
 			},
 		},
@@ -92,11 +90,9 @@ func TestLoader_LoadConfig(t *testing.T) {
 						newResponse(t, 200, appPayload, `"etag-value"`, "max-age=60"),
 					},
 					expectedErrorCode: 0, // no error expected
-					expectedModified:  true,
 				},
 				{
 					expectedErrorCode: 0, // no error expected
-					expectedModified:  false,
 				},
 			},
 		},
@@ -108,7 +104,6 @@ func TestLoader_LoadConfig(t *testing.T) {
 						newResponse(t, 200, appPayload, `"etag-value"`, "max-age=60"),
 					},
 					expectedErrorCode: 0, // no error expected
-					expectedModified:  true,
 				},
 				{
 					delay: 10 * time.Minute,
@@ -117,11 +112,9 @@ func TestLoader_LoadConfig(t *testing.T) {
 						newResponse(t, 304, map[string]any{}, `"etag-value"`, "max-age=30"),
 					},
 					expectedErrorCode: 0, // no error expected
-					expectedModified:  false,
 				},
 				{
 					expectedErrorCode: 0, // no error expected
-					expectedModified:  false,
 				},
 				{
 					delay: 31 * time.Second,
@@ -129,7 +122,6 @@ func TestLoader_LoadConfig(t *testing.T) {
 						newResponse(t, 304, map[string]any{}, `"etag-value"`, "max-age=30"),
 					},
 					expectedErrorCode: 0, // no error expected
-					expectedModified:  false,
 				},
 			},
 		},
@@ -141,7 +133,6 @@ func TestLoader_LoadConfig(t *testing.T) {
 						newResponse(t, 200, appPayload, `"etag-value"`, "max-age=60"),
 					},
 					expectedErrorCode: 0, // no error expected
-					expectedModified:  true,
 				},
 				{
 					delay: 10 * time.Minute,
@@ -149,11 +140,9 @@ func TestLoader_LoadConfig(t *testing.T) {
 						newResponse(t, 200, map[string]any{"upstreamAppUrl": "http://new-app.local"}, `"etag-new-value"`, "max-age=60"),
 					},
 					expectedErrorCode: 0, // no error expected
-					expectedModified:  true,
 				},
 				{
 					expectedErrorCode: 0, // no error expected
-					expectedModified:  false,
 				},
 			},
 		},
@@ -165,7 +154,6 @@ func TestLoader_LoadConfig(t *testing.T) {
 						newResponse(t, 200, appPayload, `"etag-value"`, "max-age=60"),
 					},
 					expectedErrorCode: 0, // no error expected
-					expectedModified:  true,
 				},
 				{
 					delay: 10 * time.Minute,
@@ -178,7 +166,6 @@ func TestLoader_LoadConfig(t *testing.T) {
 						newResponse(t, 500, map[string]any{}, "", ""),
 					},
 					expectedErrorCode: 0, // no error expected
-					expectedModified:  false,
 				},
 				{
 					delay: time.Hour,
@@ -191,7 +178,6 @@ func TestLoader_LoadConfig(t *testing.T) {
 						newResponse(t, 500, map[string]any{}, "", ""),
 					},
 					expectedErrorCode: 500,
-					expectedModified:  false,
 				},
 			},
 		},
@@ -203,12 +189,10 @@ func TestLoader_LoadConfig(t *testing.T) {
 						newResponse(t, 200, appPayload, `"etag-value"`, "max-age=7200"),
 					},
 					expectedErrorCode: 0, // no error expected
-					expectedModified:  true,
 				},
 				{
 					delay:             59 * time.Minute,
 					expectedErrorCode: 0, // no error expected
-					expectedModified:  false,
 				},
 				{
 					delay: 2 * time.Minute,
@@ -216,7 +200,6 @@ func TestLoader_LoadConfig(t *testing.T) {
 						newResponse(t, 304, map[string]any{}, `"etag-value"`, "max-age=30"),
 					},
 					expectedErrorCode: 0, // no error expected
-					expectedModified:  false,
 				},
 			},
 		},
@@ -244,7 +227,7 @@ func TestLoader_LoadConfig(t *testing.T) {
 					httpmock.ResponderFromMultipleResponses(attempt.responses, t.Log),
 				)
 
-				cfg, modified, err := loader.GetConfig(ctx, appID)
+				cfg, err := loader.GetConfig(ctx, appID)
 				if attempt.expectedErrorCode != 0 {
 					require.Error(t, err)
 					var apiErr *api.Error
@@ -255,7 +238,6 @@ func TestLoader_LoadConfig(t *testing.T) {
 					require.NoError(t, err)
 					assert.NotEmpty(t, cfg)
 				}
-				assert.Equal(t, attempt.expectedModified, modified)
 				assert.Equal(t, len(attempt.responses), transport.GetTotalCallCount())
 			}
 		})
@@ -293,7 +275,7 @@ func TestLoader_LoadConfig_Race(t *testing.T) {
 	// Load configuration 10x in parallel
 	for range 10 {
 		wg.Go(func() {
-			cfg, _, err := loader.GetConfig(ctx, appID)
+			cfg, err := loader.GetConfig(ctx, appID)
 			require.NoError(t, err)
 			assert.Equal(t, "http://app.local", cfg.UpstreamAppURL)
 			counter.Add(1)
@@ -305,6 +287,49 @@ func TestLoader_LoadConfig_Race(t *testing.T) {
 
 	// Check total requests count
 	assert.Equal(t, int64(10), counter.Load())
+}
+
+// TestLoader_GetConfig_RefreshSurvivesRequestCancellation verifies that the config
+// refresh is not aborted when the originating request's context is canceled (e.g. the
+// browser disconnects during an OAuth redirect). The refresh must run on a context
+// detached from the request so the shared cache is still updated with the new config.
+func TestLoader_GetConfig_RefreshSurvivesRequestCancellation(t *testing.T) {
+	t.Parallel()
+
+	appID := api.AppID("test")
+	appPayload := map[string]any{
+		"appId":          appID.String(),
+		"appName":        "my-test",
+		"projectId":      "123",
+		"upstreamAppUrl": "http://app.local",
+	}
+
+	clk := clockwork.NewFakeClock()
+	d, mock := dependencies.NewMockedServiceScope(t, t.Context(), config.New(), commonDeps.WithClock(clk))
+
+	transport := mock.MockedHTTPTransport()
+	transport.RegisterResponder(
+		http.MethodGet,
+		fmt.Sprintf("%s/apps/%s/proxy-config", mock.TestConfig().SandboxesAPI.URL, appID),
+		// Fail if the request context is canceled; succeed otherwise. This detects
+		// whether the refresh runs on the (canceled) request context or a detached one.
+		func(req *http.Request) (*http.Response, error) {
+			if err := req.Context().Err(); err != nil {
+				return nil, err
+			}
+			return newResponse(t, http.StatusOK, appPayload, `"etag-value"`, "max-age=60"), nil
+		},
+	)
+	loader := d.AppConfigLoader()
+
+	// Simulate a client that disconnected before the refresh completes.
+	reqCtx, cancel := context.WithCancelCause(t.Context())
+	cancel(context.Canceled)
+
+	cfg, err := loader.GetConfig(reqCtx, appID)
+	require.NoError(t, err)
+	assert.Equal(t, "http://app.local", cfg.UpstreamAppURL)
+	assert.Equal(t, 1, transport.GetTotalCallCount())
 }
 
 func newResponse(t *testing.T, code int, body map[string]any, eTag string, cacheControl string) *http.Response {

--- a/internal/pkg/service/appsproxy/dataapps/appconfig/middleware.go
+++ b/internal/pkg/service/appsproxy/dataapps/appconfig/middleware.go
@@ -21,7 +21,6 @@ const (
 type AppConfigResult struct {
 	AppID     api.AppID
 	AppConfig api.AppConfig
-	Modified  bool
 	Err       error
 }
 
@@ -39,11 +38,10 @@ func Middleware(configLoader Loader, host string) middleware.Middleware {
 			if ok {
 				ctx := req.Context()
 
-				appConfig, modified, err := configLoader.GetConfig(ctx, appID)
+				appConfig, err := configLoader.GetConfig(ctx, appID)
 				result := AppConfigResult{
 					AppID:     appID,
 					AppConfig: appConfig,
-					Modified:  modified,
 					Err:       err,
 				}
 

--- a/internal/pkg/service/appsproxy/dataapps/appconfig/middleware_test.go
+++ b/internal/pkg/service/appsproxy/dataapps/appconfig/middleware_test.go
@@ -18,7 +18,7 @@ import (
 
 type testLoader struct{}
 
-func (l *testLoader) GetConfig(ctx context.Context, appID api.AppID) (out api.AppConfig, modified bool, err error) {
+func (l *testLoader) GetConfig(ctx context.Context, appID api.AppID) (out api.AppConfig, err error) {
 	switch appID {
 	case "1":
 		return api.AppConfig{
@@ -27,7 +27,7 @@ func (l *testLoader) GetConfig(ctx context.Context, appID api.AppID) (out api.Ap
 			AppSlug:        new("app-1"),
 			ProjectID:      "1",
 			UpstreamAppURL: "https://internal.app-1.example.com",
-		}, false, nil
+		}, nil
 	case "changed":
 		return api.AppConfig{
 			ID:             "2",
@@ -35,9 +35,9 @@ func (l *testLoader) GetConfig(ctx context.Context, appID api.AppID) (out api.Ap
 			AppSlug:        new("app-2"),
 			ProjectID:      "2",
 			UpstreamAppURL: "https://internal.app-2.example.com",
-		}, true, nil
+		}, nil
 	default:
-		return api.AppConfig{}, false, errors.New("error")
+		return api.AppConfig{}, errors.New("error")
 	}
 }
 

--- a/internal/pkg/service/appsproxy/proxy/apphandler/manager.go
+++ b/internal/pkg/service/appsproxy/proxy/apphandler/manager.go
@@ -43,6 +43,15 @@ type appHandlerWrapper struct {
 	handler     http.Handler
 	cancel      context.CancelCauseFunc
 	handlerHash string // hash of UpstreamTarget + E2BAccessToken; handler is recreated when it changes
+	configETag  string // ETag of the app config the handler was built from; handler is recreated when it changes
+}
+
+// needsRebuild reports whether the cached handler must be recreated.
+// The handler is keyed on config identity (the config ETag) and the upstream
+// hash, so any config change is picked up on the next request without relying
+// on a one-shot "modified" signal from the config loader.
+func (w *appHandlerWrapper) needsRebuild(configETag, currentHash string) bool {
+	return w.handler == nil || w.configETag != configETag || w.handlerHash != currentHash
 }
 
 type dependencies interface {
@@ -94,15 +103,17 @@ func (m *Manager) HandlerFor(ctx context.Context, result appconfig.AppConfigResu
 		return m.newErrorHandler(ctx, api.AppConfig{ID: result.AppID}, result.Err)
 	}
 
-	// Create a new handler when config changed, upstream URL changed, or E2B token changed.
+	// Create a new handler when the config changed (ETag), upstream URL changed, or E2B token changed.
 	// Only a hash is stored so raw secrets don't linger in the wrapper.
 	currentHash := handlerHash(m.upstreamManager.AppInfo(ctx, result.AppID))
-	if wrapper.handler == nil || result.Modified || wrapper.handlerHash != currentHash {
+	configETag := result.AppConfig.ETag()
+	if wrapper.needsRebuild(configETag, currentHash) {
 		if wrapper.cancel != nil {
 			wrapper.cancel(errors.New("configuration changed"))
 		}
 		wrapper.handler, wrapper.cancel = m.newHandler(ctx, result.AppConfig)
 		wrapper.handlerHash = currentHash
+		wrapper.configETag = configETag
 	}
 
 	return wrapper.handler

--- a/internal/pkg/service/appsproxy/proxy/apphandler/manager_test.go
+++ b/internal/pkg/service/appsproxy/proxy/apphandler/manager_test.go
@@ -1,0 +1,37 @@
+package apphandler
+
+import (
+	"net/http"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+)
+
+// TestAppHandlerWrapper_NeedsRebuild verifies that handler recreation is keyed on
+// config identity (the config ETag) and the upstream hash, not on a one-shot
+// "modified" flag. A changed config ETag must trigger a rebuild even when the
+// upstream hash is unchanged, so a replica that missed the single "modified"
+// signal still converges to the new auth config.
+func TestAppHandlerWrapper_NeedsRebuild(t *testing.T) {
+	t.Parallel()
+
+	w := &appHandlerWrapper{}
+
+	// No handler yet → must build.
+	assert.True(t, w.needsRebuild("etag-1", "hash-1"))
+
+	// Simulate a built handler.
+	w.handler = http.HandlerFunc(func(http.ResponseWriter, *http.Request) {})
+	w.configETag = "etag-1"
+	w.handlerHash = "hash-1"
+
+	// Nothing changed → reuse the cached handler.
+	assert.False(t, w.needsRebuild("etag-1", "hash-1"))
+
+	// Config ETag changed (auth config redeployed) → rebuild, even though the
+	// upstream hash is unchanged. This is the core fix.
+	assert.True(t, w.needsRebuild("etag-2", "hash-1"))
+
+	// Upstream/E2B hash changed → rebuild.
+	assert.True(t, w.needsRebuild("etag-1", "hash-2"))
+}


### PR DESCRIPTION
## Release Notes
https://linear.app/keboola/issue/PAT-1904/apps-flaky-auth-config

App auth config changes were taking a long time to propagate and were flaky — the same app would intermittently serve the old and the new auth config (e.g. password login vs. OIDC) depending on which apps-proxy replica handled the request, sometimes for hours. Two independent apps-proxy bugs kept a deploy's new config from converging across replicas.

First, the per-app config refresh ran on the incoming HTTP request's context, so a client disconnect — common during the OAuth redirect flow — aborted the refresh with `context canceled`, returned a `503`, and left that replica's cache un-updated. The refresh now runs on a context detached from the request (`context.WithoutCancel` + a bounded `refreshTimeout`), so a disconnect can no longer abort the shared cache refresh. Second, the auth handler was rebuilt only on a one-shot `modified` flag returned by the config loader for the single request that fetched a fresh `200`; if that request didn't rebuild the handler, the replica kept serving the stale auth handler indefinitely. Handler recreation is now keyed on config identity (the config `ETag`), matching how the upstream target is already tracked, and the now-dead `modified` plumbing is removed.

Reducing cross-replica divergence during the config TTL window itself is intentionally left to the planned CRD-based config-distribution refactor already in the backlog.

## Plans for customer communication
None.

## Impact analysis
No end-user impact beyond the fix itself: app auth config deployed to a running app now converges reliably within the ~60s config TTL on every apps-proxy replica instead of intermittently serving stale config. No API, config, or behavior changes elsewhere.

## Change type
Fix

## Justification
Fix flaky/slow propagation of app auth config changes (PAT-1904).

## Deployment
Merge & automatic deploy.

## Rollback plan
Revert of this PR.

## Post release support plan
None.
