### PR TITLE
fix(stream): stop SlicePipeline.Close leaking unopened pipelines

### DIFF
--- a/internal/pkg/service/stream/storage/level/local/diskwriter/network/router/pipeline/pipeline_slice.go
+++ b/internal/pkg/service/stream/storage/level/local/diskwriter/network/router/pipeline/pipeline_slice.go
@@ -38,6 +38,7 @@ type SlicePipeline struct {
 	wg     sync.WaitGroup
 
 	lock     sync.RWMutex
+	closed   bool
 	pipeline encoding.Pipeline
 }
 
@@ -134,37 +135,51 @@ func (p *SlicePipeline) WriteRecord(c recordctx.Context) (pipelinePkg.WriteResul
 }
 
 func (p *SlicePipeline) Close(ctx context.Context, cause string) {
-	p.lock.Lock()
-	defer p.lock.Unlock()
+	// Cancel the open-retry loop right away, without waiting for the lock, so an in-flight
+	// OpenPipeline attempt (if it respects ctx) can abort instead of running to completion.
+	p.cancel(errors.New("slice pipeline closed"))
 
-	// Stop if the pipeline is not opened
-	if p.pipeline == nil {
+	p.lock.Lock()
+	// Close may be called twice: explicitly by SinkPipeline and via the closeFunc callback
+	// the underlying encoding pipeline invokes on its own connection failure.
+	if p.closed {
+		p.lock.Unlock()
 		return
 	}
+	p.closed = true
+	pipeline := p.pipeline
+	p.pipeline = nil
+	p.lock.Unlock()
 
 	p.logger.Debugf(ctx, "closing slice pipeline: %s", cause)
 
-	// Cancel open loop, if running
-	p.cancel(errors.New("slice pipeline closed"))
+	// Wait for the open-retry goroutine to stop, whether it managed to open a pipeline or not.
 	p.wg.Wait()
 
-	// Close underlying encoding pipeline
-	ctx, cancel := context.WithTimeoutCause(context.WithoutCancel(ctx), 5*time.Minute, errors.New("slice pipeline close timeout"))
-	defer cancel()
-	if err := p.pipeline.Close(ctx); err != nil {
-		p.logger.Errorf(ctx, "cannot close slice pipeline: %s", err)
-	} else {
-		p.logger.Infof(ctx, "closed slice pipeline: %s", cause)
+	// Close the underlying encoding pipeline, if it was opened.
+	if pipeline != nil {
+		closeCtx, cancel := context.WithTimeoutCause(context.WithoutCancel(ctx), 5*time.Minute, errors.New("slice pipeline close timeout"))
+		defer cancel()
+		if err := pipeline.Close(closeCtx); err != nil {
+			p.logger.Errorf(closeCtx, "cannot close slice pipeline: %s", err)
+		} else {
+			p.logger.Infof(closeCtx, "closed slice pipeline: %s", cause)
+		}
 	}
-	p.pipeline = nil
 
-	// Notify parent SinkPipeline
+	// Notify parent SinkPipeline, even if the pipeline never finished opening.
 	p.onClose(ctx, cause)
 }
 
 func (p *SlicePipeline) tryOpen() error {
 	p.lock.Lock()
 	defer p.lock.Unlock()
+
+	// Already closed, e.g. by the encoding pipeline's own closeFunc callback, don't open a
+	// pipeline that would just have to be closed again the moment Close's wg.Wait returns.
+	if p.closed {
+		return nil
+	}
 
 	ctx := p.ctx
 

--- a/internal/pkg/service/stream/storage/level/local/diskwriter/network/router/pipeline/pipeline_slice.go
+++ b/internal/pkg/service/stream/storage/level/local/diskwriter/network/router/pipeline/pipeline_slice.go
@@ -37,9 +37,10 @@ type SlicePipeline struct {
 	cancel context.CancelCauseFunc
 	wg     sync.WaitGroup
 
-	lock     sync.RWMutex
-	closed   bool
-	pipeline encoding.Pipeline
+	lock      sync.RWMutex
+	closed    bool
+	closeDone chan struct{}
+	pipeline  encoding.Pipeline
 }
 
 // SliceData is part of the Slice model that is needed to create a SlicePipeline.
@@ -69,6 +70,7 @@ func NewSlicePipeline(
 		encoding:    encoding,
 		slice:       slice,
 		onClose:     onClose,
+		closeDone:   make(chan struct{}),
 	}
 
 	ctx = ctxattr.ContextWith(ctx, slice.SliceKey.Telemetry()...)
@@ -81,7 +83,8 @@ func NewSlicePipeline(
 		defer p.wg.Done()
 		for {
 			// Try open pipeline
-			if err := p.tryOpen(); err != nil {
+			opened, err := p.tryOpen()
+			if err != nil {
 				// Wait before retry
 				delay := b.NextBackOff()
 				p.logger.Warnf(p.ctx, "%s, waiting %s", err, delay)
@@ -93,8 +96,14 @@ func NewSlicePipeline(
 				}
 			}
 
-			// Pipeline is opened, close goroutine
-			ready.NotifyReady()
+			// tryOpen returns opened=false both when it found the slice pipeline already closed
+			// and when Close raced in while it was opening (see tryOpen's own closed check,
+			// evaluated under the same lock as the pipeline assignment) - only notify readiness
+			// if it actually opened a pipeline, or SinkPipeline.UpdateSlicePipelines could be
+			// unblocked for a slice pipeline that never actually opened.
+			if opened {
+				ready.NotifyReady()
+			}
 			return
 		}
 	}()
@@ -141,15 +150,20 @@ func (p *SlicePipeline) Close(ctx context.Context, cause string) {
 
 	p.lock.Lock()
 	// Close may be called twice: explicitly by SinkPipeline and via the closeFunc callback
-	// the underlying encoding pipeline invokes on its own connection failure.
+	// the underlying encoding pipeline invokes on its own connection failure. The loser waits
+	// on closeDone instead of returning early, so callers that rely on Close blocking until the
+	// pipeline is actually closed (e.g. router.go's closeSyncer.Notify, which gates the storage
+	// coordinator on all slice pipelines being closed) see accurate close-sync semantics.
 	if p.closed {
 		p.lock.Unlock()
+		<-p.closeDone
 		return
 	}
 	p.closed = true
 	pipeline := p.pipeline
 	p.pipeline = nil
 	p.lock.Unlock()
+	defer close(p.closeDone)
 
 	p.logger.Debugf(ctx, "closing slice pipeline: %s", cause)
 
@@ -157,34 +171,40 @@ func (p *SlicePipeline) Close(ctx context.Context, cause string) {
 	p.wg.Wait()
 
 	// Close the underlying encoding pipeline, if it was opened.
+	closed := true
 	if pipeline != nil {
 		closeCtx, cancel := context.WithTimeoutCause(context.WithoutCancel(ctx), 5*time.Minute, errors.New("slice pipeline close timeout"))
 		defer cancel()
 		if err := pipeline.Close(closeCtx); err != nil {
 			p.logger.Errorf(closeCtx, "cannot close slice pipeline: %s", err)
-		} else {
-			p.logger.Infof(closeCtx, "closed slice pipeline: %s", cause)
+			closed = false
 		}
+	}
+	if closed {
+		p.logger.Infof(ctx, "closed slice pipeline: %s", cause)
 	}
 
 	// Notify parent SinkPipeline, even if the pipeline never finished opening.
 	p.onClose(ctx, cause)
 }
 
-func (p *SlicePipeline) tryOpen() error {
+// tryOpen attempts to open the underlying encoding pipeline. The returned opened flag is
+// computed under the same lock as the closed check, so it precisely reports whether this call
+// assigned p.pipeline - unlike inferring it from p.ctx.Err() afterwards, which a concurrent
+// Close (cancelling p.ctx before it can even acquire the lock) could race regardless of outcome.
+func (p *SlicePipeline) tryOpen() (opened bool, err error) {
 	p.lock.Lock()
 	defer p.lock.Unlock()
 
 	// Already closed, e.g. by the encoding pipeline's own closeFunc callback, don't open a
 	// pipeline that would just have to be closed again the moment Close's wg.Wait returns.
 	if p.closed {
-		return nil
+		return false, nil
 	}
 
 	ctx := p.ctx
 
 	// Open pipeline
-	var err error
 	p.pipeline, err = p.encoding.OpenPipeline(
 		ctx,
 		p.slice.SliceKey,
@@ -198,11 +218,11 @@ func (p *SlicePipeline) tryOpen() error {
 		nil, // Do not override network output
 	)
 	if err != nil {
-		return errors.PrefixErrorf(err, "cannot open slice pipeline")
+		return false, errors.PrefixErrorf(err, "cannot open slice pipeline")
 	}
 
 	p.logger.Infof(ctx, "opened slice pipeline")
-	return nil
+	return true, nil
 }
 
 func newOpenPipelineBackoff() *backoff.ExponentialBackOff {

--- a/internal/pkg/service/stream/storage/level/local/diskwriter/network/router/pipeline/pipeline_slice_test.go
+++ b/internal/pkg/service/stream/storage/level/local/diskwriter/network/router/pipeline/pipeline_slice_test.go
@@ -1,0 +1,142 @@
+package pipeline
+
+import (
+	"context"
+	"sync"
+	"sync/atomic"
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+
+	"github.com/keboola/keboola-as-code/internal/pkg/log"
+)
+
+// newTestSlicePipeline builds a SlicePipeline with the open-retry goroutine simulated directly
+// (no real encoding/connection managers involved), mirroring exactly the `select { case
+// <-time.After(delay): ...; case <-p.ctx.Done(): return }` shape of the real retry loop in
+// NewSlicePipeline while it waits for OpenPipeline to keep failing.
+func newTestSlicePipeline(t *testing.T, onClose func(ctx context.Context, cause string)) *SlicePipeline {
+	t.Helper()
+
+	ctx, cancel := context.WithCancelCause(context.Background())
+	t.Cleanup(func() { cancel(nil) })
+
+	p := &SlicePipeline{
+		logger:    log.NewNopLogger(),
+		ctx:       ctx,
+		cancel:    cancel,
+		closeDone: make(chan struct{}),
+		onClose:   onClose,
+	}
+
+	p.wg.Go(func() {
+		<-p.ctx.Done()
+	})
+
+	return p
+}
+
+// TestSlicePipeline_TryOpenSkipsAlreadyClosed is a regression test for the open-retry goroutine
+// signaling readiness for a slice pipeline that was actually abandoned (not opened) because Close
+// had already run. tryOpen must report opened=false without touching p.encoding at all once
+// p.closed is set - computed under the same lock as the closed check, so the caller doesn't need
+// to infer it afterwards from state a concurrent Close can independently mutate (e.g. p.ctx.Err(),
+// which Close cancels before it even attempts the lock).
+func TestSlicePipeline_TryOpenSkipsAlreadyClosed(t *testing.T) {
+	t.Parallel()
+
+	p := newTestSlicePipeline(t, func(ctx context.Context, cause string) {})
+	p.closed = true // as if Close already ran and is past the point tryOpen checks
+
+	opened, err := p.tryOpen()
+
+	require.NoError(t, err)
+	assert.False(t, opened, "tryOpen must report opened=false once the pipeline is closed")
+	assert.Nil(t, p.pipeline, "tryOpen must not touch p.encoding/assign a pipeline once closed")
+}
+
+// TestSlicePipeline_CloseWhileStillOpening is a regression test for the heap leak: Close used to
+// return early - without cancelling the async open-retry goroutine or notifying its parent - if
+// it was called while the pipeline was still opening (still in the backoff retry loop). It must
+// instead wait out the retry goroutine, leave no pipeline reference behind, and still notify
+// onClose.
+func TestSlicePipeline_CloseWhileStillOpening(t *testing.T) {
+	t.Parallel()
+
+	var onCloseCalls atomic.Int32
+	p := newTestSlicePipeline(t, func(ctx context.Context, cause string) {
+		onCloseCalls.Add(1)
+	})
+
+	p.Close(t.Context(), "test close")
+
+	// If Close returned before the goroutine's wg.Done(), a subsequent p.wg.Wait() would still
+	// block; asserting it returns immediately here proves Close already waited for it.
+	done := make(chan struct{})
+	go func() {
+		p.wg.Wait()
+		close(done)
+	}()
+	select {
+	case <-done:
+	case <-time.After(time.Second):
+		t.Fatal("open-retry goroutine did not exit by the time Close returned")
+	}
+
+	assert.Nil(t, p.pipeline, "no pipeline reference may remain once Close returns")
+	assert.EqualValues(t, 1, onCloseCalls.Load(), "onClose must be called even if the pipeline never finished opening")
+}
+
+// TestSlicePipeline_CloseIsBlockingIdempotent is a regression test for Close losing its blocking
+// idempotence: a concurrent second Close call must not return before the first (winning) Close
+// call has fully finished, since router.go's closeSyncer.Notify relies on that to gate the
+// storage coordinator on all slice pipelines being actually closed.
+func TestSlicePipeline_CloseIsBlockingIdempotent(t *testing.T) {
+	t.Parallel()
+
+	onCloseStarted := make(chan struct{})
+	releaseOnClose := make(chan struct{})
+	var onCloseCalls atomic.Int32
+	p := newTestSlicePipeline(t, func(ctx context.Context, cause string) {
+		onCloseCalls.Add(1)
+		close(onCloseStarted)
+		<-releaseOnClose
+	})
+
+	var wg sync.WaitGroup
+	wg.Add(2)
+
+	firstDone := make(chan struct{})
+	go func() {
+		defer wg.Done()
+		p.Close(t.Context(), "first")
+		close(firstDone)
+	}()
+
+	// Wait until the first (winning) Close call is stuck inside onClose, i.e. it has already
+	// set closed=true and torn down the pipeline, but hasn't returned yet.
+	<-onCloseStarted
+
+	secondDone := make(chan struct{})
+	go func() {
+		defer wg.Done()
+		p.Close(t.Context(), "second")
+		close(secondDone)
+	}()
+
+	select {
+	case <-secondDone:
+		t.Fatal("second (losing) Close call returned before the first Close call finished")
+	case <-time.After(100 * time.Millisecond):
+		// Expected: the second call is still blocked on closeDone.
+	}
+
+	close(releaseOnClose)
+	wg.Wait()
+
+	<-firstDone
+	<-secondDone
+	assert.EqualValues(t, 1, onCloseCalls.Load(), "onClose must run exactly once")
+}

--- a/internal/pkg/service/stream/storage/level/local/encoding/manager.go
+++ b/internal/pkg/service/stream/storage/level/local/encoding/manager.go
@@ -160,9 +160,10 @@ func (m *Manager) close(ctx context.Context) error {
 	wg := &sync.WaitGroup{}
 	for _, w := range m.Pipelines() {
 		wg.Go(func() {
-			// The pipeline may have already been closed concurrently by its owning
+			// The pipeline may already be closing concurrently, initiated by its owning
 			// SlicePipeline (e.g. a slice rotation racing with this shutdown sweep).
-			// That's an expected outcome, not a failure - the pipeline is closed either way.
+			// pipeline.Close returns this sentinel immediately without waiting for that
+			// in-flight close to finish - it's expected, not a failure, so don't report it.
 			if err := w.Close(ctx); err != nil && !errors.Is(err, errPipelineAlreadyClosed) {
 				errs.Append(err)
 			}

--- a/internal/pkg/service/stream/storage/level/local/encoding/manager.go
+++ b/internal/pkg/service/stream/storage/level/local/encoding/manager.go
@@ -160,7 +160,10 @@ func (m *Manager) close(ctx context.Context) error {
 	wg := &sync.WaitGroup{}
 	for _, w := range m.Pipelines() {
 		wg.Go(func() {
-			if err := w.Close(ctx); err != nil {
+			// The pipeline may have already been closed concurrently by its owning
+			// SlicePipeline (e.g. a slice rotation racing with this shutdown sweep).
+			// That's an expected outcome, not a failure - the pipeline is closed either way.
+			if err := w.Close(ctx); err != nil && !errors.Is(err, errPipelineAlreadyClosed) {
 				errs.Append(err)
 			}
 		})

--- a/internal/pkg/service/stream/storage/level/local/encoding/pipeline.go
+++ b/internal/pkg/service/stream/storage/level/local/encoding/pipeline.go
@@ -70,6 +70,10 @@ type StatisticsProvider interface {
 	UncompressedSize() datasize.ByteSize
 }
 
+// errPipelineAlreadyClosed is returned by pipeline.Close when it is called more than once,
+// for example concurrently by the owning SlicePipeline and by Manager's shutdown sweep.
+var errPipelineAlreadyClosed = errors.New("encoding pipeline is already closed")
+
 // pipeline implements Pipeline interface, it wraps common logic for all file types.
 // For conversion between record values and bytes, the encoder.Encoder is used.
 type pipeline struct {
@@ -421,7 +425,7 @@ func (p *pipeline) Close(ctx context.Context) error {
 
 	// Close only once
 	if p.isClosed() {
-		return errors.New("encoding pipeline is already closed")
+		return errPipelineAlreadyClosed
 	}
 	close(p.closed)
 


### PR DESCRIPTION
## Release Notes
- Fixes a stream-service memory leak where `SlicePipeline.Close` could return without cancelling the async open-retry goroutine or notifying its parent, if it was called while the pipeline was still opening.
- Adds an explicit `closed` flag to `SlicePipeline` instead of overloading the nil-ness of the pipeline reference.
- Restores `Close`'s blocking idempotence for concurrent callers, which the leak fix had inadvertently dropped.

## Plans for customer communication
None.

## Impact analysis
- `internal/pkg/service/stream/storage/level/local/diskwriter/network/router/pipeline/pipeline_slice.go` and `internal/pkg/service/stream/storage/level/local/encoding/manager.go`.
- Root cause: `Close()` used `p.pipeline == nil` to mean both "already closed" and "still opening" (the async `tryOpen` retry loop hadn't set `p.pipeline` yet). In the latter case `Close()` returned immediately, skipping `cancel()`/`wg.Wait()`/`onClose()`. If the retry later succeeded, the resulting `encoding.Pipeline` stayed registered in `encoding.Manager.pipelines` forever with nothing left to close it — an unbounded heap leak, matching an observed `heap_objects` growth pattern (504K → 14.3M over 3.7 days) and elevated GC CPU (heap_alloc staying above next_gc). The leak window requires opens to be *failing* at the moment of close (`tryOpen` holds the lock across `OpenPipeline`, so `Close` only meets a "still opening" pipeline while the goroutine is sitting in the backoff retry loop) — it's rotation-driven conditional on open failures (e.g. writer nodes flapping or a deploy), not purely a function of rotation frequency independent of traffic/health.
- Fix: track `closed` explicitly under the existing `p.lock`, always run cancel→wait→(close underlying pipeline if opened)→onClose exactly once. `tryOpen` also checks `closed` before dialing, so a doomed open attempt after close doesn't allocate a pipeline just to discard it (less GC churn).
- `Close` can legitimately be invoked twice concurrently (once by `SinkPipeline` on rotation, once via the `closeFunc` callback the encoding pipeline calls on its own connection failure). The `closed` flag makes this explicit, and the losing caller now blocks on a `closeDone` channel until the winner's close actually finishes, instead of returning immediately — restoring the blocking-idempotence the old nil-check based `Close` had, which `router.go`'s `closeSyncer.Notify` (and the storage coordinator's `slicerotation` gate on it) relies on.
- `tryOpen` now returns whether it actually opened a pipeline, computed under the same lock as its `closed` check, and the retry goroutine gates `ready.NotifyReady()` on that instead of inferring it from `p.ctx.Err()` afterwards — the latter is set by `Close` before it even attempts the lock, so it could misreport a pipeline that genuinely opened as abandoned if `Close` raced in (e.g. via the encoding pipeline's own `closeFunc`) while `tryOpen` was still mid-`OpenPipeline`.
- `encoding/manager.go`: corrected a comment on the already-closing sentinel handling to reflect that `pipeline.Close` returns immediately without waiting for the in-flight close, rather than "closed either way".
- Added regression tests in `pipeline_slice_test.go` covering close-while-still-opening, concurrent-close blocking idempotence, and `tryOpen`'s already-closed short-circuit.
- No API changes, no migrations. Fully backwards-compatible.

## Change type
Bug fix — Fixes a heap/resource leak and a close-blocking-idempotence regression in the stream service's storage router.

## Justification
Investigation into elevated GC CPU (~4.5 GC cycles/sec) and monotonically growing `heap_objects` on the stream service source nodes traced back to `SlicePipeline.Close` returning early during the race between slice rotation (as fast as every 30s per sink, per the default `Trigger.Interval`) and the async pipeline-open retry loop, while opens were failing. Confirmed by reading `encoding.Manager.OpenPipeline`/`removePipeline`: entries are only removed via the pipeline's own `Close`, which never ran for pipelines abandoned mid-open. The leak requires concurrent open failures, not rotation frequency alone — flagged in review and reflected above and in the Post release support plan.

## Deployment
Merge & automatic deploy.

## Rollback plan
Revert of this PR.

## Post release support plan
Monitor stream source-node `heap_objects` / GC CPU trend after rollout; growth should flatten instead of increasing monotonically with sink count and slice-rotation frequency.
