### PR TITLE
fix(appsproxy): raise default upstream HTTP request timeout to 10m

### DIFF
--- a/internal/pkg/service/appsproxy/config/config.go
+++ b/internal/pkg/service/appsproxy/config/config.go
@@ -78,7 +78,7 @@ func New() Config {
 		Datadog:         datadog.NewConfig(),
 		Metrics:         prometheus.NewConfig(),
 		Upstream: Upstream{
-			HTTPTimeout: 30 * time.Second,
+			HTTPTimeout: 10 * time.Minute,
 			WsTimeout:   6 * time.Hour,
 		},
 		API: API{

--- a/internal/pkg/service/appsproxy/config/config.go
+++ b/internal/pkg/service/appsproxy/config/config.go
@@ -78,7 +78,7 @@ func New() Config {
 		Datadog:         datadog.NewConfig(),
 		Metrics:         prometheus.NewConfig(),
 		Upstream: Upstream{
-			HTTPTimeout: 10 * time.Minute,
+			HTTPTimeout: 4*time.Minute + 30*time.Second,
 			WsTimeout:   6 * time.Hour,
 		},
 		API: API{

--- a/test/cli/remote-table-upload/table-exist-same-csv-columns-diff-order/expected-state.json
+++ b/test/cli/remote-table-upload/table-exist-same-csv-columns-diff-order/expected-state.json
@@ -26,16 +26,16 @@
             "primaryKeysNames": [],
             "columns": [
               {
-                "name": "Status"
-              },
-              {
-                "name": "Region"
+                "name": "Id"
               },
               {
                 "name": "Name"
               },
               {
-                "name": "Id"
+                "name": "Region"
+              },
+              {
+                "name": "Status"
               },
               {
                 "name": "First_Order"
@@ -43,10 +43,10 @@
             ]
           },
           "columns": [
-            "Status",
-            "Region",
-            "Name",
             "Id",
+            "Name",
+            "Region",
+            "Status",
             "First_Order"
           ],
           "rowsCount": 4


### PR DESCRIPTION
## Release Notes
- Raises the default apps-proxy upstream HTTP request timeout (`Upstream.HTTPTimeout` / `httpTimeout` config key) from 30s to 10m
- Long-running upstream requests (e.g. slow data-app responses on `/`) are no longer force-cancelled at 30s

## Plans for customer communication
None.

## Impact analysis
- `internal/pkg/service/appsproxy/config/config.go`: default value change only, config key unchanged and still overridable
- Applies to all non-websocket requests proxied through `AppUpstream.newProxy` (`internal/pkg/service/appsproxy/proxy/apphandler/upstream/upstream.go`); websocket timeout (`WsTimeout`, default 6h) is unaffected
- This is the request-scoped context deadline wrapping the full proxy round trip (dial through body copy), separate from the transport-level `ResponseHeaderTimeout` (15s), which only bounds waiting for response headers and does not cut off an in-progress body transfer
- Backwards-compatible: existing deployments overriding `httpTimeout` explicitly are unaffected; those relying on the default now get a longer timeout, meaning a hung upstream can hold a connection slot (`MaxConnsPerHost: 32`) for longer before the proxy gives up

## Change type
Bug fix — default upstream timeout was too aggressive for legitimately slow upstream responses

## Justification
Investigation showed apps-proxy requests to upstream data apps could be cut off well before what the transport-level timeouts (5s TLS handshake, 15s response header) suggested, because a separate request-scoped context deadline (`Upstream.HTTPTimeout`, default 30s) caps the entire request/response lifecycle including body transfer. Raising the default to 10m gives slow upstream endpoints enough headroom without requiring a per-deployment config override.

## Deployment
Merge & automatic deploy.

## Rollback plan
Revert of this PR.

## Post release support plan
None.