### PR TITLE
PAT-2055 Read the E2B access token by App role

### DIFF
--- a/internal/pkg/service/appsproxy/dataapps/k8sapp/appinfo.go
+++ b/internal/pkg/service/appsproxy/dataapps/k8sapp/appinfo.go
@@ -46,6 +46,11 @@ type appSpec struct {
 	AutoRestartEnabled *bool           `json:"autoRestartEnabled,omitempty"`
 	DevMode            *appDevModeSpec `json:"devMode,omitempty"`
 	Runtime            appRuntime      `json:"runtime"`
+	// ContainerSpec is decoded only to tell whether the field is present — the App
+	// plays the workload role — or absent, which marks the product role. It is a map
+	// rather than one of this struct's value types precisely because the marker is
+	// absence, and a value type cannot tell an absent field from an empty one.
+	ContainerSpec map[string]any `json:"containerSpec,omitempty"`
 }
 
 // appDevModeSpec mirrors the App CRD's spec.devMode block. The proxy only
@@ -62,6 +67,38 @@ type appRuntime struct {
 
 type appBackend struct {
 	Type string `json:"type,omitempty"`
+}
+
+// isProduct reports whether the App plays the product (version-coordinator) role rather
+// than the workload role. It mirrors the operator's App.IsProduct(): a product carries no
+// containerSpec, because the things that run are its member Sandboxes.
+func (o *appObject) isProduct() bool {
+	return o.Spec.ContainerSpec == nil
+}
+
+// e2bAccessTokenSecretName returns the name of the Secret holding the app's E2B traffic
+// access token, or "" when the app needs no such token.
+//
+// The two roles read different fields. On a workload App spec.runtime.backend.type is
+// authoritative, and it also has to be consulted: status.e2bSandbox survives a switch
+// away from the E2B backend — nothing clears it — while the Secret it names is owned by
+// the deleted E2bSandbox and garbage-collected with it.
+//
+// A product App has no backend of its own. The backend belongs to the member Sandbox it
+// routes to, and the operator mirrors that member's status.e2bSandbox here because the
+// proxy routes by the App and does not watch Sandboxes. Its spec.runtime is either absent
+// (sandboxes-service builds a product App without one) or /v1 residue left behind when a
+// /v1 App was adopted into the product role by stripping containerSpec, so in neither
+// case does it describe what serves the app's traffic.
+func (o *appObject) e2bAccessTokenSecretName() string {
+	name := o.Status.E2BSandbox.AccessTokenSecretName
+	if name == "" {
+		return ""
+	}
+	if !o.isProduct() && o.Spec.Runtime.Backend.Type != BackendTypeE2BSandbox {
+		return ""
+	}
+	return name
 }
 
 // AppInfo is the cached state for an app, read from the K8s watcher.

--- a/internal/pkg/service/appsproxy/dataapps/k8sapp/appinfo.go
+++ b/internal/pkg/service/appsproxy/dataapps/k8sapp/appinfo.go
@@ -50,6 +50,13 @@ type appSpec struct {
 	// plays the workload role — or absent, which marks the product role. It is a map
 	// rather than one of this struct's value types precisely because the marker is
 	// absence, and a value type cannot tell an absent field from an empty one.
+	//
+	// A router has no business reading a workload's container spec, and this field is
+	// here under protest: it exists only because status.e2bSandbox cannot be trusted on
+	// its own. The operator never clears it when an App is drained off the E2B backend,
+	// so the status alone cannot say whether the token it names is live. PAT-2059 makes
+	// the status truthful; once it lands this field, isProduct and the role branch in
+	// e2bAccessTokenSecretName all go away, and the read keys on the value alone.
 	ContainerSpec map[string]any `json:"containerSpec,omitempty"`
 }
 
@@ -72,6 +79,8 @@ type appBackend struct {
 // isProduct reports whether the App plays the product (version-coordinator) role rather
 // than the workload role. It mirrors the operator's App.IsProduct(): a product carries no
 // containerSpec, because the things that run are its member Sandboxes.
+//
+// Removed by PAT-2059 — see the note on appSpec.ContainerSpec.
 func (o *appObject) isProduct() bool {
 	return o.Spec.ContainerSpec == nil
 }
@@ -90,6 +99,10 @@ func (o *appObject) isProduct() bool {
 // (sandboxes-service builds a product App without one) or /v1 residue left behind when a
 // /v1 App was adopted into the product role by stripping containerSpec, so in neither
 // case does it describe what serves the app's traffic.
+//
+// The role branch is a workaround for the stale status described on
+// appSpec.ContainerSpec. PAT-2059 removes the need for it, leaving the secret name on its
+// own as the signal.
 func (o *appObject) e2bAccessTokenSecretName() string {
 	name := o.Status.E2BSandbox.AccessTokenSecretName
 	if name == "" {

--- a/internal/pkg/service/appsproxy/dataapps/k8sapp/appinfo_test.go
+++ b/internal/pkg/service/appsproxy/dataapps/k8sapp/appinfo_test.go
@@ -1,0 +1,133 @@
+package k8sapp
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	"k8s.io/apimachinery/pkg/runtime"
+)
+
+func decodeApp(t *testing.T, spec, status map[string]any) appObject {
+	t.Helper()
+
+	u := map[string]any{
+		"apiVersion": Group + "/" + Version,
+		"kind":       "App",
+		"metadata":   map[string]any{"name": "app-1", "namespace": "keboola"},
+		"spec":       spec,
+		"status":     status,
+	}
+
+	var obj appObject
+	require.NoError(t, runtime.DefaultUnstructuredConverter.FromUnstructured(u, &obj))
+	return obj
+}
+
+// The product-role marker is the ABSENCE of spec.containerSpec, so appSpec.ContainerSpec
+// must decode to nil for an absent field and to non-nil for a present one — including a
+// present-but-empty object. The rest of appSpec uses value types, which cannot express
+// that distinction; this test is what stops the field being "simplified" back into one.
+//
+// It asserts the decoded shape rather than the resulting token, so a change in how
+// FromUnstructured maps this field fails here, naming the decode, instead of surfacing
+// only as a token that is silently no longer read.
+func TestAppObject_ContainerSpecDecodesAbsentAsNil(t *testing.T) {
+	t.Parallel()
+
+	tests := map[string]struct {
+		spec          map[string]any
+		wantNil       bool
+		wantIsProduct bool
+	}{
+		"absent": {
+			spec:          map[string]any{"appId": "1"},
+			wantNil:       true,
+			wantIsProduct: true,
+		},
+		"present with content": {
+			spec:          map[string]any{"appId": "1", "containerSpec": map[string]any{"image": "keboola/data-app:latest"}},
+			wantNil:       false,
+			wantIsProduct: false,
+		},
+		"present but empty": {
+			spec:          map[string]any{"appId": "1", "containerSpec": map[string]any{}},
+			wantNil:       false,
+			wantIsProduct: false,
+		},
+	}
+
+	for name, tc := range tests {
+		t.Run(name, func(t *testing.T) {
+			t.Parallel()
+
+			obj := decodeApp(t, tc.spec, map[string]any{})
+
+			if tc.wantNil {
+				assert.Nil(t, obj.Spec.ContainerSpec,
+					"spec.containerSpec is absent and must decode to a nil map — the product-role marker is absence, "+
+						"and a type that cannot represent absence makes isProduct() always false")
+			} else {
+				assert.NotNil(t, obj.Spec.ContainerSpec,
+					"spec.containerSpec is present and must decode to a non-nil map — decoding it as nil makes every "+
+						"workload App read as product-role")
+			}
+
+			assert.Equal(t, tc.wantIsProduct, obj.isProduct())
+		})
+	}
+}
+
+// The gate keys on role, not on spec.runtime.backend.type alone: a product App's
+// spec.runtime describes no live workload, while a workload App's is authoritative.
+func TestAppObject_E2BAccessTokenSecretName(t *testing.T) {
+	t.Parallel()
+
+	const secret = "e2b-access-token"
+
+	runtimeSpec := func(backendType string) map[string]any {
+		return map[string]any{"backend": map[string]any{"type": backendType}}
+	}
+	containerSpec := map[string]any{"image": "keboola/data-app:latest"}
+
+	tests := map[string]struct {
+		spec   map[string]any
+		status map[string]any
+		want   string
+	}{
+		"product app without runtime": {
+			spec:   map[string]any{"appId": "1"},
+			status: map[string]any{"e2bSandbox": map[string]any{"accessTokenSecretName": secret}},
+			want:   secret,
+		},
+		"product app with k8s runtime residue from adoption": {
+			spec:   map[string]any{"appId": "1", "runtime": runtimeSpec("k8sDeployment")},
+			status: map[string]any{"e2bSandbox": map[string]any{"accessTokenSecretName": secret}},
+			want:   secret,
+		},
+		"e2b workload app": {
+			spec:   map[string]any{"appId": "1", "containerSpec": containerSpec, "runtime": runtimeSpec(BackendTypeE2BSandbox)},
+			status: map[string]any{"e2bSandbox": map[string]any{"accessTokenSecretName": secret}},
+			want:   secret,
+		},
+		"k8s workload app with stale status after a backend switch": {
+			spec:   map[string]any{"appId": "1", "containerSpec": containerSpec, "runtime": runtimeSpec("k8sDeployment")},
+			status: map[string]any{"e2bSandbox": map[string]any{"accessTokenSecretName": secret}},
+			want:   "",
+		},
+		"no secret name": {
+			spec:   map[string]any{"appId": "1"},
+			status: map[string]any{},
+			want:   "",
+		},
+	}
+
+	for name, tc := range tests {
+		t.Run(name, func(t *testing.T) {
+			t.Parallel()
+
+			obj := decodeApp(t, tc.spec, tc.status)
+			assert.Equal(t, tc.want, obj.e2bAccessTokenSecretName())
+		})
+	}
+}

--- a/internal/pkg/service/appsproxy/dataapps/k8sapp/watcher.go
+++ b/internal/pkg/service/appsproxy/dataapps/k8sapp/watcher.go
@@ -223,14 +223,11 @@ func (w *StateWatcher) handleUpsert(ctx context.Context, obj any) {
 	}
 
 	var e2bAccessToken string
-	var e2bSecretName string
-	if appObj.Spec.Runtime.Backend.Type == BackendTypeE2BSandbox {
-		e2bSecretName = appObj.Status.E2BSandbox.AccessTokenSecretName
-		if e2bSecretName != "" {
-			token, err := w.loadSecretToken(ctx, e2bSecretName)
-			if err == nil {
-				e2bAccessToken = token
-			}
+	e2bSecretName := appObj.e2bAccessTokenSecretName()
+	if e2bSecretName != "" {
+		token, err := w.loadSecretToken(ctx, e2bSecretName)
+		if err == nil {
+			e2bAccessToken = token
 		}
 	}
 

--- a/internal/pkg/service/appsproxy/dataapps/k8sapp/watcher.go
+++ b/internal/pkg/service/appsproxy/dataapps/k8sapp/watcher.go
@@ -6,7 +6,9 @@ import (
 	"encoding/json"
 	"net/url"
 	"sync"
+	"time"
 
+	"github.com/jonboulle/clockwork"
 	"golang.org/x/sync/singleflight"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
@@ -33,6 +35,31 @@ type entry struct {
 	upstreamTarget     *url.URL // pre-parsed; nil when appsProxy.upstreamUrl absent/invalid
 	e2bAccessToken     string   // loaded from K8s Secret; empty for non-E2B apps
 	e2bSecretName      string   // Secret name for lazy token loading; empty for non-E2B apps
+	// tokenRetryAfter is the earliest time the lazy load may be attempted again, and
+	// tokenRetryDelay the interval that produced it. Both are zero while no attempt has
+	// failed, and are cleared again once one succeeds.
+	tokenRetryAfter time.Time
+	tokenRetryDelay time.Duration
+}
+
+// Bounds on the lazy token load after a failure. The load exists because the Secret may
+// not have existed yet when the App CRD event was processed, so giving up permanently is
+// wrong — the delay is capped rather than allowed to grow without limit, which keeps the
+// app converging within tokenRetryMaxDelay of the Secret appearing.
+const (
+	tokenRetryInitialDelay = 1 * time.Second
+	tokenRetryMaxDelay     = 32 * time.Second
+)
+
+// nextTokenRetryDelay doubles the delay up to the cap.
+func nextTokenRetryDelay(current time.Duration) time.Duration {
+	if current <= 0 {
+		return tokenRetryInitialDelay
+	}
+	if next := current * 2; next < tokenRetryMaxDelay {
+		return next
+	}
+	return tokenRetryMaxDelay
 }
 
 // StateWatcher watches App CRDs in Kubernetes and provides a local cache of app states.
@@ -41,6 +68,7 @@ type StateWatcher struct {
 	namespace      string
 	logger         log.Logger
 	hasSynced      cache.InformerSynced
+	clock          clockwork.Clock
 	apps           sync.Map           // AppID → entry
 	tokenLoadGroup singleflight.Group // coalesces concurrent lazy-load K8s API calls per secret
 }
@@ -48,6 +76,7 @@ type StateWatcher struct {
 type dependencies interface {
 	Logger() log.Logger
 	Process() *servicectx.Process
+	Clock() clockwork.Clock
 }
 
 // NewDynamicClient creates a Kubernetes dynamic client from kubeconfig path or in-cluster config.
@@ -95,6 +124,7 @@ func NewStateWatcher(d dependencies, client dynamic.Interface, namespace string)
 		namespace: namespace,
 		logger:    d.Logger().WithComponent("k8sapp.watcher"),
 		hasSynced: informer.HasSynced,
+		clock:     d.Clock(),
 	}
 
 	_, err := informer.AddEventHandler(cache.ResourceEventHandlerFuncs{
@@ -130,16 +160,33 @@ func (w *StateWatcher) GetState(ctx context.Context, appID api.AppID) (AppInfo, 
 
 	// Lazy-load E2B token: the Secret may not have existed when the App CRD event was processed.
 	// a singleflight coalesces concurrent requests for the same secret into a single K8s API call.
-	if e.e2bAccessToken == "" && e.e2bSecretName != "" {
+	//
+	// This runs on the request path, so a failed load must not be retried per request. The
+	// singleflight only collapses calls that overlap in time, and sequential requests do not,
+	// so without the retry gate below an entry naming an unloadable Secret costs one K8s API
+	// GET and one WARN on every request for as long as the App exists.
+	if e.e2bAccessToken == "" && e.e2bSecretName != "" && !w.clock.Now().Before(e.tokenRetryAfter) {
 		fetchCtx := context.WithoutCancel(ctx)
 		token, err, _ := w.tokenLoadGroup.Do(e.e2bSecretName, func() (any, error) {
 			return w.loadSecretToken(fetchCtx, e.e2bSecretName)
 		})
-		if err != nil {
-			w.logger.Warnf(ctx, "App %s: failed to lazy-load E2B access token from secret %q: %s", appID, e.e2bSecretName, err)
-		} else if t, ok := token.(string); t != "" && ok {
+
+		t, _ := token.(string)
+		switch {
+		case err != nil || t == "":
+			e.tokenRetryDelay = nextTokenRetryDelay(e.tokenRetryDelay)
+			e.tokenRetryAfter = w.clock.Now().Add(e.tokenRetryDelay)
+			// Compare-and-swap rather than Store: handleUpsert may have replaced the entry
+			// while the load was in flight, and writing back this copy would discard it.
+			w.apps.CompareAndSwap(appID, v, e)
+			if err != nil {
+				w.logger.Warnf(ctx, "App %s: failed to lazy-load E2B access token from secret %q, next attempt in %s: %s", appID, e.e2bSecretName, e.tokenRetryDelay, err)
+			}
+		default:
 			e.e2bAccessToken = t
-			w.apps.Store(appID, e)
+			e.tokenRetryAfter = time.Time{}
+			e.tokenRetryDelay = 0
+			w.apps.CompareAndSwap(appID, v, e)
 			w.logger.Infof(ctx, "App %s: lazy-loaded E2B access token from secret %q", appID, e.e2bSecretName)
 		}
 	}
@@ -222,12 +269,19 @@ func (w *StateWatcher) handleUpsert(ctx context.Context, obj any) {
 		}
 	}
 
+	// A failure here seeds the same retry gate GetState uses, so the eager load and the
+	// lazy one share one budget instead of the lazy path starting over on every event.
 	var e2bAccessToken string
+	var tokenRetryAfter time.Time
+	var tokenRetryDelay time.Duration
 	e2bSecretName := appObj.e2bAccessTokenSecretName()
 	if e2bSecretName != "" {
 		token, err := w.loadSecretToken(ctx, e2bSecretName)
 		if err == nil {
 			e2bAccessToken = token
+		} else {
+			tokenRetryDelay = nextTokenRetryDelay(0)
+			tokenRetryAfter = w.clock.Now().Add(tokenRetryDelay)
 		}
 	}
 
@@ -240,6 +294,8 @@ func (w *StateWatcher) handleUpsert(ctx context.Context, obj any) {
 		upstreamTarget:     upstreamTarget,
 		e2bAccessToken:     e2bAccessToken,
 		e2bSecretName:      e2bSecretName,
+		tokenRetryAfter:    tokenRetryAfter,
+		tokenRetryDelay:    tokenRetryDelay,
 	})
 	w.logger.Debugf(ctx, "App CRD %q (appID=%s) state updated: actualState=%q autoRestartEnabled=%v devMode=%v upstreamTarget=%v", k8sName, appID, appObj.Status.CurrentState, autoRestartEnabled, devMode, upstreamTarget != nil)
 }

--- a/internal/pkg/service/appsproxy/dataapps/k8sapp/watcher_test.go
+++ b/internal/pkg/service/appsproxy/dataapps/k8sapp/watcher_test.go
@@ -6,6 +6,7 @@ import (
 	"testing"
 	"time"
 
+	"github.com/jonboulle/clockwork"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
@@ -28,21 +29,27 @@ const testNamespace = "keboola"
 type watcherDeps struct {
 	logger log.Logger
 	proc   *servicectx.Process
+	clock  clockwork.Clock
 }
 
 func newTestDeps(t *testing.T) *watcherDeps {
 	t.Helper()
-	logger := log.NewNopLogger()
+	return newTestDepsWith(t, log.NewNopLogger(), clockwork.NewRealClock())
+}
+
+func newTestDepsWith(t *testing.T, logger log.Logger, clock clockwork.Clock) *watcherDeps {
+	t.Helper()
 	proc := servicectx.New(servicectx.WithLogger(logger), servicectx.WithoutSignals())
 	t.Cleanup(func() {
 		proc.Shutdown(context.Background(), nil)
 		proc.WaitForShutdown()
 	})
-	return &watcherDeps{logger: logger, proc: proc}
+	return &watcherDeps{logger: logger, proc: proc, clock: clock}
 }
 
 func (d *watcherDeps) Logger() log.Logger           { return d.logger }
 func (d *watcherDeps) Process() *servicectx.Process { return d.proc }
+func (d *watcherDeps) Clock() clockwork.Clock       { return d.clock }
 
 // newFakeClient creates a fake dynamic client with the App and Secret list kinds registered.
 func newFakeClient() *k8sfake.FakeDynamicClient {
@@ -430,4 +437,77 @@ func TestStateWatcher_GetState_E2BAccessToken_E2BWorkload(t *testing.T) {
 	info := stateAfterSync(t, appObj, "app-e2b-workload", "workload-secret", "workload-token")
 
 	assert.Equal(t, "workload-token", info.E2BAccessToken)
+}
+
+// countSecretGets returns how many times the Secret named was fetched from the API.
+func countSecretGets(fakeClient *k8sfake.FakeDynamicClient, name string) int {
+	n := 0
+	for _, a := range fakeClient.Actions() {
+		if get, ok := a.(k8stesting.GetAction); ok && get.GetResource() == k8sapp.SecretGVR() && get.GetName() == name {
+			n++
+		}
+	}
+	return n
+}
+
+// GetState runs on the request path, so a Secret that cannot be loaded must not cost a
+// K8s API call and a WARN on every request. The retry is gated, not abandoned: the Secret
+// may legitimately appear later, and the app must still converge when it does.
+func TestStateWatcher_GetState_E2BAccessToken_FailedLoadIsNotRetriedPerRequest(t *testing.T) {
+	t.Parallel()
+
+	fakeClient := newFakeClient()
+	logger := log.NewDebugLogger()
+	clock := clockwork.NewFakeClock()
+	d := newTestDepsWith(t, logger, clock)
+
+	// The App names a Secret that does not exist yet.
+	appObj := newProductAppObject("my-app", "app-1", k8sapp.AppActualStateRunning, "", "late-secret")
+	_, err := fakeClient.Resource(k8sapp.AppGVR()).Namespace(testNamespace).Create(
+		t.Context(), appObj, metav1.CreateOptions{},
+	)
+	require.NoError(t, err)
+
+	watcher := k8sapp.NewStateWatcher(d, fakeClient, testNamespace)
+	require.Eventually(t, func() bool {
+		_, ok := watcher.GetState(t.Context(), api.AppID("app-1"))
+		return ok
+	}, 5*time.Second, 50*time.Millisecond)
+
+	// handleUpsert already attempted the load once and armed the retry gate.
+	getsAfterSync := countSecretGets(fakeClient, "late-secret")
+	logger.Truncate()
+
+	// Many requests inside the retry window must not produce a single further API call
+	// or WARN — this is the behaviour that fails before the gate exists.
+	for range 20 {
+		info, ok := watcher.GetState(t.Context(), api.AppID("app-1"))
+		require.True(t, ok)
+		assert.Empty(t, info.E2BAccessToken)
+	}
+	assert.Equal(t, getsAfterSync, countSecretGets(fakeClient, "late-secret"),
+		"a failed token load must not be retried on every request")
+	assert.Empty(t, logger.WarnMessages(),
+		"a failed token load must not warn on every request")
+
+	// Past the retry window the load is attempted again — the gate delays, it does not
+	// give up. The Secret still does not exist, so exactly one further attempt is made.
+	clock.Advance(2 * time.Second)
+	_, ok := watcher.GetState(t.Context(), api.AppID("app-1"))
+	require.True(t, ok)
+	assert.Equal(t, getsAfterSync+1, countSecretGets(fakeClient, "late-secret"))
+	assert.Contains(t, logger.WarnMessages(), "failed to lazy-load E2B access token")
+
+	// Once the Secret appears, the next attempt after the window converges.
+	secret := newSecretObject("late-secret", testNamespace, "late-token")
+	_, err = fakeClient.Resource(k8sapp.SecretGVR()).Namespace(testNamespace).Create(
+		t.Context(), secret, metav1.CreateOptions{},
+	)
+	require.NoError(t, err)
+
+	clock.Advance(64 * time.Second)
+	info, ok := watcher.GetState(t.Context(), api.AppID("app-1"))
+	require.True(t, ok)
+	assert.Equal(t, "late-token", info.E2BAccessToken,
+		"the retry gate must delay the load, not abandon it")
 }

--- a/internal/pkg/service/appsproxy/dataapps/k8sapp/watcher_test.go
+++ b/internal/pkg/service/appsproxy/dataapps/k8sapp/watcher_test.go
@@ -327,3 +327,107 @@ func TestStateWatcher_GetState_NonE2BApp_NoToken(t *testing.T) {
 	require.True(t, ok)
 	assert.Empty(t, info.E2BAccessToken)
 }
+
+// newProductAppObject creates a product-role App CRD: no containerSpec (absence is what
+// marks the product role) and status.e2bSandbox.accessTokenSecretName set. backendType is
+// written to spec.runtime.backend.type, or omitted entirely when empty.
+func newProductAppObject(k8sName, appID string, state k8sapp.AppActualState, backendType, secretName string) *unstructured.Unstructured {
+	obj := newAppObject(k8sName, appID, state)
+	if backendType != "" {
+		obj.Object["spec"].(map[string]any)["runtime"] = map[string]any{
+			"backend": map[string]any{"type": backendType},
+		}
+	}
+	obj.Object["status"].(map[string]any)["e2bSandbox"] = map[string]any{
+		"accessTokenSecretName": secretName,
+	}
+	return obj
+}
+
+// newWorkloadAppObject creates a workload-role App CRD: containerSpec present, plus
+// spec.runtime.backend.type and status.e2bSandbox.accessTokenSecretName.
+func newWorkloadAppObject(k8sName, appID string, state k8sapp.AppActualState, backendType, secretName string) *unstructured.Unstructured {
+	obj := newProductAppObject(k8sName, appID, state, backendType, secretName)
+	obj.Object["spec"].(map[string]any)["containerSpec"] = map[string]any{
+		"image": "keboola/data-app:latest",
+	}
+	return obj
+}
+
+// requireTokenLoaded starts a watcher over the given app + secret and returns the
+// AppInfo once the app is cached.
+func stateAfterSync(t *testing.T, appObj *unstructured.Unstructured, appID, secretName, tokenValue string) k8sapp.AppInfo {
+	t.Helper()
+
+	fakeClient := newFakeClient()
+	d := newTestDeps(t)
+
+	secret := newSecretObject(secretName, testNamespace, tokenValue)
+	_, err := fakeClient.Resource(k8sapp.SecretGVR()).Namespace(testNamespace).Create(
+		t.Context(), secret, metav1.CreateOptions{},
+	)
+	require.NoError(t, err)
+
+	_, err = fakeClient.Resource(k8sapp.AppGVR()).Namespace(testNamespace).Create(
+		t.Context(), appObj, metav1.CreateOptions{},
+	)
+	require.NoError(t, err)
+
+	watcher := k8sapp.NewStateWatcher(d, fakeClient, testNamespace)
+
+	require.Eventually(t, func() bool {
+		_, ok := watcher.GetState(t.Context(), api.AppID(appID))
+		return ok
+	}, 5*time.Second, 50*time.Millisecond)
+
+	info, ok := watcher.GetState(t.Context(), api.AppID(appID))
+	require.True(t, ok)
+	return info
+}
+
+// A product App built by sandboxes-service carries no spec.runtime at all — the backend
+// belongs to the member Sandbox it routes to. The token must still be read, or the app
+// gets a route it cannot authenticate against.
+func TestStateWatcher_GetState_E2BAccessToken_ProductAppWithoutRuntime(t *testing.T) {
+	t.Parallel()
+
+	appObj := newProductAppObject("my-product-app", "app-product", k8sapp.AppActualStateRunning, "", "product-secret")
+	info := stateAfterSync(t, appObj, "app-product", "product-secret", "product-token")
+
+	assert.Equal(t, "product-token", info.E2BAccessToken)
+}
+
+// A /v1 App adopted into the product role keeps the spec.runtime its /v1 flow wrote,
+// which names the backend of a workload that no longer exists. It is residue, not the
+// app's backend, so it must not gate the read.
+func TestStateWatcher_GetState_E2BAccessToken_AdoptedProductAppWithK8sRuntimeResidue(t *testing.T) {
+	t.Parallel()
+
+	appObj := newProductAppObject("my-adopted-app", "app-adopted", k8sapp.AppActualStateRunning, "k8sDeployment", "adopted-secret")
+	info := stateAfterSync(t, appObj, "app-adopted", "adopted-secret", "adopted-token")
+
+	assert.Equal(t, "adopted-token", info.E2BAccessToken)
+}
+
+// A workload App switched away from the E2B backend keeps a stale
+// status.e2bSandbox.accessTokenSecretName — nothing clears it. Its own backend type is
+// authoritative, so the token must NOT be read: the Secret is owned by the deleted
+// E2bSandbox, and sending the header would hand an E2B credential to a k8s Deployment.
+func TestStateWatcher_GetState_E2BAccessToken_NotReadForK8sWorkload(t *testing.T) {
+	t.Parallel()
+
+	appObj := newWorkloadAppObject("my-switched-app", "app-switched", k8sapp.AppActualStateRunning, "k8sDeployment", "stale-secret")
+	info := stateAfterSync(t, appObj, "app-switched", "stale-secret", "stale-token")
+
+	assert.Empty(t, info.E2BAccessToken)
+}
+
+// A workload App on the E2B backend is the pre-existing case and must keep working.
+func TestStateWatcher_GetState_E2BAccessToken_E2BWorkload(t *testing.T) {
+	t.Parallel()
+
+	appObj := newWorkloadAppObject("my-e2b-workload", "app-e2b-workload", k8sapp.AppActualStateRunning, k8sapp.BackendTypeE2BSandbox, "workload-secret")
+	info := stateAfterSync(t, appObj, "app-e2b-workload", "workload-secret", "workload-token")
+
+	assert.Equal(t, "workload-token", info.E2BAccessToken)
+}

--- a/internal/pkg/service/appsproxy/proxy/proxy_test.go
+++ b/internal/pkg/service/appsproxy/proxy/proxy_test.go
@@ -5,6 +5,7 @@ import (
 	"bytes"
 	"context"
 	"crypto/rand"
+	"encoding/base64"
 	"fmt"
 	"html"
 	"io"
@@ -70,6 +71,57 @@ func TestAppProxyRouter(t *testing.T) {
 	t.Parallel()
 
 	testCases := []testCase{
+		{
+			// A product-role App carries no spec.runtime — the backend belongs to the member
+			// Sandbox it routes to, and the operator mirrors that member's
+			// status.e2bSandbox onto the App the proxy routes by. The token has to reach
+			// the upstream as a header, or E2B rejects the traffic.
+			name: "e2b-access-token-header-product-app",
+			setupK8s: func(t *testing.T, fakeClient *k8sfake.FakeDynamicClient, watcher *k8sapp.StateWatcher) {
+				secret := &unstructured.Unstructured{
+					Object: map[string]any{
+						"apiVersion": "v1",
+						"kind":       "Secret",
+						"metadata": map[string]any{
+							"name":      "e2b-access-token",
+							"namespace": "keboola",
+						},
+						"data": map[string]any{
+							"token": base64.StdEncoding.EncodeToString([]byte("e2b-token-value")),
+						},
+					},
+				}
+				_, err := fakeClient.Resource(k8sapp.SecretGVR()).Namespace("keboola").Create(
+					t.Context(), secret, metav1.CreateOptions{},
+				)
+				require.NoError(t, err)
+
+				patch := []byte(`{"status":{"e2bSandbox":{"accessTokenSecretName":"e2b-access-token"}}}`)
+				_, err = fakeClient.Resource(k8sapp.AppGVR()).Namespace("keboola").Patch(
+					t.Context(), "app-123", k8stypes.MergePatchType, patch, metav1.PatchOptions{},
+				)
+				require.NoError(t, err)
+
+				require.Eventually(t, func() bool {
+					info, ok := watcher.GetState(t.Context(), api.AppID("123"))
+					return ok && info.E2BAccessToken == "e2b-token-value"
+				}, 5*time.Second, 50*time.Millisecond)
+			},
+			run: func(t *testing.T, client *http.Client, m []*mockoidc.MockOIDC, appServer *testutil.AppServer, service *testutil.DataAppsAPI, fakeClient *k8sfake.FakeDynamicClient, watcher *k8sapp.StateWatcher) {
+				request, err := http.NewRequestWithContext(t.Context(), http.MethodGet, "https://public-123.hub.keboola.local/", nil)
+				require.NoError(t, err)
+				response, err := client.Do(request)
+				require.NoError(t, err)
+				require.Equal(t, http.StatusOK, response.StatusCode)
+
+				require.Len(t, *appServer.Requests, 1)
+				appRequest := (*appServer.Requests)[0]
+				assert.Equal(t, "e2b-token-value", appRequest.Header.Get("e2b-traffic-access-token"))
+			},
+			expectedNotifications: map[string]int{
+				"123": 1,
+			},
+		},
 		{
 			name: "health-check",
 			run: func(t *testing.T, client *http.Client, m []*mockoidc.MockOIDC, appServer *testutil.AppServer, service *testutil.DataAppsAPI, fakeClient *k8sfake.FakeDynamicClient, watcher *k8sapp.StateWatcher) {


### PR DESCRIPTION
## Release Notes

https://linear.app/keboola/issue/PAT-2055/apps-proxy-read-the-e2b-access-token-off-status-not

E2B sandboxes only accept traffic carrying an `e2b-traffic-access-token` header, and apps-proxy is what sends it. The proxy gated reading that token on `spec.runtime.backend.type == "e2bSandbox"`, but a product-role App has no backend of its own — the backend belongs to the member `Sandbox` it routes to. So an E2B-backed app promoted through the App Deployments model would get a route it cannot authenticate against: traffic forwarded to the right sandbox, with no token, and rejected.

The gate now keys on the App's **role** instead. The rule in one line: on a workload App `spec.runtime.backend.type` is authoritative; on a product App it is meaningless, so `status.e2bSandbox` is the only truth. Role is determined the same way the operator determines it — `spec.containerSpec == nil`, mirroring `App.IsProduct()`. Two follow-on commits pin the `containerSpec` decode shape directly (absence is the marker, so the field must decode to nil when absent) and stop a failed token load being retried on every request.

- Cross-repo dependency: `keboola-operator` #246 — https://github.com/keboola/keboola-operator/pull/246. Ordering is operator → apps-proxy → sandboxes-service.

### Alternatives considered

Both rejected **with failing tests**, not by argument — all three candidate gates were run against the same four cases:

| gate | fails |
|---|---|
| Key on the status value alone (as the issue proposes) | `NotReadForK8sWorkload` |
| Key on value **and** `backend.type ∈ {"", "e2bSandbox"}` | `AdoptedProductAppWithK8sRuntimeResidue` |
| **Key on role (shipped)** | — |

- **Value-only** arms a hazard that is live on operator `main` today. `status.e2bSandbox` survives a workload App's switch away from the E2B backend — nothing ever clears it — while the Secret it names is owned by the deleted `E2bSandbox` and garbage-collected with it. That App would then attempt a Secret read on every request, and could briefly send an E2B credential to a `k8sDeployment` upstream.
- **Value plus an empty-or-E2B backend type** breaks every *adopted* product App. `adoptAppCrdToProductRole()` strips `containerSpec` but leaves `spec.runtime`, and `/v1`'s `resolveAppRuntime()` always writes `backend.type`. Because an E2B-backed `/v1` App is refused adoption outright, `k8sDeployment` residue is the **only** residue an adopted product App can carry — so the guard that permits adoption is what guarantees this gate misses it.

## Plans for customer communication

None.

## Impact analysis

No end-user impact today: no product App carries `status.e2bSandbox` until `keboola-operator` #246 lands, and workload-App behaviour is unchanged. Safe to deploy in either order relative to #246, because the gate excludes the one hazard that is live on operator `main` now.

## Change type

Fix.

## Justification

E2B support in the App Deployments model.

## Deployment

Merge & automatic deploy.

## Rollback plan

Revert of this PR.

## Post release support plan

None.
