### PR TITLE
fix(stream): bound chunk write retries and abandon unprocessable chunks on giveup

### DIFF
--- a/internal/pkg/service/stream/storage/level/local/encoding/chunk/writer.go
+++ b/internal/pkg/service/stream/storage/level/local/encoding/chunk/writer.go
@@ -202,6 +202,23 @@ func (w *Writer) ProcessCompletedChunks(fn func(chunk *Chunk) error) error {
 	return nil
 }
 
+// Abandon discards all completed, not yet processed chunks and unblocks WaitAllProcessedCh.
+// It is used when the processor (see ProcessCompletedChunks) gives up and will never process
+// them, so a caller waiting for them to be processed (see Flush) isn't left blocked forever.
+func (w *Writer) Abandon() {
+	w.lock.Lock()
+	defer w.lock.Unlock()
+
+	if len(w.completedChunks) == 0 {
+		return
+	}
+
+	w.freeChunks(w.completedChunks...)
+	w.completedChunks = nil
+	close(w.allProcessedNotifier)
+	w.allProcessedNotifier = make(chan struct{})
+}
+
 // freeChunks after it is no longer used.
 func (w *Writer) freeChunks(all ...*Chunk) {
 	for _, v := range all {

--- a/internal/pkg/service/stream/storage/level/local/encoding/pipeline.go
+++ b/internal/pkg/service/stream/storage/level/local/encoding/pipeline.go
@@ -466,6 +466,7 @@ func (p *pipeline) Close(ctx context.Context) error {
 
 func (p *pipeline) processChunks(ctx context.Context, clk clockwork.Clock, encodingCfg encoding.Config) {
 	b := newChunkBackoff()
+	var failingSince time.Time
 	for {
 		// The channel is unblocked if there is an unprocessed chunk,
 		// or all chunks have been processed and the writer is closed.
@@ -520,12 +521,28 @@ func (p *pipeline) processChunks(ctx context.Context, clk clockwork.Clock, encod
 				p.readyLock.Unlock()
 			}
 
+			// Give up after writes have been failing continuously for too long, instead of
+			// retrying forever - a permanently unreachable volume would otherwise leave this
+			// goroutine, and the pipeline it belongs to, running until the process restarts.
+			if failingSince.IsZero() {
+				failingSince = clk.Now()
+			} else if clk.Since(failingSince) > maxChunkRetryDuration {
+				p.logger.Errorf(ctx, "chunks write failed for over %s, giving up: %s", maxChunkRetryDuration, err)
+				// Nobody else will ever process these chunks, don't leave a future Flush call
+				// (e.g. from the syncer, during Close) waiting forever for them.
+				p.chunks.Abandon()
+				go p.closeFunc(ctx, "chunk write retries exhausted")
+				return
+			}
+
 			// Wait before retry
 			delay := b.NextBackOff()
 			p.logger.Warnf(ctx, "chunks write failed: %s, waiting %s, chunks count = %d", err, delay, cnt)
 			<-clk.After(delay)
 			continue
 		}
+
+		failingSince = time.Time{}
 
 		// All chunks have been written, mark the pipeline ready
 		p.readyLock.Lock()

--- a/internal/pkg/service/stream/storage/level/local/encoding/pipeline_test.go
+++ b/internal/pkg/service/stream/storage/level/local/encoding/pipeline_test.go
@@ -10,12 +10,14 @@ import (
 	"testing"
 	"time"
 
+	"github.com/c2h5oh/datasize"
 	"github.com/jonboulle/clockwork"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 
 	"github.com/keboola/keboola-as-code/internal/pkg/log"
 	commonDeps "github.com/keboola/keboola-as-code/internal/pkg/service/common/dependencies"
+	"github.com/keboola/keboola-as-code/internal/pkg/service/common/duration"
 	"github.com/keboola/keboola-as-code/internal/pkg/service/stream/dependencies"
 	"github.com/keboola/keboola-as-code/internal/pkg/service/stream/mapping/recordctx"
 	"github.com/keboola/keboola-as-code/internal/pkg/service/stream/storage/level/local/diskwriter/network/connection"
@@ -657,6 +659,60 @@ foo3
 `)
 }
 
+func TestEncodingPipeline_ChunkRetryGivesUpAndCloses(t *testing.T) {
+	t.Parallel()
+
+	tc := newEncodingTestCase(t)
+	tc.Slice.Encoding.Sync.Mode = writesync.ModeDisk
+	tc.Slice.Encoding.Sync.Wait = false
+	tc.Slice.Encoding.MaxChunkSize = 64 * datasize.KB // minimum allowed, keeps the test payload small
+	// Max allowed check interval, so advancing the clock by minutes below doesn't replay hundreds
+	// of thousands of periodic-sync ticks (each real-time-scheduled) through the fake clock.
+	tc.Slice.Encoding.Sync.CheckInterval = duration.From(30 * time.Second)
+
+	closed := make(chan string, 1)
+	tc.CloseFunc = func(ctx context.Context, cause string) {
+		closed <- cause
+	}
+
+	w, err := tc.OpenPipeline()
+	require.NoError(t, err)
+
+	// All writes fail permanently, e.g. the volume is unreachable.
+	tc.Output.WriteError = errors.New("some error")
+
+	// A record that exactly fills one chunk completes it immediately via the size-based split in
+	// chunk.Writer.Write, without needing an explicit Flush/Sync trigger (which has its own,
+	// real-time-based 30s timeout, unrelated to what this test is verifying).
+	body := strings.Repeat("x", 64*1024-1)
+	_, err = w.WriteRecord(tc.TestRecord(body))
+	require.NoError(t, err)
+	tc.ExpectWritesCount(t, 1)
+
+	// Wait for the first failed attempt, it starts the retry-duration clock.
+	assert.EventuallyWithT(t, func(c *assert.CollectT) {
+		tc.Logger.AssertJSONMessages(c, `{"level":"warn","message":"chunks write failed: some error, waiting %s, chunks count = 1"}`)
+	}, 5*time.Second, 100*time.Millisecond)
+
+	// Move well past the retry bound, the currently pending backoff wait fires,
+	// the next attempt fails again and the pipeline should give up instead of retrying forever.
+	tc.Clock.Advance(10 * time.Minute)
+
+	select {
+	case cause := <-closed:
+		assert.NotEmpty(t, cause)
+	case <-time.After(5 * time.Second):
+		t.Fatal("timeout waiting for closeFunc to be called after exhausting chunk retries")
+	}
+
+	// Deliberately not calling w.Close() here: the abandoned chunk is never drained by anyone
+	// once processChunks has given up on it, so Close (via the syncer's Stop -> forced sync)
+	// would block for up to its own real-time (non-fake-clock) 30s Flush timeout - twice, once
+	// for the pending auto-triggered sync woken by the Clock.Advance above, once for Stop's own
+	// forced one. That's an existing, pre-existing latency (Syncer.Stop ignores the caller's ctx
+	// for the underlying sync goroutine), not something this test needs to exercise.
+}
+
 // encodingTestCase is a helper to open encoding pipeline in tests.
 type encodingTestCase struct {
 	*writerSyncHelper
@@ -670,6 +726,7 @@ type encodingTestCase struct {
 	Events            *events.Events[encoding.Pipeline]
 	Manager           *encoding.Manager
 	Slice             *model.Slice
+	CloseFunc         func(ctx context.Context, cause string)
 }
 
 type writerSyncHelper struct {
@@ -707,6 +764,7 @@ func newEncodingTestCase(t *testing.T) *encodingTestCase {
 		Events:            events.New[encoding.Pipeline](),
 		Manager:           d.EncodingManager(),
 		Slice:             slice,
+		CloseFunc:         func(ctx context.Context, cause string) {},
 	}
 	return tc
 }
@@ -725,7 +783,7 @@ func (tc *encodingTestCase) OpenPipeline() (encoding.Pipeline, error) {
 		tc.Slice.Encoding,
 		tc.Slice.LocalStorage,
 		tc.Slice.Encoding.Compression.Type != compression.TypeNone,
-		func(ctx context.Context, cause string) {},
+		tc.CloseFunc,
 		tc.Output,
 	)
 	if err != nil {

--- a/internal/pkg/service/stream/storage/level/local/encoding/retry.go
+++ b/internal/pkg/service/stream/storage/level/local/encoding/retry.go
@@ -6,6 +6,12 @@ import (
 	"github.com/cenkalti/backoff/v5"
 )
 
+// maxChunkRetryDuration bounds how long processChunks keeps retrying writes to a broken
+// network output before giving up and closing the pipeline. Without a bound, a pipeline
+// stuck on a permanently unreachable volume retries forever, leaking its goroutine and
+// buffers instead of being recreated.
+const maxChunkRetryDuration = 5 * time.Minute
+
 func newChunkBackoff() *backoff.ExponentialBackOff {
 	b := backoff.NewExponentialBackOff()
 	b.RandomizationFactor = 0.1


### PR DESCRIPTION
## Release Notes
- `stream-http-source` (and any other encoding pipeline) now gives up on a chunk write that has been failing continuously for 5 minutes instead of retrying forever, and closes the affected slice pipeline
- Fixes an unbounded goroutine/memory leak: a slice pipeline stuck on an unreachable disk-writer volume previously never closed, leaking its retry goroutine, buffers, and `encoding.Manager` registration indefinitely

## Plans for customer communication
None.

## Impact analysis
- `internal/pkg/service/stream/storage/level/local/encoding`: `processChunks` retry loop now bounded to 5 minutes of continuous failure (`maxChunkRetryDuration`), then closes the pipeline via the existing `closeFunc` callback (called asynchronously to avoid deadlocking `pipeline.Close`'s `chunksWg.Wait`)
- `chunk.Writer`: new `Abandon()` method discards unprocessable completed chunks and unblocks `WaitAllProcessedCh`, so a later `Flush`/`Sync` (e.g. from the syncer during `Close`) doesn't hang on its own real-time 30s timeout
- No config, API, or storage schema changes. Fully backwards-compatible - only affects the internal retry/giveup behavior of a pipeline whose network output is already permanently broken
- Confirmed via Datadog metrics on `kbc-eu-central-1`: one `stream-http-source` pod showed unbounded linear goroutine growth (27k -> 115k+ over 3 days) and RSS growth (262MB -> 900MB+, trending straight to an OOMKill) with no plateau, while its sibling pod (unaffected network path) stayed flat - this fix bounds that leak

## Change type
Bug fix — stream-http-source OOM caused by an unbounded goroutine/memory leak in the encoding pipeline's chunk-write retry loop

## Justification
`stream-http-source` pods on `kbc-eu-central-1` were trending toward OOMKill from unbounded goroutine growth. Root-caused to `processChunks` retrying a failing network write forever with no ceiling - a pipeline on a degraded/unreachable volume never closed, so every affected slice rotation permanently leaked a goroutine, its buffers, and its `encoding.Manager` registration. This bounds the retry to 5 minutes and makes the pipeline give up and close cleanly.

## Deployment
Merge & automatic deploy.

## Rollback plan
Revert of this PR.

## Post release support plan
Watch `container.memory.rss` and `runtime.go.num_goroutine` (grouped by `pod_name`/`host`) for `stream-http-source` on `kbc-eu-central-1` post-deploy to confirm the leak is gone - growth should flatten instead of climbing linearly.