### PR TITLE
PAT-1984 Do not disclose internal upstream address to clients

### DIFF
--- a/internal/pkg/service/appsproxy/proxy/apphandler/upstream/upstream.go
+++ b/internal/pkg/service/appsproxy/proxy/apphandler/upstream/upstream.go
@@ -54,6 +54,7 @@ type AppUpstream struct {
 	manager   *Manager
 	app       api.AppConfig
 	target    *url.URL // parsed from appsProxy.upstreamUrl at creation; nil when absent
+	baseURL   *url.URL // public URL of the app, resolved at creation; see rewriteRedirectLocation
 	handler   *chain.Chain
 	wsHandler *chain.Chain
 	cancelWs  context.CancelCauseFunc
@@ -119,6 +120,7 @@ func (m *Manager) NewUpstream(ctx context.Context, app api.AppConfig) (upstream 
 		manager: m,
 		app:     app,
 		target:  target,
+		baseURL: app.BaseURL(m.config.API.PublicURL),
 	}
 	upstream.handler = upstream.newProxy(m.config.Upstream.HTTPTimeout)
 	upstream.wsHandler = upstream.newWebsocketProxy(m.config.Upstream.WsTimeout)
@@ -228,13 +230,16 @@ func (u *AppUpstream) newReverseProxy() *httputil.ReverseProxy {
 // Only URLs pointing at the upstream itself are rewritten, so redirects to third
 // parties (OAuth providers, CDNs) are left intact. Absolute URLs embedded in
 // response bodies are not covered.
+//
+// This runs for every upstream response, so it must stay allocation-free on the
+// common path where no such header is present: baseURL is resolved once at
+// creation and the headers are only parsed once a value is actually found.
 func (u *AppUpstream) rewriteRedirectLocation(res *http.Response) error {
 	if u.target == nil {
 		return nil
 	}
 
-	baseURL := u.app.BaseURL(u.manager.config.API.PublicURL)
-	for _, header := range []string{"Location", "Content-Location"} {
+	for _, header := range [...]string{"Location", "Content-Location"} {
 		value := res.Header.Get(header)
 		if value == "" {
 			continue
@@ -245,8 +250,8 @@ func (u *AppUpstream) rewriteRedirectLocation(res *http.Response) error {
 			continue
 		}
 
-		parsed.Scheme = baseURL.Scheme
-		parsed.Host = baseURL.Host
+		parsed.Scheme = u.baseURL.Scheme
+		parsed.Host = u.baseURL.Host
 		res.Header.Set(header, parsed.String())
 	}
 

--- a/internal/pkg/service/appsproxy/proxy/apphandler/upstream/upstream.go
+++ b/internal/pkg/service/appsproxy/proxy/apphandler/upstream/upstream.go
@@ -215,8 +215,47 @@ func (u *AppUpstream) newReverseProxy() *httputil.ReverseProxy {
 	}
 }
 
+// rewriteRedirectLocation replaces the upstream address in URL-bearing response
+// headers with the public URL of the app, the equivalent of nginx
+// "proxy_redirect".
+//
+// The outbound Host header is rewritten to the upstream hostname (see
+// newReverseProxy), so an app that builds absolute URLs from Host — typically a
+// framework canonicalizing a missing trailing slash — answers with the internal
+// K8s service name and backend port. Without this rewrite the proxy passes such
+// a header through and discloses the internal address to the client.
+//
+// Only URLs pointing at the upstream itself are rewritten, so redirects to third
+// parties (OAuth providers, CDNs) are left intact. Absolute URLs embedded in
+// response bodies are not covered.
+func (u *AppUpstream) rewriteRedirectLocation(res *http.Response) error {
+	if u.target == nil {
+		return nil
+	}
+
+	baseURL := u.app.BaseURL(u.manager.config.API.PublicURL)
+	for _, header := range []string{"Location", "Content-Location"} {
+		value := res.Header.Get(header)
+		if value == "" {
+			continue
+		}
+
+		parsed, err := url.Parse(value)
+		if err != nil || !strings.EqualFold(parsed.Host, u.target.Host) {
+			continue
+		}
+
+		parsed.Scheme = baseURL.Scheme
+		parsed.Host = baseURL.Host
+		res.Header.Set(header, parsed.String())
+	}
+
+	return nil
+}
+
 func (u *AppUpstream) newProxy(timeout time.Duration) *chain.Chain {
 	proxy := u.newReverseProxy()
+	proxy.ModifyResponse = u.rewriteRedirectLocation
 
 	return chain.
 		New(chain.HandlerFunc(func(w http.ResponseWriter, req *http.Request) error {
@@ -272,7 +311,8 @@ func (u *AppUpstream) newWebsocketProxy(timeout time.Duration) *chain.Chain {
 	// callback per frame without flooding the Sandboxes Service.
 	proxy.ModifyResponse = func(res *http.Response) error {
 		if res.StatusCode != http.StatusSwitchingProtocols {
-			return nil
+			// A failed handshake is a regular response and can carry a redirect.
+			return u.rewriteRedirectLocation(res)
 		}
 		rwc, ok := res.Body.(io.ReadWriteCloser)
 		if !ok {

--- a/internal/pkg/service/appsproxy/proxy/pagewriter/error.go
+++ b/internal/pkg/service/appsproxy/proxy/pagewriter/error.go
@@ -39,7 +39,7 @@ func (pw *Writer) ProxyErrorHandler(w http.ResponseWriter, req *http.Request, ap
 	pw.WriteError(w, req, &app, svcerrors.
 		NewBadGatewayError(errors.New("request to application failed")).
 		WithUserMessage("Request to application failed.").
-		WithLogMessage("badGateway: "+errors.Format(err, errors.FormatWithUnwrap(), errors.FormatWithStack())))
+		WithLogMessage(errors.Format(err, errors.FormatWithUnwrap(), errors.FormatWithStack())))
 }
 
 func (pw *Writer) WriteError(w http.ResponseWriter, req *http.Request, app *api.AppConfig, err error) {

--- a/internal/pkg/service/appsproxy/proxy/pagewriter/error.go
+++ b/internal/pkg/service/appsproxy/proxy/pagewriter/error.go
@@ -32,7 +32,14 @@ func (pw *Writer) ProxyErrorHandlerFor(app api.AppConfig) func(w http.ResponseWr
 }
 
 func (pw *Writer) ProxyErrorHandler(w http.ResponseWriter, req *http.Request, app api.AppConfig, err error) {
-	pw.WriteError(w, req, &app, svcerrors.NewBadGatewayError(err).WithUserMessage("Request to application failed."))
+	// The transport error names the internal upstream address (K8s service DNS
+	// name, pod IP, backend port). The error page is rendered for anonymous
+	// clients too, so the error is kept for the log only and replaced by a
+	// generic one for the page.
+	pw.WriteError(w, req, &app, svcerrors.
+		NewBadGatewayError(errors.New("request to application failed")).
+		WithUserMessage("Request to application failed.").
+		WithLogMessage("badGateway: "+errors.Format(err, errors.FormatWithUnwrap(), errors.FormatWithStack())))
 }
 
 func (pw *Writer) WriteError(w http.ResponseWriter, req *http.Request, app *api.AppConfig, err error) {

--- a/internal/pkg/service/appsproxy/proxy/proxy_test.go
+++ b/internal/pkg/service/appsproxy/proxy/proxy_test.go
@@ -363,6 +363,28 @@ func TestAppProxyRouter(t *testing.T) {
 			expectedNotifications: map[string]int{},
 		},
 		{
+			// The upstream sees the internal upstream address in its Host header
+			// (see "forwarded-headers-http"), so absolute URLs it builds from Host
+			// point at the internal address. Apps-proxy must rewrite such
+			// Location headers to the public app URL instead of passing them
+			// through to the client.
+			name: "public-app-absolute-redirect-does-not-leak-upstream-host",
+			run: func(t *testing.T, client *http.Client, m []*mockoidc.MockOIDC, appServer *testutil.AppServer, service *testutil.DataAppsAPI, fakeClient *k8sfake.FakeDynamicClient, watcher *k8sapp.StateWatcher) {
+				request, err := http.NewRequestWithContext(t.Context(), http.MethodGet, "https://public-123.hub.keboola.local/redirect", nil)
+				require.NoError(t, err)
+				response, err := client.Do(request)
+				require.NoError(t, err)
+				require.Equal(t, http.StatusMovedPermanently, response.StatusCode)
+
+				location := response.Header.Get("Location")
+				assert.NotContains(t, location, appServer.Listener.Addr().String())
+				assert.Equal(t, "https://public-123.hub.keboola.local/redirect/", location)
+			},
+			expectedNotifications: map[string]int{
+				"123": 1,
+			},
+		},
+		{
 			name: "public-app-sub-url",
 			run: func(t *testing.T, client *http.Client, m []*mockoidc.MockOIDC, appServer *testutil.AppServer, service *testutil.DataAppsAPI, fakeClient *k8sfake.FakeDynamicClient, watcher *k8sapp.StateWatcher) {
 				// Request to public app

--- a/internal/pkg/service/appsproxy/proxy/proxy_test.go
+++ b/internal/pkg/service/appsproxy/proxy/proxy_test.go
@@ -356,6 +356,9 @@ func TestAppProxyRouter(t *testing.T) {
 				body, err := io.ReadAll(response.Body)
 				require.NoError(t, err)
 				assert.Contains(t, string(body), `Request to application failed.`)
+
+				// The error page must not disclose the internal upstream address.
+				assert.NotContains(t, string(body), appServer.Listener.Addr().String())
 			},
 			expectedNotifications: map[string]int{},
 		},

--- a/internal/pkg/service/appsproxy/proxy/testutil/app.go
+++ b/internal/pkg/service/appsproxy/proxy/testutil/app.go
@@ -95,6 +95,19 @@ func StartAppServer(t *testing.T, pm server.PortManager) *AppServer {
 		}
 	})
 
+	// /redirect mimics slash-canonicalization redirects emitted by common app
+	// frameworks (Starlette redirect_slashes, Django APPEND_SLASH, nginx
+	// absolute_redirect on): the Location is an absolute URL built from the
+	// Host header the app received.
+	mux.HandleFunc("/redirect", func(w http.ResponseWriter, r *http.Request) {
+		lock.Lock()
+		requests = append(requests, r)
+		lock.Unlock()
+
+		w.Header().Set("Location", "http://"+r.Host+r.URL.Path+"/")
+		w.WriteHeader(http.StatusMovedPermanently)
+	})
+
 	mux.HandleFunc("/", func(w http.ResponseWriter, r *http.Request) {
 		lock.Lock()
 		defer lock.Unlock()

--- a/internal/pkg/service/common/errors/gateway.go
+++ b/internal/pkg/service/common/errors/gateway.go
@@ -9,6 +9,7 @@ import (
 type BadGatewayError struct {
 	err         error
 	userMessage string
+	logMessage  string
 }
 
 func NewBadGatewayError(err error) BadGatewayError {
@@ -34,6 +35,21 @@ func (e BadGatewayError) Error() string {
 func (e BadGatewayError) WithUserMessage(msg string) BadGatewayError {
 	e.userMessage = msg
 	return e
+}
+
+// WithLogMessage sets the message written to the log, instead of the wrapped
+// error. Use it when the wrapped error must not reach the user, so the wrapped
+// error can be replaced by a safe one and its details kept for the log only.
+func (e BadGatewayError) WithLogMessage(msg string) BadGatewayError {
+	e.logMessage = msg
+	return e
+}
+
+func (e BadGatewayError) ErrorLogMessage() string {
+	if e.logMessage != "" {
+		return e.logMessage
+	}
+	return errors.Format(e.err, errors.FormatWithUnwrap(), errors.FormatWithStack())
 }
 
 func (e BadGatewayError) ErrorUserMessage() string {

--- a/internal/pkg/service/common/errors/gateway.go
+++ b/internal/pkg/service/common/errors/gateway.go
@@ -37,19 +37,23 @@ func (e BadGatewayError) WithUserMessage(msg string) BadGatewayError {
 	return e
 }
 
-// WithLogMessage sets the message written to the log, instead of the wrapped
+// WithLogMessage sets the detail written to the log, instead of the wrapped
 // error. Use it when the wrapped error must not reach the user, so the wrapped
 // error can be replaced by a safe one and its details kept for the log only.
+// Pass the raw detail; ErrorLogMessage adds the error name prefix.
 func (e BadGatewayError) WithLogMessage(msg string) BadGatewayError {
 	e.logMessage = msg
 	return e
 }
 
 func (e BadGatewayError) ErrorLogMessage() string {
-	if e.logMessage != "" {
-		return e.logMessage
+	// Mirrors the "<name>: <detail>" format WriteError applies to errors that
+	// do not implement WithLogMessage, so logs stay consistent either way.
+	detail := e.logMessage
+	if detail == "" {
+		detail = errors.Format(e.err, errors.FormatWithUnwrap(), errors.FormatWithStack())
 	}
-	return errors.Format(e.err, errors.FormatWithUnwrap(), errors.FormatWithStack())
+	return e.ErrorName() + ": " + detail
 }
 
 func (e BadGatewayError) ErrorUserMessage() string {


### PR DESCRIPTION
## Release Notes

https://linear.app/keboola/issue/PAT-1984/apps-proxy-discloses-internal-upstream-address-to-clients

Apps Proxy disclosed the internal address of a data app — the K8s service DNS name, the `sandbox` namespace and the plaintext backend port — to clients. Reported from a security scan of an MCP Server data app ([Slack thread](https://keboolaglobal.slack.com/archives/C04L6J6CWJJ/p1785169181181619)). Two independent paths were found, each covered by a regression test in `TestAppProxyRouter` — one new case for the redirect, and an added assertion on the existing `public-app-down` case for the error page.

The outbound `Host` header is rewritten to the upstream hostname, so an app that builds absolute URLs from `Host` — typically a framework canonicalizing a missing trailing slash — answers with the internal address, and the proxy passed that header straight through (`Location: http://app-123.sandbox.svc.cluster.local:8888/api/`). Separately, `pagewriter.ProxyErrorHandler` wrapped the raw transport error in `BadGatewayError`, whose `Error()` returns it verbatim, so `WriteError` rendered `dial tcp <internal address>: connect: connection refused` into the 502 page. The second one is the higher-exposure of the two: it fires on every upstream failure — suspended app, crashed pod, DNS blip — and needs no unusual app configuration.

Key changes:

* `Location` and `Content-Location` are rewritten to the public URL of the app, the equivalent of nginx `proxy_redirect`. Only URLs whose host matches the upstream target are rewritten, so redirects to third parties such as OAuth providers pass through untouched.
* The transport error no longer reaches the error page; it is kept for the log at full fidelity via a new `WithLogMessage` builder on `BadGatewayError`.
* The rewrite is a `ModifyResponse` hook, so it runs for every upstream response. The public URL of the app is resolved once in `NewUpstream` rather than per response, which keeps the common path (no such header present) allocation-free: 195.9 ns/op and 2 allocs/op → 60.4 ns/op and 0 allocs/op.

Why the rewrite belongs in the proxy rather than in the apps: K8s and E2B must stay interchangeable so an app can be migrated between them unchanged, and E2B routes by `Host`, so the app receives an internal address in `Host` on both backends. Rewriting URL-bearing response headers at the proxy is therefore the permanent design rather than a stopgap for one backend. It is also the only part that cannot be regressed by app code, since data apps are arbitrary customer containers. What it cannot reach is absolute URLs an app embeds in HTML/JSON response bodies — those stay the app's responsibility, via `X-Forwarded-*` or an injected public URL.

Note also that the report's claim that the redirect fires *before* the auth check is not accurate — there is no proxy auth check on that path, `appHandler.serveRule` routes straight to the upstream when the matching `AuthRule` has `authRequired: false`, which is the app's own configuration. This is not a proxy auth bypass.

## Plans for customer communication
None.

## Impact analysis
No end-user impact. Clients that previously followed a redirect to an unroutable internal address now receive the public URL instead, which is the intended behaviour. The 502 error page loses the transport error detail; it is still logged, and the exception ID on the page remains the correlation key for support.

## Change type
Fix

## Justification
Internal topology disclosure reported by a security scan; hands an attacker a ready-made internal target should an SSRF exist elsewhere in the environment.

## Deployment
Merge & automatic deploy.

## Rollback plan
Revert of this PR.

## Post release support plan
None.