### PR TITLE
chore(cli-dist): trust keboola/cli release tags for S3 push role

### DIFF
--- a/provisioning/cli-dist/release_role.tf
+++ b/provisioning/cli-dist/release_role.tf
@@ -19,6 +19,7 @@ data "aws_iam_policy_document" "cli_dist_release_assume_policy_doc" {
       variable = "token.actions.githubusercontent.com:sub"
       values = [
         "repo:keboola/keboola-as-code:ref:refs/tags/*",
+        "repo:keboola/cli:ref:refs/tags/*",
       ]
     }
     condition {


### PR DESCRIPTION
## Release Notes
- The `cli-dist-release` IAM role (used to push CLI release artifacts to the S3 distribution bucket) now also trusts tag-triggered GitHub Actions workflows from `keboola/cli`, in addition to `keboola/keboola-as-code`

## Plans for customer communication
None.

## Impact analysis
- `provisioning/cli-dist`: extends the `AllowAssumeRoleFromGithub` trust policy `StringLike` condition on `cli_dist_release_role` to include `repo:keboola/cli:ref:refs/tags/*`
- No change to the role's S3 permissions (`s3:*` on the bucket) — only which repositories can assume it
- Fully backwards-compatible; existing `keboola/keboola-as-code` release workflow is unaffected
- Requires a `terraform apply` against the target AWS account (testing/production) to take effect

## Change type
Chore — IAM trust policy update for `cli-dist-release` role

## Justification
`keboola/cli` needs to push release artifacts to the same `cli-dist` S3 bucket used by `keboola/keboola-as-code`, reusing the existing `cli-dist-release` role instead of provisioning a new one.

## Deployment
Manual: `terraform apply -var-file=<production|testing>.tfvars` in `provisioning/cli-dist` against the target AWS account, after merge.

## Rollback plan
Revert this PR and re-apply Terraform.

## Post release support plan
None.