### PR TITLE
fix(ci): exclude developers.keboola.com from markdown link check

### DIFF
--- a/.github/workflows/test-lint.yml
+++ b/.github/workflows/test-lint.yml
@@ -52,6 +52,7 @@ jobs:
             --exclude '^https://community.chocolatey.org/.*'
             --exclude '^https://packages.debian.org/$'
             --exclude '^https://test.hub.keboola.local/$'
+            --exclude '^https://developers.keboola.com/.*'
 
       - name: Run code linters
         run: task lint


### PR DESCRIPTION
## Summary
- The `Lint` job intermittently fails on the markdown link check, unrelated to the actual PR changes (fails on some PRs, passes on others).

## Fix
The lychee link checker flags `https://developers.keboola.com/*` as broken because the site returns `403 Forbidden` to the CI's requests (bot protection) — the links themselves are valid. Added `--exclude '^https://developers.keboola.com/.*'`, consistent with the existing exclusions for other hosts that block or false-positive the checker (chocolatey, datadog, …).

Observed on PR #2626 (and #2625, #2620): 16 links across `docs/llms-cli.md`, `docs/templates/overview.md`, and `README.md` rejected with `403 Forbidden`.

## Test plan
- [x] Exclude regex matches the failing URLs (`https://developers.keboola.com/cli/...`)
- [ ] `Lint` job passes on this PR's CI