### PR TITLE
test(cli): pin the new import column order in the upload fixture

### DIFF
--- a/test/cli/remote-table-upload/table-exist-same-csv-columns-diff-order/expected-state.json
+++ b/test/cli/remote-table-upload/table-exist-same-csv-columns-diff-order/expected-state.json
@@ -26,16 +26,16 @@
             "primaryKeysNames": [],
             "columns": [
               {
-                "name": "Status"
-              },
-              {
-                "name": "Region"
+                "name": "Id"
               },
               {
                 "name": "Name"
               },
               {
-                "name": "Id"
+                "name": "Region"
+              },
+              {
+                "name": "Status"
               },
               {
                 "name": "First_Order"
@@ -43,10 +43,10 @@
             ]
           },
           "columns": [
-            "Status",
-            "Region",
-            "Name",
             "Id",
+            "Name",
+            "Region",
+            "Status",
             "First_Order"
           ],
           "rowsCount": 4


### PR DESCRIPTION
No ticket in this repo — the change this reacts to is [keboola/connection#8267](https://github.com/keboola/connection/pull/8267) (DMD-1991).

## Description

`TestCliE2E/remote-table-upload/table-exist-same-csv-columns-diff-order` fails on linux, mac-os and windows on every branch that has run `E2E: CLI` since 2026-09-07. The only assertion that fails is the table's column order in the resulting project state.

The test uploads a CSV whose header lists the table's existing columns in a different order (`Status,Region,Name,Id,First_Order` against a table created as `Id,Name,Region,Status,First_Order`) and asserts the project state afterwards. The CLI path is `remote table upload` → `tableimport.Run()`; the table already exists, so it skips table creation and only calls `LoadDataFromFileRequest`, i.e. `POST /v2/storage/branch/{branchId}/tables/{tableId}/import-async`, with no `columns` parameter.

That endpoint changed. `connection/legacy-app/storage/jobs/TableImport.php::setImportOptionsColumns()` resolves the column list from one of three places — an explicit `columns` request parameter, the stored columns, or the file's own CSV header. The first two already flagged a mismatch with `setReorderedColumns(true)`; the header branch did not, so a header in a different order rewrote the table's *stored* column order while the physical table kept its own (a full load is `TRUNCATE` + `INSERT INTO`). Exports, the `columns` API response and a `tables-definition` `source` copy all read the stored order, so it had silently drifted. keboola/connection#8267 added the missing comparison; its release notes call the resulting change deliberate and user-visible.

This PR updates `expected-state.json` for that test — `columns` and `definition.columns` now pin `Id, Name, Region, Status, First_Order`, the order the table is created with in `initial-state.json`, matching the actual CI output. No production code changes.

Verification that the cause is server-side, not ours:

- Last green `E2E: CLI`: run `33634674590`, 2026-09-02 13:15 UTC. First red: run `34135837010`, 2026-09-07 14:58 UTC, failing on this test alone. keboola/connection#8267 merged 2026-08-28 and reached the test stack inside that window.
- Comparing the two commits under test, the only files that differ are under `appsproxy/`, `docs/` and `scripts/` — nothing in `internal/pkg/utils/testproject`, `pkg/lib/operation/project/remote/table`, the fixtures, or `go.mod`.
- The switch from `keboola.CreateTableRequest` to `transfer.CreateTable` (`ae99d2fe2`) is not involved: both upload a CSV header file and call `POST buckets/{id}/tables-async`. Only the file name changed, and the fixtures already absorbed that in `e48a56ac5`.
- The sibling test `table-exist-columns-flag-diff-order`, which passes the reordered list via `--columns`, already expected the table order to be preserved. This fixture was the only one in `test/` pinning the old behaviour.

## Release Notes

- **Justification**
    - Storage stopped rewriting a table's stored column order when an import's CSV header lists the same columns in a different order. The E2E fixture still pinned the old behaviour and was blocking `E2E: CLI` on every branch.
    - A test's expected result was updated to match a deliberate fix made on the Storage side. Nothing in the CLI changed.
- **Plans for Customer Communication**
    - No customer communication needed. Test-only change; the behavioural change itself is communicated by keboola/connection#8267.
- **Impact Analysis**
    - Test fixture only — no production code, no runtime behaviour, no effect on single-tenant setups.
    - Not behind a feature flag.
    - The one risk is the reverse case: if the Storage fix were rolled back, this test would fail again with the orders swapped.
- **Deployment Plan**
    - Continuous deployment; nothing to roll out.
- **Rollback Plan**
    - Revert the commit.
- **Post-Release Support Plan**
    - None. Confirm `E2E: CLI` is green on the three platforms after merge.
