### PR TITLE
feat(cli-dist): trust environment-scoped OIDC sub for keboola/cli release role

### DIFF
--- a/provisioning/cli-dist/release_role.tf
+++ b/provisioning/cli-dist/release_role.tf
@@ -20,6 +20,7 @@ data "aws_iam_policy_document" "cli_dist_release_assume_policy_doc" {
       values = [
         "repo:keboola/keboola-as-code:ref:refs/tags/*",
         "repo:keboola/cli:ref:refs/tags/*",
+        "repo:keboola/cli:environment:release",
       ]
     }
     condition {

--- a/provisioning/cli-dist/release_role.tf
+++ b/provisioning/cli-dist/release_role.tf
@@ -19,7 +19,6 @@ data "aws_iam_policy_document" "cli_dist_release_assume_policy_doc" {
       variable = "token.actions.githubusercontent.com:sub"
       values = [
         "repo:keboola/keboola-as-code:ref:refs/tags/*",
-        "repo:keboola/cli:ref:refs/tags/*",
         "repo:keboola/cli:environment:release",
       ]
     }


### PR DESCRIPTION
## Release Notes
- Trusts `repo:keboola/cli:environment:release` on the `cli-dist-release` IAM role instead of `repo:keboola/cli:ref:refs/tags/*`.

## Plans for customer communication
None.

## Impact analysis
- `provisioning/cli-dist/release_role.tf`: replaces the `keboola/cli` `StringLike` trust entry on `token.actions.githubusercontent.com:sub` — `ref:refs/tags/*` swapped for `environment:release`.
- `keboola-as-code`'s own tag-based trust entry is unchanged.
- Applied automatically via `provisioning-cli-s3.yml` (testing on PR, production on merge to `main`).

## Change type
Chore — infra/IAM trust policy fix (no application code change)

## Justification
`keboola/cli`'s `release-kbagent.yml` `publish-s3` job — the only job there that assumes this role — always sets `environment: release`, so GitHub emits the OIDC `sub` claim as `repo:keboola/cli:environment:release`, never `repo:keboola/cli:ref:refs/tags/*`. The tag-based entry added in #2648 was therefore never matched (causing `AssumeRoleWithWebIdentity` denials) and would never be exercised even if it worked, so it's replaced rather than kept alongside the correct entry.

## Deployment
Merge & automatic deploy (Terraform apply runs in `provisioning-cli-s3.yml` on merge to `main`).

## Rollback plan
Revert of this PR.

## Post release support plan
None.